### PR TITLE
Fix use cache JSX slot key warnings

### DIFF
--- a/packages/next/src/compiled/react-experimental/cjs/react-jsx-dev-runtime.react-server.development.js
+++ b/packages/next/src/compiled/react-experimental/cjs/react-jsx-dev-runtime.react-server.development.js
@@ -213,6 +213,7 @@
               isStaticChildren++
             )
               validateChildKeys(children[isStaticChildren]);
+            (globalThis[Symbol.for("next.static.children")] || (globalThis[Symbol.for("next.static.children")] = new WeakSet())).add(children);
             Object.freeze && Object.freeze(children);
           } else
             console.error(

--- a/packages/next/src/compiled/react-experimental/cjs/react-jsx-runtime.react-server.development.js
+++ b/packages/next/src/compiled/react-experimental/cjs/react-jsx-runtime.react-server.development.js
@@ -213,6 +213,7 @@
               isStaticChildren++
             )
               validateChildKeys(children[isStaticChildren]);
+            (globalThis[Symbol.for("next.static.children")] || (globalThis[Symbol.for("next.static.children")] = new WeakSet())).add(children);
             Object.freeze && Object.freeze(children);
           } else
             console.error(

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.browser.development.js
@@ -2593,7 +2593,7 @@
           ((elementReference = request.temporaryReferences.get(value)),
           void 0 !== elementReference)
         )
-          return "$T" + elementReference;
+          return "$T" + (elementReference[0] === "!" ? elementReference.slice(1) : elementReference);
         elementReference = TaintRegistryObjects.get(value);
         void 0 !== elementReference && throwTaintViolation(elementReference);
         elementReference = request.writtenObjects;
@@ -2770,7 +2770,13 @@
           ((request = request.temporaryReferences.get(value)),
           void 0 !== request)
         )
-          return "$T" + request;
+          return (
+            "$T" +
+            (request[0] === "!"
+              ? (globalThis[Symbol.for("next.static.children")] && globalThis[Symbol.for("next.static.children")].has(parent) ? "!" : "") +
+                request.slice(1)
+              : request)
+          );
         request = TaintRegistryObjects.get(value);
         void 0 !== request && throwTaintViolation(request);
         if (value.$$typeof === TEMPORARY_REFERENCE_TAG)
@@ -3099,7 +3105,7 @@
         }
         if (void 0 !== request.temporaryReferences) {
           var tempRef = request.temporaryReferences.get(value);
-          if (void 0 !== tempRef) return "$T" + tempRef;
+          if (void 0 !== tempRef) return "$T" + (tempRef[0] === "!" ? tempRef.slice(1) : tempRef);
         }
         tempRef = request.writtenDebugObjects;
         var existingDebugReference = tempRef.get(value);
@@ -3399,7 +3405,7 @@
           ((counter = request.temporaryReferences.get(value)),
           void 0 !== counter)
         )
-          return "$T" + counter;
+          return "$T" + (counter[0] === "!" ? counter.slice(1) : counter);
         counter = request.writtenDebugObjects;
         ref = counter.get(value);
         if (void 0 !== ref) return ref;

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.edge.development.js
@@ -2653,7 +2653,7 @@
           ((elementReference = request.temporaryReferences.get(value)),
           void 0 !== elementReference)
         )
-          return "$T" + elementReference;
+          return "$T" + (elementReference[0] === "!" ? elementReference.slice(1) : elementReference);
         elementReference = TaintRegistryObjects.get(value);
         void 0 !== elementReference && throwTaintViolation(elementReference);
         elementReference = request.writtenObjects;
@@ -2830,7 +2830,13 @@
           ((request = request.temporaryReferences.get(value)),
           void 0 !== request)
         )
-          return "$T" + request;
+          return (
+            "$T" +
+            (request[0] === "!"
+              ? (globalThis[Symbol.for("next.static.children")] && globalThis[Symbol.for("next.static.children")].has(parent) ? "!" : "") +
+                request.slice(1)
+              : request)
+          );
         request = TaintRegistryObjects.get(value);
         void 0 !== request && throwTaintViolation(request);
         if (value.$$typeof === TEMPORARY_REFERENCE_TAG)
@@ -3169,7 +3175,7 @@
         }
         if (void 0 !== request.temporaryReferences) {
           var tempRef = request.temporaryReferences.get(value);
-          if (void 0 !== tempRef) return "$T" + tempRef;
+          if (void 0 !== tempRef) return "$T" + (tempRef[0] === "!" ? tempRef.slice(1) : tempRef);
         }
         tempRef = request.writtenDebugObjects;
         var existingDebugReference = tempRef.get(value);
@@ -3469,7 +3475,7 @@
           ((counter = request.temporaryReferences.get(value)),
           void 0 !== counter)
         )
-          return "$T" + counter;
+          return "$T" + (counter[0] === "!" ? counter.slice(1) : counter);
         counter = request.writtenDebugObjects;
         ref = counter.get(value);
         if (void 0 !== ref) return ref;

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
@@ -2930,7 +2930,7 @@
           ((elementReference = request.temporaryReferences.get(value)),
           void 0 !== elementReference)
         )
-          return "$T" + elementReference;
+          return "$T" + (elementReference[0] === "!" ? elementReference.slice(1) : elementReference);
         elementReference = TaintRegistryObjects.get(value);
         void 0 !== elementReference && throwTaintViolation(elementReference);
         elementReference = request.writtenObjects;
