### PR TITLE
Update authentication diagram URL

### DIFF
--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -16,8 +16,8 @@ This diagram shows the authentication flow using React and Next.js features:
 
 <Image
   alt="Diagram showing the authentication flow with React and Next.js features"
-  srcLight="/docs/light/authentication-overview.png"
-  srcDark="/docs/dark/authentication-overview.png"
+  srcLight="/docs/light/authentication-overview-new.png"
+  srcDark="/docs/dark/authentication-overview-new.png"
   width="1600"
   height="1383"
 />


### PR DESCRIPTION
### What?

Updates the light and dark image references in the authentication guide to use `authentication-overview-new.png`.

### Why?

The previous diagrams still showed `useFormState()` even though the documentation has migrated to `useActionState()`.

Fixes #75709

### How?

Points both themed diagram references at the corrected replacement assets.

Validation:

- Confirmed both replacement URLs return `200 image/png`
- `git diff --check`
