### PR TITLE
[turbopack] Create the JavaScript runtime for Module Federation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10803,6 +10803,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "turbopack-module-federation"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.21.4",
+ "indoc",
+ "serde_json",
+ "turbo-rcstr",
+ "turbo-tasks",
+ "turbo-tasks-fs",
+ "turbo-tasks-hash",
+ "turbopack-core",
+ "turbopack-ecmascript",
+]
+
+[[package]]
 name = "turbopack-nft"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,7 @@ turbopack-ecmascript-hmr-protocol = { path = "turbopack/crates/turbopack-ecmascr
 turbopack-env = { path = "turbopack/crates/turbopack-env" }
 turbopack-image = { path = "turbopack/crates/turbopack-image" }
 turbopack-mdx = { path = "turbopack/crates/turbopack-mdx" }
+turbopack-module-federation = { path = "turbopack/crates/turbopack-module-federation" }
 turbopack-node = { path = "turbopack/crates/turbopack-node", default-features = false }
 turbopack-resolve = { path = "turbopack/crates/turbopack-resolve" }
 turbopack-static = { path = "turbopack/crates/turbopack-static" }

--- a/turbopack/crates/turbopack-module-federation/Cargo.toml
+++ b/turbopack/crates/turbopack-module-federation/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "turbopack-module-federation"
+version = "0.1.0"
+description = "Module Federation support for Turbopack"
+license = "MIT"
+edition = "2024"
+autobenches = false
+
+[lib]
+bench = false
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+base64 = "0.21.0"
+indoc = { workspace = true }
+serde_json = { workspace = true }
+
+turbo-rcstr = { workspace = true }
+turbo-tasks = { workspace = true }
+turbo-tasks-fs = { workspace = true }
+turbo-tasks-hash = { workspace = true }
+turbopack-core = { workspace = true }
+turbopack-ecmascript = { workspace = true }

--- a/turbopack/crates/turbopack-module-federation/js/src/consume-shared.ts
+++ b/turbopack/crates/turbopack-module-federation/js/src/consume-shared.ts
@@ -1,0 +1,170 @@
+/**
+ * Selects and evaluates a shared provider.
+ *
+ * For `react` with `requiredVersion: "^19.0.0"`, the consumer finds the highest matching entry,
+ * calls its `get()` function to obtain a module factory, and then calls that factory to obtain the
+ * module namespace. That two-call shape is required when exchanging share scopes with Webpack.
+ */
+import {
+  getShareScope,
+  getSharedVersionEntries,
+  getSharedVersions,
+  initializeSharing,
+  type SharedEntry,
+} from './share-runtime'
+import { parseRange, satisfy, versionLt, type SemVerRange } from './semver'
+
+export interface ConsumeSharedOptions {
+  shareScope?: string
+  shareKey: string
+  requiredVersion?: string | false | null
+  strictVersion?: boolean
+  singleton?: boolean
+  eager?: boolean
+  fallback?: () => unknown | Promise<unknown>
+}
+
+const parsedRanges = new Map<string, SemVerRange>()
+
+function getParsedRange(requiredVersion: string): SemVerRange {
+  let range = parsedRanges.get(requiredVersion)
+  if (!range) {
+    range = parseRange(requiredVersion)
+    parsedRanges.set(requiredVersion, range)
+  }
+  return range
+}
+
+function versionSatisfies(requiredVersion: string, version: string): boolean {
+  return satisfy(getParsedRange(requiredVersion), version)
+}
+
+function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
+  return Boolean(value) && typeof (value as Promise<T>).then === 'function'
+}
+
+function getSharedModule(entry: SharedEntry): unknown | Promise<unknown> {
+  entry.loaded = 1
+  // A share entry returns a factory, not the module itself: `entry.get()()`.
+  const factory = entry.get()
+  if (isPromise(factory)) {
+    return factory.then((resolvedFactory) => resolvedFactory())
+  }
+  return factory()
+}
+
+type VersionEntry = [version: string, entry: SharedEntry]
+
+function findLatest(entries: VersionEntry[]): VersionEntry | undefined {
+  let selected: VersionEntry | undefined
+  for (const candidate of entries) {
+    if (!selected || versionLt(selected[0], candidate[0])) {
+      selected = candidate
+    }
+  }
+  return selected
+}
+
+function findSatisfying(
+  entries: VersionEntry[],
+  requiredVersion: string
+): VersionEntry | undefined {
+  let selected: VersionEntry | undefined
+  for (const candidate of entries) {
+    if (
+      versionSatisfies(requiredVersion, candidate[0]) &&
+      (!selected || versionLt(selected[0], candidate[0]))
+    ) {
+      selected = candidate
+    }
+  }
+  return selected
+}
+
+function findSingleton(entries: VersionEntry[]): VersionEntry | undefined {
+  let selected: VersionEntry | undefined
+  for (const candidate of entries) {
+    if (
+      !selected ||
+      (!selected[1].loaded && versionLt(selected[0], candidate[0]))
+    ) {
+      selected = candidate
+    }
+  }
+  return selected
+}
+
+function consumeFromScope(options: ConsumeSharedOptions): unknown {
+  const {
+    shareScope = 'default',
+    shareKey,
+    strictVersion = false,
+    singleton = false,
+    eager = false,
+    fallback,
+  } = options
+  const requiredVersion = options.requiredVersion || undefined
+  const versions = getSharedVersions(getShareScope(shareScope), shareKey)
+  const entries = versions
+    ? getSharedVersionEntries(versions).filter(
+        ([, entry]) => !eager || entry.eager
+      )
+    : []
+
+  if (entries.length === 0) {
+    if (fallback) return fallback()
+    throw new Error(
+      `Shared module "${shareKey}" is not available in share scope "${shareScope}"${
+        eager ? ' for eager consumption' : ''
+      }`
+    )
+  }
+
+  // Singletons stay on the already-loaded choice. Other shares prefer the highest version which
+  // satisfies the requested range, or simply the latest version when no range was configured.
+  let selected = singleton
+    ? findSingleton(entries)
+    : requiredVersion
+      ? findSatisfying(entries, requiredVersion)
+      : findLatest(entries)
+
+  if (!selected) {
+    if (strictVersion) {
+      if (fallback) return fallback()
+      throw new Error(
+        `No satisfying version of shared module "${shareKey}" was found in share scope "${shareScope}" (required ${requiredVersion})`
+      )
+    }
+
+    selected = findLatest(entries)
+  }
+
+  const [version, entry] = selected!
+  if (requiredVersion && !versionSatisfies(requiredVersion, version)) {
+    const message = `Unsatisfied version ${version} from ${entry.from} of shared${
+      singleton ? ' singleton' : ''
+    } module ${shareKey} (required ${requiredVersion})`
+
+    if (strictVersion) {
+      // Webpack does not use a local fallback for a strict singleton version
+      // mismatch; the already-selected singleton remains authoritative.
+      if (!singleton && fallback) return fallback()
+      throw new Error(message)
+    }
+    console.warn(message)
+  }
+
+  return getSharedModule(entry)
+}
+
+export function consumeShared(options: ConsumeSharedOptions): unknown {
+  initializeSharing(options.shareScope)
+  return consumeFromScope(options)
+}
+
+export async function consumeSharedAsync(
+  options: ConsumeSharedOptions
+): Promise<unknown> {
+  initializeSharing(options.shareScope)
+  return await consumeFromScope(options)
+}

