### PR TITLE
Trace route module preparation

### DIFF
--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -116,6 +116,10 @@ enum AppRouteRouteHandlersSpan {
   runHandler = 'AppRouteRouteHandlers.runHandler',
 }
 
+enum RouteModuleSpan {
+  prepare = 'RouteModule.prepare',
+  loadManifests = 'RouteModule.loadManifests',
+}
 enum ResolveMetadataSpan {
   generateMetadata = 'ResolveMetadata.generateMetadata',
   generateViewport = 'ResolveMetadata.generateViewport',
@@ -138,6 +142,7 @@ type SpanTypes =
   | `${DevBundlerServiceSpan}`
   | `${NodeSpan}`
   | `${AppRouteRouteHandlersSpan}`
+  | `${RouteModuleSpan}`
   | `${ResolveMetadataSpan}`
   | `${MiddlewareSpan}`
 
@@ -153,6 +158,7 @@ export const NextVanillaSpanAllowlist = new Set([
   RenderSpan.renderDocument,
   NodeSpan.runHandler,
   AppRouteRouteHandlersSpan.runHandler,
+  RouteModuleSpan.prepare,
   ResolveMetadataSpan.generateMetadata,
   ResolveMetadataSpan.generateViewport,
   NextNodeServerSpan.createComponentTree,
@@ -183,6 +189,7 @@ export {
   DevBundlerServiceSpan,
   NodeSpan,
   AppRouteRouteHandlersSpan,
+  RouteModuleSpan,
   ResolveMetadataSpan,
   MiddlewareSpan,
 }

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -29,6 +29,7 @@ import {
   LoadComponentsSpan,
   NextNodeServerSpan,
   NodeSpan,
+  RouteModuleSpan,
 } from './constants'
 import { SpanKind, SpanStatusCode, getTracer } from './tracer'
 
@@ -265,12 +266,23 @@ describe('local span recording', () => {
       LoadComponentsSpan.loadRouteModule,
     ])
 
-    process.env.NEXT_OTEL_VERBOSE = '1'
-    getTracer().trace(BaseServerSpan.render, () => undefined)
+    getTracer().trace(RouteModuleSpan.prepare, () => undefined)
+    getTracer().trace(RouteModuleSpan.loadManifests, () => undefined)
     expect(exportedSpans).toEqual([
       NodeSpan.runHandler,
       LoadComponentsSpan.loadRouteModule,
+      RouteModuleSpan.prepare,
+    ])
+
+    process.env.NEXT_OTEL_VERBOSE = '1'
+    getTracer().trace(BaseServerSpan.render, () => undefined)
+    getTracer().trace(RouteModuleSpan.loadManifests, () => undefined)
+    expect(exportedSpans).toEqual([
+      NodeSpan.runHandler,
+      LoadComponentsSpan.loadRouteModule,
+      RouteModuleSpan.prepare,
       BaseServerSpan.render,
+      RouteModuleSpan.loadManifests,
     ])
   })
 

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -68,6 +68,8 @@ import {
 import { decodePathParams } from '../lib/router-utils/decode-path-params'
 import { removeTrailingSlash } from '../../shared/lib/router/utils/remove-trailing-slash'
 import { isInterceptionRouteRewrite } from '../../lib/is-interception-route-rewrite'
+import { getTracer } from '../lib/trace/tracer'
+import { RouteModuleSpan } from '../lib/trace/constants'
 
 /**
  * RouteModuleOptions is the options that are passed to the route module, other
@@ -592,7 +594,22 @@ export abstract class RouteModule<
     return { nextConfig, deploymentId }
   }
 
-  public async prepare(
+  public prepare(
+    req: IncomingMessage | BaseNextRequest,
+    res: ServerResponse | null,
+    options: {
+      srcPage: string
+      multiZoneDraftMode?: boolean
+    }
+  ) {
+    return getTracer().trace(
+      RouteModuleSpan.prepare,
+      { spanName: 'prepare route module' },
+      () => this.prepareImpl(req, res, options)
+    )
+  }
+
+  private async prepareImpl(
     req: IncomingMessage | BaseNextRequest,
     res: ServerResponse | null,
     {
@@ -677,7 +694,11 @@ export abstract class RouteModule<
       // before the userland route handler runs.
       await ensureInstrumentationRegistered(absoluteProjectDir, this.distDir)
     }
-    const manifests = this.loadManifests(srcPage, absoluteProjectDir)
+    const manifests = getTracer().trace(
+      RouteModuleSpan.loadManifests,
+      { spanName: 'load route manifests' },
+      () => this.loadManifests(srcPage, absoluteProjectDir)
+    )
     const { routesManifest, prerenderManifest, serverFilesManifest } = manifests
 
     const { basePath, i18n, rewrites } = routesManifest

--- a/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
+++ b/test/development/app-dir/request-insights-route-preparation/request-insights-route-preparation.test.ts
@@ -26,6 +26,8 @@ describe('request-insights-route-preparation', () => {
   const routePreparationSpanType = 'DevRouteMatcherManager.ensureRoute'
   const matcherReloadSpanType = 'DevRouteMatcherManager.reloadMatchers'
   const routeCompilationSpanType = 'DevBundlerService.ensurePage'
+  const routeModulePrepareSpanType = 'RouteModule.prepare'
+  const routeManifestLoadSpanType = 'RouteModule.loadManifests'
 
   async function getRequestInsights() {
     return (await next
@@ -173,6 +175,47 @@ describe('request-insights-route-preparation', () => {
     expect(routeCompilationSpan.traceId).toBe(rootSpan?.traceId)
   }
 
+  function expectRouteModulePreparationSpans(request: RequestInsight) {
+    const rootSpan = request.spans.find(
+      (span) =>
+        span.attributes?.['next.span_type'] === 'BaseServer.handleRequest'
+    )
+    const prepareSpans = request.spans.filter(
+      (span) =>
+        span.attributes?.['next.span_type'] === routeModulePrepareSpanType
+    )
+    const manifestLoadSpans = request.spans.filter(
+      (span) =>
+        span.attributes?.['next.span_type'] === routeManifestLoadSpanType
+    )
+
+    expect(prepareSpans).toEqual([
+      expect.objectContaining({
+        name: 'prepare route module',
+        status: 'ok',
+        traceId: rootSpan?.traceId,
+        attributes: {
+          'next.span_category': 'nextjs',
+          'next.span_name': 'prepare route module',
+          'next.span_type': routeModulePrepareSpanType,
+        },
+      }),
+    ])
+    expect(manifestLoadSpans).toEqual([
+      expect.objectContaining({
+        name: 'load route manifests',
+        status: 'ok',
+        traceId: rootSpan?.traceId,
+        parentSpanId: prepareSpans[0].spanId,
+        attributes: {
+          'next.span_category': 'nextjs',
+          'next.span_name': 'load route manifests',
+          'next.span_type': routeManifestLoadSpanType,
+        },
+      }),
+    ])
+  }
+
   it('records route preparation for first and subsequent App Page requests', async () => {
     const coldRequest = await captureRequest('/', async () => {
       const response = await next.fetch('/')
@@ -187,6 +230,8 @@ describe('request-insights-route-preparation', () => {
 
     expectRoutePreparationSpans(coldRequest)
     expectRoutePreparationSpans(warmRequest)
+    expectRouteModulePreparationSpans(coldRequest)
+    expectRouteModulePreparationSpans(warmRequest)
   })
 
   it('records route preparation for first and subsequent App Route requests', async () => {
@@ -204,5 +249,7 @@ describe('request-insights-route-preparation', () => {
 
     expectRoutePreparationSpans(coldRequest)
     expectRoutePreparationSpans(warmRequest)
+    expectRouteModulePreparationSpans(coldRequest)
+    expectRouteModulePreparationSpans(warmRequest)
   })
 })

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -12,6 +12,7 @@ const EXTERNAL = {
 } as const
 
 const COLLECTOR_PORT = 9001
+const ROUTE_PREPARATION_COLLECTOR_PORT = 9002
 
 function setup({ useDirectEntrypointHandler, useNodeMiddleware }) {
   let collector: Collector
@@ -458,8 +459,43 @@ describe.each(
                 })
               }
             )
-          }
 
+            it('should trace route module preparation', async () => {
+              const pathname = '/api/app/param/data'
+              await next.fetch(pathname)
+
+              await retry(async () => {
+                const spans = getCollector().getSpans()
+                const rootSpan = spans.find(
+                  (span) =>
+                    span.attributes?.['next.span_type'] ===
+                      'BaseServer.handleRequest' &&
+                    span.attributes?.['http.target'] === pathname
+                )
+                const prepareSpans = spans.filter(
+                  (span) =>
+                    span.attributes?.['next.span_type'] ===
+                      'RouteModule.prepare' &&
+                    span.traceId === rootSpan?.traceId
+                )
+
+                expect(rootSpan).toBeDefined()
+                expect(prepareSpans).toEqual([
+                  expect.objectContaining({
+                    runtime: 'nodejs',
+                    name: 'prepare route module',
+                    traceId: rootSpan?.traceId,
+                    attributes: {
+                      'next.span_category': 'nextjs',
+                      'next.span_name': 'prepare route module',
+                      'next.span_type': 'RouteModule.prepare',
+                    },
+                    status: { code: 0 },
+                  }),
+                ])
+              })
+            })
+          }
           it('should handle route handlers in app router', async () => {
             await next.fetch('/api/app/param/data', env.fetchInit)
 
@@ -1497,6 +1533,72 @@ describe.each(
   }
 })
 
+if (isNextStart) {
+  describe('opentelemetry route module preparation with direct entrypoint handler', () => {
+    let collector: Collector | undefined
+    const { next, skipped } = nextTestSetup({
+      files: __dirname,
+      skipDeployment: true,
+      skipStart: true,
+      dependencies: require('./package.json').dependencies,
+      startCommand: 'pnpm start-entrypoint',
+      packageJson: {
+        scripts: {
+          'start-entrypoint':
+            'pnpm tsx custom-entrypoint-server.ts --without-parent-span',
+        },
+      },
+      serverReadyPattern: /- Local:/,
+      env: {
+        TEST_OTEL_COLLECTOR_PORT: String(ROUTE_PREPARATION_COLLECTOR_PORT),
+        NEXT_TELEMETRY_DISABLED: '1',
+        NODE_ENV: 'production',
+      },
+    })
+
+    if (skipped) {
+      return
+    }
+
+    afterAll(async () => {
+      await collector?.shutdown()
+    })
+
+    it('should trace route module preparation', async () => {
+      const connectedCollector = await connectCollector({
+        port: ROUTE_PREPARATION_COLLECTOR_PORT,
+      })
+      collector = connectedCollector
+      await next.start()
+
+      await next.fetch('/app/param/rsc-fetch')
+      await next.fetch('/api/app/param/data')
+
+      await retry(async () => {
+        const prepareSpans = connectedCollector
+          .getSpans()
+          .filter(
+            (span) =>
+              span.attributes?.['next.span_type'] === 'RouteModule.prepare'
+          )
+
+        expect(prepareSpans).toEqual([
+          expect.objectContaining({
+            runtime: 'nodejs',
+            name: 'prepare route module',
+            attributes: {
+              'next.span_category': 'nextjs',
+              'next.span_name': 'prepare route module',
+              'next.span_type': 'RouteModule.prepare',
+            },
+            status: { code: 0 },
+          }),
+        ])
+      })
+    })
+  })
+}
+
 describe.each(
   [
     { name: 'default', useDirectEntrypointHandler: false },
@@ -2070,8 +2172,9 @@ async function expectTrace(
       .getSpans()
       .filter(
         (span) =>
-          span.attributes?.['next.span_type'] !==
-          'LoadComponents.loadRouteModule'
+          !['LoadComponents.loadRouteModule', 'RouteModule.prepare'].includes(
+            span.attributes?.['next.span_type'] as string
+          )
       )
 
     const tree: HierSavedSpan[] = []


### PR DESCRIPTION
## Summary

- trace the full route-module preparation boundary as `RouteModule.prepare`
- record manifest loading as one aggregate `RouteModule.loadManifests` child span
- keep route preparation visible by default while exposing manifest detail only with verbose tracing
- cover normal and direct-entrypoint server lifecycles without relying on test ordering

## Why

Route preparation is the stable boundary between loading a route module and executing it. The parent span shows the total setup cost; the aggregate manifest child explains manifest work without creating per-file spans or exposing paths.

## Verification

- `pnpm build-all`
- `pnpm --filter=next build`
- `pnpm --filter=next types`
- `pnpm exec jest packages/next/src/server/lib/trace/tracer.test.ts --runInBand`
- focused OpenTelemetry E2E in development and production with Turbopack and Webpack
- Request Insights route-preparation E2E with Turbopack and Webpack
- Prettier, ESLint, and `git diff --check`

## Stack

Depends on **Trace route module loading**.