@@ -3107,7 +3107,13 @@
           ((request = request.temporaryReferences.get(value)),
           void 0 !== request)
         )
-          return "$T" + request;
+          return (
+            "$T" +
+            (request[0] === "!"
+              ? (globalThis[Symbol.for("next.static.children")] && globalThis[Symbol.for("next.static.children")].has(parent) ? "!" : "") +
+                request.slice(1)
+              : request)
+          );
         request = TaintRegistryObjects.get(value);
         void 0 !== request && throwTaintViolation(request);
         if (value.$$typeof === TEMPORARY_REFERENCE_TAG)
@@ -3536,7 +3542,7 @@
         }
         if (void 0 !== request.temporaryReferences) {
           var tempRef = request.temporaryReferences.get(value);
-          if (void 0 !== tempRef) return "$T" + tempRef;
+          if (void 0 !== tempRef) return "$T" + (tempRef[0] === "!" ? tempRef.slice(1) : tempRef);
         }
         tempRef = request.writtenDebugObjects;
         var existingDebugReference = tempRef.get(value);
@@ -3836,7 +3842,7 @@
           ((counter = request.temporaryReferences.get(value)),
           void 0 !== counter)
         )
-          return "$T" + counter;
+          return "$T" + (counter[0] === "!" ? counter.slice(1) : counter);
         counter = request.writtenDebugObjects;
         ref = counter.get(value);
         if (void 0 !== ref) return ref;

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.browser.development.js
@@ -2521,7 +2521,7 @@
           ((elementReference = request.temporaryReferences.get(value)),
           void 0 !== elementReference)
         )
-          return "$T" + elementReference;
+          return "$T" + (elementReference[0] === "!" ? elementReference.slice(1) : elementReference);
         elementReference = request.writtenObjects;
         _writtenObjects = elementReference.get(value);
         if ("function" === typeof value.then) {
@@ -2687,7 +2687,13 @@
           ((request = request.temporaryReferences.get(value)),
           void 0 !== request)
         )
-          return "$T" + request;
+          return (
+            "$T" +
+            (request[0] === "!"
+              ? (globalThis[Symbol.for("next.static.children")] && globalThis[Symbol.for("next.static.children")].has(parent) ? "!" : "") +
+                request.slice(1)
+              : request)
+          );
         if (value.$$typeof === TEMPORARY_REFERENCE_TAG)
           throw Error(
             "Could not reference an opaque temporary reference. This is likely due to misconfiguring the temporaryReferences options on the server."
@@ -2995,7 +3001,7 @@
         }
         if (void 0 !== request.temporaryReferences) {
           var tempRef = request.temporaryReferences.get(value);
-          if (void 0 !== tempRef) return "$T" + tempRef;
+          if (void 0 !== tempRef) return "$T" + (tempRef[0] === "!" ? tempRef.slice(1) : tempRef);
         }
         tempRef = request.writtenDebugObjects;
         var existingDebugReference = tempRef.get(value);
@@ -3295,7 +3301,7 @@
           ((counter = request.temporaryReferences.get(value)),
           void 0 !== counter)
         )
-          return "$T" + counter;
+          return "$T" + (counter[0] === "!" ? counter.slice(1) : counter);
         counter = request.writtenDebugObjects;
         ref = counter.get(value);
         if (void 0 !== ref) return ref;

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.edge.development.js
@@ -2581,7 +2581,7 @@
           ((elementReference = request.temporaryReferences.get(value)),
           void 0 !== elementReference)
         )
-          return "$T" + elementReference;
+          return "$T" + (elementReference[0] === "!" ? elementReference.slice(1) : elementReference);
         elementReference = request.writtenObjects;
         _writtenObjects = elementReference.get(value);
         if ("function" === typeof value.then) {
@@ -2747,7 +2747,13 @@
           ((request = request.temporaryReferences.get(value)),
           void 0 !== request)
         )
-          return "$T" + request;
+          return (
+            "$T" +
+            (request[0] === "!"
+              ? (globalThis[Symbol.for("next.static.children")] && globalThis[Symbol.for("next.static.children")].has(parent) ? "!" : "") +
+                request.slice(1)
+              : request)
+          );
         if (value.$$typeof === TEMPORARY_REFERENCE_TAG)
           throw Error(
             "Could not reference an opaque temporary reference. This is likely due to misconfiguring the temporaryReferences options on the server."
@@ -3065,7 +3071,7 @@
         }
         if (void 0 !== request.temporaryReferences) {
           var tempRef = request.temporaryReferences.get(value);
-          if (void 0 !== tempRef) return "$T" + tempRef;
+          if (void 0 !== tempRef) return "$T" + (tempRef[0] === "!" ? tempRef.slice(1) : tempRef);
         }
         tempRef = request.writtenDebugObjects;
         var existingDebugReference = tempRef.get(value);
@@ -3365,7 +3371,7 @@
           ((counter = request.temporaryReferences.get(value)),
           void 0 !== counter)
         )
-          return "$T" + counter;
+          return "$T" + (counter[0] === "!" ? counter.slice(1) : counter);
         counter = request.writtenDebugObjects;
         ref = counter.get(value);
         if (void 0 !== ref) return ref;

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
@@ -2858,7 +2858,7 @@
           ((elementReference = request.temporaryReferences.get(value)),
           void 0 !== elementReference)
         )
