### PR TITLE
[backport] Restore the live `headers()` view of the incoming request

### DIFF
--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -30,29 +30,43 @@ import type { Params } from '../request/params'
 import type { ImplicitTags } from '../lib/implicit-tags'
 import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
 
+/**
+ * Internal request headers that userland `headers()` must not expose. They stay
+ * on the shared request headers for framework plumbing.
+ *
+ * Every internal header that the client can send must be listed here. The
+ * sealed userland view reads through to the shared request headers, so an
+ * omission leaks the header to userland.
+ *
+ * The names are lowercased because `HeadersAdapter.seal` matches them in
+ * lowercase.
+ */
+const HIDDEN_REQUEST_HEADERS: ReadonlySet<string> = new Set(
+  [
+    ...FLIGHT_HEADERS,
+    // The client sends these dev-only request IDs so the server can route debug
+    // information back to the originating request. Like the flight headers,
+    // they are internal plumbing.
+    NEXT_REQUEST_ID_HEADER,
+    NEXT_HTML_REQUEST_ID_HEADER,
+  ].map((header) => header.toLowerCase())
+)
+
 function getHeaders(headers: Headers | IncomingHttpHeaders): ReadonlyHeaders {
-  // `HeadersAdapter.from` wraps `IncomingHttpHeaders` (and returns a `Headers`
-  // instance unchanged) without copying, so the `delete` calls below would
-  // otherwise mutate the caller's underlying request headers. We copy first so
-  // that stripping internal headers only affects the sealed userland view, not
-  // the shared `req.headers`. The latter matters because the dev server reads
-  // the request-id headers from the raw request again (e.g. when rendering a
-  // redirect target after a server action), and mutating them there would break
-  // the dev debug channel routing.
-  const cleaned = HeadersAdapter.from(
-    headers instanceof Headers ? new Headers(headers) : { ...headers }
+  // The sealed userland view must not copy the request headers.
+  // `HeadersAdapter.from` returns a `Headers` instance unchanged, so the view
+  // reads through to `NextRequest.headers`. A copy detaches `headers()` from
+  // the writes that Proxy makes to `NextRequest.headers` afterwards.
+  //
+  // The view must also not delete the internal headers. Because
+  // `HeadersAdapter.from` does not copy, a delete removes them from the shared
+  // `req.headers`. The dev server reads the request-id headers from the raw
+  // request again, for example when it renders a redirect target after a server
+  // action. Their removal breaks the dev debug channel routing.
+  return HeadersAdapter.seal(
+    HeadersAdapter.from(headers),
+    HIDDEN_REQUEST_HEADERS
   )
-  for (const header of FLIGHT_HEADERS) {
-    cleaned.delete(header)
-  }
-
-  // The client sends these dev-only request IDs so the server can route debug
-  // information back to the originating request. Like the flight headers, they
-  // are internal plumbing and must not be exposed to userland `headers()`.
-  cleaned.delete(NEXT_REQUEST_ID_HEADER)
-  cleaned.delete(NEXT_HTML_REQUEST_ID_HEADER)
-
-  return HeadersAdapter.seal(cleaned)
 }
 
 function getMutableCookies(

--- a/packages/next/src/server/web/spec-extension/adapters/headers.test.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/headers.test.ts
@@ -318,5 +318,135 @@ describe('HeadersAdapter', () => {
       expect(headers.get('x-custom-header')).toBe('custom3')
       expect(sealed.get('x-custom-header')).toBe('custom3')
     })
+
+    it('should return the same method instance on repeated access', () => {
+      const headers = new Headers({ 'content-type': 'application/json' })
+
+      for (const sealed of [
+        HeadersAdapter.seal(headers),
+        HeadersAdapter.seal(headers, new Set(['rsc'])),
+      ]) {
+        expect(sealed.get).toBe(sealed.get)
+        expect(sealed.has).toBe(sealed.has)
+        expect(sealed.getSetCookie).toBe(sealed.getSetCookie)
+        expect(sealed.keys).toBe(sealed.keys)
+        expect(sealed.values).toBe(sealed.values)
+        expect(sealed.entries).toBe(sealed.entries)
+        expect(sealed.forEach).toBe(sealed.forEach)
+        expect(sealed[Symbol.iterator]).toBe(sealed[Symbol.iterator])
+      }
+    })
+
+    it('should pass the sealed instance to forEach callbacks', () => {
+      const headers = new Headers({ 'content-type': 'application/json' })
+      const sealed = HeadersAdapter.seal(headers)
+
+      const parents: Headers[] = []
+      sealed.forEach((_value, _name, parent) => {
+        parents.push(parent)
+      })
+
+      expect(parents).toHaveLength(1)
+      expect(parents[0]).toBe(sealed)
+      expect(() => parents[0].set('x-escaped', 'yes')).toThrow(
+        ReadonlyHeadersError
+      )
+      expect(headers.get('x-escaped')).toBeNull()
+    })
+
+    describe('with hidden headers', () => {
+      const hidden = new Set(['rsc', 'x-nextjs-request-id'])
+
+      function createSealed() {
+        const headers = new Headers({
+          'content-type': 'application/json',
+          rsc: '1',
+          'x-nextjs-request-id': 'req-1',
+          'x-custom-header': 'custom',
+        })
+
+        return { headers, sealed: HeadersAdapter.seal(headers, hidden) }
+      }
+
+      it('should omit hidden headers from every read operation', () => {
+        const { sealed } = createSealed()
+
+        expect(sealed.get('rsc')).toBeNull()
+        expect(sealed.get('RSC')).toBeNull()
+        expect(sealed.get('x-nextjs-request-id')).toBeNull()
+        expect(sealed.has('rsc')).toBe(false)
+        expect(sealed.has('x-nextjs-request-id')).toBe(false)
+
+        expect([...sealed.keys()]).toEqual(['content-type', 'x-custom-header'])
+        expect([...sealed.values()]).toEqual(['application/json', 'custom'])
+        expect([...sealed.entries()]).toEqual([
+          ['content-type', 'application/json'],
+          ['x-custom-header', 'custom'],
+        ])
+        expect([...sealed]).toEqual([
+          ['content-type', 'application/json'],
+          ['x-custom-header', 'custom'],
+        ])
+
+        const seen: string[] = []
+        sealed.forEach((value, name, parent) => {
+          seen.push(`${name}=${value}`)
+          expect(parent).toBe(sealed)
+        })
+        expect(seen).toEqual([
+          'content-type=application/json',
+          'x-custom-header=custom',
+        ])
+
+        expect(Object.fromEntries(sealed)).toEqual({
+          'content-type': 'application/json',
+          'x-custom-header': 'custom',
+        })
+        expect([...new Headers(sealed).keys()]).toEqual([
+          'content-type',
+          'x-custom-header',
+        ])
+      })
+
+      it('should omit hidden set-cookie headers from getSetCookie', () => {
+        const headers = new Headers()
+        headers.append('set-cookie', 'a=1')
+
+        expect(HeadersAdapter.seal(headers, hidden).getSetCookie()).toEqual([
+          'a=1',
+        ])
+        expect(
+          HeadersAdapter.seal(headers, new Set(['set-cookie'])).getSetCookie()
+        ).toEqual([])
+      })
+
+      it('should not copy or mutate the underlying headers', () => {
+        const { headers, sealed } = createSealed()
+
+        expect(sealed.get('content-type')).toBe('application/json')
+        expect(headers.get('rsc')).toBe('1')
+        expect(headers.get('x-nextjs-request-id')).toBe('req-1')
+
+        expect(() => (sealed as any).delete('rsc')).toThrow(
+          ReadonlyHeadersError
+        )
+        expect(headers.get('rsc')).toBe('1')
+      })
+
+      it('should stay a live view of the underlying headers', () => {
+        const { headers, sealed } = createSealed()
+
+        headers.set('x-added-after-seal', 'live')
+        expect(sealed.get('x-added-after-seal')).toBe('live')
+
+        headers.delete('x-custom-header')
+        expect(sealed.get('x-custom-header')).toBeNull()
+
+        // Hidden headers stay hidden, no matter when they are written.
+        headers.set('rsc', '2')
+        expect(sealed.get('rsc')).toBeNull()
+        expect(headers.get('rsc')).toBe('2')
+      })
+    })
   })
 })

