### PR TITLE
refactor: move useDynamic{Route,Search}Params to reduce snapshot churn

### DIFF
--- a/packages/next/src/client/components/navigation-dynamic-rendering.ts
+++ b/packages/next/src/client/components/navigation-dynamic-rendering.ts
@@ -8,4 +8,4 @@
 export {
   useDynamicRouteParams,
   useDynamicSearchParams,
-} from '../../server/app-render/dynamic-rendering'
+} from '../../server/app-render/dynamic-rendering-client'

--- a/packages/next/src/server/app-render/dynamic-rendering-client.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering-client.ts
@@ -1,0 +1,126 @@
+import React from 'react'
+import {
+  throwForMissingRequestStore,
+  workUnitAsyncStorage,
+} from './work-unit-async-storage.external'
+import { workAsyncStorage } from '../app-render/work-async-storage.external'
+import {
+  ClientHookDynamicError,
+  makeClientHookHangingPromise,
+} from '../dynamic-rendering-utils'
+import { InvariantError } from '../../shared/lib/invariant-error'
+import { BailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
+
+// TODO(veil): This module is separated from `dynamic-rendering.ts` as a workaround.
+// When these hooks were part of `dynamic-rendering.ts, the source location of these
+// `React.use()` calls would show up in Webpack snapshots in `client-hook-abort-reasons.test.ts`,
+// which makes changes to the surrounding file needlessly churn the snapshots.
+// Until the ignore-listing is fixed, we can make this less annoying by keeping these hooks in a separate file.
+
+export function useDynamicRouteParams(expression: string) {
+  const workStore = workAsyncStorage.getStore()
+  const workUnitStore = workUnitAsyncStorage.getStore()
+  if (workStore && workUnitStore) {
+    switch (workUnitStore.type) {
+      case 'prerender-client': {
+        const fallbackParams = workUnitStore.fallbackRouteParams
+
+        if (fallbackParams && fallbackParams.size > 0) {
+          // We are in a prerender with cacheComponents semantics. We are going to
+          // hang here and never resolve. This will cause the currently
+          // rendering component to effectively be a dynamic hole.
+          React.use(
+            makeClientHookHangingPromise(
+              workUnitStore.renderSignal,
+              new ClientHookDynamicError(workStore.route, expression)
+            )
+          )
+        }
+        break
+      }
+      case 'prerender':
+        throw new InvariantError(
+          `\`${expression}\` was called from a Server Component. Next.js should be preventing ${expression} from being included in server components statically, but did not in this case.`
+        )
+      case 'validation-client': {
+        // Don't check fallbackRouteParams here. We handle params that weren't
+        // provided in the samples using a proxy that throws when accessed.
+        break
+      }
+      case 'prerender-runtime':
+        throw new InvariantError(
+          `\`${expression}\` was called during a runtime prerender. Next.js should be preventing ${expression} from being included in server components statically, but did not in this case.`
+        )
+      case 'cache':
+      case 'private-cache':
+        throw new InvariantError(
+          `\`${expression}\` was called inside a cache scope. Next.js should be preventing ${expression} from being included in server components statically, but did not in this case.`
+        )
+      case 'generate-static-params':
+        throw new InvariantError(
+          `\`${expression}\` was called in \`generateStaticParams\`. Next.js should be preventing ${expression} from being included in server component files statically, but did not in this case.`
+        )
+      case 'prerender-legacy':
+      case 'request':
+      case 'unstable-cache':
+        break
+      default:
+        workUnitStore satisfies never
+    }
+  }
+}
+
+export function useDynamicSearchParams(expression: string) {
+  const workStore = workAsyncStorage.getStore()
+  const workUnitStore = workUnitAsyncStorage.getStore()
+
+  if (!workStore) {
+    // We assume pages router context and just return
+    return
+  }
+
+  if (!workUnitStore) {
+    throwForMissingRequestStore(expression)
+  }
+
+  switch (workUnitStore.type) {
+    case 'validation-client':
+      // During instant validation we try to behave as close to client as possible,
+      // so this shouldn't hang during SSR.
+      return
+    case 'prerender-client': {
+      React.use(
+        makeClientHookHangingPromise(
+          workUnitStore.renderSignal,
+          new ClientHookDynamicError(workStore.route, expression)
+        )
+      )
+      break
+    }
+    case 'prerender-legacy': {
+      if (workStore.forceStatic) {
+        return
+      }
+      throw new BailoutToCSRError(expression)
+    }
+    case 'prerender':
+    case 'prerender-runtime':
+      throw new InvariantError(
+        `\`${expression}\` was called from a Server Component. Next.js should be preventing ${expression} from being included in server components statically, but did not in this case.`
+      )
+    case 'cache':
+    case 'unstable-cache':
+    case 'private-cache':
+      throw new InvariantError(
+        `\`${expression}\` was called inside a cache scope. Next.js should be preventing ${expression} from being included in server components statically, but did not in this case.`
+      )
+    case 'generate-static-params':
+      throw new InvariantError(
+        `\`${expression}\` was called in \`generateStaticParams\`. Next.js should be preventing ${expression} from being included in server component files statically, but did not in this case.`
+      )
+    case 'request':
+      return
+    default:
+      workUnitStore satisfies never
+  }
+}

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -20,30 +20,23 @@
  * read that data outside the cache and pass it in as an argument to the cached function.
  */
 
-import type { WorkStore } from '../app-render/work-async-storage.external'
+import type { WorkStore } from './work-async-storage.external'
 import type {
   WorkUnitStore,
   PrerenderStoreLegacy,
   PrerenderStoreModern,
   ValidationStoreClient,
   PrerenderStoreModernServer,
-} from '../app-render/work-unit-async-storage.external'
+} from './work-unit-async-storage.external'
 
 // Once postpone is in stable we should switch to importing the postpone export directly
 import React from 'react'
 
 import { DynamicServerError } from '../../client/components/hooks-server-context'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
