### PR TITLE
fix(typescript): support npm-aliased TypeScript CLI

### DIFF
--- a/packages/next/src/lib/typescript/runTypeScriptCli.ts
+++ b/packages/next/src/lib/typescript/runTypeScriptCli.ts
@@ -32,8 +32,14 @@ export function getTypeScriptPackageInfo(
   }
   const packageDir = path.dirname(packageJsonPath)
   const apiPath = path.join(packageDir, 'lib', 'typescript.js')
+  const bin = packageJson.bin
   const tscBin =
-    typeof packageJson.bin === 'string' ? packageJson.bin : packageJson.bin?.tsc
+    typeof bin === 'string'
+      ? bin
+      : (bin?.tsc ??
+        (bin && Object.keys(bin).length === 1
+          ? Object.values(bin)[0]
+          : undefined))
   const tscBinPath = tscBin ? path.resolve(packageDir, tscBin) : undefined
   let tscPath = tscBinPath
 

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -117,8 +117,14 @@ export async function verifyAndRunTypeScript({
       throw getTypeScriptApiMissingError(installedTypeScript.version)
     }
 
+    const typeScriptRequirement =
+      useTypeScriptCli && installedTypeScript?.tscPath
+        ? undefined
+        : useTypeScriptCli
+          ? typescriptCliPackage
+          : typescriptApiPackage
     const requiredPackages: MissingDependency[] = [
-      useTypeScriptCli ? typescriptCliPackage : typescriptApiPackage,
+      ...(typeScriptRequirement ? [typeScriptRequirement] : []),
       ...requiredTypePackages,
     ]
 

--- a/test/production/app-dir/typescript-cli/typescript-cli.test.ts
+++ b/test/production/app-dir/typescript-cli/typescript-cli.test.ts
@@ -169,4 +169,28 @@ describe('TypeScript CLI backend', () => {
       expect(await next.hasFile('.next/cache/.tsbuildinfo')).toBe(true)
     })
   })
+
+  describe('aliased TypeScript 6 compatibility package', () => {
+    const { next, skipped } = nextTestSetup({
+      files: __dirname,
+      skipStart: true,
+      skipDeployment: true,
+      dependencies: {
+        typescript: 'npm:@typescript/typescript6@6.0.2',
+      },
+    })
+
+    if (skipped) return
+
+    it("uses the package's sole CLI entry point", async () => {
+      const result = await next.build()
+
+      expect(result.exitCode).toBe(0)
+      expect(result.cliOutput).not.toContain(
+        'do not have the required package(s) installed'
+      )
+      expect(result.cliOutput).not.toContain('Installing dependencies')
+      expect(await next.hasFile('.next/cache/.tsbuildinfo')).toBe(true)
+    })
+  })
 })

--- a/test/unit/typescript-cli-config-origin/fixture/typescript-aliased-package/bin/tsc6
+++ b/test/unit/typescript-cli-config-origin/fixture/typescript-aliased-package/bin/tsc6
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../lib/tsc.js')

--- a/test/unit/typescript-cli-config-origin/fixture/typescript-aliased-package/package.json
+++ b/test/unit/typescript-cli-config-origin/fixture/typescript-aliased-package/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@typescript/typescript6",
+  "version": "6.0.2-test",
+  "bin": {
+    "tsc6": "./bin/tsc6"
+  }
+}

--- a/test/unit/typescript-cli-config-origin/index.test.ts
+++ b/test/unit/typescript-cli-config-origin/index.test.ts
@@ -90,4 +90,21 @@ describe('TypeScript CLI config metadata', () => {
       ),
     })
   })
+
+  it('uses the sole CLI entry from an aliased TypeScript package', () => {
+    const packageDir = path.join(testDir, 'node_modules/typescript')
+    rmSync(packageDir, { force: true, recursive: true })
+    cpSync(
+      path.join(__dirname, 'fixture/typescript-aliased-package'),
+      packageDir,
+      { recursive: true }
+    )
+
+    const packageInfo = getTypeScriptPackageInfo(testDir)
+
+    expect(packageInfo).toMatchObject({
+      version: '6.0.2-test',
+      tscPath: realpathSync(path.join(packageDir, 'bin/tsc6')),
+    })
+  })
 })


### PR DESCRIPTION
Fixes #97015

Related: #96589, #97204

## Why

TypeScript's official 6.x compatibility package is installed using an npm alias:

```json
"typescript": "npm:@typescript/typescript6@6.0.2"
```

That package exposes `tsc6` as its sole `bin` entry instead of exposing a `tsc` key. Since the TypeScript CLI backend became the default, Next.js failed to discover the executable. With webpack, config loading then silently omitted `compilerOptions.paths`, producing a module resolution error. A second hard-coded `typescript/bin/tsc` check also treated the installed alias as missing, so fixing executable discovery alone could still trigger dependency installation or fail under CI.

The regression reproduces on 16.3.0 and 16.3.1-canary.15. It does not reproduce on 16.2.12, with `experimental.useTypeScriptCli: false`, or with TypeScript 7.

## What changed

- Prefer the conventional `bin.tsc`, but accept a package's sole declared CLI entry when `tsc` is absent. Multi-entry packages without `tsc` remain ambiguous and are not guessed.
- Treat a successfully discovered local `tscPath` as satisfying the TypeScript CLI dependency preflight while continuing to check the required `@types/*` packages.
- Add unit coverage matching `@typescript/typescript6` package metadata.
- Add a production build regression test using the real npm alias. The test covers inherited `paths`, the custom tsconfig, TypeScript execution, incremental output, and ensures dependency installation is not attempted.

This differs from #97204 by keeping CLI resolution manifest-driven and by covering the independent dependency-preflight path.

## Verification

- Reporter reproduction with the locally packed candidate, `CI=1`:
  - `next build --webpack`: passes
  - `next build --turbopack`: passes
- `pnpm test-start-webpack test/production/app-dir/typescript-cli/typescript-cli.test.ts`: 8/8 passed
- `pnpm test-start-turbo test/production/app-dir/typescript-cli/typescript-cli.test.ts`: 8/8 passed
- `pnpm exec jest --runTestsByPath test/unit/typescript-cli-config-origin/index.test.ts packages/next/src/lib/typescript/runTypeScriptCli.test.ts`: 12/12 passed
- `pnpm --filter next... build`: passed
- Targeted ESLint, Prettier, `git diff --check`, and the repository's pre-commit hook: passed