-          return "$T" + elementReference;
+          return "$T" + (elementReference[0] === "!" ? elementReference.slice(1) : elementReference);
         elementReference = request.writtenObjects;
         _writtenObjects = elementReference.get(value);
         if ("function" === typeof value.then) {
@@ -3024,7 +3024,13 @@
           ((request = request.temporaryReferences.get(value)),
           void 0 !== request)
         )
-          return "$T" + request;
+          return (
+            "$T" +
+            (request[0] === "!"
+              ? (globalThis[Symbol.for("next.static.children")] && globalThis[Symbol.for("next.static.children")].has(parent) ? "!" : "") +
+                request.slice(1)
+              : request)
+          );
         if (value.$$typeof === TEMPORARY_REFERENCE_TAG)
           throw Error(
             "Could not reference an opaque temporary reference. This is likely due to misconfiguring the temporaryReferences options on the server."
@@ -3432,7 +3438,7 @@
         }
         if (void 0 !== request.temporaryReferences) {
           var tempRef = request.temporaryReferences.get(value);
-          if (void 0 !== tempRef) return "$T" + tempRef;
+          if (void 0 !== tempRef) return "$T" + (tempRef[0] === "!" ? tempRef.slice(1) : tempRef);
         }
         tempRef = request.writtenDebugObjects;
         var existingDebugReference = tempRef.get(value);
@@ -3732,7 +3738,7 @@
           ((counter = request.temporaryReferences.get(value)),
           void 0 !== counter)
         )
-          return "$T" + counter;
+          return "$T" + (counter[0] === "!" ? counter.slice(1) : counter);
         counter = request.writtenDebugObjects;
         ref = counter.get(value);
         if (void 0 !== ref) return ref;

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.browser.development.js
@@ -2593,7 +2593,7 @@
           ((elementReference = request.temporaryReferences.get(value)),
           void 0 !== elementReference)
         )
-          return "$T" + elementReference;
+          return "$T" + (elementReference[0] === "!" ? elementReference.slice(1) : elementReference);
         elementReference = TaintRegistryObjects.get(value);
         void 0 !== elementReference && throwTaintViolation(elementReference);
         elementReference = request.writtenObjects;
@@ -2770,7 +2770,13 @@
           ((request = request.temporaryReferences.get(value)),
           void 0 !== request)
         )
-          return "$T" + request;
+          return (
+            "$T" +
+            (request[0] === "!"
+              ? (globalThis[Symbol.for("next.static.children")] && globalThis[Symbol.for("next.static.children")].has(parent) ? "!" : "") +
+                request.slice(1)
+              : request)
+          );
         request = TaintRegistryObjects.get(value);
         void 0 !== request && throwTaintViolation(request);
         if (value.$$typeof === TEMPORARY_REFERENCE_TAG)
@@ -3099,7 +3105,7 @@
         }
         if (void 0 !== request.temporaryReferences) {
           var tempRef = request.temporaryReferences.get(value);
-          if (void 0 !== tempRef) return "$T" + tempRef;
+          if (void 0 !== tempRef) return "$T" + (tempRef[0] === "!" ? tempRef.slice(1) : tempRef);
         }
         tempRef = request.writtenDebugObjects;
         var existingDebugReference = tempRef.get(value);
@@ -3399,7 +3405,7 @@
           ((counter = request.temporaryReferences.get(value)),
           void 0 !== counter)
         )
-          return "$T" + counter;
+          return "$T" + (counter[0] === "!" ? counter.slice(1) : counter);
         counter = request.writtenDebugObjects;
         ref = counter.get(value);
         if (void 0 !== ref) return ref;

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.edge.development.js
@@ -2653,7 +2653,7 @@
           ((elementReference = request.temporaryReferences.get(value)),
           void 0 !== elementReference)
         )
-          return "$T" + elementReference;
+          return "$T" + (elementReference[0] === "!" ? elementReference.slice(1) : elementReference);
         elementReference = TaintRegistryObjects.get(value);
         void 0 !== elementReference && throwTaintViolation(elementReference);
         elementReference = request.writtenObjects;
@@ -2830,7 +2830,13 @@
           ((request = request.temporaryReferences.get(value)),
           void 0 !== request)
         )
-          return "$T" + request;
+          return (
+            "$T" +
+            (request[0] === "!"
+              ? (globalThis[Symbol.for("next.static.children")] && globalThis[Symbol.for("next.static.children")].has(parent) ? "!" : "") +
+                request.slice(1)
+              : request)
+          );
         request = TaintRegistryObjects.get(value);
         void 0 !== request && throwTaintViolation(request);
         if (value.$$typeof === TEMPORARY_REFERENCE_TAG)
@@ -3169,7 +3175,7 @@
         }
         if (void 0 !== request.temporaryReferences) {
           var tempRef = request.temporaryReferences.get(value);
-          if (void 0 !== tempRef) return "$T" + tempRef;
+          if (void 0 !== tempRef) return "$T" + (tempRef[0] === "!" ? tempRef.slice(1) : tempRef);
         }
         tempRef = request.writtenDebugObjects;
         var existingDebugReference = tempRef.get(value);
@@ -3469,7 +3475,7 @@
           ((counter = request.temporaryReferences.get(value)),
           void 0 !== counter)
         )