+import { getStagedRenderingController } from './work-unit-async-storage.external'
 import {
-  getStagedRenderingController,
-  throwForMissingRequestStore,
-  workUnitAsyncStorage,
-} from './work-unit-async-storage.external'
-import { workAsyncStorage } from '../app-render/work-async-storage.external'
-import {
-  ClientHookDynamicError,
   isClientHookDynamicError,
-  makeClientHookHangingPromise,
   trackRuntimeDataAccessed,
 } from '../dynamic-rendering-utils'
 import {
@@ -546,114 +539,6 @@ export function annotateDynamicAccess(
         : undefined,
       expression,
     })
-  }
-}
-
-export function useDynamicRouteParams(expression: string) {
-  const workStore = workAsyncStorage.getStore()
-  const workUnitStore = workUnitAsyncStorage.getStore()
-  if (workStore && workUnitStore) {
-    switch (workUnitStore.type) {
-      case 'prerender-client': {
-        const fallbackParams = workUnitStore.fallbackRouteParams
-
-        if (fallbackParams && fallbackParams.size > 0) {
-          // We are in a prerender with cacheComponents semantics. We are going to
-          // hang here and never resolve. This will cause the currently
-          // rendering component to effectively be a dynamic hole.
-          React.use(
-            makeClientHookHangingPromise(
-              workUnitStore.renderSignal,
-              new ClientHookDynamicError(workStore.route, expression)
-            )
-          )
-        }
-        break
-      }
-      case 'prerender':
-        throw new InvariantError(
-          `\`${expression}\` was called from a Server Component. Next.js should be preventing ${expression} from being included in server components statically, but did not in this case.`
-        )
-      case 'validation-client': {
-        // Don't check fallbackRouteParams here. We handle params that weren't
-        // provided in the samples using a proxy that throws when accessed.
-        break
-      }
-      case 'prerender-runtime':
-        throw new InvariantError(
-          `\`${expression}\` was called during a runtime prerender. Next.js should be preventing ${expression} from being included in server components statically, but did not in this case.`
-        )
-      case 'cache':
-      case 'private-cache':
-        throw new InvariantError(
-          `\`${expression}\` was called inside a cache scope. Next.js should be preventing ${expression} from being included in server components statically, but did not in this case.`
-        )
-      case 'generate-static-params':
-        throw new InvariantError(
-          `\`${expression}\` was called in \`generateStaticParams\`. Next.js should be preventing ${expression} from being included in server component files statically, but did not in this case.`
-        )
-      case 'prerender-legacy':
-      case 'request':
-      case 'unstable-cache':
-        break
-      default:
-        workUnitStore satisfies never
-    }
-  }
-}
-
-export function useDynamicSearchParams(expression: string) {
-  const workStore = workAsyncStorage.getStore()
-  const workUnitStore = workUnitAsyncStorage.getStore()
-
-  if (!workStore) {
-    // We assume pages router context and just return
-    return
-  }
-
-  if (!workUnitStore) {
-    throwForMissingRequestStore(expression)
-  }
-
-  switch (workUnitStore.type) {
-    case 'validation-client':
-      // During instant validation we try to behave as close to client as possible,
-      // so this shouldn't hang during SSR.
-      return
-    case 'prerender-client': {
-      React.use(
-        makeClientHookHangingPromise(
-          workUnitStore.renderSignal,
-          new ClientHookDynamicError(workStore.route, expression)
-        )
-      )
-      break
-    }
-    case 'prerender-legacy': {
-      if (workStore.forceStatic) {
-        return
-      }
-      throw new BailoutToCSRError(expression)
-    }
-    case 'prerender':
-    case 'prerender-runtime':
-      throw new InvariantError(
-        `\`${expression}\` was called from a Server Component. Next.js should be preventing ${expression} from being included in server components statically, but did not in this case.`
-      )
-    case 'cache':
-    case 'unstable-cache':
-    case 'private-cache':
-      throw new InvariantError(
-        `\`${expression}\` was called inside a cache scope. Next.js should be preventing ${expression} from being included in server components statically, but did not in this case.`
-      )
-    case 'generate-static-params':
-      throw new InvariantError(
-        `\`${expression}\` was called in \`generateStaticParams\`. Next.js should be preventing ${expression} from being included in server component files statically, but did not in this case.`
-      )
-    case 'request':
-      return
-    default:
-      workUnitStore satisfies never
   }
 }
 

