### PR TITLE
[turbopack] Add Module Federation configuration to Next.js

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1441,6 +1441,254 @@ pub struct ExperimentalConfig {
     // turbopack_file_system_cache_for_dev: Option<bool>,
     // turbopack_file_system_cache_for_build: Option<bool>,
     lightning_css_features: Option<LightningCssFeatures>,
+
+    /// Enables client-side Module Federation in Turbopack.
+    turbopack_module_federation: Option<ModuleFederationConfig>,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(untagged)]
+pub enum ModuleFederationExposeValue {
+    Str(RcStr),
+    Obj(ModuleFederationExposeObject),
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ModuleFederationExposeObject {
+    #[serde(rename = "import")]
+    pub import: Option<ImportValue>,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(untagged)]
+pub enum ImportValue {
+    Str(RcStr),
+    Array(Vec<RcStr>),
+}
+
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(untagged)]
+pub enum ModuleFederationRemoteValue {
+    Str(RcStr),
+    Array(Vec<RcStr>),
+    Obj(ModuleFederationRemoteObject),
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ModuleFederationRemoteObject {
+    #[serde(default)]
+    pub name: Option<RcStr>,
+    #[serde(default)]
+    pub origin: Option<ImportValue>,
+    #[serde(default)]
+    pub entry: Option<ImportValue>,
+    #[serde(default)]
+    pub share_scope: Option<RcStr>,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(untagged)]
+pub enum ModuleFederationSharedValue {
+    Bool(bool),
+    Str(RcStr),
+    Obj(ModuleFederationSharedObject),
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ModuleFederationSharedObject {
+    #[serde(default, rename = "import")]
+    pub import: Option<ImportOrFalse>,
+    #[serde(default)]
+    pub share_key: Option<RcStr>,
+    #[serde(default)]
+    pub share_scope: Option<RcStr>,
+    #[serde(default)]
+    pub version: Option<VersionOrFalse>,
+    #[serde(default)]
+    pub required_version: Option<VersionOrFalse>,
+    #[serde(default)]
+    pub singleton: Option<bool>,
+    #[serde(default)]
+    pub strict_version: Option<bool>,
+    #[serde(default)]
+    pub eager: Option<bool>,
+}
+
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(untagged)]
+pub enum ImportOrFalse {
+    Str(RcStr),
+    Bool(bool),
+}
+
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(untagged)]
+pub enum VersionOrFalse {
+    Str(RcStr),
+    Bool(bool),
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct ModuleFederationConfig {
+    pub name: RcStr,
+    #[serde(default)]
+    pub filename: Option<RcStr>,
+    #[serde(default)]
+    pub share_scope: Option<RcStr>,
+    #[serde(default)]
+    #[bincode(with = "turbo_bincode::serde_self_describing")]
+    pub exposes: Option<FxIndexMap<RcStr, ModuleFederationExposeValue>>,
+    #[serde(default)]
+    #[bincode(with = "turbo_bincode::serde_self_describing")]
+    pub remotes: Option<FxIndexMap<RcStr, ModuleFederationRemoteValue>>,
+    #[serde(default)]
+    #[bincode(with = "turbo_bincode::serde_self_describing")]
+    pub shared: Option<FxIndexMap<RcStr, ModuleFederationSharedValue>>,
+}
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionModuleFederationConfig(pub Option<ModuleFederationConfig>);
+
+impl ModuleFederationConfig {
+    pub fn filename(&self) -> RcStr {
+        self.filename
+            .clone()
+            .unwrap_or_else(|| rcstr!("static/chunks/remoteEntry.js"))
+    }
+
+    pub fn share_scope_name(&self) -> RcStr {
+        self.share_scope
+            .clone()
+            .unwrap_or_else(|| rcstr!("default"))
+    }
 }
 
 #[derive(
@@ -2882,6 +3130,14 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn output_hash_salt(&self) -> Vc<RcStr> {
         Vc::cell(self.output_hash_salt.clone().unwrap_or_default())
+    }
+
+    // ------------------------------------------------------------------
+    // Module Federation
+    // ------------------------------------------------------------------
+    #[turbo_tasks::function]
+    pub fn turbopack_module_federation(&self) -> Vc<OptionModuleFederationConfig> {
+        Vc::cell(self.experimental.turbopack_module_federation.clone())
     }
 }
 

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1467,5 +1467,6 @@
   "1466": "TypeScript %s does not provide the compiler API required by Next.js. Set %s to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1468": "Missing workUnitStore in createComponentTree",
