### PR TITLE
[ci] Fix backport canary release dispatch

### DIFF
--- a/.github/workflows/sync_backport_canary_release.yml
+++ b/.github/workflows/sync_backport_canary_release.yml
@@ -121,20 +121,14 @@ jobs:
     needs: evaluate
     if: ${{ needs.evaluate.outputs.should_dispatch == 'true' && ((github.event_name == 'workflow_dispatch' && inputs.dispatch) || (github.event_name == 'workflow_run' && vars.ENABLE_BACKPORT_CANARY_SYNC == 'true')) }}
     runs-on: ubuntu-latest
-    steps:
-      - name: Create GitHub App token
-        id: release-app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.RELEASE_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: next.js
-          permission-actions: write
+    permissions:
+      actions: write
 
+    steps:
       - uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
-          github-token: ${{ steps.release-app-token.outputs.token }}
+          # workflow_dispatch events created with GITHUB_TOKEN start workflow runs.
+          github-token: ${{ github.token }}
           script: |
             await github.request(
               "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",


### PR DESCRIPTION
## Summary

- Use the job-scoped `GITHUB_TOKEN` with explicit `actions: write` permission to dispatch `trigger_release.yml` after a stable backport.
- Avoid requesting Actions write access from the release GitHub App, which currently prevents the dispatch token from being created.
- Preserve the existing forced preminor canary release behavior.

This fixes the failure that left canary semver-behind stable after the `v16.3.1` backport. The evaluation succeeded, but the dispatch failed while creating the App token in the [failing dispatch job](https://github.com/vercel/next.js/actions/runs/31750536217/job/94615208366).

## Verification
https://github.com/vercel/next.js/actions/runs/31830288265/job/94864091005
```
should_dispatch=true
reason=Dispatching canary preminor release because stable release 16.3.1 is ahead of 16.3.1-canary.17
released_version=16.3.1
current_canary_version=16.3.1-canary.17
dispatch_input=false
auto_dispatch_enabled=true
```