### PR TITLE
Revert i18n localization change for dynamic Pages API routes (#94905)

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -55,7 +55,6 @@ import { defaultOverrides } from '../../server/require-hook'
 import { generateRoutesManifest } from '../generate-routes-manifest'
 import { Bundler } from '../../lib/bundler'
 import { resolveCacheHandlerPathToFilesystem } from '../../lib/format-dynamic-import-path'
-import { isAPIRoute } from '../../lib/is-api-route'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
 interface SharedRouteFields {
@@ -2065,7 +2064,7 @@ export async function handleBuildComplete({
     ]
 
     for (const route of routesManifest.dynamicRoutes) {
-      const shouldLocalize = Boolean(config.i18n) && !isAPIRoute(route.page)
+      const shouldLocalize = Boolean(config.i18n)
 
       const routeRegex = getNamedRouteRegex(route.page, {
         prefixRouteKeys: true,

--- a/test/production/adapter-config-i18n/adapter-config-i18n.test.ts
+++ b/test/production/adapter-config-i18n/adapter-config-i18n.test.ts
@@ -6,7 +6,11 @@ describe('adapter config with i18n routes', () => {
     files: __dirname,
   })
 
-  it('does not localize dynamic Pages API routes', async () => {
+  // Dynamic Pages API routes are localized like any other dynamic route. The
+  // Vercel adapter's i18n rules prefix the locale onto `/api/...` too, so the
+  // matcher has to expect it — if the two disagree the matcher is unreachable
+  // and requests fall through to `/{locale}/404`. See vercel/next.js#96935.
+  it('localizes dynamic Pages API routes', async () => {
     const { outputs, routing }: Parameters<NextAdapter['onBuildComplete']>[0] =
       await next.readJSON('build-complete.json')
 
@@ -22,9 +26,9 @@ describe('adapter config with i18n routes', () => {
 
     expect(apiOutput).toBeDefined()
     expect(apiRoute).toBeDefined()
-    expect(apiRoute?.sourceRegex).not.toContain('nextLocale')
+    expect(apiRoute?.sourceRegex).toContain('nextLocale')
     expect(apiRoute?.destination).toBe(
-      '/api/proxy/[[...slug]]?nxtPslug=$nxtPslug'
+      '/$nextLocale/api/proxy/[[...slug]]?nxtPslug=$nxtPslug'
     )
 
     expect(pageRoute).toBeDefined()


### PR DESCRIPTION
### What?

Partially reverts #94905 (`668cd3a`), restoring i18n locale prefixing for **dynamic Pages API routes** in the adapter build output:

```diff
-const shouldLocalize = Boolean(config.i18n) && !isAPIRoute(route.page)
+const shouldLocalize = Boolean(config.i18n)
```

The middleware rewrite query fix from the same PR (`next-server.ts`, fixes #94647) is deliberately **left in place** — it is unrelated to this routing regression.

Fixes #96935

### Why?

Whether `/api/...` carries a locale prefix has to be agreed on by two independent halves:

1. **this matcher** — whether the emitted dynamic route regex expects `(?<nextLocale>…)`
2. **the Vercel adapter's i18n rules** — whether they prepend `/{locale}` to `/api/...`

When they disagree the matcher is unreachable and the request falls through to `/{locale}/404`.

The counterpart adapter change (nextjs/adapter-vercel#81) shipped in `@vercel/next@4.21.3` on Aug 10 — roughly two months after this half landed in `v16.3.0-canary.69`. Every app in the resulting skew 404s on dynamic Pages API routes with `x-matched-path: /{locale}/404`:

| | adapter beta.24 (`@vercel/next` ≤ 4.21.2) | adapter beta.25 (4.21.3) |
| --- | --- | --- |
| Next < `16.3.0-canary.69` | ✅ | ❌ |
| Next ≥ `16.3.0-canary.69` | ❌ | ✅ |

Static Pages API routes are unaffected — they resolve directly against the filesystem. `/api/echo/%5Bslug%5D` returns 200 for the same reason: it filesystem-hits the literal `[slug]` output before any i18n rule runs.

Reverting this collapses the two behaviors back into one that holds for every Next.js version: dynamic Pages API routes are localized like any other dynamic route.

### ⚠️ Must land with the adapter revert

On its own, against `@vercel/next@4.21.3`, this **extends** the 404 to every Next.js version rather than fixing it. It pairs with nextjs/adapter-vercel#101 (already merged, published as `adapter-vercel@0.0.1-beta.26`), which has not yet been synced into a published `@vercel/next`.

| | build container ≤ 4.21.2 / beta.26 | 4.21.3 (beta.25) |
| --- | --- | --- |
| with this revert | ✅ all versions | ❌ all versions |

### How?

Removes the `!isAPIRoute(route.page)` condition and the now-unused `isAPIRoute` import, and inverts the corresponding assertion in `test/production/adapter-config-i18n` so it asserts the localized shape (`/$nextLocale/api/proxy/[[...slug]]?nxtPslug=$nxtPslug`), matching the sibling `pageRoute` assertion.

A full `git revert` of `668cd3a` was not used: the test fixture has since been renamed (`adapter-config-i18n-api` → `adapter-config-i18n`) and extended, and one of its files was renamed into an unrelated test, so a wholesale revert deletes later work.

### Verification

Reproduced offline without a deployment, by running real builds of a Pages Router + i18n fixture (`/api/ping`, `/api/echo/[slug]`, `/api/users/[...path]`, `/blog/[slug]`) against both adapter versions and replaying the emitted `config.json` route tables. The replay reproduces all four reported baselines, including both off-diagonal 404s.

- [x] Prettier clean on both changed files
- [ ] `pnpm test test/production/adapter-config-i18n` — **not run** (needs a full `pnpm --filter=next build`); please confirm in CI