--- a/packages/next/src/server/web/spec-extension/adapters/headers.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/headers.ts
@@ -25,6 +25,96 @@ export type ReadonlyHeaders = Headers & {
   /** @deprecated Method unavailable on `ReadonlyHeaders`. Read more: https://nextjs.org/docs/app/api-reference/functions/headers */
   delete(...args: any[]): void
 }
+
+/**
+ * The read methods that a sealed view provides itself instead of forwarding to
+ * the underlying `Headers`. Deriving the type from `Headers` keeps the
+ * implementations in step with the platform signatures.
+ */
+type SealedHeaderMethods = Pick<
+  Headers,
+  | 'get'
+  | 'has'
+  | 'getSetCookie'
+  | 'keys'
+  | 'values'
+  | 'entries'
+  | 'forEach'
+  | typeof Symbol.iterator
+>
+
+/**
+ * Builds the read methods for a sealed view that exposes all of `target`.
+ */
+function createPassThroughMethods(
+  target: Headers,
+  sealed: ReadonlyHeaders
+): SealedHeaderMethods {
+  return {
+    get: target.get.bind(target),
+    has: target.has.bind(target),
+    getSetCookie: target.getSetCookie.bind(target),
+    keys: target.keys.bind(target),
+    values: target.values.bind(target),
+    entries: target.entries.bind(target),
+    [Symbol.iterator]: target[Symbol.iterator].bind(target),
+    // The native method passes the unsealed target as the callback's `parent`
+    // argument. That is a mutable handle on the underlying headers. Pass the
+    // sealed view instead.
+    forEach(callbackfn, thisArg) {
+      for (const [name, value] of target.entries()) {
+        callbackfn.call(thisArg, value, name, sealed)
+      }
+    },
+  }
+}
+
+/**
+ * Builds the read methods for a sealed view that omits the header names matched
+ * by `isHidden`.
+ */
+function createHidingMethods(
+  target: Headers,
+  sealed: ReadonlyHeaders,
+  isHidden: (name: string) => boolean
+): SealedHeaderMethods {
+  function* entries(): HeadersIterator<[string, string]> {
+    for (const entry of target.entries()) {
+      if (!isHidden(entry[0])) {
+        yield entry
+      }
+    }
+  }
+
+  return {
+    entries,
+    [Symbol.iterator]: entries,
+    get: (name) => (isHidden(name) ? null : target.get(name)),
+    has: (name) => (isHidden(name) ? false : target.has(name)),
+    getSetCookie: () => (isHidden('set-cookie') ? [] : target.getSetCookie()),
+    *keys(): HeadersIterator<string> {
+      for (const name of target.keys()) {
+        if (!isHidden(name)) {
+          yield name
+        }
+      }
+    },
+    *values(): HeadersIterator<string> {
+      for (const [, value] of entries()) {
+        yield value
+      }
+    },
+    // The native method passes the unsealed target as the callback's `parent`
+    // argument. That is a mutable handle on the underlying headers. Pass the
+    // sealed view instead.
+    forEach(callbackfn, thisArg) {
+      for (const [name, value] of entries()) {
+        callbackfn.call(thisArg, value, name, sealed)
+      }
+    },
+  }
+}
+
 export class HeadersAdapter extends Headers {
   private readonly headers: IncomingHttpHeaders
 
@@ -117,20 +207,58 @@ export class HeadersAdapter extends Headers {
   /**
    * Seals a Headers instance to prevent modification by throwing an error when
    * any mutating method is called.
+   *
+   * The sealed view stays live. Later writes to `headers` remain visible
+   * through it.
+   *
+   * `hidden` omits the given header names from every read operation (`get`,
+   * `has`, `getSetCookie`, `forEach`, and iteration). The names must be
+   * lowercase. The underlying headers are neither copied nor mutated, so hidden
+   * headers remain available to the framework.
    */
-  public static seal(headers: Headers): ReadonlyHeaders {
-    return new Proxy<ReadonlyHeaders>(headers, {
+  public static seal(
+    headers: Headers,
+    hidden?: ReadonlySet<string>
+  ): ReadonlyHeaders {
+    const isHidden =
+      hidden && hidden.size > 0
+        ? (name: string): boolean => hidden.has(name.toLowerCase())
+        : null
+
+    // The methods are built once per sealed view and reused, so repeated access
+    // returns the same function instead of a fresh closure. They are assigned
+    // after the proxy exists because `forEach` hands the proxy to its callback.
+    // Creating the proxy runs no trap, so nothing can read them before then.
+    let methods: SealedHeaderMethods
+
+    const sealed: ReadonlyHeaders = new Proxy<ReadonlyHeaders>(headers, {
       get(target, prop, receiver) {
         switch (prop) {
           case 'append':
           case 'delete':
           case 'set':
             return ReadonlyHeadersError.callable
+          case Symbol.iterator:
+            return methods[Symbol.iterator]
+          case 'get':
+          case 'has':
+          case 'getSetCookie':
+          case 'keys':
+          case 'values':
+          case 'entries':
+          case 'forEach':
+            return methods[prop]
           default:
             return ReflectAdapter.get(target, prop, receiver)
         }
       },
     })
+
+    methods = isHidden
+      ? createHidingMethods(headers, sealed, isHidden)
+      : createPassThroughMethods(headers, sealed)
+
+    return sealed
   }
 
   /**

--- a/test/e2e/app-dir/proxy-headers-live-view/app/layout.tsx
+++ b/test/e2e/app-dir/proxy-headers-live-view/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/proxy-headers-live-view/app/page.tsx
+++ b/test/e2e/app-dir/proxy-headers-live-view/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/proxy-headers-live-view/next.config.js
+++ b/test/e2e/app-dir/proxy-headers-live-view/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/proxy-headers-live-view/proxy-headers-live-view.test.ts
+++ b/test/e2e/app-dir/proxy-headers-live-view/proxy-headers-live-view.test.ts
@@ -1,0 +1,31 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('proxy-headers-live-view', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should observe writes to NextRequest.headers in headers()', async () => {
+    const res = await next.fetch('/probe')
+    expect(res.status).toBe(200)
+
+    await expect(res.json()).resolves.toEqual({
+      valueBeforeMutation: null,
+      valueOnRequest: 'set-during-proxy',
+      valueOnFirstView: 'set-during-proxy',
+      valueOnSecondView: 'set-during-proxy',
+      sameView: true,
+      // Internal headers stay on the request for framework plumbing, and stay
+      // hidden from userland `headers()`, even when they are written after the
+      // first `headers()` call.
+      internalHeaderOnRequest: 'set-during-proxy',
+      internalHeaderOnView: null,
+      internalHeaderIsIterated: false,
+    })
+  })
+
+  it('should render pages that Proxy passes through', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
+})

--- a/test/e2e/app-dir/proxy-headers-live-view/proxy.ts
+++ b/test/e2e/app-dir/proxy-headers-live-view/proxy.ts
@@ -1,0 +1,31 @@
+import { headers } from 'next/headers'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+const ADDED_HEADER = 'x-added-during-proxy'
+const INTERNAL_HEADER = 'x-nextjs-request-id'
+
+export async function proxy(request: NextRequest) {
+  if (request.nextUrl.pathname !== '/probe') {
+    return NextResponse.next()
+  }
+
+  const firstView = await headers()
+  const valueBeforeMutation = firstView.get(ADDED_HEADER)
+
+  request.headers.set(ADDED_HEADER, 'set-during-proxy')
+  request.headers.set(INTERNAL_HEADER, 'set-during-proxy')
+
+  const secondView = await headers()
+
+  return NextResponse.json({
+    valueBeforeMutation,
+    valueOnRequest: request.headers.get(ADDED_HEADER),
+    valueOnFirstView: firstView.get(ADDED_HEADER),
+    valueOnSecondView: secondView.get(ADDED_HEADER),
+    sameView: firstView === secondView,
+    internalHeaderOnRequest: request.headers.get(INTERNAL_HEADER),
+    internalHeaderOnView: secondView.get(INTERNAL_HEADER),
+    internalHeaderIsIterated: [...secondView.keys()].includes(INTERNAL_HEADER),
+  })
+}


### PR DESCRIPTION
Backports #97166 ("Restore the live `headers()` view of the incoming request") to `next-16-3`.

Fixes #97049. This is a regression introduced in 16.3.0 itself. #94703 and #95116 are both in the `v16.3.0` tag, and between them they left `headers()` detached from the request it describes. A Proxy that writes a header onto `request.headers` and then reads it back through `headers()` gets the value from before the write, while reading the same header directly off `request.headers` returns the new value, so two APIs describing the same request disagree. Whether the write is seen at all depends on ordering, because the view is built on first access.

`HeadersAdapter.seal` now accepts a set of header names to omit from every read operation, and `getHeaders` seals the shared request headers directly instead of stripping them from a copy. Both earlier intentions survive: the internal headers stay on the request where the framework still reads them, they stay invisible to userland `headers()`, and the sealed view tracks the request again.

### Verification on this branch

Cherry-picked from `3c97df56ea` with no conflicts. All source files are byte-identical to canary. Behavioral verification is left to CI on this branch; the change carries unit coverage in `headers.test.ts` and the `proxy-headers-live-view` end-to-end suite.

<!-- NEXT_JS_LLM -->
