### PR TITLE
Enable strict route matching by default

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2017,7 +2017,7 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub fn strict_route_matching(&self) -> Vc<bool> {
-        Vc::cell(self.experimental.strict_route_matching.unwrap_or_default())
+        Vc::cell(self.experimental.strict_route_matching.unwrap_or(true))
     }
 
     #[turbo_tasks::function]

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -2310,7 +2310,7 @@ export const defaultConfig = Object.freeze({
     useCache: undefined,
     slowModuleDetection: undefined,
     globalNotFound: false,
-    strictRouteMatching: false,
+    strictRouteMatching: true,
     browserDebugInfoInTerminal: 'warn',
     lockDistDir: true,
     disableResumeDataCacheCompression: false,


### PR DESCRIPTION
## Summary

This makes `experimental.strictRouteMatching` default to true so canary applications and the full CI suite exercise the corrected slot and matcher semantics without requiring opt in. An explicit false keeps the legacy behavior as a temporary escape hatch while this bakes.

This PR is intentionally a temporary CI layer. The flag should be changed back to false before the feature stack lands, but keeping this commit in the stack for now gives the rest of the test suite a chance to find compatibility problems outside the focused coverage.

## Verification

- `pnpm build-all`

<!-- NEXT_JS_LLM -->
