### PR TITLE
Trace route module loading

### DIFF
--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -25,6 +25,7 @@ enum BaseServerSpan {
 enum LoadComponentsSpan {
   loadDefaultErrorComponents = 'LoadComponents.loadDefaultErrorComponents',
   loadComponents = 'LoadComponents.loadComponents',
+  loadRouteModule = 'LoadComponents.loadRouteModule',
 }
 
 enum NextServerSpan {
@@ -148,6 +149,7 @@ export const NextVanillaSpanAllowlist = new Set([
   RenderSpan.getStaticProps,
   AppRenderSpan.fetch,
   AppRenderSpan.getBodyResult,
+  LoadComponentsSpan.loadRouteModule,
   RenderSpan.renderDocument,
   NodeSpan.runHandler,
   AppRouteRouteHandlersSpan.runHandler,

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -259,9 +259,19 @@ describe('local span recording', () => {
     getTracer().trace(NodeSpan.runHandler, () => undefined)
     expect(exportedSpans).toEqual([NodeSpan.runHandler])
 
+    getTracer().trace(LoadComponentsSpan.loadRouteModule, () => undefined)
+    expect(exportedSpans).toEqual([
+      NodeSpan.runHandler,
+      LoadComponentsSpan.loadRouteModule,
+    ])
+
     process.env.NEXT_OTEL_VERBOSE = '1'
     getTracer().trace(BaseServerSpan.render, () => undefined)
-    expect(exportedSpans).toEqual([NodeSpan.runHandler, BaseServerSpan.render])
+    expect(exportedSpans).toEqual([
+      NodeSpan.runHandler,
+      LoadComponentsSpan.loadRouteModule,
+      BaseServerSpan.render,
+    ])
   })
 
   it('does not record or export hidden spans', () => {

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -172,6 +172,14 @@ export async function loadClientReferenceManifestForPage(
   }
 }
 
+function loadRouteModule(page: string, distDir: string, isAppPath: boolean) {
+  return getTracer().trace(
+    LoadComponentsSpan.loadRouteModule,
+    { spanName: 'load route module' },
+    () => requirePage(page, distDir, isAppPath)
+  )
+}
+
 async function loadComponentsImpl<
   N extends GenericComponentMod = GenericComponentMod,
 >({
@@ -305,7 +313,7 @@ async function loadComponentsImpl<
       })
     }
 
-    const ComponentMod = await requirePage(page, distDir, isAppPath)
+    const ComponentMod = await loadRouteModule(page, distDir, isAppPath)
 
     const Component = interopDefault(ComponentMod)
     const Document = interopDefault(DocumentMod)
@@ -334,7 +342,7 @@ async function loadComponentsImpl<
       routeModule,
     }
   } else {
-    const ComponentMod = await requirePage(page, distDir, isAppPath)
+    const ComponentMod = await loadRouteModule(page, distDir, isAppPath)
 
     const Component = interopDefault(ComponentMod)
     const Document = interopDefault(DocumentMod)

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -420,6 +420,46 @@ describe.each(
             ])
           })
 
+          if (env.name === 'root context' && !useDirectEntrypointHandler) {
+            it.each(['/api/app/param/data', '/pages/param/getServerSideProps'])(
+              'should trace route module loading for %s',
+              async (pathname) => {
+                await next.fetch(pathname)
+
+                await retry(async () => {
+                  const spans = getCollector().getSpans()
+                  const rootSpan = spans.find(
+                    (span) =>
+                      span.attributes?.['next.span_type'] ===
+                        'BaseServer.handleRequest' &&
+                      span.attributes?.['http.target'] === pathname
+                  )
+                  const loadSpans = spans.filter(
+                    (span) =>
+                      span.attributes?.['next.span_type'] ===
+                        'LoadComponents.loadRouteModule' &&
+                      span.traceId === rootSpan?.traceId
+                  )
+
+                  expect(rootSpan).toBeDefined()
+                  expect(loadSpans).toEqual([
+                    expect.objectContaining({
+                      runtime: 'nodejs',
+                      name: 'load route module',
+                      traceId: rootSpan?.traceId,
+                      attributes: {
+                        'next.span_category': 'nextjs',
+                        'next.span_name': 'load route module',
+                        'next.span_type': 'LoadComponents.loadRouteModule',
+                      },
+                      status: { code: 0 },
+                    }),
+                  ])
+                })
+              }
+            )
+          }
+
           it('should handle route handlers in app router', async () => {
             await next.fetch('/api/app/param/data', env.fetchInit)
 
@@ -2026,7 +2066,13 @@ async function expectTrace(
   )
 
   await retry(async () => {
-    const traces = collector.getSpans()
+    const traces = collector
+      .getSpans()
+      .filter(
+        (span) =>
+          span.attributes?.['next.span_type'] !==
+          'LoadComponents.loadRouteModule'
+      )
 
     const tree: HierSavedSpan[] = []
     const spansForTree: HierSavedSpan[] = traces.map((span) => ({


### PR DESCRIPTION
## Summary

- trace the primary App Router and Pages Router route-module load inside `loadComponents`
- expose `LoadComponents.loadRouteModule` as the default `load route module` OpenTelemetry span
- verify the span in development and production with both Turbopack and Webpack

## Why

Route-module evaluation can account for cold request time before route preparation and rendering begin. Keeping this boundary in the Next.js server makes it available to `next dev`, self-hosted `next start`, direct entrypoints, and deployment integrations without depending on an adapter-specific launcher.

The span wraps only the requested route module. It does not include `_app`, `_document`, rendering, or any adapter launcher work, and it does not add filesystem paths, raw URLs, or other high-cardinality attributes.

## Verification

- `pnpm build-all`
- `pnpm --filter=next build`
- `pnpm --filter=next types`
- `pnpm exec jest packages/next/src/server/lib/trace/tracer.test.ts --runInBand`
- focused OpenTelemetry E2E in `test-dev-turbo`, `test-dev-webpack`, `test-start-turbo`, and `test-start-webpack`
- Prettier, ESLint, and `git diff --check`