--- a/turbopack/crates/turbopack-module-federation/js/src/container.ts
+++ b/turbopack/crates/turbopack-module-federation/js/src/container.ts
@@ -1,0 +1,149 @@
+/**
+ * Creates the `{ get, init }` object published by a remote entry.
+ *
+ * For a container named `catalog`, generated code effectively does:
+ *
+ * ```js
+ * globalThis.catalog = createContainer('catalog', 'default', {
+ *   './Button': () => import('./Button').then((module) => () => module),
+ * })
+ * ```
+ *
+ * Webpack and Turbopack hosts consume the same two methods: `init` exchanges shared modules and
+ * `get` returns the factory for an exposed module.
+ */
+import {
+  createShareScope,
+  initializeSharing,
+  isSafeModuleFederationContainerName,
+  isSafeModuleFederationPropertyName,
+  mergeShareScopes,
+  setShareScope,
+  type ShareScope,
+} from './share-runtime'
+import { setCurrentRemoteGetScope } from './remote-scope'
+import { moduleFederationRuntimeState } from './runtime-state'
+
+export type ExposedModuleFactory = () => unknown
+export type ExposedModuleLoader = () => Promise<ExposedModuleFactory>
+
+export interface Container {
+  init(
+    shareScope: ShareScope,
+    initScope?: unknown[]
+  ): unknown | Promise<unknown>
+  get(request: string, getScope?: unknown): Promise<ExposedModuleFactory>
+}
+
+const globalObject = globalThis as unknown as Record<string, unknown>
+
+function hasOwn(object: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key)
+}
+
+function isShareScope(value: unknown): value is ShareScope {
+  return (
+    Boolean(value) &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    value !== Object.prototype &&
+    value !== Function.prototype
+  )
+}
+
+export function createContainer(
+  name: string,
+  shareScopeName: string,
+  moduleMap: Record<string, ExposedModuleLoader>,
+  options?: {
+    libraryType?: 'var'
+    uniqueName?: string
+    localShareScope?: ShareScope
+  }
+): Container {
+  if (!isSafeModuleFederationContainerName(name)) {
+    throw new Error(`Invalid Module Federation container name "${name}"`)
+  }
+  if (!isSafeModuleFederationPropertyName(shareScopeName)) {
+    throw new Error(`Invalid Module Federation share scope "${shareScopeName}"`)
+  }
+  if (hasOwn(globalObject, name)) {
+    throw new Error(
+      `Cannot install Module Federation container "${name}" because that global already exists`
+    )
+  }
+  if (moduleFederationRuntimeState.containers.has(name)) {
+    throw new Error(
+      `Cannot install Module Federation container "${name}" because it is already registered`
+    )
+  }
+
+  // A remote's providers must not mutate a host scope before container.init.
+  // Generated remote entries register into this private scope and init merges
+  // it into the scope supplied by either a Webpack or Turbopack host.
+  const localShareScope = options?.localShareScope || createShareScope()
+  if (!isShareScope(localShareScope)) {
+    throw new Error(
+      `Container "${name}" cannot use an invalid local share scope`
+    )
+  }
+  let initializedScope: ShareScope | undefined
+
+  const container: Container = {
+    async get(request, getScope) {
+      const loader = hasOwn(moduleMap, request) ? moduleMap[request] : undefined
+      if (!loader) {
+        throw new Error(
+          `Module "${request}" does not exist in container "${name}". Available modules: ${Object.keys(moduleMap).join(', ')}`
+        )
+      }
+
+      const previousScope = setCurrentRemoteGetScope(getScope)
+      let factoryPromise: Promise<ExposedModuleFactory>
+      try {
+        // Match Webpack by setting the current get scope only while invoking
+        // the module-map loader. The loader owns the returned async work.
+        factoryPromise = loader()
+      } finally {
+        setCurrentRemoteGetScope(previousScope)
+      }
+
+      const factory = await factoryPromise
+      // Generated loaders already return a factory. Wrapping a plain namespace also makes the
+      // public container robust for hand-written loaders.
+      return typeof factory === 'function' ? factory : () => factory
+    },
+
+    init(shareScope, initScope) {
+      if (!isShareScope(shareScope)) {
+        throw new Error(
+          `Container "${name}" cannot initialize with an invalid share scope`
+        )
+      }
+      if (initializedScope && initializedScope !== shareScope) {
+        throw new Error(
+          `Container "${name}" has already been initialized with a different share scope`
+        )
+      }
+      if (!initializedScope) {
+        setShareScope(shareScopeName, shareScope)
+        if (localShareScope !== shareScope) {
+          mergeShareScopes(shareScope, localShareScope)
+        }
+        initializedScope = shareScope
+      }
+      return initializeSharing(shareScopeName, initScope)
+    },
+  }
+
+  // `libraryType: "var"` containers are discovered through an own browser global. Refusing to
+  // replace an existing value above protects application and platform globals from being clobbered.
+  Object.defineProperty(globalObject, name, {
+    configurable: true,
+    enumerable: true,
+    value: container,
+    writable: true,
+  })
+  moduleFederationRuntimeState.containers.set(name, container)
+  return container
+}

--- a/turbopack/crates/turbopack-module-federation/js/src/provide-shared.ts
+++ b/turbopack/crates/turbopack-module-federation/js/src/provide-shared.ts
@@ -1,0 +1,72 @@
+/**
+ * Registers a local module in a share scope.
+ *
+ * Generated provider entries call this function with code equivalent to:
+ *
+ * ```js
+ * provideShared({
+ *   shareKey: 'react',
+ *   version: '19.1.0',
+ *   factory: () => reactNamespace,
+ *   eager: true,
+ * })
+ * ```
+ *
+ * A remote passes its private `scope`; a host omits it and registers in the named runtime scope.
+ */
+import {
+  getShareScope,
+  register,
+  registerShared,
+  registerSharedGetter,
+  type ShareScope,
+  type SharedModuleFactory,
+  type SharedModuleGetter,
+} from './share-runtime'
+
+interface BaseProvideSharedOptions {
+  scope?: ShareScope
+  shareScope?: string
+  shareKey: string
+  version: string | false
+  eager?: boolean
+  from?: string
+}
+
+export type ProvideSharedOptions = BaseProvideSharedOptions &
+  (
+    | { factory: SharedModuleFactory; get?: never }
+    | { factory?: never; get: SharedModuleGetter }
+  )
+
+export function provideShared({
+  scope,
+  shareScope = 'default',
+  shareKey,
+  version,
+  factory,
+  get,
+  eager = false,
+  from,
+}: ProvideSharedOptions): void {
+  // Webpack uses `0` as the key for an explicitly unversioned provider.
+  const normalizedVersion = version || '0'
+
+  if (get) {
+    registerSharedGetter(
+      scope || getShareScope(shareScope),
+      shareKey,
+      normalizedVersion,
+      get,
+      eager,
+      from
+    )
+    return
+  }
+
+  if (scope) {
+    registerShared(scope, shareKey, normalizedVersion, factory, eager, from)
+  } else {
+    register(shareKey, normalizedVersion, factory, eager, shareScope, from)
+  }
+}