-          return "$T" + counter;
+          return "$T" + (counter[0] === "!" ? counter.slice(1) : counter);
         counter = request.writtenDebugObjects;
         ref = counter.get(value);
         if (void 0 !== ref) return ref;

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
@@ -2930,7 +2930,7 @@
           ((elementReference = request.temporaryReferences.get(value)),
           void 0 !== elementReference)
         )
-          return "$T" + elementReference;
+          return "$T" + (elementReference[0] === "!" ? elementReference.slice(1) : elementReference);
         elementReference = TaintRegistryObjects.get(value);
         void 0 !== elementReference && throwTaintViolation(elementReference);
         elementReference = request.writtenObjects;
@@ -3107,7 +3107,13 @@
           ((request = request.temporaryReferences.get(value)),
           void 0 !== request)
         )
-          return "$T" + request;
+          return (
+            "$T" +
+            (request[0] === "!"
+              ? (globalThis[Symbol.for("next.static.children")] && globalThis[Symbol.for("next.static.children")].has(parent) ? "!" : "") +
+                request.slice(1)
+              : request)
+          );
         request = TaintRegistryObjects.get(value);
         void 0 !== request && throwTaintViolation(request);
         if (value.$$typeof === TEMPORARY_REFERENCE_TAG)
@@ -3536,7 +3542,7 @@
         }
         if (void 0 !== request.temporaryReferences) {
           var tempRef = request.temporaryReferences.get(value);
-          if (void 0 !== tempRef) return "$T" + tempRef;
+          if (void 0 !== tempRef) return "$T" + (tempRef[0] === "!" ? tempRef.slice(1) : tempRef);
         }
         tempRef = request.writtenDebugObjects;
         var existingDebugReference = tempRef.get(value);
@@ -3836,7 +3842,7 @@
           ((counter = request.temporaryReferences.get(value)),
           void 0 !== counter)
         )
-          return "$T" + counter;
+          return "$T" + (counter[0] === "!" ? counter.slice(1) : counter);
         counter = request.writtenDebugObjects;
         ref = counter.get(value);
         if (void 0 !== ref) return ref;

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.browser.development.js
@@ -2521,7 +2521,7 @@
           ((elementReference = request.temporaryReferences.get(value)),
           void 0 !== elementReference)
         )
-          return "$T" + elementReference;
+          return "$T" + (elementReference[0] === "!" ? elementReference.slice(1) : elementReference);
         elementReference = request.writtenObjects;
         _writtenObjects = elementReference.get(value);
         if ("function" === typeof value.then) {
@@ -2687,7 +2687,13 @@
           ((request = request.temporaryReferences.get(value)),
           void 0 !== request)
         )
-          return "$T" + request;
+          return (
+            "$T" +
+            (request[0] === "!"
+              ? (globalThis[Symbol.for("next.static.children")] && globalThis[Symbol.for("next.static.children")].has(parent) ? "!" : "") +
+                request.slice(1)
+              : request)
+          );
         if (value.$$typeof === TEMPORARY_REFERENCE_TAG)
           throw Error(
             "Could not reference an opaque temporary reference. This is likely due to misconfiguring the temporaryReferences options on the server."
@@ -2995,7 +3001,7 @@
         }
         if (void 0 !== request.temporaryReferences) {
           var tempRef = request.temporaryReferences.get(value);
-          if (void 0 !== tempRef) return "$T" + tempRef;
+          if (void 0 !== tempRef) return "$T" + (tempRef[0] === "!" ? tempRef.slice(1) : tempRef);
         }
         tempRef = request.writtenDebugObjects;
         var existingDebugReference = tempRef.get(value);
@@ -3295,7 +3301,7 @@
           ((counter = request.temporaryReferences.get(value)),
           void 0 !== counter)
         )
-          return "$T" + counter;
+          return "$T" + (counter[0] === "!" ? counter.slice(1) : counter);
         counter = request.writtenDebugObjects;
         ref = counter.get(value);
         if (void 0 !== ref) return ref;

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.edge.development.js
@@ -2581,7 +2581,7 @@
           ((elementReference = request.temporaryReferences.get(value)),
           void 0 !== elementReference)
         )
-          return "$T" + elementReference;
+          return "$T" + (elementReference[0] === "!" ? elementReference.slice(1) : elementReference);
         elementReference = request.writtenObjects;
         _writtenObjects = elementReference.get(value);
         if ("function" === typeof value.then) {
@@ -2747,7 +2747,13 @@
           ((request = request.temporaryReferences.get(value)),
           void 0 !== request)
         )
-          return "$T" + request;
+          return (
+            "$T" +
+            (request[0] === "!"
+              ? (globalThis[Symbol.for("next.static.children")] && globalThis[Symbol.for("next.static.children")].has(parent) ? "!" : "") +
+                request.slice(1)
+              : request)
+          );
         if (value.$$typeof === TEMPORARY_REFERENCE_TAG)
           throw Error(
             "Could not reference an opaque temporary reference. This is likely due to misconfiguring the temporaryReferences options on the server."
@@ -3065,7 +3071,7 @@
         }
         if (void 0 !== request.temporaryReferences) {
           var tempRef = request.temporaryReferences.get(value);
-          if (void 0 !== tempRef) return "$T" + tempRef;
+          if (void 0 !== tempRef) return "$T" + (tempRef[0] === "!" ? tempRef.slice(1) : tempRef);
         }
         tempRef = request.writtenDebugObjects;
         var existingDebugReference = tempRef.get(value);
