### PR TITLE
test: cover dynamic APIs with i18n base path

### DIFF
--- a/test/e2e/i18n-basepath-fallback-false-404/i18n-basepath-fallback-false-404.test.ts
+++ b/test/e2e/i18n-basepath-fallback-false-404/i18n-basepath-fallback-false-404.test.ts
@@ -1,0 +1,17 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('i18n-basepath-fallback-false-404', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it.each([
+    ['/docs/api/blog/first', { slug: 'first' }],
+    ['/docs/api/catchall/hello/world', { rest: ['hello', 'world'] }],
+  ])('should resolve the dynamic API route %s', async (pathname, expected) => {
+    const res = await next.fetch(pathname)
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual(expected)
+  })
+})

--- a/test/e2e/i18n-basepath-fallback-false-404/next.config.js
+++ b/test/e2e/i18n-basepath-fallback-false-404/next.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  basePath: '/docs',
+  i18n: {
+    locales: ['en', 'fr'],
+    defaultLocale: 'en',
+  },
+}

--- a/test/e2e/i18n-basepath-fallback-false-404/pages/404.tsx
+++ b/test/e2e/i18n-basepath-fallback-false-404/pages/404.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return 'not found page'
+}

--- a/test/e2e/i18n-basepath-fallback-false-404/pages/api/blog/[slug].ts
+++ b/test/e2e/i18n-basepath-fallback-false-404/pages/api/blog/[slug].ts
@@ -1,0 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.json({ slug: req.query.slug })
+}

--- a/test/e2e/i18n-basepath-fallback-false-404/pages/api/catchall/[...rest].ts
+++ b/test/e2e/i18n-basepath-fallback-false-404/pages/api/catchall/[...rest].ts
@@ -1,0 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.json({ rest: req.query.rest })
+}

--- a/test/e2e/i18n-basepath-fallback-false-404/pages/foo/[slug].tsx
+++ b/test/e2e/i18n-basepath-fallback-false-404/pages/foo/[slug].tsx
@@ -1,0 +1,14 @@
+export default function Page() {
+  return 'dynamic page'
+}
+
+export function getStaticProps() {
+  return { props: {} }
+}
+
+export function getStaticPaths() {
+  return {
+    paths: [{ params: { slug: 'first' } }],
+    fallback: false,
+  }
+}

--- a/test/e2e/i18n-basepath-fallback-false-404/pages/index.tsx
+++ b/test/e2e/i18n-basepath-fallback-false-404/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}


### PR DESCRIPTION
Recreation of https://github.com/vercel/next.js/pull/96910

### What?

Adds a test for i18n basepath fallbacks.

### Why?

We had this test in `vercel/vercel`: https://github.com/vercel/vercel/blob/main/packages/next/test/fixtures/00-i18n-basepath-fallback-false-404/index.test.js

We're getting rid of it in favor of moving it to here in Next.js. This new test is meant to be equivalent to the original.