### PR TITLE
Trace instrumentation startup

### DIFF
--- a/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
+++ b/packages/next/src/server/lib/router-utils/instrumentation-globals.external.ts
@@ -7,8 +7,57 @@ import type {
 } from '../../instrumentation/types'
 import { interopDefault } from '../../../lib/interop-default'
 import { afterRegistration as extendInstrumentationAfterRegistration } from './instrumentation-node-extensions'
+import { getTracer, SpanStatusCode } from '../trace/tracer'
+import { InstrumentationSpan } from '../trace/constants'
 
 let cachedInstrumentationModule: InstrumentationModule
+let instrumentationModuleLoadTiming: InstrumentationSpanTiming | undefined
+
+type InstrumentationSpanTiming = {
+  startTime: number
+  endTime: number
+  error?: unknown
+}
+
+function getInstrumentationTimestamp() {
+  // Date.now() is treated as synchronous I/O while Cache Components render.
+  return performance.timeOrigin + performance.now()
+}
+
+function traceBackdatedInstrumentationSpan(
+  type: InstrumentationSpan,
+  spanName: string,
+  { startTime, endTime, error }: InstrumentationSpanTiming
+) {
+  getTracer().trace(
+    type,
+    { spanName, startTime, endTime },
+    error === undefined
+      ? () => undefined
+      : (span) => {
+          span?.recordException(error as Error)
+          if (isError(error)) {
+            span?.setAttribute('error.type', error.name)
+          }
+          span?.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: isError(error) ? error.message : undefined,
+          })
+        }
+  )
+}
+
+function traceInstrumentationModuleLoad() {
+  if (!instrumentationModuleLoadTiming) return
+
+  const timing = instrumentationModuleLoadTiming
+  instrumentationModuleLoadTiming = undefined
+  traceBackdatedInstrumentationSpan(
+    InstrumentationSpan.loadModule,
+    'load instrumentation module',
+    timing
+  )
+}
 
 export async function getInstrumentationModule(
   projectDir: string,
@@ -18,6 +67,8 @@ export async function getInstrumentationModule(
     return cachedInstrumentationModule
   }
 
+  const startTime = getInstrumentationTimestamp()
+  let error: unknown
   try {
     cachedInstrumentationModule = interopDefault(
       await require(
@@ -37,7 +88,14 @@ export async function getInstrumentationModule(
       err.code !== 'MODULE_NOT_FOUND' &&
       err.code !== 'ERR_MODULE_NOT_FOUND'
     ) {
+      error = err
       throw err
+    }
+  } finally {
+    instrumentationModuleLoadTiming ??= {
+      startTime,
+      endTime: getInstrumentationTimestamp(),
+      error,
     }
   }
 }
@@ -52,15 +110,38 @@ async function registerInstrumentation(projectDir: string, distDir: string) {
   if (!instrumentationModulePromise) {
     instrumentationModulePromise = getInstrumentationModule(projectDir, distDir)
   }
-  const instrumentation = await instrumentationModulePromise
+  let instrumentation: InstrumentationModule | undefined
+  try {
+    instrumentation = await instrumentationModulePromise
+  } catch (err) {
+    // A load error is only exportable when a provider was already installed.
+    traceInstrumentationModuleLoad()
+    throw err
+  }
   if (instrumentation?.register) {
+    const startTime = getInstrumentationTimestamp()
+    let error: unknown
     try {
       await instrumentation.register()
       extendInstrumentationAfterRegistration()
     } catch (err: any) {
+      error = err
       err.message = `An error occurred while loading instrumentation hook: ${err.message}`
       throw err
+    } finally {
+      const endTime = getInstrumentationTimestamp()
+
+      // register() commonly installs the provider, so emit both lifecycle
+      // spans afterward with their original timestamps.
+      traceInstrumentationModuleLoad()
+      traceBackdatedInstrumentationSpan(
+        InstrumentationSpan.register,
+        'register instrumentation',
+        { startTime, endTime, error }
+      )
     }
+  } else {
+    traceInstrumentationModuleLoad()
   }
 }
 

--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -28,6 +28,11 @@ enum LoadComponentsSpan {
   loadRouteModule = 'LoadComponents.loadRouteModule',
 }
 
+enum InstrumentationSpan {
+  loadModule = 'Instrumentation.loadModule',
+  register = 'Instrumentation.register',
+}
+
 enum NextServerSpan {
   getRequestHandler = 'NextServer.getRequestHandler',
   getRequestHandlerWithMetadata = 'NextServer.getRequestHandlerWithMetadata',
@@ -132,6 +137,7 @@ enum MiddlewareSpan {
 type SpanTypes =
   | `${BaseServerSpan}`
   | `${LoadComponentsSpan}`
+  | `${InstrumentationSpan}`
   | `${NextServerSpan}`
   | `${StartServerSpan}`
   | `${NextNodeServerSpan}`
@@ -159,6 +165,8 @@ export const NextVanillaSpanAllowlist = new Set([
   NodeSpan.runHandler,
   AppRouteRouteHandlersSpan.runHandler,
   RouteModuleSpan.prepare,
+  InstrumentationSpan.loadModule,
+  InstrumentationSpan.register,
   ResolveMetadataSpan.generateMetadata,
   ResolveMetadataSpan.generateViewport,
   NextNodeServerSpan.createComponentTree,
@@ -179,6 +187,7 @@ export const LogSpanAllowList = new Set([
 export {
   BaseServerSpan,
   LoadComponentsSpan,
+  InstrumentationSpan,
   NextServerSpan,
   NextNodeServerSpan,
   StartServerSpan,

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -26,6 +26,7 @@ import {
 import {
   AppRenderSpan,
   BaseServerSpan,
+  InstrumentationSpan,
   LoadComponentsSpan,
   NextNodeServerSpan,
   NodeSpan,
@@ -268,21 +269,29 @@ describe('local span recording', () => {
 
     getTracer().trace(RouteModuleSpan.prepare, () => undefined)
     getTracer().trace(RouteModuleSpan.loadManifests, () => undefined)
+    getTracer().trace(InstrumentationSpan.register, () => undefined)
+    getTracer().trace(InstrumentationSpan.loadModule, () => undefined)
     expect(exportedSpans).toEqual([
       NodeSpan.runHandler,
       LoadComponentsSpan.loadRouteModule,
       RouteModuleSpan.prepare,
+      InstrumentationSpan.register,
+      InstrumentationSpan.loadModule,
     ])
 
     process.env.NEXT_OTEL_VERBOSE = '1'
     getTracer().trace(BaseServerSpan.render, () => undefined)
     getTracer().trace(RouteModuleSpan.loadManifests, () => undefined)
+    getTracer().trace(InstrumentationSpan.loadModule, () => undefined)
     expect(exportedSpans).toEqual([
       NodeSpan.runHandler,
       LoadComponentsSpan.loadRouteModule,
       RouteModuleSpan.prepare,
+      InstrumentationSpan.register,
+      InstrumentationSpan.loadModule,
       BaseServerSpan.render,
       RouteModuleSpan.loadManifests,
+      InstrumentationSpan.loadModule,
     ])
   })
 
@@ -349,6 +358,21 @@ describe('local span recording', () => {
           'next.span_type': NodeSpan.runHandler,
         }),
       }),
+    ])
+  })
+
+  it('records an explicit end time', () => {
+    const startTime = Date.now() - 10
+    const endTime = startTime + 5
+
+    getTracer().trace(
+      InstrumentationSpan.register,
+      { startTime, endTime },
+      () => undefined
+    )
+
+    expect(getSpanRecords({ name: InstrumentationSpan.register })).toEqual([
+      expect.objectContaining({ durationMs: 5 }),
     ])
   })
 

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -67,7 +67,11 @@ export function isBubbledError(error: unknown): error is BubbledError {
   return error instanceof BubbledError
 }
 
-const closeSpanWithError = (span: Span, error?: Error) => {
+const closeSpanWithError = (
+  span: Span,
+  error?: Error,
+  endTime?: Parameters<Span['end']>[0]
+) => {
   if (isBubbledError(error) && error.bubble) {
     span.setAttribute('next.bubble', true)
   } else {
@@ -77,10 +81,11 @@ const closeSpanWithError = (span: Span, error?: Error) => {
     }
     span.setStatus({ code: SpanStatusCode.ERROR, message: error?.message })
   }
-  span.end()
+  span.end(endTime)
 }
 
 type TracerSpanOptions = Omit<SpanOptions, 'attributes'> & {
+  endTime?: Parameters<Span['end']>[0]
   parentSpan?: Span
   spanName?: string
   attributes?: Partial<Record<AttributeNames, AttributeValue | undefined>>
@@ -475,13 +480,13 @@ class NextTracerImpl implements NextTracer {
             try {
               return fn(span, (err) => {
                 if (err) {
-                  closeSpanWithError(span, err)
+                  closeSpanWithError(span, err, options.endTime)
                 } else {
-                  span.end()
+                  span.end(options.endTime)
                 }
               })
             } catch (err: any) {
-              closeSpanWithError(span, err)
+              closeSpanWithError(span, err, options.endTime)
               throw err
             } finally {
               onCleanup()
@@ -494,24 +499,24 @@ class NextTracerImpl implements NextTracer {
               // If there's error make sure it throws
               return result
                 .then((res) => {
-                  span.end()
+                  span.end(options.endTime)
                   // Need to pass down the promise result,
                   // it could be react stream response with error { error, stream }
                   return res
                 })
                 .catch((err) => {
-                  closeSpanWithError(span, err)
+                  closeSpanWithError(span, err, options.endTime)
                   throw err
                 })
                 .finally(onCleanup)
             } else {
-              span.end()
+              span.end(options.endTime)
               onCleanup()
             }
 
             return result
           } catch (err: any) {
-            closeSpanWithError(span, err)
+            closeSpanWithError(span, err, options.endTime)
             onCleanup()
             throw err
           }

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -13,6 +13,7 @@ const EXTERNAL = {
 
 const COLLECTOR_PORT = 9001
 const ROUTE_PREPARATION_COLLECTOR_PORT = 9002
+const INSTRUMENTATION_STARTUP_COLLECTOR_PORT = 9003
 
 function setup({ useDirectEntrypointHandler, useNodeMiddleware }) {
   let collector: Collector
@@ -1695,6 +1696,115 @@ describe.each(
     }
   })
 })
+
+describe.each(
+  [
+    { name: 'default' },
+    isNextStart && {
+      name: 'direct entrypoints',
+      useDirectEntrypointHandler: true,
+    },
+  ].filter(Boolean)
+)(
+  'opentelemetry instrumentation startup - $name',
+  ({ useDirectEntrypointHandler }) => {
+    let collector: Collector | undefined
+    const { next, skipped } = nextTestSetup({
+      files: __dirname,
+      skipDeployment: true,
+      skipStart: true,
+      dependencies: require('./package.json').dependencies,
+      ...(!useDirectEntrypointHandler
+        ? {
+            env: {
+              TEST_OTEL_COLLECTOR_PORT: String(
+                INSTRUMENTATION_STARTUP_COLLECTOR_PORT
+              ),
+              NEXT_TELEMETRY_DISABLED: '1',
+            },
+          }
+        : {
+            startCommand: 'pnpm start-entrypoint',
+            packageJson: {
+              scripts: {
+                'start-entrypoint':
+                  'pnpm tsx custom-entrypoint-server.ts --without-parent-span',
+              },
+            },
+            serverReadyPattern: /- Local:/,
+            env: {
+              TEST_OTEL_COLLECTOR_PORT: String(
+                INSTRUMENTATION_STARTUP_COLLECTOR_PORT
+              ),
+              NEXT_TELEMETRY_DISABLED: '1',
+              NODE_ENV: 'production',
+            },
+          }),
+    })
+
+    if (skipped) {
+      return
+    }
+
+    afterAll(async () => {
+      await collector?.shutdown()
+    })
+
+    it('should trace instrumentation startup', async () => {
+      collector = await connectCollector({
+        port: INSTRUMENTATION_STARTUP_COLLECTOR_PORT,
+      })
+      await next.start()
+      await next.fetch('/app/param/rsc-fetch')
+
+      await retry(async () => {
+        const spans = collector?.getSpans() ?? []
+        const loadModuleSpan = spans.find(
+          (span) =>
+            span.attributes?.['next.span_type'] === 'Instrumentation.loadModule'
+        )
+        const registerSpan = spans.find(
+          (span) =>
+            span.attributes?.['next.span_type'] === 'Instrumentation.register'
+        )
+
+        expect(
+          spans.filter((span) =>
+            ['Instrumentation.loadModule', 'Instrumentation.register'].includes(
+              span.attributes?.['next.span_type'] as string
+            )
+          )
+        ).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              runtime: 'nodejs',
+              name: 'load instrumentation module',
+              attributes: {
+                'next.span_category': 'nextjs',
+                'next.span_name': 'load instrumentation module',
+                'next.span_type': 'Instrumentation.loadModule',
+              },
+              status: { code: 0 },
+            }),
+            expect.objectContaining({
+              runtime: 'nodejs',
+              name: 'register instrumentation',
+              attributes: {
+                'next.span_category': 'nextjs',
+                'next.span_name': 'register instrumentation',
+                'next.span_type': 'Instrumentation.register',
+              },
+              status: { code: 0 },
+            }),
+          ])
+        )
+        expect(loadModuleSpan?.timestamp).toBeLessThanOrEqual(
+          registerSpan!.timestamp!
+        )
+      })
+    })
+  }
+)
 ;(process.env.__NEXT_CACHE_COMPONENTS ? describe.skip : describe)(
   'opentelemetry NEXT_OTEL_VERBOSE=1',
   () => {
@@ -2172,9 +2282,12 @@ async function expectTrace(
       .getSpans()
       .filter(
         (span) =>
-          !['LoadComponents.loadRouteModule', 'RouteModule.prepare'].includes(
-            span.attributes?.['next.span_type'] as string
-          )
+          ![
+            'LoadComponents.loadRouteModule',
+            'RouteModule.prepare',
+            'Instrumentation.loadModule',
+            'Instrumentation.register',
+          ].includes(span.attributes?.['next.span_type'] as string)
       )
 
     const tree: HierSavedSpan[] = []


### PR DESCRIPTION
## Summary

- trace instrumentation module loading and `register()` execution as separate startup spans
- preserve the original timestamps when the OpenTelemetry provider is installed by `register()` itself
- export both lifecycle spans by default without attaching them to an unrelated request
- verify standard and direct-entrypoint startup with a collector connected before the server starts

## Why

Loading `instrumentation.ts` and running the user-defined `register()` hook have different owners and remediation paths. Separate spans make startup delays attributable while preserving honest lifecycle parentage: these spans normally occur before a request identity exists.

## Verification

- `pnpm build-all`
- `pnpm --filter=next build`
- `pnpm --filter=next types`
- `pnpm exec jest packages/next/src/server/lib/trace/tracer.test.ts --runInBand`
- focused instrumentation-startup E2E in development and production with Turbopack and Webpack
- Prettier, ESLint, and `git diff --check`

## Stack

Depends on **Trace route module preparation**.