-  "1469": "The payload's transport tree is missing a slot that exists in the loader tree: %s"
+  "1469": "The payload's transport tree is missing a slot that exists in the loader tree: %s",
+  "1471": "experimental.turbopackModuleFederation%s: %s"
 }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -14,6 +14,7 @@ import {
   type TurbopackRuleConfigCollection,
   type TurbopackRuleCondition,
   type TurbopackLoaderBuiltinCondition,
+  type TurbopackModuleFederationConfig,
 } from './config-shared'
 import type {
   Header,
@@ -190,6 +191,89 @@ const zTurbopackConfig: zod.ZodType<TurbopackOptions> = z.strictObject({
     )
     .optional(),
 })
+
+const zModuleFederationImport = z.union([
+  z.string().min(1),
+  z.array(z.string().min(1)).min(1),
+])
+
+const zModuleFederationFilename = z.custom<`static/${string}.js`>((value) => {
+  if (typeof value !== 'string') return false
+  const segments = value.split('/')
+  const outputSegments = segments.slice(1)
+  const filename = outputSegments.at(-1) ?? ''
+  return (
+    segments[0] === 'static' &&
+    outputSegments.length > 0 &&
+    filename.endsWith('.js') &&
+    filename.length > 3 &&
+    outputSegments.every(
+      (segment) =>
+        /^[A-Za-z0-9._-]+$/.test(segment) &&
+        segment !== '.' &&
+        segment !== '..' &&
+        !segment.endsWith('.') &&
+        !/^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i.test(segment)
+    )
+  )
+})
+
+const zTurbopackModuleFederationConfig: zod.ZodType<TurbopackModuleFederationConfig> =
+  z.strictObject({
+    name: z.string().min(1),
+    filename: zModuleFederationFilename.optional(),
+    exposes: z
+      .record(
+        z.string(),
+        z.union([
+          z.string().min(1),
+          z.strictObject({ import: zModuleFederationImport }),
+        ])
+      )
+      .optional(),
+    remotes: z
+      .record(
+        z.string(),
+        z.union([
+          z.string().min(1),
+          z.array(z.string().min(1)).min(1),
+          z.union([
+            z.strictObject({
+              name: z.string().min(1).optional(),
+              origin: zModuleFederationImport,
+              shareScope: z.string().min(1).optional(),
+            }),
+            z.strictObject({
+              name: z.string().min(1).optional(),
+              entry: zModuleFederationImport,
+              shareScope: z.string().min(1).optional(),
+            }),
+          ]),
+        ])
+      )
+      .optional(),
+    shared: z
+      .record(
+        z.string(),
+        z.union([
+          z.boolean(),
+          z.strictObject({
+            import: z.union([z.string().min(1), z.literal(false)]).optional(),
+            shareKey: z.string().min(1).optional(),
+            shareScope: z.string().min(1).optional(),
+            version: z.union([z.string().min(1), z.literal(false)]).optional(),
+            requiredVersion: z
+              .union([z.string().min(1), z.literal(false)])
+              .optional(),
+            singleton: z.boolean().optional(),
+            strictVersion: z.boolean().optional(),
+            eager: z.literal(true).optional(),
+          }),
+        ])
+      )
+      .optional(),
+    shareScope: z.string().min(1).optional(),
+  })
 
 export const experimentalSchema = {
   outputHashSalt: z.string().optional(),
@@ -469,6 +553,7 @@ export const experimentalSchema = {
     .optional(),
   globalNotFound: z.boolean().optional(),
   turbopackRustReactCompiler: z.boolean().optional(),
+  turbopackModuleFederation: zTurbopackModuleFederationConfig.optional(),
   browserDebugInfoInTerminal: z
     .union([
       z.boolean(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -237,6 +237,77 @@ export type TurbopackRuleConfigCollection =
   | TurbopackRuleConfigItem
   | (TurbopackLoaderItem | TurbopackRuleConfigItem)[]
 
+export interface ModuleFederationExposeConfig {
+  /** Project-relative module requests. The last request provides the exposed module. */
+  import: string | string[]
+}
+
+interface ModuleFederationRemoteConfigBase {
+  /** Remote container name. Defaults to the key in `remotes`. */
+  name?: string
+  shareScope?: string
+}
+
+export type ModuleFederationRemoteConfig = ModuleFederationRemoteConfigBase &
+  (
+    | {
+        /** One or more Next.js application origins or base paths, tried in order. */
+        origin: string | string[]
+        entry?: never
+      }
+    | {
+        /** One or more explicit remote entry URLs, tried in order. */
+        entry: string | string[]
+        origin?: never
+      }
+  )
+
+export interface ModuleFederationSharedConfig {
+  import?: string | false
+  shareKey?: string
+  /** Must match the top-level `shareScope`; per-entry scopes are not supported. */
+  shareScope?: string
+  /**
+   * Provider version. Required when a locally imported shared module also sets
+   * `requiredVersion`.
+   */
+  version?: string | false
+  requiredVersion?: string | false
+  singleton?: boolean
+  strictVersion?: boolean
+  /** Only eager shared modules are currently supported. */
+  eager?: true
+}
+
+/**
+ * The experimental, client-only Turbopack Module Federation configuration.
+ *
+ * This enables Turbopack's first-class Module Federation support and
+ * interoperability with Webpack's built-in ModuleFederationPlugin. It applies
+ * to browser client graphs; React Server Components and server-side rendering
+ * do not consume remote modules.
+ */
+export interface TurbopackModuleFederationConfig {
+  /**
+   * Container name and browser global. Must be a non-reserved JavaScript
+   * identifier.
+   */
+  name: string
+  /**
+   * Output `.js` filename within the client `static/` directory.
+   * Defaults to `static/chunks/remoteEntry.js`.
+   */
+  filename?: `static/${string}.js`
+  /** Project-relative modules exposed by the container. */
+  exposes?: Record<string, string | ModuleFederationExposeConfig>
+  /** Remote Next.js origins, or explicit remote entry configuration. */
+  remotes?: Record<string, string | string[] | ModuleFederationRemoteConfig>
+  /** Eager shared modules, such as `{ react: { singleton: true } }`. */
+  shared?: Record<string, boolean | ModuleFederationSharedConfig>
+  /** Default share scope name. Defaults to `"default"`. */
+  shareScope?: string
+}
+
 export interface TurbopackOptions {
   /**
    * (`next --turbopack` only) A mapping of aliased imports to modules to load in their place.
@@ -1352,6 +1423,38 @@ export interface ExperimentalConfig {
   turbopackRustReactCompiler?: boolean
 
   /**
+   * @experimental Turbopack Module Federation configuration
+   *
+   * Implements Turbopack Module Federation for interoperability with Webpack's
+   * built-in ModuleFederationPlugin. Remote modules are not consumed by React
+   * Server Components or during server-side rendering.
+   *
+   * @example
+   * ```js
+   * // next.config.js
+   * module.exports = {
+   *   experimental: {
+   *     turbopackModuleFederation: {
+   *       name: 'shell',
+   *       exposes: {
+   *         './Button': './components/Button'
+   *       },
+   *       remotes: {
+   *         remoteApp: 'http://localhost:3001'
+   *       },
+   *       shared: {
+   *         react: { singleton: true },
+   *         'react-dom': { singleton: true }
+   *       },
+   *       shareScope: 'default'
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  turbopackModuleFederation?: TurbopackModuleFederationConfig
+
+  /**
    * Enable debug information to be forwarded from browser to dev server stdout/stderr.
    *
    * - `'warn'` (default): Forward warnings and errors to terminal
@@ -2401,6 +2504,7 @@ export interface NextConfigRuntime {
     | 'exposeTestingApiInProductionBuild'
     | 'instantInsights'
     | 'requestInsights'
+    | 'turbopackModuleFederation'
   > & {
     // Pick on @internal fields generates invalid .d.ts files
     /** @internal */
@@ -2468,6 +2572,7 @@ export function getNextConfigRuntime(
     exposeTestingApiInProductionBuild: ex.exposeTestingApiInProductionBuild,
     instantInsights: ex.instantInsights,
     requestInsights: ex.requestInsights,
+    turbopackModuleFederation: ex.turbopackModuleFederation,
 
     trustHostHeader: ex.trustHostHeader,
     isExperimentalCompile: ex.isExperimentalCompile,

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -242,4 +242,340 @@ describe('loadConfig', () => {
       expect(result.experimental.cssChunking).toBe('graph')
     })
   })
+
+  describe('experimental.turbopackModuleFederation validation', () => {
+    let configNumber = 0
+
+    async function expectInvalidConfig(config: unknown, message: RegExp) {
+      configNumber++
+      await expect(
+        loadConfig(
+          PHASE_PRODUCTION_BUILD,
+          `${__dirname}/module-federation-${configNumber}`,
+          {
+            customConfig: {
+              experimental: {
+                turbopackModuleFederation: config,
+              },
+            },
+          }
+        )
+      ).rejects.toThrow(message)
+    }
+
+    it('accepts the supported client-only eager configuration', async () => {
+      const result = await loadConfig(
+        PHASE_PRODUCTION_BUILD,
+        `${__dirname}/module-federation-valid`,
+        {
+          customConfig: {
+            experimental: {
+              turbopackModuleFederation: {
+                name: 'remoteApp',
+                filename: 'static/chunks/remoteEntry.js',
+                exposes: {
+                  './Button': {
+                    import: ['./polyfill', './components/Button'],
+                  },
+                },
+                remotes: {
+                  shell: {
+                    origin: ['https://example.com', '/fallback'],
+                    shareScope: 'default',
+                  },
+                  products: {
+                    name: 'productContainer',
+                    entry: 'https://cdn.example.com/products-entry.js',
+                  },
+                  account: 'https://account.example.com',
+                },
+                shared: {
+                  react: {
+                    shareScope: 'default',
+                    version: '19.1.0',
+                    requiredVersion: '^19.0.0',
+                    singleton: true,
+                    strictVersion: true,
+                    eager: true,
+                  },
+                  'react-dom': false,
+                  localState: { import: './lib/local-state', eager: true },
+                  consumerOnly: {
+                    import: false,
+                    requiredVersion: '^1.0.0',
+                    strictVersion: true,
+                  },
+                },
+              },
+            },
+          },
+        }
+      )
+
+      expect(result.experimental.turbopackModuleFederation?.name).toBe(
+        'remoteApp'
+      )
+    })
+
+    it('rejects names that cannot safely identify browser containers', async () => {
+      await expectInvalidConfig(
+        { name: 'remote-app' },
+        /\.name: must be a valid JavaScript identifier/
+      )
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          remotes: {
+            remoteApp: {
+              name: 'remote-app',
+              origin: 'https://example.com',
+            },
+          },
+        },
+        /\.remotes\["remoteApp"\]\.name: must be a valid JavaScript identifier/
+      )
+      for (const reservedName of [
+        'window',
+        'self',
+        'globalThis',
+        'document',
+        'location',
+        'top',
+        'parent',
+        'frames',
+        'navigator',
+        'history',
+        'name',
+        'alert',
+        'TURBOPACK',
+        '__webpack_share_scopes__',
+        '__webpack_init_sharing__',
+        '__TURBOPACK_MF_CONTAINERS__',
+      ]) {
+        await expectInvalidConfig(
+          { name: reservedName },
+          /\.name: must not overwrite a reserved browser or bundler global/
+        )
+      }
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          remotes: {
+            next: {
+              name: 'window',
+              origin: 'https://example.com',
+            },
+          },
+        },
+        /\.remotes\["next"\]\.name: must not overwrite a reserved browser or bundler global/
+      )
+    })
+
+    it('rejects prototype-sensitive object property names', async () => {
+      for (const name of ['__proto__', 'prototype', 'constructor']) {
+        await expectInvalidConfig(
+          { name },
+          /\.name: must not be "__proto__", "prototype", or "constructor"/
+        )
+      }
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          remotes: {
+            remoteApp: {
+              name: 'constructor',
+              origin: 'https://example.com',
+            },
+          },
+        },
+        /\.remotes\["remoteApp"\]\.name: must not be "__proto__", "prototype", or "constructor"/
+      )
+      await expectInvalidConfig(
+        { name: 'shell', shareScope: '__proto__' },
+        /\.shareScope: must not be "__proto__", "prototype", or "constructor"/
+      )
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          remotes: {
+            remoteApp: {
+              origin: '/remote',
+              shareScope: 'prototype',
+            },
+          },
+        },
+        /\.remotes\["remoteApp"\]\.shareScope: must not be "__proto__", "prototype", or "constructor"/
+      )
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          shared: { constructor: true },
+        },
+        /\.shared\["constructor"\]: must not be "__proto__", "prototype", or "constructor"/
+      )
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          shared: { react: { shareKey: '__proto__' } },
+        },
+        /\.shared\["react"\]\.shareKey: must not be "__proto__", "prototype", or "constructor"/
+      )
+    })
+
+    it('keeps emitted filenames inside the served client static directory', async () => {
+      const result = await loadConfig(
+        PHASE_PRODUCTION_BUILD,
+        `${__dirname}/module-federation-custom-static-filename`,
+        {
+          customConfig: {
+            experimental: {
+              turbopackModuleFederation: {
+                name: 'remoteApp',
+                filename: 'static/custom-v1.2/remote_entry-1.2.js',
+              },
+            },
+          },
+        }
+      )
+      expect(result.experimental.turbopackModuleFederation?.filename).toBe(
+        'static/custom-v1.2/remote_entry-1.2.js'
+      )
+
+      for (const filename of [
+        'static',
+        'static/',
+        'static/chunks',
+        'static/chunks/remoteEntry.css',
+        'static/chunks/.js',
+        'static/%2e%2e/remoteEntry.js',
+        'static/chunks%2FremoteEntry.js',
+        'static/chunks/remote:Entry.js',
+        'static/chunks/"remoteEntry".js',
+        'static/chunks/remote*Entry.js',
+        'static/chunks/remote<Entry.js',
+        'static/chunks/remote>Entry.js',
+        'static/chunks/remote|Entry.js',
+        'static/CON.js',
+        'static/nul/remoteEntry.js',
+        'static/aux.txt.js',
+        'static/com1/remoteEntry.js',
+        'static/LPT9.js',
+        'remoteEntry.js',
+        'chunks/remoteEntry.js',
+        'assets/remoteEntry.js',
+        '/remoteEntry.js',
+        '../remoteEntry.js',
+        'static/../remoteEntry.js',
+        'static\\remoteEntry.js',
+        'C:/remoteEntry.js',
+        'static//remoteEntry.js',
+        'remoteEntry.js?x=1',
+      ]) {
+        await expectInvalidConfig(
+          { name: 'remoteApp', filename },
+          /\.filename: must name a portable \.js file below "static\/" using only letters, numbers, dots, underscores, and hyphens/
+        )
+      }
+    })
+
+    it('only permits safe project-relative exposed module requests', async () => {
+      await expectInvalidConfig(
+        {
+          name: 'remoteApp',
+          exposes: { Button: './components/Button' },
+        },
+        /\.exposes\["Button"\].*project-relative module request/
+      )
+      await expectInvalidConfig(
+        {
+          name: 'remoteApp',
+          exposes: { './Button': '../components/Button' },
+        },
+        /\.exposes\["\.\/Button"\]\.import.*project-relative module request/
+      )
+    })
+
+    it('only permits supported remote URL schemes and safe URLs', async () => {
+      for (const remote of [
+        ['javascript', ':alert(1)'].join(''),
+        'data:text/javascript,alert(1)',
+        'file:///tmp/remoteEntry.js',
+        'ftp://example.com/remoteEntry.js',
+        'https://example.com/remote Entry.js',
+        'https://example.com\\remoteEntry.js',
+        'https://example.com/remoteEntry.js\nignored',
+      ]) {
+        await expectInvalidConfig(
+          { name: 'shell', remotes: { remoteApp: remote } },
+          /\.remotes\["remoteApp"\]\.origin: must be an HTTP\(S\) or relative URL/
+        )
+      }
+
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          remotes: {
+            remoteApp: 'remoteApp@https://example.com/static/remoteEntry.js',
+          },
+        },
+        /\.remotes\["remoteApp"\]\.origin: must not include a "containerName@" prefix/
+      )
+
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          remotes: {
+            remoteApp: 'https://example.com/_next/static/chunks/remoteEntry.js',
+          },
+        },
+        /\.remotes\["remoteApp"\]\.origin: must be an application origin or base path; use \{ entry \}/
+      )
+    })
+
+    it('rejects unsupported or inconsistent shared settings', async () => {
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          shared: { react: { eager: false } },
+        },
+        /\.shared\["react"\]\.eager: only eager shared modules are supported/
+      )
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          shared: { react: '^19.0.0' },
+        },
+        /\.shared\["react"\]: string version shorthand is not supported/
+      )
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          shareScope: 'host',
+          shared: { react: { shareScope: 'remote' } },
+        },
+        /\.shared\["react"\]\.shareScope: must match the top-level shareScope \("host"\)/
+      )
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          shared: { react: { requiredVersion: '^19.0.0' } },
+        },
+        /\.shared\["react"\]\.version: is required when a locally provided shared module sets requiredVersion/
+      )
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          shared: { react: { version: 'not-semver' } },
+        },
+        /\.shared\["react"\]\.version: must be a valid semantic version/
+      )
+      await expectInvalidConfig(
+        {
+          name: 'shell',
+          shared: { react: { strictVersion: true } },
+        },
+        /\.shared\["react"\]\.strictVersion: requires a requiredVersion range/
+      )
+    })
+  })
 })

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -23,6 +23,7 @@ import type {
   NextConfigComplete,
   NextConfig,
   NextConfigRuntime,
+  TurbopackModuleFederationConfig,
 } from './config-shared'
 
 import { loadWebpackHook } from './config-utils'
