### PR TITLE
[backport] Revert i18n localization change for dynamic Pages API routes (#94905)

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -55,7 +55,6 @@ import { defaultOverrides } from '../../server/require-hook'
 import { generateRoutesManifest } from '../generate-routes-manifest'
 import { Bundler } from '../../lib/bundler'
 import { resolveCacheHandlerPathToFilesystem } from '../../lib/format-dynamic-import-path'
-import { isAPIRoute } from '../../lib/is-api-route'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
 interface SharedRouteFields {
@@ -2065,7 +2064,7 @@ export async function handleBuildComplete({
     ]
 
     for (const route of routesManifest.dynamicRoutes) {
-      const shouldLocalize = Boolean(config.i18n) && !isAPIRoute(route.page)
+      const shouldLocalize = Boolean(config.i18n)
 
       const routeRegex = getNamedRouteRegex(route.page, {
         prefixRouteKeys: true,

--- a/test/production/adapter-config-i18n/adapter-config-i18n.test.ts
+++ b/test/production/adapter-config-i18n/adapter-config-i18n.test.ts
@@ -6,7 +6,11 @@ describe('adapter config with i18n routes', () => {
     files: __dirname,
   })
 
-  it('does not localize dynamic Pages API routes', async () => {
+  // Dynamic Pages API routes are localized like any other dynamic route. The
+  // Vercel adapter's i18n rules prefix the locale onto `/api/...` too, so the
+  // matcher has to expect it — if the two disagree the matcher is unreachable
+  // and requests fall through to `/{locale}/404`. See vercel/next.js#96935.
+  it('localizes dynamic Pages API routes', async () => {
     const { outputs, routing }: Parameters<NextAdapter['onBuildComplete']>[0] =
       await next.readJSON('build-complete.json')
 
@@ -22,9 +26,9 @@ describe('adapter config with i18n routes', () => {
 
     expect(apiOutput).toBeDefined()
     expect(apiRoute).toBeDefined()
-    expect(apiRoute?.sourceRegex).not.toContain('nextLocale')
+    expect(apiRoute?.sourceRegex).toContain('nextLocale')
     expect(apiRoute?.destination).toBe(
-      '/api/proxy/[[...slug]]?nxtPslug=$nxtPslug'
+      '/$nextLocale/api/proxy/[[...slug]]?nxtPslug=$nxtPslug'
     )
 
     expect(pageRoute).toBeDefined()


### PR DESCRIPTION
Backports #97327 ("Revert i18n localization change for dynamic Pages API routes (#94905)") to `next-16-3`.

Clean cherry-pick of `2f84a1f` — `next-16-3` carries the exact code being reverted, so it applies as-is.

Restores i18n locale prefixing for dynamic Pages API routes, so the emitted matcher and the adapter's i18n rules agree again on whether `/api/...` carries a locale prefix. When they disagree the matcher is unreachable and requests fall through to `/{locale}/404`.

Pairs with the adapter revert (nextjs/adapter-vercel#101, published as `adapter-vercel@0.0.1-beta.26`). Full rationale and reproduction in #97327.