@@ -3365,7 +3371,7 @@
           ((counter = request.temporaryReferences.get(value)),
           void 0 !== counter)
         )
-          return "$T" + counter;
+          return "$T" + (counter[0] === "!" ? counter.slice(1) : counter);
         counter = request.writtenDebugObjects;
         ref = counter.get(value);
         if (void 0 !== ref) return ref;

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
@@ -2858,7 +2858,7 @@
           ((elementReference = request.temporaryReferences.get(value)),
           void 0 !== elementReference)
         )
-          return "$T" + elementReference;
+          return "$T" + (elementReference[0] === "!" ? elementReference.slice(1) : elementReference);
         elementReference = request.writtenObjects;
         _writtenObjects = elementReference.get(value);
         if ("function" === typeof value.then) {
@@ -3024,7 +3024,13 @@
           ((request = request.temporaryReferences.get(value)),
           void 0 !== request)
         )
-          return "$T" + request;
+          return (
+            "$T" +
+            (request[0] === "!"
+              ? (globalThis[Symbol.for("next.static.children")] && globalThis[Symbol.for("next.static.children")].has(parent) ? "!" : "") +
+                request.slice(1)
+              : request)
+          );
         if (value.$$typeof === TEMPORARY_REFERENCE_TAG)
           throw Error(
             "Could not reference an opaque temporary reference. This is likely due to misconfiguring the temporaryReferences options on the server."
@@ -3432,7 +3438,7 @@
         }
         if (void 0 !== request.temporaryReferences) {
           var tempRef = request.temporaryReferences.get(value);
-          if (void 0 !== tempRef) return "$T" + tempRef;
+          if (void 0 !== tempRef) return "$T" + (tempRef[0] === "!" ? tempRef.slice(1) : tempRef);
         }
         tempRef = request.writtenDebugObjects;
         var existingDebugReference = tempRef.get(value);
@@ -3732,7 +3738,7 @@
           ((counter = request.temporaryReferences.get(value)),
           void 0 !== counter)
         )
-          return "$T" + counter;
+          return "$T" + (counter[0] === "!" ? counter.slice(1) : counter);
         counter = request.writtenDebugObjects;
         ref = counter.get(value);
         if (void 0 !== ref) return ref;

--- a/packages/next/src/compiled/react/cjs/react-jsx-dev-runtime.react-server.development.js
+++ b/packages/next/src/compiled/react/cjs/react-jsx-dev-runtime.react-server.development.js
@@ -213,6 +213,7 @@
               isStaticChildren++
             )
               validateChildKeys(children[isStaticChildren]);
+            (globalThis[Symbol.for("next.static.children")] || (globalThis[Symbol.for("next.static.children")] = new WeakSet())).add(children);
             Object.freeze && Object.freeze(children);
           } else
             console.error(

--- a/packages/next/src/compiled/react/cjs/react-jsx-runtime.react-server.development.js
+++ b/packages/next/src/compiled/react/cjs/react-jsx-runtime.react-server.development.js
@@ -213,6 +213,7 @@
               isStaticChildren++
             )
               validateChildKeys(children[isStaticChildren]);
