### PR TITLE
Avoid optimistic routes for rewrite-matched URLs

### DIFF
--- a/packages/next/src/build/build-context.ts
+++ b/packages/next/src/build/build-context.ts
@@ -6,6 +6,7 @@ import type { Span } from '../trace'
 import type getBaseWebpackConfig from './webpack-config'
 import type { TelemetryPluginState } from './webpack/plugins/telemetry-plugin/telemetry-plugin'
 import type { Telemetry } from '../telemetry/storage'
+import type { ProxyMatcher } from './analysis/get-page-static-info'
 
 // A layer for storing data that is used by plugins to communicate with each
 // other between different steps of the build process. This is only internal
@@ -77,6 +78,7 @@ export const NextBuildContext: Partial<{
   mappedAppPages: MappedPages | undefined
   mappedRootPaths: MappedPages
   hasInstrumentationHook: boolean
+  middlewareMatchers: ProxyMatcher[] | undefined
 
   // misc fields
   telemetry: Telemetry

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -5,6 +5,7 @@ import type {
 } from '../server/config-shared'
 import type { ProxyMatcher } from './analysis/get-page-static-info'
 import type { Rewrite } from '../lib/load-custom-routes'
+import { buildCustomRoute } from '../lib/build-custom-route'
 import path from 'node:path'
 import { needsExperimentalReact } from '../lib/needs-experimental-react'
 import {
@@ -42,6 +43,11 @@ export interface DefineEnvOptions {
 
 const DEFINE_ENV_EXPRESSION = Symbol('DEFINE_ENV_EXPRESSION')
 
+type RouteResolutionMatcher = {
+  regexp: string
+  caseSensitive: boolean
+}
+
 interface DefineEnv {
   [key: string]:
     | string
@@ -50,6 +56,7 @@ interface DefineEnv {
     | boolean
     | { [DEFINE_ENV_EXPRESSION]: string }
     | ProxyMatcher[]
+    | RouteResolutionMatcher[]
     | BloomFilter
     | Partial<NextConfigComplete['images']>
     | NextConfigComplete['cacheLife']
@@ -74,6 +81,34 @@ function serializeDefineEnv(defineEnv: DefineEnv): SerializedDefineEnv {
     ])
   )
   return defineEnvStringified
+}
+
+function getRouteResolutionMatchers(
+  rewrites: DefineEnvOptions['rewrites'],
+  middlewareMatchers: ProxyMatcher[] | undefined,
+  caseSensitiveRoutes: boolean
+): RouteResolutionMatcher[] {
+  const matchers = new Map<string, boolean>()
+
+  for (const matcher of middlewareMatchers ?? []) {
+    // Proxy matchers are evaluated on the server using a flagless RegExp.
+    matchers.set(matcher.regexp, true)
+  }
+
+  // beforeFiles and afterFiles rewrites run before dynamic filesystem routes,
+  // which are the routes optimistic routing predicts. Fallback rewrites run
+  // after dynamic routes, so a learned App Router pattern takes precedence and
+  // cannot be affected by them.
+  for (const rewrite of [...rewrites.beforeFiles, ...rewrites.afterFiles]) {
+    const regexp = buildCustomRoute('rewrite', rewrite).regex
+    const existingCaseSensitivity = matchers.get(regexp) ?? true
+    matchers.set(regexp, existingCaseSensitivity && caseSensitiveRoutes)
+  }
+
+  return Array.from(matchers, ([regexp, caseSensitive]) => ({
+    regexp,
+    caseSensitive,
+  }))
 }
 
 function getImageConfig(
@@ -218,6 +253,16 @@ export function getDefineEnv({
     'process.env.__NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING':
       process.env.__NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING || false,
     'process.env.__NEXT_FETCH_CACHE_KEY_PREFIX': fetchCacheKeyPrefix ?? '',
+    ...(isClient
+      ? {
+          'process.env.__NEXT_ROUTE_RESOLUTION_MATCHERS':
+            getRouteResolutionMatchers(
+              rewrites,
+              middlewareMatchers,
+              Boolean(config.experimental.caseSensitiveRoutes)
+            ),
+        }
+      : {}),
     ...(isTurbopack
       ? {}
       : {

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1428,11 +1428,49 @@ export default async function build(
         )
       }
 
+      const middlewareFile = normalizePathSep(
+        proxyFilePath || middlewareFilePath || ''
+      )
+      const middlewarePage = middlewareFile.split('.')[0]
+      const defaultMiddlewareMatchers = [
+        {
+          regexp: '^.*$',
+          originalSource: '/:path*',
+        },
+      ]
+      let middlewareStaticInfo:
+        | Awaited<ReturnType<typeof getStaticInfoIncludingLayouts>>
+        | undefined
+
+      // Turbopack creates its define environment before its entrypoints are
+      // analyzed. Read the proxy config now so client code can conservatively
+      // avoid predicting pathnames that the proxy may rewrite.
+      if (middlewareFile && bundler === Bundler.Turbopack) {
+        middlewareStaticInfo = await getStaticInfoIncludingLayouts({
+          isInsideAppDir: false,
+          pageFilePath: path.join(dir, middlewareFile),
+          config,
+          appDir,
+          pageExtensions: config.pageExtensions,
+          isDev: false,
+          page: middlewarePage,
+        })
+
+        if (middlewareStaticInfo.hadUnsupportedValue) {
+          errorFromUnsupportedSegmentConfig()
+        }
+      }
+
       const hasInstrumentationHook = Boolean(instrumentationHookFilePath)
       const hasMiddlewareFile = Boolean(middlewareFilePath)
       const hasProxyFile = Boolean(proxyFilePath)
 
       NextBuildContext.hasInstrumentationHook = hasInstrumentationHook
+      NextBuildContext.middlewareMatchers =
+        middlewareFile && bundler === Bundler.Turbopack
+          ? (middlewareStaticInfo?.middleware?.matchers ??
+            defaultMiddlewareMatchers)
+          : undefined
 
       const previewProps: __ApiPreviewProps = await generatePreviewKeys({
         isBuild: true,
@@ -2758,41 +2796,31 @@ export default async function build(
         )
       }
 
-      const middlewareFile = normalizePathSep(
-        proxyFilePath || middlewareFilePath || ''
-      )
       let hasNodeMiddleware = false
 
       if (middlewareFile) {
-        // Is format of `(/src)/(proxy|middleware).<ext>`, so split by
-        // "." and get the first part, regard rest of the extensions
-        // to match the `page` value format.
-        const page = middlewareFile.split('.')[0]
-
-        const staticInfo = await getStaticInfoIncludingLayouts({
-          isInsideAppDir: false,
-          pageFilePath: path.join(dir, middlewareFile),
-          config,
-          appDir,
-          pageExtensions: config.pageExtensions,
-          isDev: false,
-          page,
-        })
+        const staticInfo =
+          middlewareStaticInfo ??
+          (await getStaticInfoIncludingLayouts({
+            isInsideAppDir: false,
+            pageFilePath: path.join(dir, middlewareFile),
+            config,
+            appDir,
+            pageExtensions: config.pageExtensions,
+            isDev: false,
+            page: middlewarePage,
+          }))
 
         if (staticInfo.hadUnsupportedValue) {
           errorFromUnsupportedSegmentConfig()
         }
 
-        if (staticInfo.runtime === 'nodejs' || isProxyFile(page)) {
+        if (staticInfo.runtime === 'nodejs' || isProxyFile(middlewarePage)) {
           hasNodeMiddleware = true
           functionsConfigManifest.functions['/_middleware'] = {
             runtime: 'nodejs',
-            matchers: staticInfo.middleware?.matchers ?? [
-              {
-                regexp: '^.*$',
-                originalSource: '/:path*',
-              },
-            ],
+            matchers:
+              staticInfo.middleware?.matchers ?? defaultMiddlewareMatchers,
           }
 
           if (bundler === Bundler.Turbopack) {

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -102,8 +102,7 @@ export async function turbopackBuild(telemetry: Telemetry): Promise<{
       projectPath: dir,
       fetchCacheKeyPrefix: config.experimental.fetchCacheKeyPrefix,
       hasRewrites,
-      // Implemented separately in Turbopack, doesn't have to be passed here.
-      middlewareMatchers: undefined,
+      middlewareMatchers: NextBuildContext.middlewareMatchers,
       rewrites,
     }),
     buildId,

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -35,7 +35,8 @@
  * Cache invalidation on deploy clears everything anyway.
  *
  * Current limitations (deopt to server resolution):
- * - Rewrites: Detected during traversal (tree not populated, but route cached)
+ * - Rewrites: Known proxy/config matchers bail out before prediction. Any
+ *   remaining rewrite mismatches are detected during traversal.
  * - Intercepted routes: The route tree varies by referrer (Next-Url header),
  *   so we can't predict the correct structure from the URL alone. Patterns are
  *   still stored during discovery (so the trie stays populated for non-
@@ -202,6 +203,35 @@ function createEmptyPart(): KnownRoutePart {
 
 // The root of the known route tree.
 let knownRouteTreeRoot: KnownRoutePart = createEmptyPart()
+
+let routeResolutionRegexes: RegExp[] | null = null
+
+/**
+ * Returns whether a pathname may be changed before filesystem route matching.
+ *
+ * Proxy and rewrite conditions can depend on server-only data like headers and
+ * HttpOnly cookies. The client therefore checks only the pathname portion of
+ * each matcher. A false positive safely skips an optimization; a false negative
+ * could expose params from a route tree the server would never render.
+ */
+function mayBeRewritten(pathname: string): boolean {
+  const matchers = process.env.__NEXT_ROUTE_RESOLUTION_MATCHERS as
+    | Array<{ regexp: string; caseSensitive: boolean }>
+    | undefined
+
+  if (matchers === undefined || matchers.length === 0) {
+    return false
+  }
+
+  if (routeResolutionRegexes === null) {
+    routeResolutionRegexes = matchers.map(
+      (matcher) =>
+        new RegExp(matcher.regexp, matcher.caseSensitive ? undefined : 'i')
+    )
+  }
+
+  return routeResolutionRegexes.some((matcher) => matcher.test(pathname))
+}
 
 /**
  * Learns a route pattern from a server response and inserts it into the cache.
@@ -732,6 +762,13 @@ export function matchKnownRoute(
   pathname: string,
   search: NormalizedSearch
 ): FulfilledRouteCacheEntry | null {
+  // A matching proxy or rewrite can resolve this pathname to a different route
+  // tree. Since prediction happens before a server response, it cannot know
+  // which params that tree would contain. Wait for server resolution instead.
+  if (mayBeRewritten(pathname)) {
+    return null
+  }
+
   const pathnameParts = splitPathnameIntoParts(pathname)
   const resolvedParams: ResolvedParams = new Map()
   const match = matchKnownRoutePart(

--- a/test/e2e/app-dir/optimistic-routing/app/[locale]/loading.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/[locale]/loading.tsx
@@ -1,0 +1,3 @@
+export default function LocaleLoading() {
+  return <p id="locale-loading">Loading locale...</p>
+}

--- a/test/e2e/app-dir/optimistic-routing/app/[locale]/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/[locale]/page.tsx
@@ -1,0 +1,16 @@
+import { connection } from 'next/server'
+
+export default async function LocalePage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  await connection()
+
+  return (
+    <h1 id="locale-page" data-locale={locale}>
+      Locale: {locale}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/[locale]/team/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/[locale]/team/page.tsx
@@ -1,0 +1,16 @@
+import { connection } from 'next/server'
+
+export default async function TeamPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>
+}) {
+  const { locale } = await params
+  await connection()
+
+  return (
+    <h1 id="team-page" data-locale={locale}>
+      Team: {locale}
+    </h1>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/page.tsx
@@ -10,6 +10,27 @@ export default function Home() {
         same pattern should show the loading state instantly.
       </p>
 
+      <h2>Proxy Rewrite</h2>
+      <p>
+        The proxy rewrites /team to /en/team. A route prediction learned from
+        /de must not treat &quot;team&quot; as the locale.
+      </p>
+      <ul>
+        <li>
+          <LinkAccordion href="/de">German locale</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/team" prefetch={false}>
+            Team (rewritten, prefetch disabled)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/CONFIG-TEAM" prefetch={false}>
+            Config team, mixed case (rewritten, prefetch disabled)
+          </LinkAccordion>
+        </li>
+      </ul>
+
       <h2>Basic Dynamic Route</h2>
       <ul>
         <li>

--- a/test/e2e/app-dir/optimistic-routing/next.config.js
+++ b/test/e2e/app-dir/optimistic-routing/next.config.js
@@ -7,6 +7,16 @@ const nextConfig = {
     optimisticRouting: true,
     varyParams: true,
   },
+  async rewrites() {
+    return {
+      beforeFiles: [
+        {
+          source: '/config-team',
+          destination: '/en/team',
+        },
+      ],
+    }
+  },
   productionBrowserSourceMaps: true,
 }
 

--- a/test/e2e/app-dir/optimistic-routing/optimistic-routing.test.ts
+++ b/test/e2e/app-dir/optimistic-routing/optimistic-routing.test.ts
@@ -44,6 +44,98 @@ describe('optimistic-routing', () => {
     return
   }
 
+  it('does not predict a route for a URL that proxy may rewrite', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Prefetch /de to learn the /[locale] route pattern.
+    const revealDe = await browser.elementByCss(
+      'input[data-link-accordion="/de"]'
+    )
+    await act(
+      async () => {
+        await revealDe.click()
+      },
+      {
+        includes: 'locale-loading',
+      }
+    )
+
+    // /team matches the learned dynamic route, but proxy rewrites it to
+    // /en/team. Since prefetching is disabled, a synthetic route prediction
+    // would render locale="team" before the server corrects it to "en".
+    await act(async () => {
+      const revealTeam = await browser.elementByCss(
+        'input[data-link-accordion="/team"]'
+      )
+      await revealTeam.click()
+    }, 'no-requests')
+
+    const teamLink = await browser.elementByCss('a[href="/team"]')
+    await act(async () => {
+      await teamLink.click()
+    })
+
+    const teamPage = await browser.elementById('team-page')
+    expect(await teamPage.getAttribute('data-locale')).toBe('en')
+
+    // The client must never expose params from the predicted, pre-rewrite
+    // pathname. The final route keeps the visible /team URL but uses the
+    // server-resolved locale.
+    expect(await getRenderedRouteHistory(browser)).toEqual([
+      { url: '/', params: {} },
+      { url: '/team', params: { locale: 'en' } },
+    ])
+  })
+
+  it('does not predict a route for a URL that next.config may rewrite', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Prefetch /de to learn the /[locale] route pattern.
+    const revealDe = await browser.elementByCss(
+      'input[data-link-accordion="/de"]'
+    )
+    await act(
+      async () => {
+        await revealDe.click()
+      },
+      {
+        includes: 'locale-loading',
+      }
+    )
+
+    // /CONFIG-TEAM matches the learned dynamic route, but the case-insensitive
+    // beforeFiles rewrite resolves it to /en/team. The client must wait for
+    // that server resolution instead of treating "CONFIG-TEAM" as a locale.
+    await act(async () => {
+      const revealTeam = await browser.elementByCss(
+        'input[data-link-accordion="/CONFIG-TEAM"]'
+      )
+      await revealTeam.click()
+    }, 'no-requests')
+
+    const teamLink = await browser.elementByCss('a[href="/CONFIG-TEAM"]')
+    await act(async () => {
+      await teamLink.click()
+    })
+
+    const teamPage = await browser.elementById('team-page')
+    expect(await teamPage.getAttribute('data-locale')).toBe('en')
+    expect(await getRenderedRouteHistory(browser)).toEqual([
+      { url: '/', params: {} },
+      { url: '/CONFIG-TEAM', params: { locale: 'en' } },
+    ])
+  })
+
   it('basic dynamic route prediction: shows loading state instantly for unprefetched route', async () => {
     let act: ReturnType<typeof createRouterAct>
     const browser = await next.browser('/', {

--- a/test/e2e/app-dir/optimistic-routing/proxy.ts
+++ b/test/e2e/app-dir/optimistic-routing/proxy.ts
@@ -4,6 +4,15 @@ import type { NextRequest } from 'next/server'
 export function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname
 
+  // Rewrite /team to /en/team. Once the client has learned the /[locale]
+  // pattern from /de, it must not predict that "team" is a locale because
+  // this pathname is covered by the proxy matcher.
+  if (pathname === '/team') {
+    const url = request.nextUrl.clone()
+    url.pathname = '/en/team'
+    return NextResponse.rewrite(url)
+  }
+
   // Rewrite /rewritten/[slug] to /actual/[slug]
   // This creates a mismatch between URL and route structure that should
   // mark the route as having a dynamic rewrite.
@@ -41,5 +50,10 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/rewritten/:path*', '/search-rewrite', '/products/promo/:path*'],
+  matcher: [
+    '/team',
+    '/rewritten/:path*',
+    '/search-rewrite',
+    '/products/promo/:path*',
+  ],
 }


### PR DESCRIPTION
## Summary

Prevent optimistic routing from synthesizing a route tree for URLs that may be changed by Proxy or by `beforeFiles`/`afterFiles` rewrites. These navigations now wait for server route resolution, so application code never observes params from a route the server did not render.

Matcher case sensitivity is kept consistent with server routing, and URLs outside those matcher scopes retain optimistic prediction.

Fixes #96893

## Verification

- Full existing optimistic-routing suite under Turbopack and Webpack (12/12 in each mode, including instant prediction on unaffected URLs)
- Existing rewrite-detection regression suite under Turbopack and Webpack (3/3 in each mode)
- Manually verified the reporter's reproduction: `/team` renders `Team (en)` with zero bogus-param sightings and a single `/team` RSC request

<!-- NEXT_JS_LLM -->