--- a/turbopack/crates/turbopack-module-federation/js/src/remote-loader.ts
+++ b/turbopack/crates/turbopack-module-federation/js/src/remote-loader.ts
@@ -1,0 +1,364 @@
+/**
+ * Loads a remote entry script and asks its global container for one exposed module.
+ *
+ * ```js
+ * await loadRemoteModule(
+ *   'catalog',
+ *   'https://cdn.example.com/remoteEntry.js',
+ *   './Button'
+ * )
+ * ```
+ *
+ * Loading happens in three deliberate phases: select a working script/container, initialize its
+ * share scope, then call `get()` and the returned module factory. Only the first phase tries a
+ * configured fallback, so an error inside an exposed module is surfaced instead of hidden.
+ */
+import { getCurrentRemoteGetScope } from './remote-scope'
+import { moduleFederationRuntimeState } from './runtime-state'
+import {
+  getShareScope,
+  initializeSharing,
+  isSafeModuleFederationContainerName,
+  isSafeModuleFederationPropertyName,
+  type ShareScope,
+} from './share-runtime'
+
+export interface ParsedRemote {
+  name: string
+  url: string
+  shareScope: string
+}
+
+export interface RemoteContainer {
+  init(
+    shareScope: ShareScope,
+    initScope?: unknown[]
+  ): unknown | Promise<unknown>
+  get(request: string, getScope?: unknown): Promise<() => unknown>
+}
+
+export interface LoadedRemoteContainer {
+  container: RemoteContainer
+  remote: ParsedRemote
+}
+
+export interface RemoteScriptLoadOptions {
+  timeoutMs?: number
+  crossOrigin?: string
+  nonce?: string
+}
+
+const globalObject = globalThis as unknown as Record<string, unknown>
+// These caches come from the symbol-backed runtime state, so separately bundled host and remote
+// runtimes still deduplicate the same script URL and container.
+const scriptCache = moduleFederationRuntimeState.scriptLoads
+const scriptElements = moduleFederationRuntimeState.scriptElements
+const remoteCache = moduleFederationRuntimeState.remoteContainers as Map<
+  string,
+  Promise<RemoteContainer>
+>
+
+export const REMOTE_SCRIPT_LOAD_TIMEOUT_MS = 120_000
+export const REMOTE_SCRIPT_RETRY_BASE_DELAY_MS = 200
+export const REMOTE_SCRIPT_RETRY_MAX_JITTER_MS = 400
+
+function hasOwn(object: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key)
+}
+
+class InvalidRemoteContainerError extends Error {}
+class RetryableRemoteScriptLoadError extends Error {}
+
+function isRemoteContainer(value: unknown): value is RemoteContainer {
+  if (!value || (typeof value !== 'object' && typeof value !== 'function')) {
+    return false
+  }
+  const container = value as Partial<RemoteContainer>
+  return (
+    typeof container.get === 'function' && typeof container.init === 'function'
+  )
+}
+
+function validContainerName(name: string): boolean {
+  return isSafeModuleFederationContainerName(name)
+}
+
+function validShareScopeName(name: string): boolean {
+  return isSafeModuleFederationPropertyName(name)
+}
+
+function validRemoteUrl(url: string): boolean {
+  const value = url.trim()
+  if (!value || /[\r\n\0\\]/.test(url)) return false
+  const schemeMatch = /^([A-Za-z][A-Za-z0-9+.-]*):/.exec(value)
+  const scheme = schemeMatch?.[1]?.toLowerCase()
+  return !scheme || scheme === 'http' || scheme === 'https'
+}
+
+export function parseRemoteSyntax(remote: string): {
+  name: string
+  url: string
+} {
+  // Split at the first `@` so the URL may still contain credentials or query values with `@`.
+  const separator = remote.indexOf('@')
+  if (separator <= 0) {
+    throw new Error(`Invalid remote "${remote}". Expected "containerName@url".`)
+  }
+
+  const name = remote.slice(0, separator).trim()
+  const url = remote.slice(separator + 1).trim()
+  if (!validContainerName(name)) {
+    throw new Error(`Invalid remote container name "${name}"`)
+  }
+  if (!validRemoteUrl(url)) {
+    throw new Error(`Invalid remote URL "${url}"`)
+  }
+  return { name, url }
+}
+
+export function parseRemoteConfig(
+  remoteKey: string,
+  config:
+    | string
+    | string[]
+    | { external: string | string[]; shareScope?: string },
+  defaultShareScope: string = 'default'
+): ParsedRemote[] {
+  const external =
+    typeof config === 'object' && !Array.isArray(config)
+      ? config.external
+      : config
+  const shareScope =
+    typeof config === 'object' && !Array.isArray(config)
+      ? config.shareScope || defaultShareScope
+      : defaultShareScope
+
+  if (!validShareScopeName(shareScope)) {
+    throw new Error(`Invalid remote share scope "${shareScope}"`)
+  }
+
+  const entries = Array.isArray(external) ? external : [external]
+  return entries.map((entry) => {
+    if (entry.includes('@')) {
+      return { ...parseRemoteSyntax(entry), shareScope }
+    }
+    if (!validContainerName(remoteKey) || !validRemoteUrl(entry)) {
+      throw new Error(`Invalid remote configuration for "${remoteKey}"`)
+    }
+    return { name: remoteKey, url: entry.trim(), shareScope }
+  })
+}
+
+function evictScript(url: string): void {
+  scriptCache.delete(url)
+  const script = scriptElements.get(url)
+  if (!script) return
+
+  script.onload = null
+  script.onerror = null
+  script.remove()
+  scriptElements.delete(url)
+}
+
+export function loadScript(
+  url: string,
+  options: RemoteScriptLoadOptions = {}
+): Promise<void> {
+  if (!validRemoteUrl(url)) {
+    return Promise.reject(new Error(`Invalid remote URL "${url}"`))
+  }
+
+  const cached = scriptCache.get(url)
+  if (cached) return cached
+
+  const promise = new Promise<void>((resolve, reject) => {
+    if (typeof document === 'undefined') {
+      reject(new Error(`Cannot load remote script "${url}" outside a browser`))
+      return
+    }
+
+    // A classic script is required because Webpack's `var` library type installs its container on
+    // the global object as a side effect of evaluating remoteEntry.js.
+    const script = document.createElement('script')
+    script.src = url
+    script.async = true
+    if (options.crossOrigin) script.crossOrigin = options.crossOrigin
+    if (options.nonce) script.nonce = options.nonce
+    scriptElements.set(url, script)
+
+    const timeoutMs = options.timeoutMs ?? REMOTE_SCRIPT_LOAD_TIMEOUT_MS
+    const timeout = setTimeout(() => {
+      evictScript(url)
+      reject(
+        new RetryableRemoteScriptLoadError(
+          `Loading remote entry script "${url}" timed out after ${timeoutMs}ms`
+        )
+      )
+    }, timeoutMs)
+
+    script.onload = () => {
+      clearTimeout(timeout)
+      script.onload = null
+      script.onerror = null
+      resolve()
+    }
+    script.onerror = () => {
+      clearTimeout(timeout)
+      evictScript(url)
+      reject(
+        new RetryableRemoteScriptLoadError(
+          `Failed to load remote entry script "${url}"`
+        )
+      )
+    }
+    ;(document.head || document.body).appendChild(script)
+  })
+
+  scriptCache.set(url, promise)
+  void promise.catch(() => evictScript(url))
+  return promise
+}
+
+function readGlobalContainer(name: string): RemoteContainer | undefined {
+  if (!hasOwn(globalObject, name)) return undefined
+
+  const container = globalObject[name]
+  if (!isRemoteContainer(container)) {
+    throw new InvalidRemoteContainerError(
+      `The global "${name}" exists but is not a Module Federation container`
+    )
+  }
+  return container
+}
+
+export async function loadRemoteContainer(
+  name: string,
+  url: string,
+  options?: RemoteScriptLoadOptions
+): Promise<RemoteContainer> {
+  if (!validContainerName(name)) {
+    throw new Error(`Invalid remote container name "${name}"`)
+  }
+
+  // Webpack's script external resolves immediately when its global is already
+  // installed. This also prevents duplicate evaluation across runtimes.
+  const installed = readGlobalContainer(name)
+  if (installed) return installed
+
+  const cacheKey = `${name}@${url}`
+  const cached = remoteCache.get(cacheKey)
+  if (cached) return cached
+
+  const promise = (async () => {
+    await loadScript(url, options)
+    const container = readGlobalContainer(name)
+    if (!container) {
+      evictScript(url)
+      throw new Error(
+        `Container "${name}" was not registered after loading "${url}"`
+      )
+    }
+    return container
+  })()
+
+  remoteCache.set(cacheKey, promise)
+  void promise.catch(() => remoteCache.delete(cacheKey))
+  return promise
+}
+
+export async function loadRemoteContainerFromFallbacks(
+  remotes: ParsedRemote[],
+  options?: RemoteScriptLoadOptions
+): Promise<LoadedRemoteContainer> {
+  let lastError: unknown
+
+  // Match Webpack's fallback external: only locating/loading the external
+  // container falls through. init(), get(), and the exposed factory run after
+  // a container is selected, so their application errors are never hidden.
+  for (const remote of remotes) {
+    try {
+      let container: RemoteContainer
+      try {
+        container = await loadRemoteContainer(remote.name, remote.url, options)
+      } catch (error) {
+        if (!(error instanceof RetryableRemoteScriptLoadError)) throw error
+
+        const jitter = Math.floor(
+          Math.random() * (REMOTE_SCRIPT_RETRY_MAX_JITTER_MS + 1)
+        )
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, REMOTE_SCRIPT_RETRY_BASE_DELAY_MS + jitter)
+        })
+        container = await loadRemoteContainer(remote.name, remote.url, options)
+      }
+      return {
+        container,
+        remote,
+      }
+    } catch (error) {
+      // A truthy external has already been selected. Webpack surfaces its
+      // protocol error instead of hiding it by trying a later external.
+      if (error instanceof InvalidRemoteContainerError) throw error
+      lastError = error
+    }
+  }
+
+  if (lastError !== undefined) throw lastError
+  throw new Error('Unable to load Module Federation remote')
+}
+
+export async function loadRemoteModuleFromContainer(
+  container: RemoteContainer,
+  expose: string,
+  shareScopeName: string = 'default',
+  initScope: unknown[] = [],
+  getScope: unknown = getCurrentRemoteGetScope() || []
+): Promise<unknown> {
+  // Initialize sharing before `get`, then preserve Webpack's factory boundary: `get` returns the
+  // factory and the consumer invokes it exactly once.
+  initializeSharing(shareScopeName, initScope)
+  const shareScope = getShareScope(shareScopeName)
+  try {
+    await container.init(shareScope, initScope)
+  } catch (error) {
+    // Webpack treats a selected external's sharing-init failure as a warning
+    // and still asks it for the exposed module. It never tries a fallback.
+    console.warn(`Initialization of sharing external failed: ${error}`)
+  }
+
+  const request = expose.startsWith('.') ? expose : `./${expose}`
+  const factory = await container.get(request, getScope)
+  return factory()
+}
+
+export async function loadRemoteModuleFromFallbacks(
+  remotes: ParsedRemote[],
+  expose: string,
+  initScope: unknown[] = [],
+  getScope: unknown = getCurrentRemoteGetScope() || [],
+  options?: RemoteScriptLoadOptions
+): Promise<unknown> {
+  const { container, remote } = await loadRemoteContainerFromFallbacks(
+    remotes,
+    options
+  )
+  return loadRemoteModuleFromContainer(
+    container,
+    expose,
+    remote.shareScope,
+    initScope,
+    getScope
+  )
+}
+
+export async function loadRemoteModule(
+  remoteName: string,
+  remoteUrl: string,
+  expose: string,
+  shareScopeName: string = 'default'
+): Promise<unknown> {
+  return loadRemoteModuleFromFallbacks(
+    [{ name: remoteName, url: remoteUrl, shareScope: shareScopeName }],
+    expose
+  )
+}