@@ -302,6 +303,391 @@ function warnCustomizedOption(
     Log.warn(
       `The "${key}" option has been modified. ${customMessage ? customMessage + '. ' : ''}It should be removed from your ${configFileName}.`
     )
+  }
+}
+
+const moduleFederationIdentifier = /^[A-Za-z_$][A-Za-z0-9_$]*$/
+const moduleFederationReservedContainerNames = new Set([
+  'window',
+  'self',
+  'globalThis',
+  'document',
+  'location',
+  'top',
+  'parent',
+  'frames',
+  'navigator',
+  'history',
+  'name',
+  'alert',
+  'TURBOPACK',
+  'TURBOPACK_ASSET_SUFFIX',
+  'TURBOPACK_CHUNK_LISTS',
+  'TURBOPACK_CHUNK_UPDATE_LISTENERS',
+  'TURBOPACK_NEXT_CHUNK_URLS',
+  '__webpack_share_scopes__',
+  '__webpack_init_sharing__',
+  '__turbopack_share_scopes__',
+  '__turbopack_init_sharing__',
+  '__TURBOPACK_MF_CONTAINERS__',
+])
+const moduleFederationDangerousPropertyNames = new Set([
+  '__proto__',
+  'prototype',
+  'constructor',
+])
+
+function hasModuleFederationControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index)
+    if (code <= 0x1f || code === 0x7f || code === 0x2028 || code === 0x2029) {
+      return true
+    }
+  }
+  return false
+}
+
+function moduleFederationConfigError(path: string, message: string): never {
+  throw new Error(`experimental.turbopackModuleFederation${path}: ${message}`)
+}
+
+function validateModuleFederationIdentifier(value: string, path: string): void {
+  if (!moduleFederationIdentifier.test(value)) {
+    moduleFederationConfigError(path, 'must be a valid JavaScript identifier')
+  }
+}
+
+function validateModuleFederationPropertyName(
+  value: string,
+  path: string
+): void {
+  if (moduleFederationDangerousPropertyNames.has(value)) {
+    moduleFederationConfigError(
+      path,
+      'must not be "__proto__", "prototype", or "constructor"'
+    )
+  }
+}
+
+function validateModuleFederationContainerName(
+  value: string,
+  path: string
+): void {
+  validateModuleFederationIdentifier(value, path)
+  validateModuleFederationPropertyName(value, path)
+  if (moduleFederationReservedContainerNames.has(value)) {
+    moduleFederationConfigError(
+      path,
+      'must not overwrite a reserved browser or bundler global'
+    )
+  }
+}
+
+function validateModuleFederationLabel(value: string, path: string): void {
+  if (
+    !value ||
+    value.trim() !== value ||
+    hasModuleFederationControlCharacter(value) ||
+    /["\\]/.test(value)
+  ) {
+    moduleFederationConfigError(
+      path,
+      'must be a non-empty string without quotes, backslashes, or control characters'
+    )
+  }
+  validateModuleFederationPropertyName(value, path)
+}
+
+function validateModuleFederationFilename(filename: string): void {
+  const segments = filename.split('/')
+  const outputSegments = segments.slice(1)
+  const filenameBase = segments.at(-1) ?? ''
+  if (
+    !filename ||
+    filename.trim() !== filename ||
+    segments[0] !== 'static' ||
+    outputSegments.length === 0 ||
+    !filename.endsWith('.js') ||
+    filenameBase.length <= 3 ||
+    /^[A-Za-z]:/.test(filename) ||
+    /[\\?#]/.test(filename) ||
+    hasModuleFederationControlCharacter(filename) ||
+    outputSegments.some(
+      (segment) =>
+        !/^[A-Za-z0-9._-]+$/.test(segment) ||
+        segment === '.' ||
+        segment === '..' ||
+        segment.endsWith('.') ||
+        /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i.test(segment)
+    )
+  ) {
+    moduleFederationConfigError(
+      '.filename',
+      'must name a portable .js file below "static/" using only letters, numbers, dots, underscores, and hyphens'
+    )
+  }
+}
+
+function validateModuleFederationModuleRequest(
+  request: string,
+  path: string,
+  projectRelative: boolean
+): void {
+  const segments = request.split('/')
+  if (
+    !request ||
+    request.trim() !== request ||
+    request.startsWith('/') ||
+    /^[A-Za-z]:/.test(request) ||
+    /[\\?#]/.test(request) ||
+    hasModuleFederationControlCharacter(request) ||
+    segments.some((segment, index) =>
+      projectRelative && index === 0
+        ? segment !== '.'
+        : !segment || segment === '.' || segment === '..'
+    )
+  ) {
+    moduleFederationConfigError(
+      path,
+      projectRelative
+        ? 'must be a project-relative module request without path traversal'
+        : 'must be a module request without an absolute path or path traversal'
+    )
+  }
+}
+
+function validateModuleFederationRemoteUrl(url: string, path: string): void {
+  if (/^[^/?#\\]+@(?:https?:|\/\/|\/)/i.test(url)) {
+    moduleFederationConfigError(
+      path,
+      'must not include a "containerName@" prefix; set the object\'s name field separately'
+    )
+  }
+  const scheme = /^([A-Za-z][A-Za-z0-9+.-]*):/.exec(url)?.[1].toLowerCase()
+  if (
+    !url ||
+    url.trim() !== url ||
+    /[\s\\]/.test(url) ||
+    hasModuleFederationControlCharacter(url) ||
+    (scheme !== undefined && scheme !== 'http' && scheme !== 'https')
+  ) {
+    moduleFederationConfigError(
+      path,
+      'must be an HTTP(S) or relative URL without whitespace, backslashes, or control characters'
+    )
+  }
+
+  if (scheme || url.startsWith('//')) {
+    try {
+      const parsed = new URL(url, 'http://next.invalid')
+      if (!parsed.hostname) {
+        moduleFederationConfigError(path, 'must include a hostname')
+      }
+    } catch {
+      moduleFederationConfigError(path, 'must be a valid URL')
+    }
+  }
+}
+
+function validateModuleFederationRemoteOrigin(
+  origin: string,
+  path: string
+): void {
+  validateModuleFederationRemoteUrl(origin, path)
+  const parsed = new URL(origin, 'http://next.invalid')
+  if (parsed.search || parsed.hash || /\.m?js$/i.test(parsed.pathname)) {
+    moduleFederationConfigError(
+      path,
+      'must be an application origin or base path; use { entry } for an explicit remote entry URL'
+    )
+  }
+}
+
+function validateTurbopackModuleFederationConfig(
+  config: TurbopackModuleFederationConfig
+): void {
+  if (!config.name || typeof config.name !== 'string') {
+    moduleFederationConfigError('.name', 'is required')
+  }
+  validateModuleFederationContainerName(config.name, '.name')
+
+  if (config.filename !== undefined) {
+    validateModuleFederationFilename(config.filename)
+  }
+  if (config.shareScope !== undefined) {
+    validateModuleFederationLabel(config.shareScope, '.shareScope')
+  }
+  const localShareScope = config.shareScope ?? 'default'
+
+  for (const [exposeName, exposeConfig] of Object.entries(
+    config.exposes ?? {}
+  )) {
+    validateModuleFederationModuleRequest(
+      exposeName,
+      `.exposes[${JSON.stringify(exposeName)}]`,
+      true
+    )
+    const requests =
+      typeof exposeConfig === 'string'
+        ? [exposeConfig]
+        : Array.isArray(exposeConfig.import)
+          ? exposeConfig.import
+          : [exposeConfig.import]
+    for (const request of requests) {
+      validateModuleFederationModuleRequest(
+        request,
+        `.exposes[${JSON.stringify(exposeName)}].import`,
+        true
+      )
+    }
+  }
+
+  for (const [remoteAlias, remoteConfig] of Object.entries(
+    config.remotes ?? {}
+  )) {
+    validateModuleFederationIdentifier(
+      remoteAlias,
+      `.remotes[${JSON.stringify(remoteAlias)}]`
+    )
+    let locations: string | string[]
+    let usesExplicitEntry = false
+    let containerName = remoteAlias
+    let shareScope: string | undefined
+    if (typeof remoteConfig === 'object' && !Array.isArray(remoteConfig)) {
+      containerName = remoteConfig.name ?? remoteAlias
+      shareScope = remoteConfig.shareScope
+      if (remoteConfig.entry !== undefined) {
+        locations = remoteConfig.entry
+        usesExplicitEntry = true
+      } else if (remoteConfig.origin !== undefined) {
+        locations = remoteConfig.origin
+      } else {
+        moduleFederationConfigError(
+          `.remotes[${JSON.stringify(remoteAlias)}]`,
+          'must set either origin or entry'
+        )
+      }
+    } else {
+      locations = remoteConfig
+    }
+    validateModuleFederationContainerName(
+      containerName,
+      `.remotes[${JSON.stringify(remoteAlias)}].name`
+    )
+    if (shareScope !== undefined) {
+      validateModuleFederationLabel(
+        shareScope,
+        `.remotes[${JSON.stringify(remoteAlias)}].shareScope`
+      )
+    }
+    const locationPath = `.remotes[${JSON.stringify(remoteAlias)}].${
+      usesExplicitEntry ? 'entry' : 'origin'
+    }`
+    for (const location of Array.isArray(locations) ? locations : [locations]) {
+      if (usesExplicitEntry) {
+        validateModuleFederationRemoteUrl(location, locationPath)
+      } else {
+        validateModuleFederationRemoteOrigin(location, locationPath)
+      }
+    }
+  }
+
+  const semver =
+    require('next/dist/compiled/semver') as typeof import('next/dist/compiled/semver')
+  for (const [sharedName, sharedConfig] of Object.entries(
+    config.shared ?? {}
+  )) {
+    validateModuleFederationModuleRequest(
+      sharedName,
+      `.shared[${JSON.stringify(sharedName)}]`,
+      false
+    )
+    validateModuleFederationPropertyName(
+      sharedName,
+      `.shared[${JSON.stringify(sharedName)}]`
+    )
+    if (typeof sharedConfig === 'string') {
+      moduleFederationConfigError(
+        `.shared[${JSON.stringify(sharedName)}]`,
+        'string version shorthand is not supported; use an object with requiredVersion and version'
+      )
+    }
+    if (typeof sharedConfig !== 'object' || sharedConfig === null) {
+      continue
+    }
+    if ((sharedConfig as { eager?: boolean }).eager === false) {
+      moduleFederationConfigError(
+        `.shared[${JSON.stringify(sharedName)}].eager`,
+        'only eager shared modules are supported'
+      )
+    }
+    if (typeof sharedConfig.import === 'string') {
+      validateModuleFederationModuleRequest(
+        sharedConfig.import,
+        `.shared[${JSON.stringify(sharedName)}].import`,
+        sharedConfig.import.startsWith('./')
+      )
+    }
+    if (sharedConfig.shareKey !== undefined) {
+      validateModuleFederationModuleRequest(
+        sharedConfig.shareKey,
+        `.shared[${JSON.stringify(sharedName)}].shareKey`,
+        false
+      )
+      validateModuleFederationPropertyName(
+        sharedConfig.shareKey,
+        `.shared[${JSON.stringify(sharedName)}].shareKey`
+      )
+    }
+    if (sharedConfig.shareScope !== undefined) {
+      validateModuleFederationLabel(
+        sharedConfig.shareScope,
+        `.shared[${JSON.stringify(sharedName)}].shareScope`
+      )
+      if (sharedConfig.shareScope !== localShareScope) {
+        moduleFederationConfigError(
+          `.shared[${JSON.stringify(sharedName)}].shareScope`,
+          `must match the top-level shareScope (${JSON.stringify(localShareScope)}); per-entry share scopes are not supported`
+        )
+      }
+    }
+    if (
+      typeof sharedConfig.version === 'string' &&
+      semver.valid(sharedConfig.version) === null
+    ) {
+      moduleFederationConfigError(
+        `.shared[${JSON.stringify(sharedName)}].version`,
+        'must be a valid semantic version'
+      )
+    }
+    if (
+      typeof sharedConfig.requiredVersion === 'string' &&
+      semver.validRange(sharedConfig.requiredVersion) === null
+    ) {
+      moduleFederationConfigError(
+        `.shared[${JSON.stringify(sharedName)}].requiredVersion`,
+        'must be a valid semantic version range'
+      )
+    }
+    if (
+      typeof sharedConfig.requiredVersion === 'string' &&
+      sharedConfig.import !== false &&
+      typeof sharedConfig.version !== 'string'
+    ) {
+      moduleFederationConfigError(
+        `.shared[${JSON.stringify(sharedName)}].version`,
+        'is required when a locally provided shared module sets requiredVersion'
+      )
+    }
+    if (
+      sharedConfig.strictVersion &&
+      typeof sharedConfig.requiredVersion !== 'string'
+    ) {
+      moduleFederationConfigError(
+        `.shared[${JSON.stringify(sharedName)}].strictVersion`,
+        'requires a requiredVersion range'
+      )
+    }
   }
 }
 
@@ -1126,6 +1512,13 @@ function assignDefaultsAndValidate(
     if (!g.startsWith('TURBOPACK_')) {
       result.turbopack.chunkLoadingGlobal = `TURBOPACK_${g}`
     }
+  }
+
+  // Validate Module Federation config when present
+  if (result.experimental?.turbopackModuleFederation) {
+    validateTurbopackModuleFederationConfig(
+      result.experimental.turbopackModuleFederation
+    )
   }
 
   if (


### PR DESCRIPTION
Here's what the config for module federation looks like:

```js
module.exports = {
  experimental: {
    turbopackModuleFederation: {
      name: 'host',
      remotes: {
        remoteApp: 'http://localhost:3001',
      },
      exposes: {
        './Button': './components/Button',
      },
      shared: {
        react: { singleton: true },
      },
    },
  },
}
```

The equivalent Webpack configuration would look like:

```js
const { ModuleFederationPlugin } = require('webpack').container

module.exports = {
  plugins: [
    new ModuleFederationPlugin({
      name: 'host',
      remotes: {
        remoteApp:
          'remoteApp@http://localhost:3001/_next/static/chunks/remoteEntry.js',
      },
      exposes: {
        './Button': './components/Button',
      },
      shared: {
        react: { singleton: true },
      },
    }),
  ],
}
```

Very similar. Most notable thing is we auto-append "/_next/static/chunks/remoteEntry.js"
