### PR TITLE
Fix spurious key warning for JSX props in `use cache` functions

### DIFF
--- a/packages/next/src/server/use-cache/mark-passthrough-elements-validated.ts
+++ b/packages/next/src/server/use-cache/mark-passthrough-elements-validated.ts
@@ -1,0 +1,90 @@
+import { isValidElement } from 'react'
+
+const MAX_DEPTH = 10
+
+interface DevElement {
+  readonly props: unknown
+  readonly _store?: { validated?: number }
+}
+
+/**
+ * Marks React elements passed into a `"use cache"` function as already
+ * key-validated, before they're encoded as temporary references.
+ *
+ * Such an element comes back out of the cached stream as the very same object,
+ * but it has skipped the dev JSX runtime's static-children validation on the
+ * way: inside the cache the prop is an opaque proxy, not an element, so `jsxs`
+ * has nothing to mark. Rendering two slots side by side then produces a bogus
+ * "Each child in a list should have a unique key prop" warning.
+ * See https://github.com/vercel/next.js/issues/97047.
+ *
+ * Elements sitting directly inside an array are left alone, so a genuinely
+ * unkeyed list handed to a cached component still warns.
+ */
+export function markPassthroughElementsValidated(args: unknown[]): void {
+  // This only sharpens a dev warning, so a hostile getter or proxy buried in
+  // the args must never take the render down with it.
+  try {
+    const seen = new WeakSet<object>()
+
+    for (const arg of args) {
+      visit(arg, false, seen, 0)
+    }
+  } catch {}
+}
+
+function visit(
+  value: unknown,
+  insideArray: boolean,
+  seen: WeakSet<object>,
+  depth: number
+): void {
+  // Temporary references from an enclosing cache scope are function proxies
+  // that throw on any unrecognized property, so the typeof check has to come
+  // before anything touches `value`.
+  if (depth > MAX_DEPTH || value === null || typeof value !== 'object') {
+    return
+  }
+
+  if (seen.has(value)) {
+    return
+  }
+
+  seen.add(value)
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visit(item, true, seen, depth + 1)
+    }
+
+    return
+  }
+
+  if (isValidElement(value)) {
+    const { props, _store } = value as unknown as DevElement
+
+    if (!insideArray && _store && !_store.validated) {
+      _store.validated = 1
+    }
+
+    visit(props, false, seen, depth + 1)
+
+    return
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+
+  if (prototype !== Object.prototype && prototype !== null) {
+    return
+  }
+
+  for (const key of Object.keys(value)) {
+    // Read through the descriptor to avoid invoking getters, which are the
+    // serializer's business, not ours.
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+
+    if (descriptor && 'value' in descriptor) {
+      visit(descriptor.value, false, seen, depth + 1)
+    }
+  }
+}

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -93,6 +93,7 @@ import {
   UseCacheDeadlockError,
   UseCacheTimeoutError,
 } from './use-cache-errors'
+import { markPassthroughElementsValidated } from './mark-passthrough-elements-validated'
 import {
   createHangingInputAbortSignal,
   throwToInterruptStaticGeneration,
@@ -2142,6 +2143,10 @@ export async function cache(
   }
 
   const temporaryReferences = createClientTemporaryReferenceSet()
+
+  if (process.env.NODE_ENV !== 'production') {
+    markPassthroughElementsValidated(args)
+  }
 
   // The base serialized cache key doesn't include the cookies or headers that
   // private caches are allowed to read. In production this is because private


### PR DESCRIPTION
# Fix React element validation warnings with `use cache`
Fixes #97047

## What changed

Added a small validation pass before `use cache` arguments are serialized.

The new `markPassthroughElementsValidated` helper walks the arguments and marks React elements as already key-validated. This prevents the same element from triggering the warning again when it passes through the cache boundary.

The traversal is intentionally conservative:

* Recurses through arrays and plain objects
* Marks React elements when they are not directly inside an array
* Uses `Object.getOwnPropertyDescriptor` so getters are not invoked
* Skips class instances, Maps, promises, proxies, etc.
* Uses a `WeakSet` to handle cycles
* Has a depth limit of 10
* Never lets the validation pass break rendering

The validation is only enabled in development and runs before the cache key is built, so it covers all `use cache` calls, including page and layout segment functions.

## Why

Some React elements passed through `use cache` were triggering key validation warnings even though they were already going through the expected cache serialization flow.

Marking the element as validated before serialization fixes the warning at the source. The same element identity is preserved through the temporary reference set.

One important detail is that elements directly passed as props are marked, while elements inside arrays are not. This keeps the existing warnings for cases where they are still meaningful.

## Testing

Verified:

* Full `use-cache` suite across dev/start and cacheComponents combinations
* `use-cache-with-server-function-props` unaffected
* `use-cache-private` unaffected
* Prettier passes
* ESLint passes
* TypeScript checks pass
* Original issue reproduction renders correctly with zero warnings on both cache miss and cache hit
* Manually confirmed the warning returns when the fix is disabled

Also checked cached layouts with multiple slots and `SegmentViewNode` to make sure they were not involved in this issue.