--- a/turbopack/crates/turbopack-module-federation/js/src/remote-scope.ts
+++ b/turbopack/crates/turbopack-module-federation/js/src/remote-scope.ts
@@ -1,0 +1,18 @@
+/**
+ * Carries Webpack's optional `getScope` value while a container starts an exposed-module load.
+ *
+ * `container.get("./Button", scope)` sets this value only while it invokes the generated loader.
+ * If that loader immediately requests another remote, the remote loader can pass the same scope
+ * along and avoid re-entering a container already being visited.
+ */
+let currentRemoteGetScope: unknown
+
+export function getCurrentRemoteGetScope(): unknown {
+  return currentRemoteGetScope
+}
+
+export function setCurrentRemoteGetScope(scope: unknown): unknown {
+  const previous = currentRemoteGetScope
+  currentRemoteGetScope = scope
+  return previous
+}

--- a/turbopack/crates/turbopack-module-federation/js/src/runtime-state.ts
+++ b/turbopack/crates/turbopack-module-federation/js/src/runtime-state.ts
@@ -1,0 +1,70 @@
+/**
+ * State shared by every copy of the Turbopack Module Federation runtime on a page.
+ *
+ * A host and several remote entries can each contain this runtime. `Symbol.for` lets those copies
+ * reuse script loads and container registrations without exposing Webpack's private runtime
+ * globals or evaluating the same remote entry twice.
+ */
+const MODULE_FEDERATION_STATE_VERSION = 2 as const
+
+export const MODULE_FEDERATION_STATE_SYMBOL = Symbol.for(
+  `turbopack.module-federation.runtime.v${MODULE_FEDERATION_STATE_VERSION}`
+)
+
+export interface ModuleFederationRuntimeState {
+  readonly version: typeof MODULE_FEDERATION_STATE_VERSION
+  readonly scriptLoads: Map<string, Promise<void>>
+  readonly scriptElements: Map<string, HTMLScriptElement>
+  readonly remoteContainers: Map<string, Promise<unknown>>
+  readonly containers: Map<string, unknown>
+}
+
+const globalObject = globalThis as unknown as Record<PropertyKey, unknown>
+
+function createRuntimeState(): ModuleFederationRuntimeState {
+  return {
+    version: MODULE_FEDERATION_STATE_VERSION,
+    scriptLoads: new Map(),
+    scriptElements: new Map(),
+    remoteContainers: new Map(),
+    containers: new Map(),
+  }
+}
+
+function isRuntimeState(value: unknown): value is ModuleFederationRuntimeState {
+  if (!value || typeof value !== 'object') return false
+
+  const state = value as Partial<ModuleFederationRuntimeState>
+  return (
+    state.version === MODULE_FEDERATION_STATE_VERSION &&
+    state.scriptLoads instanceof Map &&
+    state.scriptElements instanceof Map &&
+    state.remoteContainers instanceof Map &&
+    state.containers instanceof Map
+  )
+}
+
+function initializeRuntimeState(): ModuleFederationRuntimeState {
+  const existing = globalObject[MODULE_FEDERATION_STATE_SYMBOL]
+  if (existing !== undefined) {
+    if (!isRuntimeState(existing)) {
+      throw new Error(
+        'The Turbopack Module Federation runtime state is incompatible with this runtime version'
+      )
+    }
+    return existing
+  }
+
+  const state = createRuntimeState()
+  // Install a non-enumerable value so application code does not encounter this state during normal
+  // global-object iteration. A versioned symbol lets a future incompatible runtime fail clearly.
+  Object.defineProperty(globalObject, MODULE_FEDERATION_STATE_SYMBOL, {
+    configurable: false,
+    enumerable: false,
+    value: state,
+    writable: false,
+  })
+  return state
+}
+
+export const moduleFederationRuntimeState = initializeRuntimeState()

--- a/turbopack/crates/turbopack-module-federation/js/src/semver.ts
+++ b/turbopack/crates/turbopack-module-federation/js/src/semver.ts
@@ -1,0 +1,278 @@
+/*
+ * MIT License http://www.opensource.org/licenses/mit-license.php
+ * Author Tobias Koppers @sokra
+ *
+ * Adapted from webpack/lib/util/semver.js. Keeping Webpack's range encoding
+ * and comparison rules is intentional: share scopes cross bundler runtimes,
+ * so npm-semver-like behavior is not close enough for interoperability.
+ *
+ * Treat the compact range arrays below as compatibility data, not a general-purpose public
+ * representation. Changes should be checked against Webpack's implementation and the differential
+ * cases in `js/tests/runtime.test.ts`.
+ */
+
+/* eslint-disable eqeqeq, no-sparse-arrays */
+
+type SemVerValue = any
+export type SemVerRange = SemVerValue[]
+
+export function parseVersion(value: string): SemVerValue[] {
+  const splitAndConvert = (part: string): SemVerValue[] =>
+    part.split('.').map((item) => (+item == (item as any) ? +item : item))
+
+  const match = /^([^-+]+)?(?:-([^+]+))?(?:\+(.+))?$/.exec(value)!
+  const version = match[1] ? splitAndConvert(match[1]) : []
+
+  if (match[2]) {
+    version.length++
+    version.push(...splitAndConvert(match[2]))
+  }
+  if (match[3]) {
+    version.push([])
+    version.push(...splitAndConvert(match[3]))
+  }
+  return version
+}
+
+export function versionLt(a: string, b: string): boolean {
+  const left = parseVersion(a)
+  const right = parseVersion(b)
+  let index = 0
+
+  for (;;) {
+    if (index >= left.length) {
+      return index < right.length && typeof right[index] !== 'undefined'
+    }
+
+    const leftValue = left[index]
+    const leftType = typeof leftValue
+    if (index >= right.length) return leftType === 'undefined'
+
+    const rightValue = right[index]
+    const rightType = typeof rightValue
+    if (leftType === rightType) {
+      if (
+        leftType !== 'object' &&
+        leftType !== 'undefined' &&
+        leftValue != rightValue
+      ) {
+        return leftValue < rightValue
+      }
+      index++
+    } else {
+      if (leftType === 'object' && rightType === 'number') return true
+      return rightType === 'string' || leftType === 'undefined'
+    }
+  }
+}
+
+export function parseRange(value: string): SemVerRange {
+  const splitAndConvert = (part: string): SemVerValue[] =>
+    part
+      .split('.')
+      .map((item) => (item !== 'NaN' && `${+item}` === item ? +item : item))
+
+  const parsePartial = (part: string): SemVerRange => {
+    const match = /^([^-+]+)?(?:-([^+]+))?(?:\+(.+))?$/.exec(part)!
+    const version: SemVerRange = match[1]
+      ? [0, ...splitAndConvert(match[1])]
+      : [0]
+
+    if (match[2]) {
+      version.length++
+      version.push(...splitAndConvert(match[2]))
+    }
+
+    let last = version[version.length - 1]
+    while (
+      version.length > 0 &&
+      (last === undefined || /^[*xX]$/.test(last as string))
+    ) {
+      version.pop()
+      last = version[version.length - 1]
+    }
+    return version
+  }
+
+  const toFixed = (range: SemVerRange): SemVerRange => {
+    if (range.length === 1) return [0]
+    if (range.length === 2) return [1, ...range.slice(1)]
+    if (range.length === 3) return [2, ...range.slice(1)]
+    return [range.length, ...range.slice(1)]
+  }
+
+  const negate = (range: SemVerRange): SemVerRange => [
+    -(range[0] as number) - 1,
+    ...range.slice(1),
+  ]
+
+  const parseSimple = (part: string): SemVerRange => {
+    const match = /^(\^|~|<=|<|>=|>|=|v|!)/.exec(part)
+    const start = match ? match[0] : ''
+    const remainder = parsePartial(
+      start.length > 0 ? part.slice(start.length).trim() : part.trim()
+    )
+
+    switch (start) {
+      case '^':
+        if (remainder.length > 1 && remainder[1] === 0) {
+          if (remainder.length > 2 && remainder[2] === 0) {
+            return [3, ...remainder.slice(1)]
+          }
+          return [2, ...remainder.slice(1)]
+        }
+        return [1, ...remainder.slice(1)]
+      case '~':
+        if (remainder.length === 2 && remainder[0] === 0) {
+          return [1, ...remainder.slice(1)]
+        }
+        return [2, ...remainder.slice(1)]
+      case '>=':
+        return remainder
+      case '=':
+      case 'v':
+      case '':
+        return toFixed(remainder)
+      case '<':
+        return negate(remainder)
+      case '>': {
+        const fixed = toFixed(remainder)
+        return [, fixed, 0, remainder, 2]
+      }
+      case '<=':
+        return [, toFixed(remainder), negate(remainder), 1]
+      case '!': {
+        const fixed = toFixed(remainder)
+        return [, fixed, 0]
+      }
+      default:
+        throw new Error(`Unexpected semver range prefix "${start}"`)
+    }
+  }
+
+  const combine = (items: SemVerRange[], operation: 1 | 2): SemVerRange => {
+    if (items.length === 1) return items[0]!
+
+    const combined: SemVerRange = []
+    for (const item of items.slice().reverse()) {
+      if (0 in item) combined.push(item)
+      else combined.push(...item.slice(1))
+    }
+    return [, ...combined, ...items.slice(1).map(() => operation)]
+  }
+
+  const parseJoinedRange = (part: string): SemVerRange => {
+    const hyphenated = part.split(/\s+-\s+/)
+    if (hyphenated.length === 1) {
+      part = part.trim()
+      const items: SemVerRange[] = []
+      const separator = /[-0-9A-Za-z]\s+/g
+      let start = 0
+      let match: RegExpExecArray | null
+      while ((match = separator.exec(part))) {
+        const end = match.index + 1
+        items.push(parseSimple(part.slice(start, end).trim()))
+        start = end
+      }
+      items.push(parseSimple(part.slice(start).trim()))
+      return combine(items, 2)
+    }
+
+    const left = parsePartial(hyphenated[0]!)
+    const right = parsePartial(hyphenated[1]!)
+    return [, toFixed(right), negate(right), 1, left, 2]
+  }
+
+  return combine(value.split(/\s*\|\|\s*/).map(parseJoinedRange), 1)
+}
+
+export function satisfy(
+  range: SemVerRange,
+  versionValue: string | SemVerValue[]
+): boolean {
+  if (0 in range) {
+    const version = Array.isArray(versionValue)
+      ? versionValue
+      : parseVersion(versionValue)
+    let fixCount = range[0] as number
+    const negated = fixCount < 0
+    if (negated) fixCount = -fixCount - 1
+
+    for (let versionIndex = 0, rangeIndex = 1, equal = true; ; ) {
+      const rangeType =
+        rangeIndex < range.length ? typeof range[rangeIndex] : ''
+      let versionItem: SemVerValue
+      let versionType: string | undefined
+
+      if (
+        versionIndex >= version.length ||
+        ((versionItem = version[versionIndex]),
+        (versionType = typeof versionItem),
+        versionType === 'object')
+      ) {
+        if (!equal) return true
+        if (rangeType === 'undefined') {
+          return rangeIndex > fixCount && !negated
+        }
+        return (rangeType === '') !== negated
+      }
+
+      if (versionType === 'undefined') {
+        if (!equal || rangeType !== 'undefined') return false
+      } else if (equal) {
+        if (rangeType === versionType) {
+          if (rangeIndex <= fixCount) {
+            if (versionItem != range[rangeIndex]) return false
+          } else {
+            if (
+              negated
+                ? versionItem > range[rangeIndex]
+                : versionItem < range[rangeIndex]
+            ) {
+              return false
+            }
+            if (versionItem != range[rangeIndex]) equal = false
+          }
+        } else if (rangeType !== 'string' && rangeType !== 'number') {
+          if (negated || rangeIndex <= fixCount) return false
+          equal = false
+          rangeIndex--
+        } else {
+          const typeComesBeforeRange = versionType < rangeType
+          if (rangeIndex <= fixCount || typeComesBeforeRange !== negated) {
+            return false
+          }
+          equal = false
+        }
+      } else if (rangeType !== 'string' && rangeType !== 'number') {
+        equal = false
+        rangeIndex--
+      }
+
+      rangeIndex++
+      versionIndex++
+    }
+  }
+
+  const stack: Array<boolean | number> = []
+  const pop = (): boolean | number => stack.pop()!
+  for (let index = 1; index < range.length; index++) {
+    const item = range[index] as SemVerRange | 0 | 1 | 2
+    stack.push(
+      item == 1
+        ? Number(pop()) | Number(pop())
+        : item == 2
+          ? Number(pop()) & Number(pop())
+          : item
+            ? satisfy(item, versionValue)
+            : !pop()
+    )
+  }
+  return Boolean(pop())
+}
+
+export function versionSatisfies(range: string, version: string): boolean {
+  return satisfy(parseRange(range), version)
+}
+
+/* eslint-enable eqeqeq, no-sparse-arrays */

