### PR TITLE
Respect async field of server actions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -793,6 +793,7 @@ export async function handleAction({
       async (): Promise<HandleActionResult> => {
         // We only use these for fetch actions -- MPA actions handle them inside `decodeAction`.
         let actionModId: string | number | undefined
+        let actionAsync: boolean | undefined
         let boundActionArguments: unknown[] = []
 
         const defaultBodySizeLimit = '1 MB'
@@ -867,7 +868,10 @@ export async function handleAction({
               // A fetch action with a multipart body.
 
               try {
-                actionModId = getActionModIdOrError(actionId, serverModuleMap)
+                ;({ actionModId, actionAsync } = getActionOrError(
+                  actionId,
+                  serverModuleMap
+                ))
               } catch (err) {
                 return handleUnrecognizedFetchAction(err)
               }
@@ -931,7 +935,10 @@ export async function handleAction({
             }
 
             try {
-              actionModId = getActionModIdOrError(actionId, serverModuleMap)
+              ;({ actionModId, actionAsync } = getActionOrError(
+                actionId,
+                serverModuleMap
+              ))
             } catch (err) {
               return handleUnrecognizedFetchAction(err)
             }
@@ -1028,7 +1035,10 @@ export async function handleAction({
               // A fetch action with a multipart body.
 
               try {
-                actionModId = getActionModIdOrError(actionId, serverModuleMap)
+                ;({ actionModId, actionAsync } = getActionOrError(
+                  actionId,
+                  serverModuleMap
+                ))
               } catch (err) {
                 return handleUnrecognizedFetchAction(err)
               }
@@ -1140,7 +1150,10 @@ export async function handleAction({
             }
 
             try {
-              actionModId = getActionModIdOrError(actionId, serverModuleMap)
+              ;({ actionModId, actionAsync } = getActionOrError(
+                actionId,
+                serverModuleMap
+              ))
             } catch (err) {
               return handleUnrecognizedFetchAction(err)
             }
@@ -1185,9 +1198,11 @@ export async function handleAction({
         // / -> fire action -> POST / -> appRender1 -> modId for the action file
         // /foo -> fire action -> POST /foo -> appRender2 -> modId for the action file
 
-        const actionMod = (await ComponentMod.__next_app__.require(
-          actionModId
-        )) as Record<string, (...args: unknown[]) => Promise<unknown>>
+        const actionMod = (
+          actionAsync
+            ? await ComponentMod.__next_app__.require(actionModId)
+            : ComponentMod.__next_app__.require(actionModId)
+        ) as Record<string, (...args: unknown[]) => Promise<unknown>>
         const actionHandler =
           actionMod[
             // `actionId` must exist if we got here, as otherwise we would have thrown an error above
@@ -1456,10 +1471,10 @@ async function executeActionAndPrepareForRender<
  * the action came from a different deployment. It could also simply be an invalid POST request that is not a server action.
  * In either case, we'll throw an error to be handled by the caller.
  */
-function getActionModIdOrError(
+function getActionOrError(
   actionId: string | null,
   serverModuleMap: ServerModuleMap
-): string | number {
+): { actionModId: string | number; actionAsync: boolean } {
   // if we're missing the action ID header, we can't do any further processing
   if (!actionId) {
     throw new InvariantError("Missing 'next-action' header.")
@@ -1480,7 +1495,7 @@ function getActionModIdOrError(
       : getInvalidServerReferenceIdError(actionId)
   }
 
-  return entry.id
+  return { actionModId: entry.id, actionAsync: entry.async ?? false }
 }
 
 const $ACTION_ = '$ACTION_'


### PR DESCRIPTION
Why were we not actually using the `async: boolean` field when loading the module?