+            (globalThis[Symbol.for("next.static.children")] || (globalThis[Symbol.for("next.static.children")] = new WeakSet())).add(children);
             Object.freeze && Object.freeze(children);
           } else
             console.error(

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -1,4 +1,5 @@
 import type { DeepReadonly } from '../../shared/lib/deep-readonly'
+import { isValidElement } from 'react'
 /* eslint-disable import/no-extraneous-dependencies */
 import {
   renderToReadableStream,
@@ -113,6 +114,74 @@ import {
 import * as Log from '../../build/output/log'
 import { getServerReact, getClientReact } from '../runtime-reacts.external'
 import { createPromiseWithResolvers } from '../../shared/lib/promise-with-resolvers'
+
+const USE_CACHE_TEMPORARY_REFERENCE_PREFIX = '!'
+const VALIDATED_TEMPORARY_REFERENCE_PREFIX = '$!'
+
+/**
+ * Opts this temporary reference set into preserving React's static child key
+ * validation across the private Flight stream used by `use cache`.
+ *
+ * The vendored Flight server recognizes the prefix and removes it before
+ * serializing the reference. If the reference is inside a static JSX children
+ * array, it replaces the prefix with a validation marker for the client set.
+ */
+function createUseCacheServerTemporaryReferenceSet() {
+  const temporaryReferences = createServerTemporaryReferenceSet()
+
+  if (process.env.NODE_ENV === 'development') {
+    const getTemporaryReference =
+      temporaryReferences.get.bind(temporaryReferences)
+
+    temporaryReferences.get = (reference) => {
+      const id = getTemporaryReference(reference)
+      return id === undefined
+        ? undefined
+        : USE_CACHE_TEMPORARY_REFERENCE_PREFIX + id
+    }
+  }
+
+  return temporaryReferences
+}
+
+/**
+ * Restores React's static child key validation on JSX elements that crossed
+ * the private `use cache` Flight boundary as temporary references.
+ */
+function createUseCacheClientTemporaryReferenceSet() {
+  const temporaryReferences = createClientTemporaryReferenceSet()
+
+  if (process.env.NODE_ENV === 'development') {
+    const getTemporaryReference =
+      temporaryReferences.get.bind(temporaryReferences)
+
+    temporaryReferences.get = (reference) => {
+      const wasValidated = reference.startsWith(
+        VALIDATED_TEMPORARY_REFERENCE_PREFIX
+      )
+      const normalizedReference = wasValidated
+        ? '$' + reference.slice(VALIDATED_TEMPORARY_REFERENCE_PREFIX.length)
+        : reference
+      const value = getTemporaryReference(normalizedReference)
+
+      if (wasValidated && isValidElement(value)) {
+        const store = (
+          value as typeof value & {
+            _store?: { validated: number }
+          }
+        )._store
+
+        if (store) {
+          store.validated = 1
+        }
+      }
+
+      return value
+    }
+  }
+
+  return temporaryReferences
+}
 
 interface PrivateCacheContext {
   readonly kind: 'private'
@@ -1283,7 +1352,7 @@ async function generateCacheEntryImpl(
   timeoutError: UseCacheTimeoutError,
   deadlockError: UseCacheDeadlockError | undefined
 ): Promise<GenerateCacheEntryResult> {
-  const temporaryReferences = createServerTemporaryReferenceSet()
+  const temporaryReferences = createUseCacheServerTemporaryReferenceSet()
   const outerWorkUnitStore = cacheContext.outerWorkUnitStore
 
   const [, , args] =
@@ -2141,7 +2210,7 @@ export async function cache(
     args.unshift(boundArgs)
   }
 
-  const temporaryReferences = createClientTemporaryReferenceSet()
+  const temporaryReferences = createUseCacheClientTemporaryReferenceSet()
 
   // The base serialized cache key doesn't include the cookies or headers that
   // private caches are allowed to read. In production this is because private

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1521,6 +1521,70 @@ export async function copy_vendor_react(task_) {
         )
     }
 
+    const staticChildrenSet = 'globalThis[Symbol.for("next.static.children")]'
+
+    function markReactStaticChildren(source) {
+      const original = 'Object.freeze && Object.freeze(children);'
+      const replacement = `(${staticChildrenSet} || (${staticChildrenSet} = new WeakSet())).add(children);
+            ${original}`
+
+      if (source.split(original).length !== 2) {
+        throw new Error(
+          'Expected exactly one static children array freeze in the React development JSX runtime bundle.'
+        )
+      }
+
+      return source.replace(original, replacement)
+    }
+
+    function forwardUseCacheStaticChildValidation(source) {
+      const original = 'return "$T" + request;'
+      const replacement = `return (
+            "$T" +
+            (request[0] === "!"
+              ? (${staticChildrenSet} && ${staticChildrenSet}.has(parent) ? "!" : "") +
+                request.slice(1)
+              : request)
+          );`
+
+      if (source.split(original).length !== 2) {
+        throw new Error(
+          'Expected exactly one temporary function reference serialization in the React development server bundle.'
+        )
+      }
+
+      return source.replace(original, replacement)
+    }
+
+    function normalizeUseCacheTemporaryReferenceIds(source) {
+      const replacements = [
+        [
+          'return "$T" + elementReference;',
+          'return "$T" + (elementReference[0] === "!" ? elementReference.slice(1) : elementReference);',
+        ],
+        [
+          'if (void 0 !== tempRef) return "$T" + tempRef;',
+          'if (void 0 !== tempRef) return "$T" + (tempRef[0] === "!" ? tempRef.slice(1) : tempRef);',
+        ],
+        [
+          'return "$T" + counter;',
+          'return "$T" + (counter[0] === "!" ? counter.slice(1) : counter);',
+        ],
+      ]
+
+      for (const [original, replacement] of replacements) {
+        if (source.split(original).length !== 2) {
+          throw new Error(
+            'Expected exactly one additional temporary reference serialization in the React development server bundle.'
+          )
+        }
+
+        source = source.replace(original, replacement)
+      }
+
+      return source
+    }
+
     const schedulerDir = dirname(
       relative(__dirname, require.resolve(`scheduler-${channel}/package.json`))
     )
@@ -1563,7 +1627,16 @@ export async function copy_vendor_react(task_) {
       .source(join(reactDir, 'cjs/**/*.{js,map}'))
       // eslint-disable-next-line require-yield
       .run({ every: true }, function* (file) {
-        const source = file.data.toString()
+        let source = file.data.toString()
+
+        if (
+          (file.base.startsWith('react-jsx-runtime.') ||
+            file.base.startsWith('react-jsx-dev-runtime.')) &&
+          file.base.endsWith('.react-server.development.js')
+        ) {
+          source = markReactStaticChildren(source)
+        }
+
         // We replace the module/chunk loading code with our own implementation in Next.js.
         file.data = aliasVendoredReactPackages(source)
       })
@@ -1684,6 +1757,17 @@ export async function copy_vendor_react(task_) {
       )
       // eslint-disable-next-line require-yield
       .run({ every: true }, function* (file) {
+        let source = file.data.toString()
+
+        if (
+          file.base.includes('-server.') &&
+          file.base.endsWith('.development.js')
+        ) {
+          source = forwardUseCacheStaticChildValidation(source)
+          source = normalizeUseCacheTemporaryReferenceIds(source)
+          file.data = source
+        }
+
         // We replace the module/chunk loading code with our own implementation in Next.js.
         // NOTE: We only replace module/chunk loading for server builds because the server
         // bundles have unique constraints like a runtime bundle. For browser builds this
@@ -1696,7 +1780,6 @@ export async function copy_vendor_react(task_) {
             !file.base.startsWith('react-server-dom-webpack-server.browser'))
         ) {
           const filepath = file.dir + '/' + file.base
-          const source = file.data.toString()
           const ast = parseFile(source, { sourceFileName: filepath })
           replaceIdentifiersInAst(
             ast,
@@ -1738,6 +1821,17 @@ export async function copy_vendor_react(task_) {
       )
       // eslint-disable-next-line require-yield
       .run({ every: true }, function* (file) {
+        let source = file.data.toString()
+
+        if (
+          file.base.includes('-server.') &&
+          file.base.endsWith('.development.js')
+        ) {
+          source = forwardUseCacheStaticChildValidation(source)
+          source = normalizeUseCacheTemporaryReferenceIds(source)
+          file.data = source
+        }
+
         // We replace the module loading code with our own implementation in Next.js.
         // NOTE: We only replace module loading for server builds because the server
         // bundles have unique constraints like a runtime bundle. For browser builds this
@@ -1749,7 +1843,6 @@ export async function copy_vendor_react(task_) {
             file.base.startsWith('react-server-dom-turbopack-server')) &&
           !file.base.includes('.browser.')
         ) {
-          const source = file.data.toString()
           const filepath = file.dir + '/' + file.base
           const ast = parseFile(source, { sourceFileName: filepath })
 

--- a/test/development/app-dir/use-cache-jsx-key-warning/app/layout.tsx
+++ b/test/development/app-dir/use-cache-jsx-key-warning/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/use-cache-jsx-key-warning/app/nested-unkeyed-list/page.tsx
+++ b/test/development/app-dir/use-cache-jsx-key-warning/app/nested-unkeyed-list/page.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react'
+
+let cacheFillCount = 0
+
+function RuntimeList({
+  first,
+  second,
+  fillCount,
+}: {
+  first: ReactNode
+  second: ReactNode
+  fillCount: number
+}) {
+  const items = Object.freeze([first, second])
+
+  return (
+    <section id="nested-unkeyed-list" data-cache-fill-count={fillCount}>
+      {items}
+    </section>
+  )
+}
+
+async function CachedList({
+  first,
+  second,
+}: {
+  first: ReactNode
+  second: ReactNode
+}) {
+  'use cache'
+
+  cacheFillCount++
+
+  return (
+    <RuntimeList first={first} second={second} fillCount={cacheFillCount} />
+  )
+}
+
+export default function Page() {
+  return (
+    <CachedList
+      first={<article>nested first item</article>}
+      second={<article>nested second item</article>}
+    />
+  )
+}

--- a/test/development/app-dir/use-cache-jsx-key-warning/app/nested/page.tsx
+++ b/test/development/app-dir/use-cache-jsx-key-warning/app/nested/page.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react'
+
+function SlotContainer({
+  navigation,
+  content,
+}: {
+  navigation: ReactNode
+  content: ReactNode
+}) {
+  return (
+    <section id="nested-cached-shell">
+      {navigation}
+      {content}
+    </section>
+  )
+}
+
+async function CachedShell({
+  navigation,
+  content,
+}: {
+  navigation: ReactNode
+  content: ReactNode
+}) {
+  'use cache'
+
+  return <SlotContainer navigation={navigation} content={content} />
+}
+
+export default function Page() {
+  return (
+    <CachedShell
+      navigation={<nav>nested navigation slot</nav>}
+      content={<main>nested content slot</main>}
+    />
+  )
+}

--- a/test/development/app-dir/use-cache-jsx-key-warning/app/page.tsx
+++ b/test/development/app-dir/use-cache-jsx-key-warning/app/page.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react'
+
+let cacheFillCount = 0
+
+async function CachedShell({
+  navigation,
+  content,
+}: {
+  navigation: ReactNode
+  content: ReactNode
+}) {
+  'use cache'
+
+  cacheFillCount++
+
+  return (
+    <section id="cached-shell" data-cache-fill-count={cacheFillCount}>
+      {navigation}
+      {content}
+    </section>
+  )
+}
+
+export default function Page() {
+  return (
+    <CachedShell
+      navigation={<nav>navigation slot</nav>}
+      content={<main>content slot</main>}
+    />
+  )
+}

--- a/test/development/app-dir/use-cache-jsx-key-warning/app/unkeyed-list/page.tsx
+++ b/test/development/app-dir/use-cache-jsx-key-warning/app/unkeyed-list/page.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react'
+
+let cacheFillCount = 0
+
+async function CachedList({
+  first,
+  second,
+}: {
+  first: ReactNode
+  second: ReactNode
+}) {
+  'use cache'
+
+  cacheFillCount++
+
+  const items = Object.freeze([first, second])
+
+  return (
+    <section id="unkeyed-list" data-cache-fill-count={cacheFillCount}>
+      {items}
+    </section>
+  )
+}
+
+export default function Page() {
+  return (
+    <CachedList
+      first={<article>first item</article>}
+      second={<article>second item</article>}
+    />
+  )
+}

--- a/test/development/app-dir/use-cache-jsx-key-warning/next.config.js
+++ b/test/development/app-dir/use-cache-jsx-key-warning/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/use-cache-jsx-key-warning/use-cache-jsx-key-warning.test.ts
+++ b/test/development/app-dir/use-cache-jsx-key-warning/use-cache-jsx-key-warning.test.ts
@@ -1,0 +1,107 @@
+import { nextTestSetup } from 'e2e-utils'
+
+const keyWarning = 'Each child in a list should have a unique "key" prop.'
+
+describe('use-cache-jsx-key-warning', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  async function captureKeyWarnings(pathname: string, markerId?: string) {
+    const outputIndex = next.cliOutput.length
+    const browser = await next.browser(pathname, {
+      disableBrowserLog: true,
+    })
+
+    await browser.eval(
+      'new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))'
+    )
+
+    const browserWarnings = (await browser.log()).filter((log) =>
+      log.message.includes(keyWarning)
+    )
+    const terminalWarnings = next.cliOutput
+      .slice(outputIndex)
+      .split('\n')
+      .filter((line) => line.includes(keyWarning))
+    const renderedText = await browser.eval('document.body.textContent')
+    const cacheFillCount = markerId
+      ? await browser.eval(
+          `document.getElementById(${JSON.stringify(markerId)})?.getAttribute('data-cache-fill-count')`
+        )
+      : null
+
+    await browser.close()
+
+    return {
+      browserWarnings,
+      terminalWarnings,
+      renderedText,
+      cacheFillCount,
+    }
+  }
+
+  it('does not warn for multiple pass-through JSX slots on misses or hits', async () => {
+    const first = await captureKeyWarnings('/', 'cached-shell')
+    const second = await captureKeyWarnings('/', 'cached-shell')
+
+    expect(first.browserWarnings).toEqual([])
+    expect(first.terminalWarnings).toEqual([])
+    expect(second.browserWarnings).toEqual([])
+    expect(second.terminalWarnings).toEqual([])
+    expect(first.renderedText).toContain('navigation slot')
+    expect(first.renderedText).toContain('content slot')
+    expect(second.renderedText).toContain('navigation slot')
+    expect(second.renderedText).toContain('content slot')
+    expect(first.cacheFillCount).not.toBeNull()
+    expect(second.cacheFillCount).toBe(first.cacheFillCount)
+  })
+
+  it('does not warn when a nested Server Component renders the slots', async () => {
+    const { browserWarnings, terminalWarnings, renderedText } =
+      await captureKeyWarnings('/nested')
+
+    expect(browserWarnings).toEqual([])
+    expect(terminalWarnings).toEqual([])
+    expect(renderedText).toContain('nested navigation slot')
+    expect(renderedText).toContain('nested content slot')
+  })
+
+  it('still warns for a frozen unkeyed list on cache misses and hits', async () => {
+    const first = await captureKeyWarnings('/unkeyed-list', 'unkeyed-list')
+    const second = await captureKeyWarnings('/unkeyed-list', 'unkeyed-list')
+
+    expect(
+      first.browserWarnings.length + first.terminalWarnings.length
+    ).toBeGreaterThan(0)
+    expect(
+      second.browserWarnings.length + second.terminalWarnings.length
+    ).toBeGreaterThan(0)
+    expect(first.cacheFillCount).not.toBeNull()
+    expect(second.cacheFillCount).toBe(first.cacheFillCount)
+  })
+
+  it('still warns when a nested component creates the frozen unkeyed list', async () => {
+    const first = await captureKeyWarnings(
+      '/nested-unkeyed-list',
+      'nested-unkeyed-list'
+    )
+    const second = await captureKeyWarnings(
+      '/nested-unkeyed-list',
+      'nested-unkeyed-list'
+    )
+
+    expect(
+      first.browserWarnings.length + first.terminalWarnings.length
+    ).toBeGreaterThan(0)
+    expect(
+      second.browserWarnings.length + second.terminalWarnings.length
+    ).toBeGreaterThan(0)
+    expect(first.renderedText).toContain('nested first item')
+    expect(first.renderedText).toContain('nested second item')
+    expect(second.renderedText).toContain('nested first item')
+    expect(second.renderedText).toContain('nested second item')
+    expect(first.cacheFillCount).not.toBeNull()
+    expect(second.cacheFillCount).toBe(first.cacheFillCount)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #97047

- preserve React's static-child key validation when JSX slots pass through a `use cache` temporary reference
- normalize the private marker in React's separate development debug-model serialization paths
- keep genuine missing-key warnings for runtime-created lists, including frozen arrays
- update stable and experimental React vendored outputs for Webpack and Turbopack

## Verification

- `CI=1 pnpm build-all`
- `pnpm test-dev-turbo test/development/app-dir/use-cache-jsx-key-warning/use-cache-jsx-key-warning.test.ts`
- `pnpm test-dev-webpack test/development/app-dir/use-cache-jsx-key-warning/use-cache-jsx-key-warning.test.ts`
- `pnpm exec prettier --check packages/next/src/server/use-cache/use-cache-wrapper.ts packages/next/taskfile.js test/development/app-dir/use-cache-jsx-key-warning`
- `pnpm lint-eslint packages/next/src/server/use-cache/use-cache-wrapper.ts packages/next/taskfile.js test/development/app-dir/use-cache-jsx-key-warning`
- `git diff --check`

<!-- NEXT_JS_LLM -->