--- a/turbopack/crates/turbopack-module-federation/js/src/share-runtime.ts
+++ b/turbopack/crates/turbopack-module-federation/js/src/share-runtime.ts
@@ -1,0 +1,250 @@
+/**
+ * Storage and registration primitives for shared modules.
+ *
+ * The shape intentionally matches the object exchanged through Webpack's `container.init()`:
+ *
+ * ```js
+ * scope.react['19.1.0'] = {
+ *   get: () => () => reactNamespace,
+ *   from: 'host',
+ *   eager: true,
+ * }
+ * ```
+ *
+ * Selection by version lives in `consume-shared.ts`; this file only owns safe dictionaries,
+ * registration, and scope merging.
+ */
+export type SharedModuleFactory = () => unknown | Promise<unknown>
+export type SharedModuleGetter = () =>
+  | SharedModuleFactory
+  | Promise<SharedModuleFactory>
+
+export interface SharedEntry {
+  get: SharedModuleGetter
+  from: string | undefined
+  eager: boolean
+  loaded?: boolean | number
+}
+
+export type SharedVersions = Record<string, SharedEntry>
+export type ShareScope = Record<string, SharedVersions>
+type ShareScopeMap = Record<string, ShareScope>
+
+const dangerousPropertyNames = new Set([
+  '__proto__',
+  'prototype',
+  'constructor',
+])
+const reservedContainerNames = new Set([
+  'window',
+  'self',
+  'globalThis',
+  'document',
+  'location',
+  'top',
+  'parent',
+  'frames',
+  'history',
+  'navigator',
+  'name',
+  'alert',
+  'TURBOPACK',
+  'TURBOPACK_ASSET_SUFFIX',
+  'TURBOPACK_CHUNK_LISTS',
+  'TURBOPACK_CHUNK_UPDATE_LISTENERS',
+  '__webpack_share_scopes__',
+  '__webpack_init_sharing__',
+  '__turbopack_share_scopes__',
+  '__turbopack_init_sharing__',
+  '__TURBOPACK_MF_CONTAINERS__',
+])
+
+export function createDictionary<T>(): Record<string, T> {
+  // Share keys come from configuration and from external containers. A null prototype prevents
+  // names such as `toString` from accidentally reading properties inherited from Object.prototype.
+  return Object.create(null) as Record<string, T>
+}
+
+function hasOwn(object: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key)
+}
+
+function setOwn<T>(object: Record<string, T>, key: string, value: T): void {
+  Object.defineProperty(object, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  })
+}
+
+export function isSafeModuleFederationPropertyName(name: string): boolean {
+  return name.length > 0 && !dangerousPropertyNames.has(name)
+}
+
+export function isSafeModuleFederationContainerName(name: string): boolean {
+  return (
+    /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name) &&
+    isSafeModuleFederationPropertyName(name) &&
+    !reservedContainerNames.has(name)
+  )
+}
+
+function assertSafePropertyName(name: string, kind: string): void {
+  if (!isSafeModuleFederationPropertyName(name)) {
+    throw new Error(`Invalid Module Federation ${kind} "${name}"`)
+  }
+}
+
+// Like Webpack's __webpack_share_scopes__, these belong to one compiled
+// runtime. A container adopts the exact host-owned object passed to init().
+// Keeping this map module-local prevents independent hosts on the same page
+// from clobbering each other's default scope.
+export const shareScopeMap: ShareScopeMap = createDictionary<ShareScope>()
+const initTokens = new Map<string, object>()
+
+export function createShareScope(): ShareScope {
+  return createDictionary<SharedVersions>()
+}
+
+export function getShareScope(name: string = 'default'): ShareScope {
+  assertSafePropertyName(name, 'share scope')
+  if (hasOwn(shareScopeMap, name)) return shareScopeMap[name]!
+
+  const scope = createShareScope()
+  setOwn(shareScopeMap, name, scope)
+  return scope
+}
+
+export function setShareScope(name: string, scope: ShareScope): void {
+  assertSafePropertyName(name, 'share scope')
+  const existing = hasOwn(shareScopeMap, name) ? shareScopeMap[name] : undefined
+  if (existing && existing !== scope) {
+    throw new Error(
+      `Share scope "${name}" has already been initialized with a different object`
+    )
+  }
+  setOwn(shareScopeMap, name, scope)
+}
+
+export function getSharedVersions(
+  scope: ShareScope,
+  name: string
+): SharedVersions | undefined {
+  assertSafePropertyName(name, 'shared module key')
+  return hasOwn(scope, name) ? scope[name] : undefined
+}
+
+export function getSharedVersionEntries(
+  versions: SharedVersions
+): Array<[string, SharedEntry]> {
+  const entries = Object.entries(versions)
+  for (const [version] of entries) {
+    assertSafePropertyName(version, 'shared module version')
+  }
+  return entries
+}
+
+function shouldReplaceSharedEntry(
+  current: SharedEntry | undefined,
+  candidate: SharedEntry
+): boolean {
+  // Keep a loaded provider stable. Before anything is loaded, prefer an eager provider and then
+  // use `from` as a deterministic tie-breaker, matching Webpack's share-scope behavior.
+  return (
+    !current ||
+    (!current.loaded &&
+      (candidate.eager !== current.eager
+        ? candidate.eager
+        : candidate.from !== undefined &&
+          current.from !== undefined &&
+          candidate.from > current.from))
+  )
+}
+
+export function mergeShareScopes(target: ShareScope, source: ShareScope): void {
+  // `target` may come from Webpack and therefore may be a normal object. Always use own-property
+  // reads and define own values instead of trusting its prototype chain.
+  for (const [key, sourceVersions] of Object.entries(source)) {
+    assertSafePropertyName(key, 'shared module key')
+    let targetVersions = getSharedVersions(target, key)
+    if (!targetVersions) {
+      targetVersions = createDictionary<SharedEntry>()
+      setOwn(target, key, targetVersions)
+    }
+
+    for (const [version, entry] of getSharedVersionEntries(sourceVersions)) {
+      const current = hasOwn(targetVersions, version)
+        ? targetVersions[version]
+        : undefined
+      if (shouldReplaceSharedEntry(current, entry)) {
+        setOwn(targetVersions, version, entry)
+      }
+    }
+  }
+}
+
+export function registerSharedGetter(
+  scope: ShareScope,
+  name: string,
+  version: string,
+  get: SharedModuleGetter,
+  eager: boolean = false,
+  from: string = 'turbopack'
+): void {
+  assertSafePropertyName(name, 'shared module key')
+  assertSafePropertyName(version, 'shared module version')
+
+  let versions = getSharedVersions(scope, name)
+  if (!versions) {
+    versions = createDictionary<SharedEntry>()
+    setOwn(scope, name, versions)
+  }
+
+  const current = hasOwn(versions, version) ? versions[version] : undefined
+  const candidate: SharedEntry = { get, from, eager }
+  if (shouldReplaceSharedEntry(current, candidate)) {
+    setOwn(versions, version, candidate)
+  }
+}
+
+export function registerShared(
+  scope: ShareScope,
+  name: string,
+  version: string,
+  factory: SharedModuleFactory,
+  eager: boolean = false,
+  from: string = 'turbopack'
+): void {
+  // Webpack share entries expose a getter for the module factory. Keeping
+  // that two-step ABI is what lets both bundlers exchange a share scope.
+  registerSharedGetter(scope, name, version, () => factory, eager, from)
+}
+
+export function register(
+  name: string,
+  version: string,
+  factory: SharedModuleFactory,
+  eager: boolean = false,
+  scopeName: string = 'default',
+  from?: string
+): void {
+  registerShared(getShareScope(scopeName), name, version, factory, eager, from)
+}
+
+export function initializeSharing(
+  name: string = 'default',
+  initScope: unknown[] = []
+): void {
+  getShareScope(name)
+
+  // Webpack passes this array through container initialization to break
+  // cycles. Each compiled runtime owns one token per share scope.
+  let token = initTokens.get(name)
+  if (!token) {
+    token = {}
+    initTokens.set(name, token)
+  }
+  if (initScope.includes(token)) return
+  initScope.push(token)
+}

