### PR TITLE
fix(turbo-persistence): allow 32-bit usize conversion

### DIFF
--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -584,7 +584,7 @@ const fn usize_from_u32(value: u32) -> usize {
     // This should always be true, as we assume at least a 32-bit width architecture for Turbopack.
     // Since this is a const expression, we expect it to be compiled away.
     const {
-        assert!(u32::BITS < usize::BITS);
+        assert!(u32::BITS <= usize::BITS);
     };
     value as usize
 }


### PR DESCRIPTION
### What?

Change the pointer-width assertion in `usize_from_u32` from `<` to `<=`, allowing the conversion to compile on 32-bit targets.

### Why?

The surrounding comment states that Turbopack assumes a pointer width of at least 32 bits, but the strict comparison rejects exactly 32-bit targets. Since `u32` and `usize` have the same width on these targets, the conversion remains lossless.

This currently causes `rspack-turbo-persistence` to fail to compile with `error[E0080]` in Rspack's [`i686-pc-windows-msvc` CI job](https://github.com/web-infra-dev/rspack/actions/runs/31665978273/job/94340544786#step:25:446).

### How?

Allow equal source and target bit widths in the compile-time assertion.