### PR TITLE
Adopt SelectedMetadata for metadata rendering

### DIFF
--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -5,13 +5,12 @@ import type { LoaderTree } from '../../server/lib/app-dir-module'
 import type { SearchParams } from '../../server/request/search-params'
 import {
   type MetadataErrorType,
+  type SelectedMetadata,
+  createSelectedMetadata,
   resolveMetadata,
   resolveViewport,
 } from './resolve-metadata'
-import type {
-  ResolvedMetadata,
-  ResolvedViewport,
-} from './types/metadata-interface'
+import type { ResolvedViewport } from './types/metadata-interface'
 import { isHTTPAccessFallbackError } from '../../client/components/http-access-fallback/http-access-fallback'
 import type { MetadataContext } from './types/resolvers'
 import { createServerSearchParamsForMetadata } from '../../server/request/search-params'
@@ -249,7 +248,7 @@ async function renderMetadata(
     interpolatedParams,
     metadataContext
   )
-  return <>{createMetadataElements(resolvedMetadata)}</>
+  return <>{createMetadataElements(createSelectedMetadata(resolvedMetadata))}</>
 }
 
 async function renderViewport(
@@ -344,14 +343,14 @@ function createViewportElements(
 // ---------------------------------------------------------------------------
 
 function createMetadataElements(
-  metadata: ResolvedMetadata
+  metadata: SelectedMetadata
 ): React.ReactElement[] {
   const tags: React.ReactElement[] = []
   let i = 0
 
   // --- Title ---
-  if (metadata.title !== null && metadata.title.absolute) {
-    tags.push(<title key={i++}>{metadata.title.absolute}</title>)
+  if (metadata.title) {
+    tags.push(<title key={i++}>{metadata.title}</title>)
   }
 
   // --- Basic meta tags ---
@@ -735,10 +734,8 @@ function createMetadataElements(
         <meta key={i++} property="og:determiner" content={og.determiner} />
       )
     }
-    if (og.title?.absolute) {
-      tags.push(
-        <meta key={i++} property="og:title" content={og.title.absolute} />
-      )
+    if (og.title) {
+      tags.push(<meta key={i++} property="og:title" content={og.title} />)
     }
     if (og.description) {
       tags.push(
@@ -1446,10 +1443,8 @@ function createMetadataElements(
         <meta key={i++} name="twitter:creator:id" content={tw.creatorId} />
       )
     }
-    if (tw.title?.absolute) {
-      tags.push(
-        <meta key={i++} name="twitter:title" content={tw.title.absolute} />
-      )
+    if (tw.title) {
+      tags.push(<meta key={i++} name="twitter:title" content={tw.title} />)
     }
     if (tw.description) {
       tags.push(

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -93,6 +93,32 @@ export type MetadataItems = Array<
 
 export type ViewportItems = Array<Viewport | ViewportResolver | null>
 
+type WithSelectedTitle<T> = T extends { title: AbsoluteTemplateString }
+  ? Omit<T, 'title'> & { title: string }
+  : T
+
+/**
+ * Metadata that has finished route-level resolution and post-processing. It
+ * contains only values that can be turned into metadata elements; it is never
+ * used as the parent of another metadata resolver.
+ */
+export type SelectedMetadata = Omit<
+  ResolvedMetadata,
+  | 'metadataBase'
+  | 'title'
+  | 'openGraph'
+  | 'twitter'
+  | 'themeColor'
+  | 'colorScheme'
+  | 'viewport'
+> & {
+  title: string | null
+  openGraph: WithSelectedTitle<
+    NonNullable<ResolvedMetadata['openGraph']>
+  > | null
+  twitter: WithSelectedTitle<NonNullable<ResolvedMetadata['twitter']>> | null
+}
+
 type TitleTemplates = {
   title: string | null
   twitter: string | null
@@ -1020,6 +1046,37 @@ function postProcessMetadata(
   }
 
   return metadata
+}
+
+export function createSelectedMetadata(
+  metadata: ResolvedMetadata
+): SelectedMetadata {
+  const {
+    metadataBase,
+    title,
+    openGraph,
+    twitter,
+    themeColor,
+    colorScheme,
+    viewport,
+    ...metadataTagFields
+  } = metadata
+
+  // These fields are only used while resolving metadata, or are rendered by
+  // the separate viewport pipeline.
+  void metadataBase
+  void themeColor
+  void colorScheme
+  void viewport
+
+  return {
+    ...metadataTagFields,
+    title: title?.absolute || null,
+    openGraph: openGraph
+      ? { ...openGraph, title: openGraph.title.absolute }
+      : null,
+    twitter: twitter ? { ...twitter, title: twitter.title.absolute } : null,
+  }
 }
 
 type Result<T> = null | T | Promise<null | T> | PromiseLike<null | T>


### PR DESCRIPTION
The metadata resolver currently passes ResolvedMetadata directly to tag rendering even though several fields only exist to carry state between route layers.

Introduce SelectedMetadata as the post-processed, tag-ready representation and convert the current resolved output before rendering. This makes the final selection boundary explicit without changing generated tags, preparing the metadata pipeline for multiple independently resolved branches.

<!-- NEXT_JS_LLM -->