--- a/turbopack/crates/turbopack-module-federation/js/tests/runtime.test.ts
+++ b/turbopack/crates/turbopack-module-federation/js/tests/runtime.test.ts
@@ -1,0 +1,507 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { afterEach, describe, it } from 'node:test'
+
+import { consumeShared, consumeSharedAsync } from '../src/consume-shared'
+import { createContainer } from '../src/container'
+import {
+  loadRemoteContainer,
+  loadRemoteContainerFromFallbacks,
+  loadRemoteModuleFromContainer,
+  parseRemoteConfig,
+  parseRemoteSyntax,
+  REMOTE_SCRIPT_LOAD_TIMEOUT_MS,
+  REMOTE_SCRIPT_RETRY_BASE_DELAY_MS,
+  REMOTE_SCRIPT_RETRY_MAX_JITTER_MS,
+} from '../src/remote-loader'
+import {
+  createShareScope,
+  getSharedVersions,
+  registerShared,
+  registerSharedGetter,
+  setShareScope,
+  type ShareScope,
+} from '../src/share-runtime'
+import { parseRange, parseVersion, satisfy, versionLt } from '../src/semver'
+
+const require = createRequire(import.meta.url)
+const webpackSemver = require('webpack/lib/util/semver') as {
+  parseRange(value: string): unknown[]
+  parseVersion(value: string): unknown[]
+  satisfy(range: unknown[], version: string): boolean
+  versionLt(left: string, right: string): boolean
+}
+
+let id = 0
+const installedGlobals: string[] = []
+
+function uniqueName(prefix: string): string {
+  id++
+  return `${prefix}${process.pid}_${id}`
+}
+
+function installGlobal(name: string, value: unknown): void {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    value,
+    writable: true,
+  })
+  installedGlobals.push(name)
+}
+
+afterEach(() => {
+  for (const name of installedGlobals.splice(0)) {
+    Reflect.deleteProperty(globalThis, name)
+  }
+})
+
+describe('Webpack semver compatibility', () => {
+  const versions = [
+    '0.0.0',
+    '0.1.0',
+    '1.0.0',
+    '1.2.3',
+    '1.2.3-alpha.1',
+    '1.2.3+build.5',
+    '1.10.0',
+    '2.0.0',
+    '10.0.0',
+  ]
+  const ranges = [
+    '',
+    '*',
+    '1',
+    '1.2',
+    '1.2.3',
+    '^1.2.3',
+    '^0.2.3',
+    '^0.0.3',
+    '~1.2.3',
+    '>=1.0.0',
+    '>1.0.0',
+    '<2.0.0',
+    '<=1.2.3',
+    '1.0.0 - 2.0.0',
+    '^1.0.0 || >=2.0.0',
+    '!=1.2.3',
+    '1.0.0-alpha ',
+    '>=1.0.0-alpha ',
+    '!1.2.3 ',
+  ]
+
+  it('uses Webpack-compatible version parsing and ordering', () => {
+    for (const version of versions) {
+      assert.deepEqual(
+        parseVersion(version),
+        webpackSemver.parseVersion(version)
+      )
+    }
+
+    for (const left of versions) {
+      for (const right of versions) {
+        assert.equal(
+          versionLt(left, right),
+          webpackSemver.versionLt(left, right),
+          `${left} < ${right}`
+        )
+      }
+    }
+  })
+
+  it('uses Webpack-compatible range parsing and satisfaction', () => {
+    for (const value of ranges) {
+      const range = parseRange(value)
+      const webpackRange = webpackSemver.parseRange(value)
+      assert.deepEqual(range, webpackRange, `parseRange(${value})`)
+
+      for (const version of versions) {
+        assert.equal(
+          satisfy(range, version),
+          webpackSemver.satisfy(webpackRange, version),
+          `${version} satisfies ${value}`
+        )
+      }
+    }
+  })
+})
+
+describe('Webpack share ABI', () => {
+  it('registers a getter which returns a module factory', () => {
+    const scope = createShareScope()
+    const module = { source: 'turbopack' }
+    registerShared(scope, 'react', '19.0.0', () => module, false, 'remote')
+
+    const entry = getSharedVersions(scope, 'react')?.['19.0.0']
+    assert.ok(entry)
+    const factory = entry.get()
+    assert.equal(typeof factory, 'function')
+    assert.equal((factory as () => unknown)(), module)
+  })
+
+  it('consumes a synchronous Webpack-shaped getter', () => {
+    const shareScope = uniqueName('share')
+    const scope = createShareScope()
+    const module = { source: 'webpack' }
+    registerSharedGetter(
+      scope,
+      'react',
+      '19.0.0',
+      () => () => module,
+      false,
+      'webpack-host'
+    )
+
+    const consumed = consumeFrom(scope, shareScope, {
+      shareKey: 'react',
+      requiredVersion: '^19.0.0',
+    })
+    assert.equal(consumed, module)
+    assert.equal(getSharedVersions(scope, 'react')?.['19.0.0'].loaded, 1)
+  })
+
+  it('consumes an asynchronous Webpack-shaped getter', async () => {
+    const shareScope = uniqueName('share')
+    const scope = createShareScope()
+    const module = { source: 'webpack-async' }
+    registerSharedGetter(
+      scope,
+      'react',
+      '19.0.0',
+      async () => () => module,
+      false,
+      'webpack-host'
+    )
+
+    const consumed = await consumeFromAsync(scope, shareScope, {
+      shareKey: 'react',
+      requiredVersion: '^19.0.0',
+    })
+    assert.equal(consumed, module)
+  })
+
+  it('selects the highest satisfying version', () => {
+    const shareScope = uniqueName('share')
+    const scope = createShareScope()
+    registerShared(scope, 'library', '1.0.0', () => 'one')
+    registerShared(scope, 'library', '1.5.0', () => 'one-five')
+    registerShared(scope, 'library', '2.0.0', () => 'two')
+
+    assert.equal(
+      consumeFrom(scope, shareScope, {
+        shareKey: 'library',
+        requiredVersion: '^1.0.0',
+      }),
+      'one-five'
+    )
+  })
+})
+
+describe('container and remote protocol', () => {
+  it('exposes the standard get/init container ABI', async () => {
+    const name = uniqueName('TurbopackContainer')
+    const shareScopeName = uniqueName('scope')
+    const localShareScope = createShareScope()
+    registerShared(localShareScope, 'react', '19.0.0', () => 'react')
+
+    const container = createContainer(
+      name,
+      shareScopeName,
+      { './value': async () => () => ({ value: 42 }) },
+      { localShareScope }
+    )
+    installedGlobals.push(name)
+
+    const hostScope = createShareScope()
+    const initScope: unknown[] = []
+    await container.init(hostScope, initScope)
+    const factory = await container.get('./value', [])
+
+    assert.deepEqual(factory(), { value: 42 })
+    assert.ok(getSharedVersions(hostScope, 'react')?.['19.0.0'])
+    assert.ok(initScope.length > 0)
+    await assert.rejects(container.get('./missing'))
+    assert.throws(() => container.init(createShareScope(), []))
+  })
+
+  it('uses an already-installed Webpack container without a DOM', async () => {
+    const name = uniqueName('WebpackContainer')
+    let receivedScope: ShareScope | undefined
+    let receivedInitScope: unknown[] | undefined
+    let receivedGetScope: unknown
+    const container = {
+      init(scope: ShareScope, initScope?: unknown[]) {
+        receivedScope = scope
+        receivedInitScope = initScope
+      },
+      async get(request: string, getScope?: unknown) {
+        assert.equal(request, './button')
+        receivedGetScope = getScope
+        return () => ({ source: 'webpack' })
+      },
+    }
+    installGlobal(name, container)
+
+    assert.equal(
+      await loadRemoteContainer(name, 'https://example.test/remote.js'),
+      container
+    )
+
+    const initScope: unknown[] = []
+    const getScope: unknown[] = []
+    assert.deepEqual(
+      await loadRemoteModuleFromContainer(
+        container,
+        'button',
+        uniqueName('scope'),
+        initScope,
+        getScope
+      ),
+      { source: 'webpack' }
+    )
+    assert.ok(receivedScope)
+    assert.equal(receivedInitScope, initScope)
+    assert.equal(receivedGetScope, getScope)
+  })
+
+  it('does not hide a malformed truthy external behind a fallback', async () => {
+    const malformedName = uniqueName('MalformedContainer')
+    const fallbackName = uniqueName('FallbackContainer')
+    installGlobal(malformedName, {})
+    installGlobal(fallbackName, {
+      init() {},
+      async get() {
+        return () => 'fallback'
+      },
+    })
+
+    await assert.rejects(
+      loadRemoteContainerFromFallbacks([
+        {
+          name: malformedName,
+          shareScope: 'default',
+          url: 'https://one.test/remote.js',
+        },
+        {
+          name: fallbackName,
+          shareScope: 'default',
+          url: 'https://two.test/remote.js',
+        },
+      ]),
+      /not a Module Federation container/
+    )
+  })
+
+  it('retries one failed script with bounded jitter before falling back', async () => {
+    const primaryName = uniqueName('PrimaryContainer')
+    const fallbackName = uniqueName('FallbackContainer')
+    const primaryUrl = 'https://primary.test/remote.js'
+    const fallbackUrl = 'https://fallback.test/remote.js'
+    const scripts: Array<{
+      async: boolean
+      onerror: (() => void) | null
+      onload: (() => void) | null
+      remove(): void
+      src: string
+    }> = []
+    const delays: number[] = []
+    const originalDocument = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'document'
+    )
+    const originalRandom = Math.random
+    const originalSetTimeout = globalThis.setTimeout
+    const originalClearTimeout = globalThis.clearTimeout
+
+    Math.random = () => 0.5
+    globalThis.setTimeout = ((callback: () => void, delay?: number) => {
+      const normalizedDelay = delay || 0
+      delays.push(normalizedDelay)
+      if (normalizedDelay < REMOTE_SCRIPT_LOAD_TIMEOUT_MS) {
+        queueMicrotask(callback)
+      }
+      return 1
+    }) as typeof setTimeout
+    globalThis.clearTimeout = (() => undefined) as typeof clearTimeout
+
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: {
+        createElement() {
+          return {
+            async: false,
+            onerror: null,
+            onload: null,
+            remove() {},
+            src: '',
+          }
+        },
+        head: {
+          appendChild(script: (typeof scripts)[number]) {
+            scripts.push(script)
+            if (scripts.length === 1) {
+              queueMicrotask(() => script.onerror?.())
+            } else {
+              installGlobal(primaryName, {
+                init() {},
+                async get() {
+                  return () => 'primary'
+                },
+              })
+              queueMicrotask(() => script.onload?.())
+            }
+            return script
+          },
+        },
+      },
+    })
+    installGlobal(fallbackName, {
+      init() {},
+      async get() {
+        return () => 'fallback'
+      },
+    })
+
+    try {
+      const loaded = await loadRemoteContainerFromFallbacks([
+        { name: primaryName, shareScope: 'default', url: primaryUrl },
+        { name: fallbackName, shareScope: 'default', url: fallbackUrl },
+      ])
+      assert.equal(loaded.remote.name, primaryName)
+      assert.deepEqual(
+        scripts.map((script) => script.src),
+        [primaryUrl, primaryUrl]
+      )
+      assert.ok(
+        delays.includes(
+          REMOTE_SCRIPT_RETRY_BASE_DELAY_MS +
+            Math.floor(0.5 * (REMOTE_SCRIPT_RETRY_MAX_JITTER_MS + 1))
+        )
+      )
+    } finally {
+      Math.random = originalRandom
+      globalThis.setTimeout = originalSetTimeout
+      globalThis.clearTimeout = originalClearTimeout
+      if (originalDocument) {
+        Object.defineProperty(globalThis, 'document', originalDocument)
+      } else {
+        Reflect.deleteProperty(globalThis, 'document')
+      }
+    }
+  })
+
+  it('accepts callable containers with get and init properties', async () => {
+    const name = uniqueName('CallableContainer')
+    const container = Object.assign(() => undefined, {
+      init() {},
+      async get() {
+        return () => 'callable'
+      },
+    })
+    installGlobal(name, container)
+
+    assert.equal(
+      await loadRemoteContainer(name, 'https://example.test/remote.js'),
+      container
+    )
+  })
+
+  it('warns on selected-container init failure and still calls get', async () => {
+    const warning = new Error('share init failed')
+    const originalWarn = console.warn
+    const warnings: unknown[][] = []
+    console.warn = (...args: unknown[]) => warnings.push(args)
+    try {
+      const container = {
+        init() {
+          throw warning
+        },
+        async get() {
+          return () => 'value'
+        },
+      }
+
+      assert.equal(
+        await loadRemoteModuleFromContainer(
+          container,
+          './value',
+          uniqueName('scope')
+        ),
+        'value'
+      )
+      assert.match(String(warnings[0]?.[0]), /share init failed/)
+    } finally {
+      console.warn = originalWarn
+    }
+  })
+
+  it('rejects different objects for one runtime share scope', () => {
+    const shareScopeName = uniqueName('scope')
+    const firstName = uniqueName('TurbopackContainer')
+    const secondName = uniqueName('TurbopackContainer')
+    const first = createContainer(firstName, shareScopeName, {})
+    const second = createContainer(secondName, shareScopeName, {})
+    installedGlobals.push(firstName, secondName)
+
+    first.init(createShareScope())
+    assert.throws(() => second.init(createShareScope()))
+  })
+
+  it('rejects prototype objects as host and local share scopes', () => {
+    const firstName = uniqueName('TurbopackContainer')
+    const container = createContainer(firstName, uniqueName('scope'), {})
+    installedGlobals.push(firstName)
+
+    assert.throws(() => container.init(Object.prototype as ShareScope))
+    assert.throws(() =>
+      createContainer(
+        uniqueName('TurbopackContainer'),
+        uniqueName('scope'),
+        {},
+        { localShareScope: Object.prototype as ShareScope }
+      )
+    )
+  })
+
+  it('parses Webpack-compatible remote shorthand and arrays', () => {
+    assert.deepEqual(
+      parseRemoteSyntax('dashboard@https://example.test/remote.js'),
+      { name: 'dashboard', url: 'https://example.test/remote.js' }
+    )
+    assert.deepEqual(
+      parseRemoteConfig('dashboard', [
+        'dashboard@https://one.test/remote.js',
+        'https://two.test/remote.js',
+      ]),
+      [
+        {
+          name: 'dashboard',
+          shareScope: 'default',
+          url: 'https://one.test/remote.js',
+        },
+        {
+          name: 'dashboard',
+          shareScope: 'default',
+          url: 'https://two.test/remote.js',
+        },
+      ]
+    )
+  })
+})
+
+function consumeFrom(
+  scope: ShareScope,
+  shareScope: string,
+  options: Omit<Parameters<typeof consumeShared>[0], 'shareScope'>
+): unknown {
+  setShareScope(shareScope, scope)
+  return consumeShared({ ...options, shareScope })
+}
+
+async function consumeFromAsync(
+  scope: ShareScope,
+  shareScope: string,
+  options: Omit<Parameters<typeof consumeSharedAsync>[0], 'shareScope'>
+): Promise<unknown> {
+  setShareScope(shareScope, scope)
+  return consumeSharedAsync({ ...options, shareScope })
+}

