### PR TITLE
Turbopack: exclude virtual modules from NFT traces

### DIFF
--- a/crates/next-api/src/nft.rs
+++ b/crates/next-api/src/nft.rs
@@ -10,7 +10,7 @@ use turbo_tasks::{
     FxIndexMap, FxIndexSet, ReadRef, ResolvedVc, TraitRef, TryFlatJoinIterExt, TryJoinIterExt, Vc,
 };
 use turbo_tasks_fs::{
-    DirectoryEntry, FileSystemPath,
+    DirectoryEntry, FileSystem, FileSystemPath,
     glob::{Glob, GlobOptions},
 };
 use turbo_tasks_hash::HashAlgorithm;
@@ -97,6 +97,8 @@ pub async fn trace_endpoint(
             .to_resolved()
             .await?;
         let module_paths = module_data.await?.idents;
+        let project_root = project.project_fs().root().owned().await?;
+        let output_root = project.output_fs().root().owned().await?;
 
         let modules = all_modules
             .iter()
@@ -107,6 +109,16 @@ pub async fn trace_endpoint(
                     .await?
                     .context("missing path for module")?;
                 let referenced_chunk_path = &entry.path;
+
+                // Only modules in the project or output file systems correspond to deployable
+                // files. Other modules, such as embedded virtual modules, may still be part of the
+                // traced graph. Keep traversing through them above so their dependencies are
+                // traced, then omit them from the final file list.
+                if !referenced_chunk_path.is_inside_ref(&project_root)
+                    && !referenced_chunk_path.is_inside_ref(&output_root)
+                {
+                    return Ok(None);
+                }
 
                 if referenced_chunk_path.has_extension(".map") {
                     return Ok(None);

--- a/test/e2e/app-dir/external-wasm-tracing/app/image/route.tsx
+++ b/test/e2e/app-dir/external-wasm-tracing/app/image/route.tsx
@@ -1,0 +1,9 @@
+import { ImageResponse } from '@takumi-rs/image-response'
+
+export async function GET() {
+  return new ImageResponse(<div>Hello, world!</div>, {
+    width: 1200,
+    height: 630,
+    format: 'webp',
+  })
+}

--- a/test/e2e/app-dir/external-wasm-tracing/app/layout.tsx
+++ b/test/e2e/app-dir/external-wasm-tracing/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/external-wasm-tracing/app/page.tsx
+++ b/test/e2e/app-dir/external-wasm-tracing/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/external-wasm-tracing/external-wasm-tracing.test.ts
+++ b/test/e2e/app-dir/external-wasm-tracing/external-wasm-tracing.test.ts
@@ -1,0 +1,31 @@
+import { isNextStart, nextTestSetup } from 'e2e-utils'
+
+describe('external-wasm-tracing', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    dependencies: {
+      '@takumi-rs/image-response': '1.0.9',
+    },
+  })
+
+  it('traces and serves an external package that uses WASM', async () => {
+    const response = await next.fetch('/image')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('image/webp')
+    expect((await response.arrayBuffer()).byteLength).toBeGreaterThan(100)
+
+    if (isNextStart) {
+      const trace = JSON.parse(
+        await next.readFile('.next/server/app/image/route.js.nft.json')
+      )
+
+      expect(
+        trace.files.some((file: string) => file.endsWith('takumi_wasm_bg.wasm'))
+      ).toBe(true)
+      expect(
+        trace.files.some((file: string) => file.includes('[turbopack-wasm]'))
+      ).toBe(false)
+    }
+  })
+})

--- a/test/e2e/app-dir/external-wasm-tracing/next.config.js
+++ b/test/e2e/app-dir/external-wasm-tracing/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  serverExternalPackages: ['@takumi-rs/image-response'],
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
### What?

Exclude virtual modules from the final NFT file list after tracing their dependency graph.

This adds an end-to-end regression test using `@takumi-rs/image-response@1.0.9`. The test verifies that a production build succeeds, the image route serves a WebP response, and the resulting NFT trace contains the real Takumi WASM file without the embedded Turbopack WASM loader.

### Why?

The embedded `[turbopack-wasm]` loader introduced in #94373 can be reached while tracing an external package that loads WASM. `NftJsonAsset` only accepts deployable paths under the project or output file systems, so including that virtual loader in the final module set causes the build to panic.

Virtual modules still need to participate in graph traversal so that their on-disk dependencies are discovered. They only need to be omitted from the final list passed to NFT.

### How?

Resolve the project and output roots once, then filter traced modules outside both file systems immediately before constructing the final `EndpointTraceResult`. This preserves traversal through virtual modules while limiting the emitted trace to deployable files.

### Testing

- `cargo fmt --all -- --check`
- `cargo check -p next-api`
- `cargo test -p next-api --lib`
- `pnpm build-all`
- `pnpm test-start-turbo test/e2e/app-dir/external-wasm-tracing/external-wasm-tracing.test.ts`
- `pnpm test-start-webpack test/e2e/app-dir/external-wasm-tracing/external-wasm-tracing.test.ts`
- `pnpm test-start-turbo test/production/build-trace-extra-entries-turbo/build-trace-extra-entries-turbo.test.ts`
- Full Fumadocs/Takumi reproduction: production build and `next start`, with `/og` returning a 46,634-byte `image/webp`

Fixes #96897

<!-- NEXT_JS_LLM -->
