### PR TITLE
[backport] [turbopack] Fix HMR for dynamic imports evaluated from layouts

### DIFF
--- a/test/development/app-dir/layout-dynamic-import-hmr/app/[locale]/layout.tsx
+++ b/test/development/app-dir/layout-dynamic-import-hmr/app/[locale]/layout.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react'
+
+export default async function LocaleLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  const messages = (await import(`../../messages/${locale}.json`)).default
+
+  return (
+    <>
+      <p id="subtitle">{messages.subtitle}</p>
+      {children}
+    </>
+  )
+}

--- a/test/development/app-dir/layout-dynamic-import-hmr/app/[locale]/page.tsx
+++ b/test/development/app-dir/layout-dynamic-import-hmr/app/[locale]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <main id="page">page</main>
+}

--- a/test/development/app-dir/layout-dynamic-import-hmr/app/layout.tsx
+++ b/test/development/app-dir/layout-dynamic-import-hmr/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/layout-dynamic-import-hmr/layout-dynamic-import-hmr.test.ts
+++ b/test/development/app-dir/layout-dynamic-import-hmr/layout-dynamic-import-hmr.test.ts
@@ -1,0 +1,24 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('layout-dynamic-import-hmr', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should pick up edits to a file that is dynamically imported from a layout', async () => {
+    const $ = await next.render$('/en')
+    expect($('#subtitle').text()).toBe('original')
+
+    await next.patchFile(
+      'messages/en.json',
+      JSON.stringify({ subtitle: 'updated' }, null, 2),
+      async () => {
+        await retry(async () => {
+          const $updated = await next.render$('/en')
+          expect($updated('#subtitle').text()).toBe('updated')
+        })
+      }
+    )
+  })
+})

--- a/test/development/app-dir/layout-dynamic-import-hmr/messages/en.json
+++ b/test/development/app-dir/layout-dynamic-import-hmr/messages/en.json
@@ -1,0 +1,3 @@
+{
+  "subtitle": "original"
+}

--- a/test/development/app-dir/layout-dynamic-import-hmr/next.config.js
+++ b/test/development/app-dir/layout-dynamic-import-hmr/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -237,6 +237,7 @@ impl EcmascriptBuildNodeEntryChunk {
         EcmascriptBuildNodeChunkListContent::new(
             *self.chunking_context,
             *self.other_chunks,
+            *self.referenced_output_assets,
             *self.references,
         )
     }

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk_list_content.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk_list_content.rs
@@ -58,6 +58,7 @@ impl EcmascriptBuildNodeChunkListContent {
     pub async fn new(
         chunking_context: ResolvedVc<NodeJsChunkingContext>,
         chunks: ResolvedVc<OutputAssets>,
+        referenced_assets: ResolvedVc<OutputAssets>,
         references: ResolvedVc<OutputAssetsReferences>,
     ) -> Result<Vc<Self>> {
         let output_root = chunking_context.output_root().owned().await?;
@@ -66,12 +67,24 @@ impl EcmascriptBuildNodeChunkListContent {
         // imported chunks. `inner=false`: only follow Reference edges (async
         // loaders), not Asset-adjacent files like source maps that aren't part
         // of the module graph and can't be hot-reloaded.
+        //
+        // `referenced_assets` covers async chunks that were already expanded by
+        // the caller (e.g. chunks reachable from concatenated chunk groups).
+        // They must be tracked here too, otherwise an edit inside one of them
+        // produces no chunk list update at all.
         let async_chunks = expand_output_assets(
-            references
+            referenced_assets
                 .await?
                 .iter()
                 .copied()
-                .map(ExpandOutputAssetsInput::Reference),
+                .map(ExpandOutputAssetsInput::Asset)
+                .chain(
+                    references
+                        .await?
+                        .iter()
+                        .copied()
+                        .map(ExpandOutputAssetsInput::Reference),
+                ),
             false,
         )
         .await?;


### PR DESCRIPTION
Backports #97213 ("[turbopack] Fix HMR for dynamic imports evaluated from layouts") to `next-16-3`.

Async chunks that the caller had already expanded (e.g. those reachable from concatenated chunk
groups) were not tracked in the chunk list, so an edit inside one of them produced no HMR update at
all. This shows up with the common `await import(\`../../messages/${locale}.json\`)` pattern in a
layout.

Cherry-picked from 04e9933b33906622e4f36761f0697ae0059a62b1 with no conflicts. All 8 files are
byte-identical to canary.

### Verification on this branch

- `cargo fmt --check -p turbopack-nodejs` — clean
- `cargo check -p next-api`, `cargo clippy -p next-api` — clean (these build `turbopack-nodejs`
  with its real feature set)
- `pnpm build-all` — 18/18 tasks
- `test/development/app-dir/layout-dynamic-import-hmr` — passes with Turbopack and with webpack
- `test/development/acceptance-app/{app-hmr-changes,ReactRefreshModule}` — 2/2 pass

The new test was confirmed to actually cover the fix: reverting only the two Rust files (keeping the
fixture) makes it fail with `Expected: "updated" / Received: "original"`, and restoring them makes it
pass again.

Note: `cargo check -p turbopack-nodejs` in isolation fails on `turbopack-node/src/pool_stats.rs`
with an unresolved `tokio`. That reproduces identically on unmodified `next-16-3` and is present on
canary too (`mod pool_stats;` is ungated while `tokio` is optional behind `process_pool`/
`worker_pool`), so it is pre-existing and unrelated to this backport.

<!-- NEXT_JS_LLM -->