--- a/turbopack/crates/turbopack-module-federation/js/tsconfig.json
+++ b/turbopack/crates/turbopack-module-federation/js/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/turbopack/crates/turbopack-module-federation/src/lib.rs
+++ b/turbopack/crates/turbopack-module-federation/src/lib.rs
@@ -1,0 +1,4 @@
+//! Framework-neutral Module Federation support for Turbopack.
+//!
+//! The browser runtime lands first. Later stack layers add Turbopack's generated container sources
+//! and import resolution while keeping the runtime independently testable.


### PR DESCRIPTION
This PR introduces a new runtime that allows Turbopack to engage with module federation.

`container.ts` contains the equivalents of the `get` & `init` APIs mentioned on https://webpack.js.org/concepts/module-federation/.


```javascript
const catalog = createContainer('catalog', 'default', {
  './Button': async () => () => Button,
})

await catalog.init(sharedDependencies)

const createButtonModule = await catalog.get('./Button')
const buttonModule = createButtonModule()
```

The PR also introduces `loadRemoteModule()`:

```javascript
const buttonModule = await loadRemoteModule(
  'catalog',
  'https://example.com/remoteEntry.js',
  './Button'
)
```

Using this method triggers this flow:

```
load remoteEntry.js
        ↓
find its container
        ↓
container.init(shared modules)
        ↓
container.get("./Button")
        ↓
run the returned factory
        ↓
receive the Button module
```