--- a/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
@@ -314,17 +314,16 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                    - [block] Set \`export const instant = false\` to allow a blocking route
 
                  Learn more: https://nextjs.org/docs/messages/blocking-prerender-client-hook
-                     at Object.useDynamicSearchParams (webpack:///<next-src>)
                      at useSearchParams (webpack:///<next-src>)
                      at UseSearchParams (webpack:///app/client-hook-abort-reasons/client.tsx:27:18)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-search-params/[id]/page.tsx:8:7)
-                   622 |       return
-                   623 |     case 'prerender-client': {
-                 > 624 |       React.use(
-                       |             ^
-                   625 |         makeClientHookHangingPromise(
-                   626 |           workUnitStore.renderSignal,
-                   627 |           new ClientHookDynamicError(workStore.route, expression) {
+                   54 | // Client components API
+                   55 | export function useSearchParams(): ReadonlyURLSearchParams {
+                 > 56 |   useDynamicSearchParams?.('useSearchParams()')
+                      |                         ^
+                   57 |
+                   58 |   const searchParams = useContext(SearchParamsContext)
+                   59 | {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-search-params/[id]" in your browser to investigate the error.
@@ -604,17 +603,16 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                    - [block] Set \`export const instant = false\` to allow a blocking route
 
                  Learn more: https://nextjs.org/docs/messages/blocking-prerender-client-hook
-                     at Object.useDynamicRouteParams (webpack:///<next-src>)
                      at usePathname (webpack:///<next-src>)
                      at UsePathname (webpack:///app/client-hook-abort-reasons/client.tsx:22:14)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-pathname/[id]/page.tsx:7:7)
-                   562 |           // hang here and never resolve. This will cause the currently
-                   563 |           // rendering component to effectively be a dynamic hole.
-                 > 564 |           React.use(
-                       |                 ^
-                   565 |             makeClientHookHangingPromise(
-                   566 |               workUnitStore.renderSignal,
-                   567 |               new ClientHookDynamicError(workStore.route, expression) {
+                   111 | // Client components API
+                   112 | export function usePathname(): string {
+                 > 113 |   useDynamicRouteParams?.('usePathname()')
+                       |                        ^
+                   114 |
+                   115 |   // In the case where this is \`null\`, the compat types added in \`next-env.d.ts\`
+                   116 |   // will add a new overload that changes the return type to include \`null\`. {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-pathname/[id]" in your browser to investigate the error.
@@ -894,17 +892,16 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                    - [block] Set \`export const instant = false\` to allow a blocking route
 
                  Learn more: https://nextjs.org/docs/messages/blocking-prerender-client-hook
-                     at Object.useDynamicRouteParams (webpack:///<next-src>)
                      at useParams (webpack:///<next-src>)
                      at UseParams (webpack:///app/client-hook-abort-reasons/client.tsx:17:12)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-params/[id]/page.tsx:8:7)
-                   562 |           // hang here and never resolve. This will cause the currently
-                   563 |           // rendering component to effectively be a dynamic hole.
-                 > 564 |           React.use(
-                       |                 ^
-                   565 |             makeClientHookHangingPromise(
-                   566 |               workUnitStore.renderSignal,
-                   567 |               new ClientHookDynamicError(workStore.route, expression) {
+                   214 | // Client components API
+                   215 | export function useParams<T extends Params = Params>(): T {
+                 > 216 |   useDynamicRouteParams?.('useParams()')
+                       |                        ^
+                   217 |
+                   218 |   const params = useContext(PathParamsContext) as T
+                   219 | {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-params/[id]" in your browser to investigate the error.
@@ -1184,17 +1181,16 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                    - [block] Set \`export const instant = false\` to allow a blocking route
 
                  Learn more: https://nextjs.org/docs/messages/blocking-prerender-client-hook
-                     at Object.useDynamicRouteParams (webpack:///<next-src>)
                      at useSelectedLayoutSegments (webpack:///<next-src>)
                      at UseSelectedLayoutSegments (webpack:///app/client-hook-abort-reasons/client.tsx:37:28)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-selected-layout-segments/[id]/page.tsx:7:7)
-                   562 |           // hang here and never resolve. This will cause the currently
-                   563 |           // rendering component to effectively be a dynamic hole.
-                 > 564 |           React.use(
-                       |                 ^
-                   565 |             makeClientHookHangingPromise(
-                   566 |               workUnitStore.renderSignal,
-                   567 |               new ClientHookDynamicError(workStore.route, expression) {
+                   268 |   parallelRouteKey: string = 'children'
+                   269 | ): string[] {
+                 > 270 |   useDynamicRouteParams?.('useSelectedLayoutSegments()')
+                       |                        ^
+                   271 |
+                   272 |   const context = useContext(LayoutRouterContext)
+                   273 |   // @ts-expect-error This only happens in \`pages\`. Type is overwritten in navigation.d.ts {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-selected-layout-segments/[id]" in your browser to investigate the error.
@@ -1474,17 +1470,16 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                    - [block] Set \`export const instant = false\` to allow a blocking route
 
                  Learn more: https://nextjs.org/docs/messages/blocking-prerender-client-hook
-                     at Object.useDynamicRouteParams (webpack:///<next-src>)
                      at useSelectedLayoutSegment (webpack:///<next-src>)
                      at UseSelectedLayoutSegment (webpack:///app/client-hook-abort-reasons/client.tsx:32:27)
                      at Page (webpack:///app/client-hook-abort-reasons/normal/use-selected-layout-segment/[id]/page.tsx:8:7)
-                   562 |           // hang here and never resolve. This will cause the currently
-                   563 |           // rendering component to effectively be a dynamic hole.
-                 > 564 |           React.use(
-                       |                 ^
-                   565 |             makeClientHookHangingPromise(
-                   566 |               workUnitStore.renderSignal,
-                   567 |               new ClientHookDynamicError(workStore.route, expression) {
+                   323 |   parallelRouteKey: string = 'children'
+                   324 | ): string | null {
+                 > 325 |   useDynamicRouteParams?.('useSelectedLayoutSegment()')
+                       |                        ^
+                   326 |   const navigationPromises = useContext(NavigationPromisesContext)
+                   327 |   const selectedLayoutSegments = useSelectedLayoutSegments(parallelRouteKey)
+                   328 | {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/normal/use-selected-layout-segment/[id]" in your browser to investigate the error.
@@ -2194,17 +2189,16 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                    - [block] Set \`export const instant = false\` to allow a blocking route
 
                  Learn more: https://nextjs.org/docs/messages/blocking-prerender-client-hook
-                     at Object.useDynamicRouteParams (webpack:///<next-src>)
                      at useParams (webpack:///<next-src>)
                      at UseParams (webpack:///app/client-hook-abort-reasons/client.tsx:17:12)
                      at Page (webpack:///app/client-hook-abort-reasons/sync-io/use-params/[id]/page.tsx:7:7)
-                   562 |           // hang here and never resolve. This will cause the currently
-                   563 |           // rendering component to effectively be a dynamic hole.
-                 > 564 |           React.use(
-                       |                 ^
-                   565 |             makeClientHookHangingPromise(
-                   566 |               workUnitStore.renderSignal,
-                   567 |               new ClientHookDynamicError(workStore.route, expression) {
+                   214 | // Client components API
+                   215 | export function useParams<T extends Params = Params>(): T {
+                 > 216 |   useDynamicRouteParams?.('useParams()')
+                       |                        ^
+                   217 |
+                   218 |   const params = useContext(PathParamsContext) as T
+                   219 | {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/sync-io/use-params/[id]" in your browser to investigate the error.
@@ -2693,17 +2687,16 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
                    - [block] Set \`export const instant = false\` to allow a blocking route
 
                  Learn more: https://nextjs.org/docs/messages/blocking-prerender-client-hook
-                     at Object.useDynamicRouteParams (webpack:///<next-src>)
                      at useSelectedLayoutSegment (webpack:///<next-src>)
                      at UseSelectedLayoutSegment (webpack:///app/client-hook-abort-reasons/client.tsx:32:27)
                      at Page (webpack:///app/client-hook-abort-reasons/sync-io/use-selected-layout-segment/[id]/page.tsx:8:7)
-                   562 |           // hang here and never resolve. This will cause the currently
-                   563 |           // rendering component to effectively be a dynamic hole.
-                 > 564 |           React.use(
-                       |                 ^
-                   565 |             makeClientHookHangingPromise(
-                   566 |               workUnitStore.renderSignal,
-                   567 |               new ClientHookDynamicError(workStore.route, expression) {
+                   323 |   parallelRouteKey: string = 'children'
+                   324 | ): string | null {
+                 > 325 |   useDynamicRouteParams?.('useSelectedLayoutSegment()')
+                       |                        ^
+                   326 |   const navigationPromises = useContext(NavigationPromisesContext)
+                   327 |   const selectedLayoutSegments = useSelectedLayoutSegments(parallelRouteKey)
+                   328 | {
                    digest: 'CLIENT_HOOK_DYNAMIC'
                  }
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-hook-abort-reasons/sync-io/use-selected-layout-segment/[id]" in your browser to investigate the error.


### PR DESCRIPTION
Relocates `useDynamicRouteParams` and `useDynamicSearchParams` to avoid having to update `client-hook-abort-reasons.test.ts` every time there's changes in `dynamic-rendering.ts`. Webpack leaked the source location of the `React.use` calls inside, so any code change that moved the source of the hook would require a snapshot update.

For reasons i don't quite understand, moving the hooks to a different file improved the ignore-listing, i.e. we no longer point to the internals of the hooks. This is surprising but not unwelcome.