### PR TITLE
[backport] [test] Compile the middleware redirect routes up front in dev

### DIFF
--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -1029,6 +1029,17 @@ describe('app dir - navigation', () => {
 
   describe('middleware redirect', () => {
     it('should change browser location when router.refresh() gets a redirect response', async () => {
+      if (isNextDev) {
+        // The browser location only changes at the end of a chain of requests:
+        // the page posts to `/api/set-token`, calls `router.refresh()`, and the
+        // refresh gets a middleware redirect to the dashboard. In dev the first
+        // request to each of those routes compiles it on demand, which costs
+        // seconds on a CI runner. Hit them here so the chain below does not pay
+        // for it.
+        await next.fetch('/api/set-token', { method: 'POST' })
+        await next.fetch('/redirect-on-refresh/dashboard')
+      }
+
       const browser = await next.browser('/redirect-on-refresh/auth')
       await retry(async () =>
         expect(await browser.url()).toBe(


### PR DESCRIPTION
Backports #97190 ("[test] Compile the middleware redirect routes up front in dev") to `next-16-3`.

<!-- NEXT_JS_LLM -->
