### PR TITLE
Fix prefetch starvation when a sibling teaches the route pattern first

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -711,18 +711,34 @@ export function readOrCreateRouteCacheEntry(
 ): RouteCacheEntry {
   attachInvalidationListener(task)
 
-  const existingEntry = readRouteCacheEntry(now, key)
-  if (existingEntry !== null) {
-    return existingEntry
-  }
-  // Create a pending entry and add it to the cache.
-  const pendingEntry = createDetachedRouteCacheEntry()
   const varyPath: RouteVaryPath = getRouteVaryPath(
     key.pathname,
     key.search,
     key.nextUrl
   )
   const isRevalidation = false
+  // When the route cache had no entry, not even a predicted one, at the time
+  // the task was scheduled, the task committed to fetching the route tree.
+  // Look up the cache map directly, without the predicted-entry fallback in
+  // readRouteCacheEntry: a pattern learned in the meantime from a sibling's
+  // response contains none of this URL's own data, and consuming it would
+  // complete the task without fetching anything. A concrete entry written in
+  // the meantime still satisfies the task.
+  const existingEntry = task.routeCacheMissedWhenScheduled
+    ? getFromCacheMap(
+        now,
+        getCurrentRouteCacheVersion(),
+        routeCacheMap,
+        varyPath,
+        isRevalidation,
+        false
+      )
+    : readRouteCacheEntry(now, key)
+  if (existingEntry !== null) {
+    return existingEntry
+  }
+  // Create a pending entry and add it to the cache.
+  const pendingEntry = createDetachedRouteCacheEntry()
   setInCacheMap(routeCacheMap, varyPath, pendingEntry, isRevalidation)
   return pendingEntry
 }

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -168,6 +168,24 @@ export type PrefetchTask = {
   isCanceled: boolean
 
   /**
+   * True if the route cache had no entry for the task's URL, not even a
+   * predicted (matchKnownRoute) entry, at the time the task was scheduled.
+   *
+   * A task resolves its route against the cache state at schedule time. When
+   * this is true, the task committed to fetching the route tree, and a route
+   * pattern learned later from a sibling's response must not satisfy it: a
+   * predicted entry describes the route's structure but contains none of this
+   * URL's own data, so a task that consumed one would complete without
+   * fetching anything. This happens when more siblings are prefetched in one
+   * tick than the concurrent request limit allows. The first responses teach
+   * the pattern while the excess tasks are still waiting for bandwidth.
+   *
+   * A concrete entry that appears later (e.g. another task fetched the same
+   * URL) still satisfies the task.
+   */
+  routeCacheMissedWhenScheduled: boolean
+
+  /**
    * Tracks whether the task has attempted to upgrade a fallback ISR response
    * to one based on concrete params.
    *
@@ -353,6 +371,8 @@ export function schedulePrefetchTask(
     fetchStrategy,
     sortId: sortIdCounter++,
     isCanceled: false,
+    routeCacheMissedWhenScheduled:
+      readRouteCacheEntry(Date.now(), key) === null,
     fallbackRetryStatus: EntryStatus.Empty,
     onInvalidate,
     _heapIndex: -1,
@@ -421,6 +441,10 @@ export function reschedulePrefetchTask(
 
   task.treeAtTimeOfPrefetch = treeAtTimeOfPrefetch
   task.fetchStrategy = fetchStrategy
+  // A reschedule is a fresh scheduling decision, so re-evaluate the route
+  // cache state (see the field's docs).
+  task.routeCacheMissedWhenScheduled =
+    readRouteCacheEntry(Date.now(), task.key) === null
 
   trackMostRecentlyHoveredLink(task)
 

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-prefetch-starvation-regression/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-prefetch-starvation-regression/app/layout.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <div>Root layout static text</div>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-prefetch-starvation-regression/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-prefetch-starvation-regression/app/page.tsx
@@ -1,0 +1,10 @@
+import { PrefetchButtons } from '../components/prefetch-buttons'
+
+export default function HomePage() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <PrefetchButtons />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-prefetch-starvation-regression/app/products/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-prefetch-starvation-regression/app/products/[slug]/page.tsx
@@ -1,0 +1,41 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+type Params = { slug: string }
+
+// Every param value is known via `generateStaticParams`, so each URL has its
+// own prerender with the param-dependent content baked in, plus one dynamic
+// hole. The baked content is only delivered by that URL's own prefetch
+// response. A sibling's response cannot supply it.
+export async function generateStaticParams(): Promise<Array<Params>> {
+  return [
+    { slug: 'alpha' },
+    { slug: 'bravo' },
+    { slug: 'charlie' },
+    { slug: 'delta' },
+    { slug: 'echo' },
+  ]
+}
+
+export default function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      <Suspense fallback={<p>Loading static content...</p>}>
+        <SlugContent params={params} />
+      </Suspense>
+      <Suspense fallback={<p>Loading dynamic content...</p>}>
+        <DynamicContent />
+      </Suspense>
+    </main>
+  )
+}
+
+async function SlugContent({ params }: { params: Promise<Params> }) {
+  const { slug } = await params
+  return <p id="slug-content">{`Content of ${slug}`}</p>
+}
+
+async function DynamicContent() {
+  await connection()
+  return <p id="dynamic-content">Dynamic content</p>
+}

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-prefetch-starvation-regression/components/prefetch-buttons.tsx
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-prefetch-starvation-regression/components/prefetch-buttons.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+const slugs = ['alpha', 'bravo', 'charlie', 'delta', 'echo']
+
+export function PrefetchButtons() {
+  const router = useRouter()
+  return (
+    <>
+      <button
+        data-prefetch-all
+        onClick={() => {
+          // Schedule all sibling prefetches in the same tick, exceeding the
+          // scheduler's concurrent request limit.
+          for (const slug of slugs) {
+            router.prefetch(`/products/${slug}`)
+          }
+        }}
+      >
+        Prefetch all siblings
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-prefetch-starvation-regression/next.config.js
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-prefetch-starvation-regression/next.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/optimistic-routing-prefetch-starvation-regression/optimistic-routing-prefetch-starvation-regression.test.ts
+++ b/test/e2e/app-dir/segment-cache/optimistic-routing-prefetch-starvation-regression/optimistic-routing-prefetch-starvation-regression.test.ts
@@ -1,0 +1,51 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import type * as Playwright from 'playwright'
+
+// Regression test for a starvation bug in the prefetch scheduler
+// (issue #96965). When more sibling URLs of a dynamic route are prefetched in
+// one tick than the scheduler's concurrent request limit allows, the excess
+// tasks wait for bandwidth. The first responses to arrive teach the optimistic
+// routing trie the route's pattern, so when a waiting task finally runs, its
+// cache lookup matches a synthetic (predicted) route entry and the task
+// completes without ever fetching the URL's own route tree. Every later
+// prefetch of that URL hits the same synthetic entry, so the URL can never be
+// warmed for the lifetime of the page.
+describe('optimistic routing prefetch starvation', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    test('prefetching is disabled', () => {})
+    return
+  }
+
+  it('fetches the route tree of every sibling prefetched in the same tick, beyond the concurrent request limit', async () => {
+    const treeRequests = new Set<string>()
+    const browser = await next.browser('/', {
+      beforePageLoad(page: Playwright.Page) {
+        page.on('request', (request) => {
+          if (request.headers()['next-router-segment-prefetch'] === '/_tree') {
+            treeRequests.add(new URL(request.url()).pathname)
+          }
+        })
+      },
+    })
+
+    // Schedule all five sibling prefetches in the same tick. The concurrent
+    // request limit is four, so the first-scheduled sibling (the task queue is
+    // most-recent-first) waits for bandwidth while the others' responses
+    // arrive and teach the route's pattern.
+    await browser.elementByCss('[data-prefetch-all]').click()
+
+    await retry(async () => {
+      expect([...treeRequests].sort()).toEqual([
+        '/products/alpha',
+        '/products/bravo',
+        '/products/charlie',
+        '/products/delta',
+        '/products/echo',
+      ])
+    })
+  })
+})


### PR DESCRIPTION
Fixes #96965.

Prefetch more sibling URLs of a dynamic route in one tick than the scheduler's request limit, and the excess tasks wait for bandwidth. The first responses teach the optimistic routing trie the route's pattern. When a waiting task finally runs, its cache lookup falls back to `matchKnownRoute` and gets a synthetic entry. The entry is Fulfilled, so the task completes without fetching the URL's own route tree. Later prefetches of that URL hit the same synthetic entry, so the URL can never be warmed for the lifetime of the page. The issue reports this from two production apps: one warm sibling, every other sibling pays the full dynamic request on click.

The fix makes a prefetch task resolve its route against the cache state at schedule time. `schedulePrefetchTask` (and reschedule) records whether the route cache had an entry for the URL, predicted or concrete. If it did, nothing changes: the task may consume a predicted entry, which keeps the intended reuse cases (prefetching a sibling after the pattern is known, or the same pathname with different search params) at zero requests. If it did not, the task committed to a fetch, and a pattern learned in the meantime from a sibling's response must not satisfy it: the task's lookup reads the cache map directly and skips the predicted-entry fallback. A concrete entry written in the meantime still satisfies it.

The new e2e test prefetches five prerendered siblings in one tick and asserts a route tree request fires for each, including the first-scheduled one, which only gets bandwidth after sibling responses have arrived. On canary it fails with exactly `/products/alpha` missing; with the change all five fire.