### PR TITLE
Turbopack: Fix polling watcher dropping rapid edits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5196,9 +5196,8 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "8.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3163f59cd3fa0e9ef8c32f242966a7b9994fd7378366099593e0e73077cd8c97"
+version = "8.2.0"
+source = "git+https://github.com/marcoshernanz/notify.git?rev=8e42e82e0710643d8f85eba2b2086bf8fb1b8427#8e42e82e0710643d8f85eba2b2086bf8fb1b8427"
 dependencies = [
  "bitflags 2.9.1",
  "fsevent-sys",
@@ -5215,8 +5214,7 @@ dependencies = [
 [[package]]
 name = "notify-types"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+source = "git+https://github.com/marcoshernanz/notify.git?rev=8e42e82e0710643d8f85eba2b2086bf8fb1b8427#8e42e82e0710643d8f85eba2b2086bf8fb1b8427"
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,6 +367,8 @@ vergen-gitcl = { version = "1.0.8", features = ["cargo"] }
 webbrowser = "1.0.6"
 
 [patch.crates-io]
+# TODO: Remove after https://github.com/notify-rs/notify/pull/981 is released.
+notify = { git = "https://github.com/marcoshernanz/notify.git", rev = "8e42e82e0710643d8f85eba2b2086bf8fb1b8427" }
 bincode = { git = "https://github.com/bgw/bincode.git", branch = "bgw/patches" }
 virtue = { git = "https://github.com/bgw/virtue.git", branch = "bgw/fix-generic-default-parsing" }
 # We have to very frequently bump the swc major version of mdxjs-rs

--- a/turbopack/crates/turbo-tasks-fs/src/watcher/mod.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher/mod.rs
@@ -1053,6 +1053,45 @@ mod tests {
             .unwrap();
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn polling_detects_subsecond_mtime_changes() {
+        let tt = TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        tt.run_once(async move {
+            let fs = MockFileSystem::new(DiskWatcherConfig {
+                recursive_mode: Some(DiskWatcherRecursiveMode::NonRecursive),
+                poll_interval: Some(Duration::from_millis(100)),
+                report_invalidation_reason: true,
+            });
+            let file_path = fs.root_path.join("file.txt");
+            let initial_mtime = SystemTime::UNIX_EPOCH
+                + Duration::from_secs(1_000_000)
+                + Duration::from_millis(100);
+            fs::write(&file_path, "initial")?;
+            fs::File::options()
+                .write(true)
+                .open(&file_path)?
+                .set_modified(initial_mtime)?;
+
+            DiskWatcher::start_watching(fs.clone()).await?;
+            assert_eq!(fs.tracked_read_strongly_consistent(&file_path).await, 1);
+
+            // Keep this mtime-only so the test never exposes a transient current-time mtime.
+            fs::File::options()
+                .write(true)
+                .open(&file_path)?
+                .set_modified(initial_mtime + Duration::from_millis(100))?;
+            wait_for_rerun(&fs, &file_path, 1).await;
+
+            fs.watcher.stop_watching().await;
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
     /// `recursive_mode` is set explicitly rather than left to the platform default so that both
     /// watching strategies are covered on every host. `TURBO_TASKS_FORCE_WATCH_MODE` still
     /// overrides it, collapsing these into two cases.


### PR DESCRIPTION
## What?

Fixes Turbopack polling mode permanently dropping rapid file edits by pinning a `notify` 8.2.0 backport that preserves subsecond file mtime precision.

Adds a deterministic `turbo-tasks-fs` regression test that advances a watched file's mtime twice within one second and verifies the task is invalidated.

Upstream dependency fix: https://github.com/notify-rs/notify/pull/981

## Why?

`watchOptions.pollIntervalMs` selects `notify::PollWatcher`. Released `notify` versions convert `SystemTime` to whole seconds before comparing snapshots. With content hashing disabled, two writes within the same second compare equal, so the second edit emits no event and remains stale until a later edit changes the truncated timestamp.

This is not Windows-only:

- Issue repro on Windows: 22/25 edits detected; all 25 mtimes advanced.
- Unmodified `canary` on Linux: one polling run detected 24/25 edits and never recovered within the 8-second observation window; native control detected 25/25.
- The deterministic regression timed out after 5 seconds against released `notify`.

PR #96440 correctly handles `WriteTime` events once emitted, but cannot recover an event that `PollWatcher` never produces.

The behavior affects the intended Docker/WSL/network-filesystem polling escape hatch. Related reports include #80665, #80687, #71622, and #94146.

## How?

The pinned dependency keeps nanosecond precision for ordinary files without enabling `compare_contents`, which would hash every watched file on every poll. It retains whole-second behavior for directories and content-hashed watchers to avoid additional directory events and preserve existing event classification.

The pin is based on stable `notify` 8.2.0 rather than 8.1.0, so it includes the intervening inotify fixes. A TODO links the upstream PR for removal after release.

## Verification

- Baseline, original reporter repo, current canary, Linux:
  - polling: 24/25, then 25/25
  - native controls: 25/25 and 25/25
- Candidate, untouched reporter probe packaged from this branch:
  - polling: 25/25 and 25/25
  - interleaved native control: 25/25
- `notify` 8.2.0 backport: 10 passed, 1 ignored; 5 doc tests passed
- current upstream `notify`: 82 passed, 2 ignored; hashing/race/serialization integration tests and 8 doc tests passed
- `cargo test -p turbo-tasks-fs`: 119 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p turbo-tasks-fs --tests -- -D warnings`
- Full local Next.js package and native binding build
- Independent closeout review: no actionable findings

Fixes #96982
