### PR TITLE
fix(use-cache): avoid retaining composite AbortSignal after prerender…

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -1386,32 +1386,67 @@ async function generateCacheEntryImpl(
       const dynamicAccessAbortSignal =
         dynamicAccessAsyncStorage.getStore()?.abortController.signal
 
-      const abortSignal = dynamicAccessAbortSignal
-        ? AbortSignal.any([
-            dynamicAccessAbortSignal,
-            timeoutAbortController.signal,
-          ])
-        : timeoutAbortController.signal
+      // `prerender` attaches an abort listener to the signal we hand it. Node
+      // pins an `AbortSignal.any` composite in its global `gcPersistentSignals`
+      // set for as long as any listener is attached, so a composite would keep
+      // the whole cached render alive after it finishes. Own the signal instead
+      // and forward the two sources through listeners we can remove once the
+      // render settles.
+      const abortController = new AbortController()
+      const abortSignal = abortController.signal
 
-      const { prelude } = await prerender(
-        resultPromise,
-        clientReferenceManifest.clientModules,
-        {
-          environmentName: 'Cache',
-          filterStackFrame,
-          signal: abortSignal,
-          temporaryReferences,
-          onError(error) {
-            if (abortSignal.aborted && abortSignal.reason === error) {
-              return undefined
-            }
+      const onTimeoutAbort = () => {
+        abortController.abort(timeoutAbortController.signal.reason)
+      }
+      timeoutAbortController.signal.addEventListener('abort', onTimeoutAbort)
 
-            return handleError(error)
-          },
+      let onDynamicAccessAbort: (() => void) | undefined
+      if (dynamicAccessAbortSignal) {
+        onDynamicAccessAbort = () => {
+          abortController.abort(dynamicAccessAbortSignal.reason)
         }
-      )
+        dynamicAccessAbortSignal.addEventListener('abort', onDynamicAccessAbort)
+        // A composite also aborts immediately when a source is already aborted
+        // at creation time.
+        if (dynamicAccessAbortSignal.aborted) {
+          abortController.abort(dynamicAccessAbortSignal.reason)
+        }
+      }
 
-      clearTimeout(timer)
+      let prelude: ReadableStream<Uint8Array>
+      try {
+        prelude = (
+          await prerender(
+            resultPromise,
+            clientReferenceManifest.clientModules,
+            {
+              environmentName: 'Cache',
+              filterStackFrame,
+              signal: abortSignal,
+              temporaryReferences,
+              onError(error) {
+                if (abortSignal.aborted && abortSignal.reason === error) {
+                  return undefined
+                }
+
+                return handleError(error)
+              },
+            }
+          )
+        ).prelude
+      } finally {
+        clearTimeout(timer)
+        timeoutAbortController.signal.removeEventListener(
+          'abort',
+          onTimeoutAbort
+        )
+        if (dynamicAccessAbortSignal && onDynamicAccessAbort) {
+          dynamicAccessAbortSignal.removeEventListener(
+            'abort',
+            onDynamicAccessAbort
+          )
+        }
+      }
 
       if (timeoutAbortController.signal.aborted) {
         // When the timeout is reached we always error the stream. Even for


### PR DESCRIPTION
### What?

prerender was receiving a composite AbortSignal that could retain completed cached renders after the render had finished.

This change gives the prerender operation an owned AbortController and forwards aborts from the timeout and dynamic access signals to it, avoiding the need to monkey-patch AbortSignal methods.

### Why?

AbortSignal.any can retain its composite signal while listeners remain attached. Since prerender attaches an abort listener to the signal it receives, the composite signal could keep the completed cached render reachable after prerendering finished, resulting in memory retention.

### How?

Create a dedicated AbortController for the prerender operation and forward aborts from the timeout and dynamic access signals:

```ts
const abortController = new AbortController()
const abortSignal = abortController.signal

const onTimeoutAbort = () => {
  abortController.abort(timeoutAbortController.signal.reason)
}

timeoutAbortController.signal.addEventListener('abort', onTimeoutAbort)
```

The dynamic access abort signal is handled in the same way. Once prerendering finishes, the forwarding listeners are removed in the finally block so the signals can be released cleanly.

This keeps the existing abort behaviour while avoiding monkey-patching and explicitly managing the lifecycle of the signal used by prerender.



### Testing
You can create a `.tgz` file from the Next.js repo by simply going to the `packages/next` directory and running:

```bash
pnpm run build
or
pnpm run build
or
yarn build
```

And once the build has finished, you need to run:

```bash
pnpm pack
```

Then clone this repo: `https://github.com/devopsaptlife/nextjs-prerender-abort-retention`, and from the root directory of the repo, run:

```bash
1. pnpm install
2. pnpm build
3. node --expose-gc --inspect=127.0.0.1:9231 --require ./preload-any.cjs .next/standalone/server.js &
for i in $(seq 1 40); do curl -s -o /dev/null "http://localhost:3000/p/f-$i"; done
4. node check-composites.mjs
```

And you will see:

```bash
composites created: 2   STILL ALIVE after GC: 2 
```
or
```bash
composites created: 1   STILL ALIVE after GC: 1 
```

which means GC doesn't collect the composite cause is still alive

```bash
2. rm -rf .next # delete .next folder cache
2. pnpm remove next
3. pnpm add YOUR_LOCAL_NEXT_JS_FOLDER_PATH/packages/next/next-16.3.1-canary.17.tgz
4. pnpm run build
5. node --expose-gc --inspect=127.0.0.1:9231 --require ./preload-any.cjs .next/standalone/server.js &
for i in $(seq 1 40); do curl -s -o /dev/null "http://localhost:3000/p/f-$i"; done
6. node check-composites.mjs
```

And you should see:

```bash
composites created: 1   STILL ALIVE after GC: 0
```


Fixes [#97363](https://github.com/vercel/next.js/issues/97363)