The PR also includes `provideShared()` and `consumeShared()` which are Webpack APIs that are being ported over:

```javascript
provideShared({
  shareKey: 'react',
  version: '19.1.0',
  factory: () => React,
  eager: true,
})
```

```javascript
const React = consumeShared({
  shareKey: 'react',
  requiredVersion: '^19.0.0',
  singleton: true,
})
```

#### Codex's Webpack comparison

| Turbopack file / API | Purpose | Webpack equivalent |
|---|---|---|
| [`container.ts`](https://github.com/vercel/next.js/blob/sp/turbopack/mf/javascript-runtime/turbopack/crates/turbopack-module-federation/js/src/container.ts)<br>`createContainer()`, `container.init()`, and `container.get()` | Creates a remote container, connects shared dependencies, and returns exposed modules | [`ContainerEntryModule.js`](https://github.com/webpack/webpack/blob/main/lib/container/ContainerEntryModule.js) |
| [`remote-loader.ts`](https://github.com/vercel/next.js/blob/sp/turbopack/mf/javascript-runtime/turbopack/crates/turbopack-module-federation/js/src/remote-loader.ts)<br>`loadScript()` and the remote-loading helpers | Loads `remoteEntry.js`, finds its container, and requests a module | [`RemoteRuntimeModule.js`](https://github.com/webpack/webpack/blob/main/lib/container/RemoteRuntimeModule.js) and [`LoadScriptRuntimeModule.js`](https://github.com/webpack/webpack/blob/main/lib/runtime/LoadScriptRuntimeModule.js) |
| [`remote-loader.ts`](https://github.com/vercel/next.js/blob/sp/turbopack/mf/javascript-runtime/turbopack/crates/turbopack-module-federation/js/src/remote-loader.ts)<br>Remote fallback handling | Tries the configured remote locations until a container can be loaded | [`FallbackModule.js`](https://github.com/webpack/webpack/blob/main/lib/container/FallbackModule.js) |
| [`share-runtime.ts`](https://github.com/vercel/next.js/blob/sp/turbopack/mf/javascript-runtime/turbopack/crates/turbopack-module-federation/js/src/share-runtime.ts)<br>Share-scope creation, registration, merging, and initialization | Maintains the collection of dependencies shared between hosts and remotes | [`ShareRuntimeModule.js`](https://github.com/webpack/webpack/blob/main/lib/sharing/ShareRuntimeModule.js) |
| [`provide-shared.ts`](https://github.com/vercel/next.js/blob/sp/turbopack/mf/javascript-runtime/turbopack/crates/turbopack-module-federation/js/src/provide-shared.ts)<br>`provideShared()` | Makes a local dependency and its version available to other applications | [`ProvideSharedModule.js`](https://github.com/webpack/webpack/blob/main/lib/sharing/ProvideSharedModule.js) |
| [`consume-shared.ts`](https://github.com/vercel/next.js/blob/sp/turbopack/mf/javascript-runtime/turbopack/crates/turbopack-module-federation/js/src/consume-shared.ts)<br>`consumeShared()` and `consumeSharedAsync()` | Selects and loads an appropriate version of a shared dependency | [`ConsumeSharedRuntimeModule.js`](https://github.com/webpack/webpack/blob/main/lib/sharing/ConsumeSharedRuntimeModule.js) |
| [`semver.ts`](https://github.com/vercel/next.js/blob/sp/turbopack/mf/javascript-runtime/turbopack/crates/turbopack-module-federation/js/src/semver.ts)<br>Version parsing and matching | Implements Webpack-compatible checks such as `^19.0.0` | [`semver.js`](https://github.com/webpack/webpack/blob/main/lib/util/semver.js) |
| [`remote-scope.ts`](https://github.com/vercel/next.js/blob/sp/turbopack/mf/javascript-runtime/turbopack/crates/turbopack-module-federation/js/src/remote-scope.ts)<br>Remote request scope tracking | Carries information through nested remote requests and prevents repeated work | [`RemoteRuntimeModule.js`](https://github.com/webpack/webpack/blob/main/lib/container/RemoteRuntimeModule.js) and [`RuntimeGlobals.currentRemoteGetScope`](https://github.com/webpack/webpack/blob/main/lib/RuntimeGlobals.js) |
| [`runtime-state.ts`](https://github.com/vercel/next.js/blob/sp/turbopack/mf/javascript-runtime/turbopack/crates/turbopack-module-federation/js/src/runtime-state.ts)<br>Shared runtime state and caches | Deduplicates containers and script loads across Turbopack runtime copies | Webpack distributes this state across [`RuntimeGlobals.js`](https://github.com/webpack/webpack/blob/main/lib/RuntimeGlobals.js), [`RemoteRuntimeModule.js`](https://github.com/webpack/webpack/blob/main/lib/container/RemoteRuntimeModule.js), and [`LoadScriptRuntimeModule.js`](https://github.com/webpack/webpack/blob/main/lib/runtime/LoadScriptRuntimeModule.js) |
| [`runtime.test.ts`](https://github.com/vercel/next.js/blob/sp/turbopack/mf/javascript-runtime/turbopack/crates/turbopack-module-federation/js/tests/runtime.test.ts)<br>Runtime compatibility tests | Verifies container behavior, shared dependencies, version matching, retries, and fallbacks | Webpack’s [`container`](https://github.com/webpack/webpack/tree/main/test/configCases/container) and [`sharing`](https://github.com/webpack/webpack/tree/main/test/configCases/sharing) test suites |
