### PR TITLE
Turbopack: Split the read and write codepath data structures for symlinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10260,6 +10260,7 @@ dependencies = [
  "turbo-unix-path",
  "url",
  "urlencoding",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -361,6 +361,7 @@ unsize = "1.1.0"
 unty = "0.0.4"
 url = "2.2.2"
 urlencoding = "2.1.2"
+windows-sys = "0.60"
 uuid = "1.18.1"
 vergen = { version = "9.0.6", features = ["cargo"] }
 vergen-gitcl = { version = "1.0.8", features = ["cargo"] }

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -285,22 +285,14 @@ async fn assets_diff(
                 ),
             }
         }
-        (
-            AssetContent::Redirect {
-                target: target1,
-                link_type: link_type1,
-            },
-            AssetContent::Redirect {
-                target: target2,
-                link_type: link_type2,
-            },
-        ) => {
-            if target1 == target2 && link_type1 == link_type2 {
+        (AssetContent::Redirect(content1), AssetContent::Redirect(content2)) => {
+            if content1.target == content2.target && content1.target_type == content2.target_type {
                 None
             } else {
                 Some(format!(
-                    "assets at the same path are both redirects but point to different targets: \
-                     {target1} vs {target2}"
+                    "assets at the same path are both redirects but disagree: {:?} ({:?}) vs {:?} \
+                     ({:?})",
+                    content1.target, content1.target_type, content2.target, content2.target_type,
                 ))
             }
         }

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -58,9 +58,11 @@ use turbo_tasks::{
     unmark_top_level_task_may_leak_eventually_consistent_state,
 };
 use turbo_tasks_backend::db_invalidation::invalidation_reasons;
+#[cfg(windows)]
+use turbo_tasks_fs::windows::to_verbatim_with_case_folded_disk;
 use turbo_tasks_fs::{
     DiskFileSystem, FileContent, FileSystem, FileSystemPath, canonicalize_to_rcstr, invalidation,
-    to_verbatim_with_case_folded_disk, util::uri_from_file,
+    util::uri_from_file,
 };
 use turbo_unix_path::{get_relative_path_to, unix_to_sys};
 use turbopack_core::{
@@ -2385,9 +2387,12 @@ fn parse_and_canonicalize_source_url(source_url: &str) -> Result<(RcStr, Option<
         Err(_) => {
             // The file may not exist (e.g. a stale stack frame). Fall back to a purely lexical
             // normalization that approximates the canonical format.
-            if cfg!(windows) {
+            #[cfg(windows)]
+            {
                 to_verbatim_with_case_folded_disk(&path).unwrap_or(path)
-            } else {
+            }
+            #[cfg(not(windows))]
+            {
                 path
             }
         }

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -59,6 +59,11 @@ urlencoding = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 omnipath = "0.1.6"
+windows-sys = { workspace = true, features = [
+  "Win32_Foundation",
+  "Win32_Storage_FileSystem",
+  "Win32_System_SystemServices",
+] }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
@@ -68,4 +73,3 @@ sha2 = { workspace = true }
 tempfile = { workspace = true }
 turbo-tasks-testing = { workspace = true }
 turbo-tasks-backend = { workspace = true }
-

--- a/turbopack/crates/turbo-tasks-fs/src/content.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/content.rs
@@ -214,14 +214,18 @@ impl LinkTarget {
 pub enum LinkContent {
     /// A valid symbolic link pointing to `target`.
     Link { target: LinkTarget },
-    /// There is no file at this path.
-    NotFound,
-    /// There is no usable symbolic link at this path or some other error occurred.
+    /// The link itself does not exist at the path given to [`FileSystemPath::read_link`].
     ///
-    /// A relative target that steps out of the root and back into it is `Invalid`, since resolving
-    /// it would need the names of the root's own ancestors, which a root-relative path doesn't
-    /// carry.
-    Invalid,
+    /// This says nothing about whether the link's target exists: a dangling link is still
+    /// returned as [`LinkContent::Link`].
+    NotFound,
+    /// The link could not be read.
+    ///
+    /// This includes all I/O errors other than `NotFound`, denied paths, and targets that leave the
+    /// filesystem root. A relative target that steps out of the root and back into it is also
+    /// invalid, since resolving it would need the names of the root's own ancestors, which a
+    /// root-relative path doesn't carry.
+    Invalid { reason: RcStr },
 }
 
 #[turbo_tasks::value_impl]
@@ -246,7 +250,7 @@ impl LinkContent {
                 LinkTarget::Relative { raw, resolved: _ } => SimplifiedLinkContent::Relative(&raw),
             },
             LinkContent::NotFound => SimplifiedLinkContent::NotFound,
-            LinkContent::Invalid => SimplifiedLinkContent::Invalid,
+            LinkContent::Invalid { reason: _ } => SimplifiedLinkContent::Invalid,
         };
         Ok(Vc::cell(RcStr::from(deterministic_hash(
             &salt.await?,

--- a/turbopack/crates/turbo-tasks-fs/src/content.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/content.rs
@@ -224,6 +224,38 @@ pub enum LinkContent {
     Invalid,
 }
 
+#[turbo_tasks::value_impl]
+impl LinkContent {
+    /// Hashes the link itself (its target and type), not the content of whatever the link points
+    /// at. This mirrors [`FileContent::hash`] and is the right content hash for consumers that
+    /// re-create a symlink as a symlink instead of copying the resolved file.
+    #[turbo_tasks::function]
+    pub async fn hash(&self, salt: Vc<RcStr>, algorithm: HashAlgorithm) -> Result<Vc<RcStr>> {
+        #[derive(DeterministicHash)]
+        enum SimplifiedLinkContent<'a> {
+            Absolute(&'a RcStr),
+            Relative(&'a RcStr),
+            NotFound,
+            Invalid, // the actual error message doesn't matter for this API
+        }
+        let simplified = match self {
+            LinkContent::Link { target } => match target {
+                LinkTarget::Absolute { resolved } => {
+                    SimplifiedLinkContent::Absolute(&resolved.path)
+                }
+                LinkTarget::Relative { raw, resolved: _ } => SimplifiedLinkContent::Relative(&raw),
+            },
+            LinkContent::NotFound => SimplifiedLinkContent::NotFound,
+            LinkContent::Invalid => SimplifiedLinkContent::Invalid,
+        };
+        Ok(Vc::cell(RcStr::from(deterministic_hash(
+            &salt.await?,
+            simplified,
+            algorithm,
+        ))))
+    }
+}
+
 /// The target of a symbolic link to create, used by [`WriteLinkContent`].
 ///
 /// Unlike [`LinkTarget`] this carries only the raw path: the write side never needs the target
@@ -261,21 +293,6 @@ pub enum WriteLinkTargetType {
 pub struct WriteLinkContent {
     pub target: WriteLinkTarget,
     pub target_type: WriteLinkTargetType,
-}
-
-#[turbo_tasks::value_impl]
-impl LinkContent {
-    /// Hashes the link itself (its target and type), not the content of whatever the link points
-    /// at. This mirrors [`FileContent::hash`] and is the right content hash for consumers that
-    /// re-create a symlink as a symlink instead of copying the resolved file.
-    #[turbo_tasks::function]
-    pub async fn hash(&self, salt: Vc<RcStr>, algorithm: HashAlgorithm) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(RcStr::from(deterministic_hash(
-            &salt.await?,
-            self,
-            algorithm,
-        ))))
-    }
 }
 
 #[turbo_tasks::value(shared)]

--- a/turbopack/crates/turbo-tasks-fs/src/content.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/content.rs
@@ -10,7 +10,6 @@ use std::{
 
 use anyhow::{Result, bail};
 use bincode::{Decode, Encode};
-use bitflags::bitflags;
 use jsonc_parser::{ParseOptions, parse_to_serde_value};
 use mime::Mime;
 use serde_json::Value;
@@ -21,6 +20,7 @@ use turbo_tasks_hash::{
 };
 
 use crate::{
+    FileSystemEntryType, FileSystemPath,
     json::UnparsableJson,
     retry::retry_blocking,
     rope::{Rope, RopeReader},
@@ -163,47 +163,104 @@ pub(crate) enum FileComparison {
     NotEqual,
 }
 
-bitflags! {
-  #[derive(
-    Default,
-    TraceRawVcs,
-    NonLocalValue,
-    DeterministicHash,
-    Encode,
-    Decode,
-  )]
-  pub struct LinkType: u8 {
-      const DIRECTORY = 0b00000001;
-      const ABSOLUTE = 0b00000010;
-  }
+/// The target of a symbolic link, as read from a filesystem.
+///
+/// Every variant carries the `resolved` path the link points at, computed once by
+/// [`crate::FileSystem::read_link`], which is also what guarantees the target stays inside the
+/// filesystem root — a link whose target leaves the root is [`LinkContent::Invalid`] instead.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, TraceRawVcs, NonLocalValue, Encode, Decode)]
+pub enum LinkTarget {
+    /// The link is an absolute path on disk.
+    Absolute { resolved: FileSystemPath },
+    Relative {
+        /// The value read from the link. The path is lexically converted to a [unix-style
+        /// path][turbo_unix_path::sys_to_unix], but it may contain `..` relative to the *directory
+        /// containing the link*.
+        raw: RcStr,
+        /// The link target relative the a `DiskFileSystem` root.
+        resolved: FileSystemPath,
+    },
 }
 
-/// The contents of a symbolic link. On Windows, this may be a junction point.
+impl LinkTarget {
+    /// The path this link points at.
+    pub fn file_system_path(&self) -> &FileSystemPath {
+        match self {
+            LinkTarget::Absolute { resolved } | LinkTarget::Relative { resolved, .. } => resolved,
+        }
+    }
+
+    /// The type of the file this link points at.
+    ///
+    /// This only follows a single link: if the target is itself a symbolic link, this returns
+    /// [`FileSystemEntryType::Symlink`]. Use [`FileSystemPath::realpath`] to follow a chain of
+    /// links.
+    ///
+    /// A dangling link returns [`FileSystemEntryType::NotFound`].
+    pub async fn target_type(&self) -> Result<FileSystemEntryType> {
+        Ok(*self.file_system_path().get_type().await?)
+    }
+}
+
+/// The contents of a symbolic link, as read from a filesystem. On Windows, this may be a junction
+/// point.
 ///
-/// When reading, we treat symbolic links and junction points on Windows as equivalent. When
-/// creating a new link, we always create junction points, because symlink creation may fail if
-/// Windows "developer mode" is not enabled and we're running in an unprivileged environment.
+/// We treat symbolic links and junction points on Windows as equivalent when reading.
+///
+/// This describes the link itself and never the type of the file it points at. Use
+/// [`LinkTarget::target_type`] if you need the type of the target.
 #[turbo_tasks::value(shared)]
-#[derive(Debug, DeterministicHash)]
+#[derive(Debug)]
 pub enum LinkContent {
-    /// A valid symbolic link pointing to `target`, a unix-style path.
-    ///
-    /// If [`LinkType::ABSOLUTE`] is set, `target` is normalized and relative to the *filesystem
-    /// root* (so that absolute system paths never end up in the persistent cache). Otherwise,
-    /// `target` is the raw value read from the link — unnormalized, may contain `..` — and is
-    /// relative to the *directory containing the link*.
-    ///
-    /// A relative `target` must stay raw so that [`FileSystem::write_link`] round-trips it
-    /// exactly: the value is written verbatim and compared against [`std::fs::read_link`] to
-    /// skip unchanged links.
-    Link {
-        target: RcStr,
-        link_type: LinkType,
-    },
-    // Invalid means the link is invalid it points out of the filesystem root
-    Invalid,
-    // The target was not found
+    /// A valid symbolic link pointing to `target`.
+    Link { target: LinkTarget },
+    /// There is no file at this path.
     NotFound,
+    /// There is no usable symbolic link at this path or some other error occurred.
+    ///
+    /// A relative target that steps out of the root and back into it is `Invalid`, since resolving
+    /// it would need the names of the root's own ancestors, which a root-relative path doesn't
+    /// carry.
+    Invalid,
+}
+
+/// The target of a symbolic link to create, used by [`WriteLinkContent`].
+///
+/// Unlike [`LinkTarget`] this carries only the raw path: the write side never needs the target
+/// resolved, and the link being created may not even exist yet.
+#[derive(
+    Clone, Debug, Hash, PartialEq, Eq, TraceRawVcs, NonLocalValue, DeterministicHash, Encode, Decode,
+)]
+pub enum WriteLinkTarget {
+    /// Normalized and relative to the *filesystem root*.
+    Absolute(RcStr),
+    /// Written verbatim, relative to the *directory containing the link*.
+    Relative(RcStr),
+}
+
+/// The file type of the target of a newly written link. This value is only used on Windows.
+#[derive(
+    Clone, Debug, Hash, PartialEq, Eq, TraceRawVcs, NonLocalValue, DeterministicHash, Encode, Decode,
+)]
+pub enum WriteLinkTargetType {
+    /// Represents a link to a file or a symbolic link that is not a junction point. This is likely
+    /// to fail on Windows, where symbolic links are not enabled by default.
+    FileNonPortable,
+    /// Represents a link to a directory. On Windows, this may also be a link to a junction point.
+    DirectoryOrJunctionPoint,
+}
+
+/// The symbolic link to create at a path, passed to [`FileSystemPath::write_link`].
+///
+/// This is separate from [`LinkContent`] because writing needs to know whether the target is a
+/// directory, while reading a link does not: on Windows we always create junction points for
+/// directories, because symlink creation may fail if "developer mode" is not enabled and we're
+/// running in an unprivileged environment.
+#[turbo_tasks::value(shared)]
+#[derive(Clone, Debug, DeterministicHash)]
+pub struct WriteLinkContent {
+    pub target: WriteLinkTarget,
+    pub target_type: WriteLinkTargetType,
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbo-tasks-fs/src/content.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/content.rs
@@ -247,7 +247,7 @@ impl LinkContent {
                 LinkTarget::Absolute { resolved } => {
                     SimplifiedLinkContent::Absolute(&resolved.path)
                 }
-                LinkTarget::Relative { raw, resolved: _ } => SimplifiedLinkContent::Relative(&raw),
+                LinkTarget::Relative { raw, resolved: _ } => SimplifiedLinkContent::Relative(raw),
             },
             LinkContent::NotFound => SimplifiedLinkContent::NotFound,
             LinkContent::Invalid { reason: _ } => SimplifiedLinkContent::Invalid,

--- a/turbopack/crates/turbo-tasks-fs/src/disk.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/disk.rs
@@ -7,7 +7,7 @@ use std::{
     future::Future,
     io::{self, ErrorKind, Write as _},
     mem::take,
-    path::{Component, MAIN_SEPARATOR, Path, PathBuf},
+    path::{Component, MAIN_SEPARATOR, Path, PathBuf, Prefix},
     sync::{Arc, LazyLock, Weak},
 };
 
@@ -910,7 +910,7 @@ impl FileSystem for DiskFileSystem {
         inner.register_read_invalidator(&full_link_path).await?;
 
         let _lock = inner.lock_path(full_link_path.clone()).await;
-        let target_sys_path = match retry_blocking(|| std::fs::read_link(&**full_link_path))
+        let mut target_sys_path = match retry_blocking(|| std::fs::read_link(&**full_link_path))
             .instrument(tracing::info_span!("read symlink", name = ?full_link_path))
             .concurrency_limited(&inner.read_semaphore)
             .await
@@ -926,6 +926,14 @@ impl FileSystem for DiskFileSystem {
                 .cell());
             }
         };
+
+        if cfg!(windows) && target_sys_path.has_root() && !target_sys_path.is_absolute() {
+            // On windows, `\foo` has a root but no drive and is not absolute. Just convert it to
+            // absolute and treat it like it's absolute.
+            let mut absolute_target = inner.root_path().to_path_buf();
+            absolute_target.push(target_sys_path);
+            target_sys_path = absolute_target;
+        }
 
         let target = if target_sys_path.is_absolute() {
             // First try a cheap, purely lexical conversion of the raw target. `relative_to` is
@@ -958,20 +966,36 @@ impl FileSystem for DiskFileSystem {
                 resolved: target_fs_path,
             }
         } else {
-            // A Windows target can be partially qualified: `\foo` has a root but no drive and
-            // `C:foo` has a drive but no root, so neither is `is_absolute()`, yet neither is
-            // relative to the link's directory either. Joining one onto that directory would
-            // silently produce a plausible but wrong in-root path.
-            if target_sys_path.has_root()
-                || matches!(
-                    target_sys_path.components().next(),
-                    Some(Component::Prefix(_))
-                )
+            if cfg!(windows)
+                && let Some(Component::Prefix(target_prefix)) = target_sys_path.components().next()
             {
-                return Ok(LinkContent::Invalid {
-                    reason: rcstr!("the symlink target is not a fully qualified or relative path"),
+                // Edge case: Windows supports relative file paths with a prefixed disk, e.g.
+                // `C:foo`. These only make sense when the drive letter matches the
+                // DiskFileSystem root. If it matches, we can safely strip it.
+                let Prefix::Disk(target_drive) = target_prefix.kind() else {
+                    unreachable!(
+                        "path is relative, but contains a prefix that should form an absolute path"
+                    );
+                };
+                let root_drive = match inner.root_path().components().next() {
+                    Some(Component::Prefix(root_prefix)) => match root_prefix.kind() {
+                        Prefix::Disk(drive) | Prefix::VerbatimDisk(drive) => Some(drive),
+                        _ => None,
+                    },
+                    _ => None,
+                };
+                if root_drive
+                    .is_none_or(|root_drive| !target_drive.eq_ignore_ascii_case(&root_drive))
+                {
+                    return Ok(LinkContent::Invalid {
+                        reason: rcstr!(
+                            "the symlink target uses a different drive than the filesystem root"
+                        ),
+                    }
+                    .cell());
                 }
-                .cell());
+
+                target_sys_path = target_sys_path.components().skip(1).collect();
             }
 
             // The raw value read from the link, converted to a unix-style format. A relative
@@ -1881,7 +1905,7 @@ mod tests {
                 assert!(
                     matches!(
                         &result.path_result,
-                        Err(RealPathResultError::Invalid(reason))
+                        Err(RealPathResultError::Invalid { reason })
                             if reason == "a symlink target does not exist"
                     ),
                     "realpath must report the missing target as an invalid chain: {:?}",
@@ -1901,7 +1925,7 @@ mod tests {
                 assert!(
                     matches!(
                         &result.path_result,
-                        Err(RealPathResultError::Invalid(reason))
+                        Err(RealPathResultError::Invalid { reason })
                             if reason == "a symlink target does not exist"
                     ),
                     "realpath must report a missing target later in a chain as invalid: {:?}",

--- a/turbopack/crates/turbo-tasks-fs/src/disk.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/disk.rs
@@ -7,11 +7,11 @@ use std::{
     future::Future,
     io::{self, ErrorKind, Write as _},
     mem::take,
-    path::{MAIN_SEPARATOR, Path, PathBuf},
+    path::{Component, MAIN_SEPARATOR, Path, PathBuf},
     sync::{Arc, LazyLock, Weak},
 };
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use bincode::{Decode, Encode};
 #[cfg(windows)]
@@ -32,10 +32,12 @@ use turbo_tasks::{
 use turbo_tasks_hash::{hash_xxh3_hash64, hash_xxh3_hash128};
 use turbo_unix_path::{normalize_path, sys_to_unix, unix_to_sys};
 
+#[cfg(windows)]
+use crate::windows::{is_link_junction_point, to_verbatim_with_case_folded_disk};
 use crate::{
-    AnyhowWrapper, File, FileComparison, FileContent, FileMeta, FileSystem, FileSystemEntryType,
-    FileSystemPath, LinkContent, LinkType, PersistedFileContent, RawDirectoryContent,
-    RawDirectoryEntry,
+    AnyhowWrapper, File, FileComparison, FileContent, FileMeta, FileSystem, FileSystemPath,
+    LinkContent, LinkTarget, PersistedFileContent, RawDirectoryContent, RawDirectoryEntry,
+    WriteLinkContent, WriteLinkTarget, WriteLinkTargetType,
     invalidation::Write,
     invalidator_map::InvalidatorMap,
     mutex_map::MutexMap,
@@ -537,8 +539,7 @@ impl DiskFileSystem {
             // Unlike `std::fs::canonicalize`, this is a purely lexical operation: it does not
             // resolve symlinks or 8.3 short name format.
             #[cfg(windows)]
-            let normalized_sys_path =
-                crate::windows::to_verbatim_with_case_folded_disk(sys_path).ok()?;
+            let normalized_sys_path = to_verbatim_with_case_folded_disk(sys_path).ok()?;
 
             normalized_sys_path
                 .strip_prefix(self.inner.root_path())
@@ -899,7 +900,7 @@ impl FileSystem for DiskFileSystem {
         let this = self.await?;
         let inner = &this.inner;
         if inner.is_path_denied(&fs_path) {
-            return Ok(LinkContent::NotFound.cell());
+            return Ok(LinkContent::Invalid.cell());
         }
         let full_link_path = Arc::new(this.to_sys_path_raw(&fs_path));
 
@@ -912,55 +913,95 @@ impl FileSystem for DiskFileSystem {
             .await
         {
             Ok(res) => res,
-            Err(_) => return Ok(LinkContent::NotFound.cell()),
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                return Ok(LinkContent::NotFound.cell());
+            }
+            // The path doesn't exist or isn't a symbolic link.
+            Err(_) => return Ok(LinkContent::Invalid.cell()),
         };
 
-        // A relative symlink target is resolved relative to the directory *containing* the link,
-        // not the link path itself, so pass the parent as `relative_to`. (For absolute targets
-        // `try_from_sys_path` ignores `relative_to`.)
-        let link_parent = fs_path.parent();
-        // First try a cheap, purely lexical conversion of the raw target.
-        let mut target_fs_path = this.try_from_sys_path(self, &target_sys_path, Some(&link_parent));
+        let target = if target_sys_path.is_absolute() {
+            // First try a cheap, purely lexical conversion of the raw target. `relative_to` is
+            // ignored for absolute targets.
+            let mut target_fs_path = this.try_from_sys_path(self, &target_sys_path, None);
 
-        // If the lexical try_from_sys_path failed for an absolute target, the target may just be
-        // spelled differently than our canonicalized filesystem root (e.g. case insensitive
-        // filesystem, a Windows 8.3 short name, or a symlink in the path). This performs
-        // session-dependent IO to resolve the fs root path.
-        if target_fs_path.is_none() && target_sys_path.is_absolute() {
-            target_fs_path = this
-                .resolve_link_target_ancestry_slow_path(self, &target_sys_path)
-                .await?;
-        }
+            // If that failed, the target may just be spelled differently than our canonicalized
+            // filesystem root (e.g. case insensitive filesystem, a Windows 8.3 short name, or a
+            // symlink in the path). This performs session-dependent IO to resolve the fs root
+            // path.
+            if target_fs_path.is_none() {
+                target_fs_path = this
+                    .resolve_link_target_ancestry_slow_path(self, &target_sys_path)
+                    .await?;
+            }
 
-        let Some(target_fs_path) = target_fs_path else {
-            // The target leaves the filesystem root (or is a dangling link whose parent directory
-            // couldn't be canonicalized).
-            return Ok(LinkContent::Invalid.cell());
-        };
-
-        let mut link_type = LinkType::default();
-        // TODO(bgw): Reading the type here is silly, the callers could do it.
-        // The reason `LinkContent` contains the type information is just for the `write_link`
-        // codepath, which needs to know if it can create a Windows junction point or not.
-        let file_type = target_fs_path.get_type().await?;
-        if matches!(&*file_type, FileSystemEntryType::Directory) {
-            link_type |= LinkType::DIRECTORY;
-        }
-
-        let target;
-        if target_sys_path.is_absolute() {
-            // absolute path, rewrite from the sys root to the DiskFileSystem root
-            target = target_fs_path.path;
-            link_type |= LinkType::ABSOLUTE;
+            let Some(target_fs_path) = target_fs_path else {
+                // The target leaves the filesystem root (or is a dangling link whose parent
+                // directory couldn't be canonicalized).
+                return Ok(LinkContent::Invalid.cell());
+            };
+            // Rewrite from the sys root to the DiskFileSystem root.
+            LinkTarget::Absolute {
+                resolved: target_fs_path,
+            }
         } else {
-            // link-relative, the raw value read from the link, converted to a unix-style format
+            // A Windows target can be partially qualified: `\foo` has a root but no drive and
+            // `C:foo` has a drive but no root, so neither is `is_absolute()`, yet neither is
+            // relative to the link's directory either. Joining one onto that directory would
+            // silently produce a plausible but wrong in-root path.
+            if target_sys_path.has_root()
+                || matches!(
+                    target_sys_path.components().next(),
+                    Some(Component::Prefix(_))
+                )
+            {
+                return Ok(LinkContent::Invalid.cell());
+            }
+
+            // The raw value read from the link, converted to a unix-style format. A relative
+            // target is resolved against the directory *containing* the link, not the link itself.
             let target_str = target_sys_path.to_str().with_context(|| {
                 format!("symlink target {target_sys_path:?} is not valid unicode")
             })?;
-            target = RcStr::from(sys_to_unix(target_str));
+            let raw = RcStr::from(sys_to_unix(target_str));
+
+            // Require the target to stay within the filesystem root at every step, not just at
+            // the end. A target like `../../<root dir name>/foo` steps out of the root and back
+            // in; resolving that needs the names of the root's own ancestors, which a
+            // root-relative `FileSystemPath` doesn't carry. Rejecting it here is what lets
+            // `LinkTarget` carry a resolved path at all.
+            let Some(resolved) = fs_path.parent().try_join(&raw) else {
+                return Ok(LinkContent::Invalid.cell());
+            };
+            LinkTarget::Relative { raw, resolved }
         };
 
-        Ok(LinkContent::Link { target, link_type }.cell())
+        Ok(LinkContent::Link { target }.cell())
+    }
+
+    #[turbo_tasks::function(fs, session_dependent)]
+    async fn is_junction_point(&self, fs_path: FileSystemPath) -> Result<Vc<bool>> {
+        #[cfg(windows)]
+        {
+            if self.inner.is_path_denied(&fs_path) {
+                return Ok(Vc::cell(false));
+            }
+            let full_path = Arc::new(self.to_sys_path_raw(&fs_path));
+            self.inner.register_read_invalidator(&full_path).await?;
+
+            let _lock = self.inner.lock_path(full_path.clone()).await;
+            let is_junction_point = retry_blocking(|| is_link_junction_point(&full_path))
+                .instrument(tracing::info_span!("read junction point", name = ?full_path))
+                .concurrency_limited(&self.inner.read_semaphore)
+                .await
+                .with_context(|| format!("checking junction point {full_path:?}"))?;
+            Ok(Vc::cell(is_junction_point))
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = fs_path;
+            Ok(Vc::cell(false))
+        }
     }
 
     #[turbo_tasks::function(fs)]
@@ -1185,7 +1226,7 @@ impl FileSystem for DiskFileSystem {
     async fn write_link(
         self: ResolvedVc<Self>,
         fs_path: FileSystemPath,
-        target: ResolvedVc<LinkContent>,
+        target: ResolvedVc<WriteLinkContent>,
     ) -> Result<()> {
         // You might be tempted to use `session_dependent` here, but we purely declare a side
         // effect and does not need to be re-executed in the next session. All side effects are
@@ -1206,7 +1247,7 @@ impl FileSystem for DiskFileSystem {
         struct WriteLinkEffect {
             full_path: Arc<PathBuf>,
             fs: ResolvedVc<DiskFileSystem>,
-            target: ResolvedVc<LinkContent>,
+            target: ResolvedVc<WriteLinkContent>,
             content_hash: u128,
         }
 
@@ -1242,7 +1283,7 @@ impl FileSystem for DiskFileSystem {
         struct CapturedWriteLinkEffect {
             full_path: Arc<PathBuf>,
             inner: Arc<DiskFileSystemInner>,
-            content: Option<ReadRef<LinkContent>>,
+            content: Option<ReadRef<WriteLinkContent>>,
             content_hash: u128,
         }
 
@@ -1268,46 +1309,33 @@ impl FileSystem for DiskFileSystem {
         }
 
         impl CapturedWriteLinkEffect {
-            async fn apply_inner(&self, content: &ReadRef<LinkContent>) -> anyhow::Result<()> {
+            async fn apply_inner(&self, content: &ReadRef<WriteLinkContent>) -> anyhow::Result<()> {
                 let full_path = self.full_path.clone();
 
                 let _lock = self.inner.lock_path(full_path.clone()).await;
 
-                enum OsSpecificLinkContent {
-                    Link {
-                        #[cfg(windows)]
-                        is_directory: bool,
-                        target: PathBuf,
-                    },
-                    NotFound,
-                    Invalid,
-                }
-
-                let os_specific_link_content = match &**content {
-                    LinkContent::Link { target, link_type } => {
-                        let is_directory = link_type.contains(LinkType::DIRECTORY);
-                        let target_path = if link_type.contains(LinkType::ABSOLUTE) {
-                            self.inner.root_path().join(unix_to_sys(target).as_ref())
+                let WriteLinkContent {
+                    target,
+                    target_type,
+                } = &**content;
+                let is_directory =
+                    matches!(target_type, WriteLinkTargetType::DirectoryOrJunctionPoint);
+                let target = match target {
+                    WriteLinkTarget::Absolute(target) => {
+                        self.inner.root_path().join(unix_to_sys(target).as_ref())
+                    }
+                    WriteLinkTarget::Relative(target) => {
+                        let relative_target = PathBuf::from(unix_to_sys(target).as_ref());
+                        if cfg!(windows) && is_directory {
+                            // Windows junction points must always be stored as absolute
+                            full_path
+                                .parent()
+                                .unwrap_or(&full_path)
+                                .join(relative_target)
                         } else {
-                            let relative_target = PathBuf::from(unix_to_sys(target).as_ref());
-                            if cfg!(windows) && is_directory {
-                                // Windows junction points must always be stored as absolute
-                                full_path
-                                    .parent()
-                                    .unwrap_or(&full_path)
-                                    .join(relative_target)
-                            } else {
-                                relative_target
-                            }
-                        };
-                        OsSpecificLinkContent::Link {
-                            #[cfg(windows)]
-                            is_directory,
-                            target: target_path,
+                            relative_target
                         }
                     }
-                    LinkContent::Invalid => OsSpecificLinkContent::Invalid,
-                    LinkContent::NotFound => OsSpecificLinkContent::NotFound,
                 };
 
                 let old_content = match retry_blocking(|| std::fs::read_link(&**full_path))
@@ -1318,134 +1346,119 @@ impl FileSystem for DiskFileSystem {
                     Ok(res) => Some((res.is_absolute(), res)),
                     Err(_) => None,
                 };
-                let is_equal = match (&os_specific_link_content, &old_content) {
-                    (
-                        OsSpecificLinkContent::Link { target, .. },
-                        Some((old_is_absolute, old_target)),
-                    ) => target == old_target && target.is_absolute() == *old_is_absolute,
-                    (OsSpecificLinkContent::NotFound, None) => true,
-                    _ => false,
+                #[cfg(not(windows))]
+                let is_equal = match &old_content {
+                    Some((old_is_absolute, old_target)) => {
+                        target == *old_target && target.is_absolute() == *old_is_absolute
+                    }
+                    None => false,
+                };
+                #[cfg(windows)]
+                let is_equal = match &old_content {
+                    Some((old_is_absolute, old_target)) => {
+                        target == *old_target
+                            && target.is_absolute() == *old_is_absolute
+                            && is_link_junction_point(&full_path).ok() == Some(is_directory)
+                    }
+                    None => false,
                 };
                 if is_equal {
                     return Ok(());
                 }
 
-                match os_specific_link_content {
-                    OsSpecificLinkContent::Link {
-                        target,
-                        #[cfg(windows)]
-                        is_directory,
-                        ..
-                    } => {
-                        #[derive(thiserror::Error, Debug)]
-                        #[error("{msg}: {source}")]
-                        struct SymlinkCreationError {
-                            msg: &'static str,
-                            #[source]
-                            source: io::Error,
-                        }
-
-                        let mut missing_parent_dir = false;
-                        let mut has_old_content = old_content.is_some();
-                        let try_create_link = || {
-                            if missing_parent_dir && let Some(parent) = full_path.parent() {
-                                std::fs::create_dir_all(parent).map_err(|err| {
-                                    SymlinkCreationError {
-                                        msg: "failed to create directory",
-                                        source: err,
-                                    }
-                                })?;
-                                missing_parent_dir = false;
-                            }
-                            if has_old_content {
-                                // Remove existing symlink before creating a new one. On Unix,
-                                // symlink(2) fails with EEXIST if the link already exists instead
-                                // of overwriting it. Windows has similar behavior with junction
-                                // points.
-                                remove_symbolic_link_dir_helper(&full_path).map_err(|err| {
-                                    SymlinkCreationError {
-                                        msg: "removal of existing symbolic link or junction point \
-                                              failed",
-                                        source: err,
-                                    }
-                                })?;
-                                has_old_content = false;
-                            }
-                            #[cfg(not(windows))]
-                            let io_result = std::os::unix::fs::symlink(&target, &**full_path);
-                            #[cfg(windows)]
-                            let io_result = if is_directory {
-                                std::os::windows::fs::junction_point(&target, &**full_path)
-                            } else {
-                                std::os::windows::fs::symlink_file(&target, &**full_path)
-                            };
-                            io_result.map_err(|err| {
-                                match err.kind() {
-                                    ErrorKind::NotFound => {
-                                        // create the parent dirs in the next attempt
-                                        missing_parent_dir = true;
-                                    }
-                                    ErrorKind::AlreadyExists => {
-                                        // try to remove the symlink on the next attempt
-                                        has_old_content = true;
-                                    }
-                                    _ => {}
-                                }
-                                SymlinkCreationError {
-                                    msg: "creation of a new symbolic link or junction point failed",
-                                    source: err,
-                                }
-                            })
-                        };
-                        fn can_retry_link(err: &SymlinkCreationError) -> bool {
-                            matches!(
-                                err.source.kind(),
-                                ErrorKind::NotFound | ErrorKind::AlreadyExists
-                            ) || can_retry(&err.source)
-                        }
-                        let err_context = || {
-                            #[cfg(not(windows))]
-                            let message = format!(
-                                "failed to create symlink at {full_path:?} pointing to {target:?}"
-                            );
-                            #[cfg(windows)]
-                            let message = if is_directory {
-                                format!(
-                                    "failed to create junction point at {full_path:?} pointing to \
-                                     {target:?}"
-                                )
-                            } else {
-                                format!(
-                                    "failed to create symlink at {full_path:?} pointing to \
-                                     {target:?}\n\
-                                    (Note: creating file symlinks on Windows require developer \
-                                     mode or admin permissions: \
-                                     https://learn.microsoft.com/en-us/windows/advanced-settings/developer-mode)",
-                                )
-                            };
-                            message
-                        };
-                        retry_blocking_custom(try_create_link, can_retry_link)
-                            .instrument(tracing::info_span!(
-                                "write symlink",
-                                name = ?full_path,
-                                target = ?target,
-                            ))
-                            .concurrency_limited(&self.inner.write_semaphore)
-                            .await
-                            .with_context(err_context)?;
-                    }
-                    OsSpecificLinkContent::Invalid => {
-                        bail!("invalid symlink target: {full_path:?}");
-                    }
-                    OsSpecificLinkContent::NotFound => {
-                        retry_blocking(|| remove_symbolic_link_dir_helper(&full_path))
-                            .instrument(tracing::info_span!("remove symlink", name = ?full_path))
-                            .concurrency_limited(&self.inner.write_semaphore)
-                            .await
-                            .with_context(|| format!("removing {full_path:?} failed"))?;
-                    }
+                #[derive(thiserror::Error, Debug)]
+                #[error("{msg}: {source}")]
+                struct SymlinkCreationError {
+                    msg: &'static str,
+                    #[source]
+                    source: io::Error,
                 }
+
+                let mut missing_parent_dir = false;
+                let mut has_old_content = old_content.is_some();
+                let try_create_link = || {
+                    if missing_parent_dir && let Some(parent) = full_path.parent() {
+                        std::fs::create_dir_all(parent).map_err(|err| SymlinkCreationError {
+                            msg: "failed to create directory",
+                            source: err,
+                        })?;
+                        missing_parent_dir = false;
+                    }
+                    if has_old_content {
+                        // Remove existing symlink before creating a new one. On Unix,
+                        // symlink(2) fails with EEXIST if the link already exists instead
+                        // of overwriting it. Windows has similar behavior with junction
+                        // points.
+                        remove_symbolic_link_dir_helper(&full_path).map_err(|err| {
+                            SymlinkCreationError {
+                                msg: "removal of existing symbolic link or junction point failed",
+                                source: err,
+                            }
+                        })?;
+                        has_old_content = false;
+                    }
+                    #[cfg(not(windows))]
+                    let io_result = std::os::unix::fs::symlink(&target, &**full_path);
+                    #[cfg(windows)]
+                    let io_result = if is_directory {
+                        std::os::windows::fs::junction_point(&target, &**full_path)
+                    } else {
+                        std::os::windows::fs::symlink_file(&target, &**full_path)
+                    };
+                    io_result.map_err(|err| {
+                        match err.kind() {
+                            ErrorKind::NotFound => {
+                                // create the parent dirs in the next attempt
+                                missing_parent_dir = true;
+                            }
+                            ErrorKind::AlreadyExists => {
+                                // try to remove the symlink on the next attempt
+                                has_old_content = true;
+                            }
+                            _ => {}
+                        }
+                        SymlinkCreationError {
+                            msg: "creation of a new symbolic link or junction point failed",
+                            source: err,
+                        }
+                    })
+                };
+                fn can_retry_link(err: &SymlinkCreationError) -> bool {
+                    matches!(
+                        err.source.kind(),
+                        ErrorKind::NotFound | ErrorKind::AlreadyExists
+                    ) || can_retry(&err.source)
+                }
+                let err_context = || {
+                    #[cfg(not(windows))]
+                    let message =
+                        format!("failed to create symlink at {full_path:?} pointing to {target:?}");
+                    #[cfg(windows)]
+                    let message = if is_directory {
+                        format!(
+                            "failed to create junction point at {full_path:?} pointing to \
+                             {target:?}"
+                        )
+                    } else {
+                        format!(
+                            "failed to create symlink at {full_path:?} pointing to \
+                             {target:?}\n\
+                            (Note: creating file symlinks on Windows require developer \
+                             mode or admin permissions: \
+                             https://learn.microsoft.com/en-us/windows/advanced-settings/developer-mode)",
+                        )
+                    };
+                    message
+                };
+                retry_blocking_custom(try_create_link, can_retry_link)
+                    .instrument(tracing::info_span!(
+                        "write symlink",
+                        name = ?full_path,
+                        target = ?target,
+                    ))
+                    .concurrency_limited(&self.inner.write_semaphore)
+                    .await
+                    .with_context(err_context)?;
 
                 // Invalidate any read tasks tracking this path so they re-read the new content
                 self.inner.invalidate_from_write(&self.full_path);
@@ -1657,8 +1670,9 @@ mod tests {
 
         use super::extract_effects_operation;
         use crate::{
-            DiskFileSystem, FileSystem, FileSystemPath, LinkContent, LinkType,
-            canonicalize_to_rcstr,
+            DiskFileSystem, FileSystem, FileSystemEntryType, FileSystemPath, LinkContent,
+            LinkTarget, RealPathResultError, WriteLinkContent, WriteLinkTarget,
+            WriteLinkTargetType, canonicalize_to_rcstr,
         };
 
         #[turbo_tasks::function(operation, root)]
@@ -1670,9 +1684,9 @@ mod tests {
             let write_file = |f| {
                 fs.write_link(
                     f,
-                    LinkContent::Link {
-                        target: format!("{target}/data.txt").into(),
-                        link_type: LinkType::empty(),
+                    WriteLinkContent {
+                        target: WriteLinkTarget::Relative(format!("{target}/data.txt").into()),
+                        target_type: WriteLinkTargetType::FileNonPortable,
                     }
                     .cell(),
                 )
@@ -1684,9 +1698,9 @@ mod tests {
             let write_dir = |f| {
                 fs.write_link(
                     f,
-                    LinkContent::Link {
-                        target: target.clone(),
-                        link_type: LinkType::DIRECTORY,
+                    WriteLinkContent {
+                        target: WriteLinkTarget::Relative(target.clone()),
+                        target_type: WriteLinkTargetType::DirectoryOrJunctionPoint,
                     }
                     .cell(),
                 )
@@ -1779,8 +1793,10 @@ mod tests {
             assert_eq!(
                 *sibling,
                 LinkContent::Link {
-                    target: rcstr!("foo.txt"),
-                    link_type: LinkType::empty(),
+                    target: LinkTarget::Relative {
+                        raw: rcstr!("foo.txt"),
+                        resolved: root_path.join("sub/foo.txt")?,
+                    },
                 }
             );
 
@@ -1789,12 +1805,199 @@ mod tests {
             assert_eq!(
                 *parent,
                 LinkContent::Link {
-                    target: rcstr!("../root.txt"),
-                    link_type: LinkType::empty(),
+                    target: LinkTarget::Relative {
+                        raw: rcstr!("../root.txt"),
+                        resolved: root_path.join("root.txt")?,
+                    },
                 }
             );
 
             Ok(())
+        }
+
+        /// `read_link` never looks at the target, so a dangling link still reads back as a valid
+        /// [`LinkContent::Link`]. Resolving it is what discovers the target is missing.
+        #[turbo_tasks::function(operation, root)]
+        async fn assert_dangling_symlink_operation(
+            fs: ResolvedVc<DiskFileSystem>,
+            root_path: FileSystemPath,
+        ) -> anyhow::Result<()> {
+            let link_path = root_path.join("sub/link-dangling")?;
+
+            // The link itself is perfectly valid; only its target is missing.
+            let link = fs.read_link(link_path.clone()).await?;
+            let LinkContent::Link { target } = &*link else {
+                anyhow::bail!("expected a valid link, got {link:?}");
+            };
+            assert_eq!(
+                *target,
+                LinkTarget::Relative {
+                    raw: rcstr!("missing.txt"),
+                    resolved: root_path.join("sub/missing.txt")?,
+                }
+            );
+            assert_eq!(target.target_type().await?, FileSystemEntryType::NotFound,);
+
+            // `realpath` follows the link, so it must report the missing target rather than
+            // succeeding with a path that doesn't exist.
+            let result = link_path.realpath_with_links().await?;
+            assert_eq!(
+                result.path_result,
+                Err(RealPathResultError::NotFound),
+                "realpath must not succeed with a nonexistent path"
+            );
+
+            // Resolving a path that simply doesn't exist is not an error, though: there is no
+            // link involved, so it resolves to itself.
+            let missing = root_path.join("sub/missing.txt")?;
+            let result = missing.realpath_with_links().await?;
+            assert_eq!(result.path_result, Ok(missing));
+
+            Ok(())
+        }
+
+        #[cfg(unix)]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_dangling_symlink() {
+            use std::os::unix::fs::symlink;
+
+            let scratch = tempfile::tempdir().unwrap();
+            let path = scratch.path().to_owned();
+            create_dir_all(path.join("sub")).unwrap();
+            symlink("missing.txt", path.join("sub/link-dangling")).unwrap();
+
+            let root = canonicalize_to_rcstr(&path).unwrap();
+
+            let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+                BackendOptions::default(),
+                noop_backing_storage(),
+            ));
+
+            tt.run_once(async move {
+                let fs = disk_file_system_operation(root)
+                    .resolve()
+                    .strongly_consistent()
+                    .await?;
+
+                assert_dangling_symlink_operation(fs, disk_file_system_root(fs))
+                    .read_strongly_consistent()
+                    .await?;
+
+                anyhow::Ok(())
+            })
+            .await
+            .unwrap();
+
+            tt.stop_and_wait().await;
+        }
+
+        /// A relative target must stay inside the filesystem root at every step, not just at the
+        /// end. Both of these step above the root; one comes back into it and one doesn't, but
+        /// neither can be resolved against a root-relative [`FileSystemPath`], so `read_link`
+        /// rejects both and every [`LinkContent::Link`] stays resolvable by construction.
+        #[turbo_tasks::function(operation, root)]
+        async fn assert_read_escaping_relative_symlink_operation(
+            fs: ResolvedVc<DiskFileSystem>,
+            root_path: FileSystemPath,
+        ) -> anyhow::Result<()> {
+            // sub/link-reentrant -> ../../<root dir name>/root.txt, which steps above the root
+            // and back down into it. Resolving this would need the names of the root's own
+            // ancestors, which a root-relative path doesn't carry.
+            let reentrant = fs.read_link(root_path.join("sub/link-reentrant")?).await?;
+            assert_eq!(*reentrant, LinkContent::Invalid);
+
+            // sub/link-sideways -> ../../sibling/root.txt, which steps above the root and down
+            // into a sibling, so it genuinely ends outside.
+            let sideways = fs.read_link(root_path.join("sub/link-sideways")?).await?;
+            assert_eq!(*sideways, LinkContent::Invalid);
+
+            // `\` is a legal filename character on unix, so a raw target may contain one. It must
+            // not be treated as a separator, and must not trip `join_path`'s debug assertion.
+            let backslash_path = root_path.join("sub/link-backslash")?;
+            let backslash = fs.read_link(backslash_path.clone()).await?;
+            assert_eq!(
+                *backslash,
+                LinkContent::Link {
+                    target: LinkTarget::Relative {
+                        raw: rcstr!("a\\b.txt"),
+                        resolved: root_path.join("sub/a\\b.txt")?,
+                    },
+                }
+            );
+
+            // A relative target that stays within the root throughout is still fine.
+            let inside_path = root_path.join("sub/link-inside")?;
+            let inside = fs.read_link(inside_path.clone()).await?;
+            let LinkContent::Link { target } = &*inside else {
+                anyhow::bail!("expected a valid link, got {inside:?}");
+            };
+            assert_eq!(
+                *target,
+                LinkTarget::Relative {
+                    raw: rcstr!("../root.txt"),
+                    resolved: root_path.join("root.txt")?,
+                }
+            );
+            assert_eq!(target.target_type().await?, FileSystemEntryType::File,);
+
+            Ok(())
+        }
+
+        #[cfg(unix)]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_read_escaping_relative_symlink() {
+            use std::os::unix::fs::symlink;
+
+            let scratch = tempfile::tempdir().unwrap();
+            // The fs root is a subdirectory, so that `../..` can step above it and back in.
+            let path = scratch.path().join("the-root");
+            create_dir_all(path.join("sub")).unwrap();
+            File::create_new(path.join("root.txt"))
+                .unwrap()
+                .write_all(b"root")
+                .unwrap();
+            // Steps above the root and back down into it.
+            symlink("../../the-root/root.txt", path.join("sub/link-reentrant")).unwrap();
+            // Steps above the root and back down into a sibling of the root, so it escapes.
+            create_dir_all(scratch.path().join("sibling")).unwrap();
+            File::create_new(scratch.path().join("sibling/root.txt"))
+                .unwrap()
+                .write_all(b"sibling")
+                .unwrap();
+            symlink("../../sibling/root.txt", path.join("sub/link-sideways")).unwrap();
+            // Stays inside the root the whole way.
+            symlink("../root.txt", path.join("sub/link-inside")).unwrap();
+            // A target naming a file that literally contains a backslash.
+            File::create_new(path.join("sub/a\\b.txt"))
+                .unwrap()
+                .write_all(b"backslash")
+                .unwrap();
+            symlink("a\\b.txt", path.join("sub/link-backslash")).unwrap();
+
+            let root = canonicalize_to_rcstr(&path).unwrap();
+
+            let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+                BackendOptions::default(),
+                noop_backing_storage(),
+            ));
+
+            tt.run_once(async move {
+                let fs = disk_file_system_operation(root)
+                    .resolve()
+                    .strongly_consistent()
+                    .await?;
+                let root_path = disk_file_system_root(fs);
+
+                assert_read_escaping_relative_symlink_operation(fs, root_path)
+                    .read_strongly_consistent()
+                    .await?;
+
+                anyhow::Ok(())
+            })
+            .await
+            .unwrap();
+
+            tt.stop_and_wait().await;
         }
 
         #[cfg(unix)]
@@ -1896,8 +2099,9 @@ mod tests {
                 assert_eq!(
                     *via_alias,
                     LinkContent::Link {
-                        target: rcstr!("foo.txt"),
-                        link_type: LinkType::ABSOLUTE,
+                        target: LinkTarget::Absolute {
+                            resolved: root_path.join("foo.txt")?,
+                        },
                     }
                 );
 
@@ -1958,9 +2162,9 @@ mod tests {
                     async move {
                         fs.write_link(
                             symlink_path,
-                            LinkContent::Link {
-                                target,
-                                link_type: LinkType::DIRECTORY,
+                            WriteLinkContent {
+                                target: WriteLinkTarget::Relative(target),
+                                target_type: WriteLinkTargetType::DirectoryOrJunctionPoint,
                             }
                             .cell(),
                         )

--- a/turbopack/crates/turbo-tasks-fs/src/disk.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/disk.rs
@@ -23,7 +23,7 @@ use tokio::{
     sync::{RwLock, RwLockReadGuard},
 };
 use tracing::Instrument;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     CapturedEffect, Effect, EffectExt, EffectStateStorage, InvalidationReason, NonLocalValue,
     ReadRef, ResolvedVc, TurboTasksApi, ValueToString, Vc, debug::ValueDebugFormat, parallel,
@@ -900,7 +900,10 @@ impl FileSystem for DiskFileSystem {
         let this = self.await?;
         let inner = &this.inner;
         if inner.is_path_denied(&fs_path) {
-            return Ok(LinkContent::Invalid.cell());
+            return Ok(LinkContent::Invalid {
+                reason: rcstr!("access to the symlink path is denied"),
+            }
+            .cell());
         }
         let full_link_path = Arc::new(this.to_sys_path_raw(&fs_path));
 
@@ -916,8 +919,12 @@ impl FileSystem for DiskFileSystem {
             Err(err) if err.kind() == ErrorKind::NotFound => {
                 return Ok(LinkContent::NotFound.cell());
             }
-            // The path doesn't exist or isn't a symbolic link.
-            Err(_) => return Ok(LinkContent::Invalid.cell()),
+            Err(err) => {
+                return Ok(LinkContent::Invalid {
+                    reason: RcStr::from(err.to_string()),
+                }
+                .cell());
+            }
         };
 
         let target = if target_sys_path.is_absolute() {
@@ -938,7 +945,13 @@ impl FileSystem for DiskFileSystem {
             let Some(target_fs_path) = target_fs_path else {
                 // The target leaves the filesystem root (or is a dangling link whose parent
                 // directory couldn't be canonicalized).
-                return Ok(LinkContent::Invalid.cell());
+                return Ok(LinkContent::Invalid {
+                    reason: rcstr!(
+                        "the symlink target leaves the filesystem root or its parent directory \
+                         could not be resolved"
+                    ),
+                }
+                .cell());
             };
             // Rewrite from the sys root to the DiskFileSystem root.
             LinkTarget::Absolute {
@@ -955,14 +968,22 @@ impl FileSystem for DiskFileSystem {
                     Some(Component::Prefix(_))
                 )
             {
-                return Ok(LinkContent::Invalid.cell());
+                return Ok(LinkContent::Invalid {
+                    reason: rcstr!("the symlink target is not a fully qualified or relative path"),
+                }
+                .cell());
             }
 
             // The raw value read from the link, converted to a unix-style format. A relative
             // target is resolved against the directory *containing* the link, not the link itself.
-            let target_str = target_sys_path.to_str().with_context(|| {
-                format!("symlink target {target_sys_path:?} is not valid unicode")
-            })?;
+            let Some(target_str) = target_sys_path.to_str() else {
+                return Ok(LinkContent::Invalid {
+                    reason: RcStr::from(format!(
+                        "the symlink target {target_sys_path:?} is not valid unicode"
+                    )),
+                }
+                .cell());
+            };
             let raw = RcStr::from(sys_to_unix(target_str));
 
             // Require the target to stay within the filesystem root at every step, not just at
@@ -971,7 +992,10 @@ impl FileSystem for DiskFileSystem {
             // root-relative `FileSystemPath` doesn't carry. Rejecting it here is what lets
             // `LinkTarget` carry a resolved path at all.
             let Some(resolved) = fs_path.parent().try_join(&raw) else {
-                return Ok(LinkContent::Invalid.cell());
+                return Ok(LinkContent::Invalid {
+                    reason: rcstr!("the symlink target leaves the filesystem root"),
+                }
+                .cell());
             };
             LinkTarget::Relative { raw, resolved }
         };
@@ -1841,10 +1865,34 @@ mod tests {
             // `realpath` follows the link, so it must report the missing target rather than
             // succeeding with a path that doesn't exist.
             let result = link_path.realpath_with_links().await?;
-            assert_eq!(
-                result.path_result,
-                Err(RealPathResultError::NotFound),
-                "realpath must not succeed with a nonexistent path"
+            assert!(
+                matches!(
+                    &result.path_result,
+                    Err(RealPathResultError::Invalid(reason))
+                        if reason == "a symlink target does not exist"
+                ),
+                "realpath must report the missing target as an invalid chain: {:?}",
+                result.path_result
+            );
+            let error = result.path_result.as_ref().unwrap_err();
+            let message = error.as_error_message(&link_path, &result).await?;
+            assert!(
+                message.contains("could not be resolved: a symlink target does not exist"),
+                "unexpected error message: {message}"
+            );
+
+            // The same missing target after another link is still an invalid chain, never a
+            // missing initial link.
+            let chain_path = root_path.join("sub/link-chain")?;
+            let result = chain_path.realpath_with_links().await?;
+            assert!(
+                matches!(
+                    &result.path_result,
+                    Err(RealPathResultError::Invalid(reason))
+                        if reason == "a symlink target does not exist"
+                ),
+                "realpath must report a missing target later in a chain as invalid: {:?}",
+                result.path_result
             );
 
             // Resolving a path that simply doesn't exist is not an error, though: there is no
@@ -1865,6 +1913,7 @@ mod tests {
             let path = scratch.path().to_owned();
             create_dir_all(path.join("sub")).unwrap();
             symlink("missing.txt", path.join("sub/link-dangling")).unwrap();
+            symlink("link-dangling", path.join("sub/link-chain")).unwrap();
 
             let root = canonicalize_to_rcstr(&path).unwrap();
 
@@ -1904,12 +1953,20 @@ mod tests {
             // and back down into it. Resolving this would need the names of the root's own
             // ancestors, which a root-relative path doesn't carry.
             let reentrant = fs.read_link(root_path.join("sub/link-reentrant")?).await?;
-            assert_eq!(*reentrant, LinkContent::Invalid);
+            assert!(matches!(
+                &*reentrant,
+                LinkContent::Invalid { reason }
+                    if reason == "the symlink target leaves the filesystem root"
+            ));
 
             // sub/link-sideways -> ../../sibling/root.txt, which steps above the root and down
             // into a sibling, so it genuinely ends outside.
             let sideways = fs.read_link(root_path.join("sub/link-sideways")?).await?;
-            assert_eq!(*sideways, LinkContent::Invalid);
+            assert!(matches!(
+                &*sideways,
+                LinkContent::Invalid{reason}
+                    if reason == "the symlink target leaves the filesystem root"
+            ));
 
             // `\` is a legal filename character on unix, so a raw target may contain one. It must
             // not be treated as a separator, and must not trip `join_path`'s debug assertion.
@@ -2107,7 +2164,11 @@ mod tests {
 
                 // link-outside -> <scratch>/outside.txt  (outside of the fs root)
                 let outside = fs.read_link(root_path.join("link-outside")?).await?;
-                assert_eq!(*outside, LinkContent::Invalid);
+                assert!(matches!(
+                    &*outside,
+                    LinkContent::Invalid { reason}
+                        if reason.contains("leaves the filesystem root")
+                ));
 
                 Ok(())
             }

--- a/turbopack/crates/turbo-tasks-fs/src/disk.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/disk.rs
@@ -1841,69 +1841,6 @@ mod tests {
 
         /// `read_link` never looks at the target, so a dangling link still reads back as a valid
         /// [`LinkContent::Link`]. Resolving it is what discovers the target is missing.
-        #[turbo_tasks::function(operation, root)]
-        async fn assert_dangling_symlink_operation(
-            fs: ResolvedVc<DiskFileSystem>,
-            root_path: FileSystemPath,
-        ) -> anyhow::Result<()> {
-            let link_path = root_path.join("sub/link-dangling")?;
-
-            // The link itself is perfectly valid; only its target is missing.
-            let link = fs.read_link(link_path.clone()).await?;
-            let LinkContent::Link { target } = &*link else {
-                anyhow::bail!("expected a valid link, got {link:?}");
-            };
-            assert_eq!(
-                *target,
-                LinkTarget::Relative {
-                    raw: rcstr!("missing.txt"),
-                    resolved: root_path.join("sub/missing.txt")?,
-                }
-            );
-            assert_eq!(target.target_type().await?, FileSystemEntryType::NotFound,);
-
-            // `realpath` follows the link, so it must report the missing target rather than
-            // succeeding with a path that doesn't exist.
-            let result = link_path.realpath_with_links().await?;
-            assert!(
-                matches!(
-                    &result.path_result,
-                    Err(RealPathResultError::Invalid(reason))
-                        if reason == "a symlink target does not exist"
-                ),
-                "realpath must report the missing target as an invalid chain: {:?}",
-                result.path_result
-            );
-            let error = result.path_result.as_ref().unwrap_err();
-            let message = error.as_error_message(&link_path, &result).await?;
-            assert!(
-                message.contains("could not be resolved: a symlink target does not exist"),
-                "unexpected error message: {message}"
-            );
-
-            // The same missing target after another link is still an invalid chain, never a
-            // missing initial link.
-            let chain_path = root_path.join("sub/link-chain")?;
-            let result = chain_path.realpath_with_links().await?;
-            assert!(
-                matches!(
-                    &result.path_result,
-                    Err(RealPathResultError::Invalid(reason))
-                        if reason == "a symlink target does not exist"
-                ),
-                "realpath must report a missing target later in a chain as invalid: {:?}",
-                result.path_result
-            );
-
-            // Resolving a path that simply doesn't exist is not an error, though: there is no
-            // link involved, so it resolves to itself.
-            let missing = root_path.join("sub/missing.txt")?;
-            let result = missing.realpath_with_links().await?;
-            assert_eq!(result.path_result, Ok(missing));
-
-            Ok(())
-        }
-
         #[cfg(unix)]
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn test_dangling_symlink() {
@@ -1917,6 +1854,69 @@ mod tests {
 
             let root = canonicalize_to_rcstr(&path).unwrap();
 
+            #[turbo_tasks::function(operation, root)]
+            async fn assert_operation(
+                fs: ResolvedVc<DiskFileSystem>,
+                root_path: FileSystemPath,
+            ) -> anyhow::Result<()> {
+                let link_path = root_path.join("sub/link-dangling")?;
+
+                // The link itself is perfectly valid; only its target is missing.
+                let link = fs.read_link(link_path.clone()).await?;
+                let LinkContent::Link { target } = &*link else {
+                    anyhow::bail!("expected a valid link, got {link:?}");
+                };
+                assert_eq!(
+                    *target,
+                    LinkTarget::Relative {
+                        raw: rcstr!("missing.txt"),
+                        resolved: root_path.join("sub/missing.txt")?,
+                    }
+                );
+                assert_eq!(target.target_type().await?, FileSystemEntryType::NotFound,);
+
+                // `realpath` follows the link, so it must report the missing target rather than
+                // succeeding with a path that doesn't exist.
+                let result = link_path.realpath_with_links().await?;
+                assert!(
+                    matches!(
+                        &result.path_result,
+                        Err(RealPathResultError::Invalid(reason))
+                            if reason == "a symlink target does not exist"
+                    ),
+                    "realpath must report the missing target as an invalid chain: {:?}",
+                    result.path_result
+                );
+                let error = result.path_result.as_ref().unwrap_err();
+                let message = error.as_error_message(&link_path, &result).await?;
+                assert!(
+                    message.contains("could not be resolved: a symlink target does not exist"),
+                    "unexpected error message: {message}"
+                );
+
+                // The same missing target after another link is still an invalid chain, never a
+                // missing initial link.
+                let chain_path = root_path.join("sub/link-chain")?;
+                let result = chain_path.realpath_with_links().await?;
+                assert!(
+                    matches!(
+                        &result.path_result,
+                        Err(RealPathResultError::Invalid(reason))
+                            if reason == "a symlink target does not exist"
+                    ),
+                    "realpath must report a missing target later in a chain as invalid: {:?}",
+                    result.path_result
+                );
+
+                // Resolving a path that simply doesn't exist is not an error, though: there is no
+                // link involved, so it resolves to itself.
+                let missing = root_path.join("sub/missing.txt")?;
+                let result = missing.realpath_with_links().await?;
+                assert_eq!(result.path_result, Ok(missing));
+
+                Ok(())
+            }
+
             let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
                 BackendOptions::default(),
                 noop_backing_storage(),
@@ -1928,7 +1928,7 @@ mod tests {
                     .strongly_consistent()
                     .await?;
 
-                assert_dangling_symlink_operation(fs, disk_file_system_root(fs))
+                assert_operation(fs, disk_file_system_root(fs))
                     .read_strongly_consistent()
                     .await?;
 
@@ -1944,62 +1944,6 @@ mod tests {
         /// end. Both of these step above the root; one comes back into it and one doesn't, but
         /// neither can be resolved against a root-relative [`FileSystemPath`], so `read_link`
         /// rejects both and every [`LinkContent::Link`] stays resolvable by construction.
-        #[turbo_tasks::function(operation, root)]
-        async fn assert_read_escaping_relative_symlink_operation(
-            fs: ResolvedVc<DiskFileSystem>,
-            root_path: FileSystemPath,
-        ) -> anyhow::Result<()> {
-            // sub/link-reentrant -> ../../<root dir name>/root.txt, which steps above the root
-            // and back down into it. Resolving this would need the names of the root's own
-            // ancestors, which a root-relative path doesn't carry.
-            let reentrant = fs.read_link(root_path.join("sub/link-reentrant")?).await?;
-            assert!(matches!(
-                &*reentrant,
-                LinkContent::Invalid { reason }
-                    if reason == "the symlink target leaves the filesystem root"
-            ));
-
-            // sub/link-sideways -> ../../sibling/root.txt, which steps above the root and down
-            // into a sibling, so it genuinely ends outside.
-            let sideways = fs.read_link(root_path.join("sub/link-sideways")?).await?;
-            assert!(matches!(
-                &*sideways,
-                LinkContent::Invalid{reason}
-                    if reason == "the symlink target leaves the filesystem root"
-            ));
-
-            // `\` is a legal filename character on unix, so a raw target may contain one. It must
-            // not be treated as a separator, and must not trip `join_path`'s debug assertion.
-            let backslash_path = root_path.join("sub/link-backslash")?;
-            let backslash = fs.read_link(backslash_path.clone()).await?;
-            assert_eq!(
-                *backslash,
-                LinkContent::Link {
-                    target: LinkTarget::Relative {
-                        raw: rcstr!("a\\b.txt"),
-                        resolved: root_path.join("sub/a\\b.txt")?,
-                    },
-                }
-            );
-
-            // A relative target that stays within the root throughout is still fine.
-            let inside_path = root_path.join("sub/link-inside")?;
-            let inside = fs.read_link(inside_path.clone()).await?;
-            let LinkContent::Link { target } = &*inside else {
-                anyhow::bail!("expected a valid link, got {inside:?}");
-            };
-            assert_eq!(
-                *target,
-                LinkTarget::Relative {
-                    raw: rcstr!("../root.txt"),
-                    resolved: root_path.join("root.txt")?,
-                }
-            );
-            assert_eq!(target.target_type().await?, FileSystemEntryType::File,);
-
-            Ok(())
-        }
-
         #[cfg(unix)]
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn test_read_escaping_relative_symlink() {
@@ -2033,11 +1977,67 @@ mod tests {
 
             let root = canonicalize_to_rcstr(&path).unwrap();
 
+            #[turbo_tasks::function(operation, root)]
+            async fn assert_operation(
+                fs: ResolvedVc<DiskFileSystem>,
+                root_path: FileSystemPath,
+            ) -> anyhow::Result<()> {
+                // sub/link-reentrant -> ../../<root dir name>/root.txt, which steps above the root
+                // and back down into it. Resolving this would need the names of the root's own
+                // ancestors, which a root-relative path doesn't carry.
+                let reentrant = fs.read_link(root_path.join("sub/link-reentrant")?).await?;
+                assert!(matches!(
+                    &*reentrant,
+                    LinkContent::Invalid { reason }
+                        if reason == "the symlink target leaves the filesystem root"
+                ));
+
+                // sub/link-sideways -> ../../sibling/root.txt, which steps above the root and down
+                // into a sibling, so it genuinely ends outside.
+                let sideways = fs.read_link(root_path.join("sub/link-sideways")?).await?;
+                assert!(matches!(
+                    &*sideways,
+                    LinkContent::Invalid{reason}
+                        if reason == "the symlink target leaves the filesystem root"
+                ));
+
+                // `\` is a legal filename character on unix, so a raw target may contain one. It
+                // must not be treated as a separator, and must not trip
+                // `join_path`'s debug assertion.
+                let backslash_path = root_path.join("sub/link-backslash")?;
+                let backslash = fs.read_link(backslash_path.clone()).await?;
+                assert_eq!(
+                    *backslash,
+                    LinkContent::Link {
+                        target: LinkTarget::Relative {
+                            raw: rcstr!("a\\b.txt"),
+                            resolved: root_path.join("sub/a\\b.txt")?,
+                        },
+                    }
+                );
+
+                // A relative target that stays within the root throughout is still fine.
+                let inside_path = root_path.join("sub/link-inside")?;
+                let inside = fs.read_link(inside_path.clone()).await?;
+                let LinkContent::Link { target } = &*inside else {
+                    anyhow::bail!("expected a valid link, got {inside:?}");
+                };
+                assert_eq!(
+                    *target,
+                    LinkTarget::Relative {
+                        raw: rcstr!("../root.txt"),
+                        resolved: root_path.join("root.txt")?,
+                    }
+                );
+                assert_eq!(target.target_type().await?, FileSystemEntryType::File,);
+
+                Ok(())
+            }
+
             let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
                 BackendOptions::default(),
                 noop_backing_storage(),
             ));
-
             tt.run_once(async move {
                 let fs = disk_file_system_operation(root)
                     .resolve()
@@ -2045,7 +2045,7 @@ mod tests {
                     .await?;
                 let root_path = disk_file_system_root(fs);
 
-                assert_read_escaping_relative_symlink_operation(fs, root_path)
+                assert_operation(fs, root_path)
                     .read_strongly_consistent()
                     .await?;
 

--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, bail};
 use auto_hash_map::AutoMap;
 use include_dir::{Dir, DirEntry};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ValueToString, Vc};
 
 use crate::{
@@ -38,7 +38,10 @@ impl FileSystem for EmbeddedFileSystem {
 
     #[turbo_tasks::function]
     fn read_link(&self, _path: FileSystemPath) -> Vc<LinkContent> {
-        LinkContent::Invalid.cell()
+        LinkContent::Invalid {
+            reason: rcstr!("the filesystem does not support symbolic links"),
+        }
+        .cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{ValueToString, Vc};
 
 use crate::{
     File, FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent,
-    RawDirectoryEntry,
+    RawDirectoryEntry, WriteLinkContent,
 };
 
 #[derive(ValueToString)]
@@ -38,7 +38,12 @@ impl FileSystem for EmbeddedFileSystem {
 
     #[turbo_tasks::function]
     fn read_link(&self, _path: FileSystemPath) -> Vc<LinkContent> {
-        LinkContent::NotFound.cell()
+        LinkContent::Invalid.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn is_junction_point(&self, _path: FileSystemPath) -> Vc<bool> {
+        Vc::cell(false)
     }
 
     #[turbo_tasks::function]
@@ -77,7 +82,7 @@ impl FileSystem for EmbeddedFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _path: FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
+    fn write_link(&self, _path: FileSystemPath, _target: Vc<WriteLinkContent>) -> Result<Vc<()>> {
         bail!("Writing is not possible to the embedded filesystem")
     }
 

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -33,7 +33,8 @@ pub mod source_context;
 pub mod util;
 pub(crate) mod virtual_fs;
 mod watcher;
-mod windows;
+#[cfg(windows)]
+pub mod windows;
 
 use std::{fmt::Debug, fs::FileType, path::PathBuf};
 
@@ -53,7 +54,8 @@ pub(crate) use crate::{
 pub use crate::{
     content::{
         File, FileContent, FileJsonContent, FileLine, FileLinesContent, FileMeta, LinkContent,
-        LinkType, Permissions, PersistedFileContent,
+        LinkTarget, Permissions, PersistedFileContent, WriteLinkContent, WriteLinkTarget,
+        WriteLinkTargetType,
     },
     disk::{DiskFileSystem, canonicalize_to_rcstr, validate_path_length},
     null_fs::NullFileSystem,
@@ -73,23 +75,20 @@ pub trait FileSystem: ValueToString {
     }
     #[turbo_tasks::function]
     fn read(self: Vc<Self>, fs_path: FileSystemPath) -> Vc<FileContent>;
-    /// Reads the target of a symbolic link (or of a junction point on Windows).
-    ///
-    /// The base of the returned [`LinkContent::Link`] `target` depends on the link's
-    /// [`LinkType`]: root-relative and normalized for [`LinkType::ABSOLUTE`] links, or the raw
-    /// link-relative on-disk value otherwise.
-    ///
-    /// Returns [`LinkContent::Invalid`] if the target points outside of the filesystem root, and
-    /// [`LinkContent::NotFound`] if `fs_path` doesn't exist or isn't a link.
+    /// Reads the target of a symbolic link (or junction point on Windows). See [`LinkContent`].
     #[turbo_tasks::function]
     fn read_link(self: Vc<Self>, fs_path: FileSystemPath) -> Vc<LinkContent>;
+    /// Returns whether a symbolic link is a junction point on Windows. Always `false` on all other
+    /// platforms.
+    #[turbo_tasks::function]
+    fn is_junction_point(self: Vc<Self>, fs_path: FileSystemPath) -> Vc<bool>;
     #[turbo_tasks::function]
     fn raw_read_dir(self: Vc<Self>, fs_path: FileSystemPath) -> Vc<RawDirectoryContent>;
     #[turbo_tasks::function]
     fn write(self: Vc<Self>, fs_path: FileSystemPath, content: Vc<FileContent>) -> Vc<()>;
-    /// See [`FileSystemPath::write_symbolic_link_dir`].
+    /// Creates a symbolic link. See [`WriteLinkContent`] and [`FileSystemPath::write_link`].
     #[turbo_tasks::function]
-    fn write_link(self: Vc<Self>, fs_path: FileSystemPath, target: Vc<LinkContent>) -> Vc<()>;
+    fn write_link(self: Vc<Self>, fs_path: FileSystemPath, target: Vc<WriteLinkContent>) -> Vc<()>;
     #[turbo_tasks::function]
     fn metadata(self: Vc<Self>, fs_path: FileSystemPath) -> Vc<FileMeta>;
 }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -63,7 +63,6 @@ pub use crate::{
     read_glob::ReadGlobResult,
     virtual_fs::VirtualFileSystem,
     watcher::{DiskWatcherConfig, DiskWatcherPathMatcher, DiskWatcherRecursiveMode},
-    windows::to_verbatim_with_case_folded_disk,
 };
 
 #[turbo_tasks::value_trait]

--- a/turbopack/crates/turbo-tasks-fs/src/null_fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/null_fs.rs
@@ -2,7 +2,10 @@
 
 use turbo_tasks::{ValueToString, Vc};
 
-use crate::{FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent};
+use crate::{
+    FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent,
+    WriteLinkContent,
+};
 
 #[derive(ValueToString)]
 #[value_to_string("null")]
@@ -18,7 +21,12 @@ impl FileSystem for NullFileSystem {
 
     #[turbo_tasks::function]
     fn read_link(&self, _fs_path: FileSystemPath) -> Vc<LinkContent> {
-        LinkContent::NotFound.cell()
+        LinkContent::Invalid.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn is_junction_point(&self, _fs_path: FileSystemPath) -> Vc<bool> {
+        Vc::cell(false)
     }
 
     #[turbo_tasks::function]
@@ -30,7 +38,7 @@ impl FileSystem for NullFileSystem {
     fn write(&self, _fs_path: FileSystemPath, _content: Vc<FileContent>) {}
 
     #[turbo_tasks::function]
-    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<LinkContent>) {}
+    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<WriteLinkContent>) {}
 
     #[turbo_tasks::function]
     fn metadata(&self, _fs_path: FileSystemPath) -> Vc<FileMeta> {

--- a/turbopack/crates/turbo-tasks-fs/src/null_fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/null_fs.rs
@@ -1,5 +1,6 @@
 //! [`NullFileSystem`], a filesystem where every path is empty/not-found.
 
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ValueToString, Vc};
 
 use crate::{
@@ -21,7 +22,10 @@ impl FileSystem for NullFileSystem {
 
     #[turbo_tasks::function]
     fn read_link(&self, _fs_path: FileSystemPath) -> Vc<LinkContent> {
-        LinkContent::Invalid.cell()
+        LinkContent::Invalid {
+            reason: rcstr!("the filesystem does not support symbolic links"),
+        }
+        .cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbo-tasks-fs/src/path.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/path.rs
@@ -16,8 +16,8 @@ use turbo_unix_path::{get_parent_path, get_relative_path_to, join_path, normaliz
 
 use crate::{
     DirectoryContent, DirectoryEntry, FileContent, FileJsonContent, FileMeta, FileSystem,
-    FileSystemEntryType, LinkContent, LinkType, RawDirectoryContent, RawDirectoryEntry,
-    ReadGlobResult,
+    FileSystemEntryType, LinkContent, RawDirectoryContent, RawDirectoryEntry, ReadGlobResult,
+    WriteLinkContent,
     glob::Glob,
     read_glob::{read_glob, track_glob},
 };
@@ -391,6 +391,10 @@ impl FileSystemPath {
         self.fs().read_link(self.clone())
     }
 
+    pub fn is_junction_point(&self) -> Vc<bool> {
+        self.fs().is_junction_point(self.clone())
+    }
+
     pub fn read_json(&self) -> Vc<FileJsonContent> {
         self.fs().read(self.clone()).parse_json()
     }
@@ -420,24 +424,20 @@ impl FileSystemPath {
         self.fs().write(self.clone(), content)
     }
 
-    /// Creates a symbolic link to a directory on *nix platforms, or a directory junction point on
-    /// Windows.
+    /// Creates a symbolic link on *nix platforms. On Windows, directory links are created as
+    /// junction points. Links to files on Windows are attempted to be created as symbolic links.
     ///
     /// [Windows supports symbolic links][windows-symlink], but they [can require elevated
     /// privileges][windows-privileges] if "developer mode" is not enabled, so we can't safely use
     /// them. Using junction points [matches the behavior of pnpm][pnpm-windows].
     ///
-    /// This only supports directories because Windows junction points are incompatible with files.
-    /// To ensure compatibility, this will return an error if the target is a file, even on
-    /// platforms with full symlink support.
-    ///
-    /// **We intentionally do not provide an API for symlinking a file**, as we cannot support that
-    /// on all Windows configurations.
+    /// It is not recommended to create non-directory links, as this is not portable and will likely
+    /// fail on Windows.
     ///
     /// [windows-symlink]: https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/
     /// [windows-privileges]: https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/create-symbolic-links
     /// [pnpm-windows]: https://pnpm.io/faq#does-it-work-on-windows
-    pub fn write_symbolic_link_dir(&self, target: Vc<LinkContent>) -> Vc<()> {
+    pub fn write_link(&self, target: Vc<WriteLinkContent>) -> Vc<()> {
         self.fs().write_link(self.clone(), target)
     }
 
@@ -511,8 +511,10 @@ pub struct RealPathResult {
 pub enum RealPathResultError {
     TooManySymlinks,
     CycleDetected,
-    Invalid,
+    /// See: [LinkContent::NotFound].
     NotFound,
+    /// See: [LinkContent::Invalid].
+    Invalid,
 }
 
 impl RealPathResultError {
@@ -537,7 +539,8 @@ impl RealPathResultError {
                 turbofmt!("Symlink {orig} is in a symlink loop: {symlinks_dbg}").await?
             }
             RealPathResultError::Invalid => {
-                turbofmt!("Symlink {orig} is invalid, it points out of the filesystem root").await?
+                turbofmt!("Symlink {orig} is invalid, its target leaves the filesystem root")
+                    .await?
             }
             RealPathResultError::NotFound => {
                 turbofmt!("Symlink {orig} is invalid, it points at a file that doesn't exist")
@@ -605,6 +608,9 @@ async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>>
     let mut symlinks: IndexSet<FileSystemPath> = IndexSet::new();
     let mut visited: AutoSet<RcStr> = AutoSet::new();
     let mut error = RealPathResultError::TooManySymlinks;
+    // Whether a previous iteration resolved a symbolic link, so `current_path` is now a link
+    // target rather than the path we were asked about.
+    let mut followed_link = false;
     // Pick some arbitrary symlink depth limit... similar to the ELOOP logic for realpath(3).
     // SYMLOOP_MAX is 40 for Linux: https://unix.stackexchange.com/q/721724
     for _i in 0..40 {
@@ -630,25 +636,31 @@ async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>>
             .rsplit_once('/')
             .map_or(current_path.path.as_str(), |(_, name)| name);
         symlinks.extend(parent_result.symlinks);
-        let parent_path = match parent_result.path_result {
+        match parent_result.path_result {
             Ok(path) => {
                 if path != parent {
                     current_path = path.join(basename)?;
                 }
-                path
             }
             Err(parent_error) => {
                 error = parent_error;
                 break;
             }
-        };
+        }
 
         // use `get_type` before trying `read_link`, as there's a good chance of a cache hit on
         // `get_type`, and `read_link` isn't the common codepath.
-        if !matches!(
-            *current_path.get_type().await?,
-            FileSystemEntryType::Symlink
-        ) {
+        let entry_type = *current_path.get_type().await?;
+        if !matches!(entry_type, FileSystemEntryType::Symlink) {
+            // A link we followed points at something that doesn't exist. `read_link` can't detect
+            // this, as it never looks at the target, so a dangling link reads back as valid.
+            //
+            // Only report this for a link we actually followed: resolving a path that simply
+            // doesn't exist is not an error, it just resolves to itself.
+            if followed_link && matches!(entry_type, FileSystemEntryType::NotFound) {
+                error = RealPathResultError::NotFound;
+                break;
+            }
             return Ok(RealPathResult {
                 path_result: Ok(current_path),
                 symlinks: symlinks.into_iter().collect(), // convert set to vec
@@ -656,15 +668,13 @@ async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>>
             .cell());
         }
 
-        match &*current_path.read_link().await? {
-            LinkContent::Link { target, link_type } => {
-                symlinks.insert(current_path.clone());
-                current_path = if link_type.contains(LinkType::ABSOLUTE) {
-                    current_path.root().owned().await?
-                } else {
-                    parent_path
-                }
-                .join(target)?;
+        let link_content = current_path.read_link().await?;
+        match &*link_content {
+            LinkContent::Link { target } => {
+                let target_path = target.file_system_path().clone();
+                symlinks.insert(current_path);
+                current_path = target_path;
+                followed_link = true;
             }
             LinkContent::NotFound => {
                 error = RealPathResultError::NotFound;

--- a/turbopack/crates/turbo-tasks-fs/src/path.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/path.rs
@@ -6,7 +6,7 @@ use anyhow::{Result, bail};
 use auto_hash_map::{AutoMap, AutoSet};
 use bincode::{Decode, Encode};
 use indexmap::IndexSet;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, NonLocalValue, ResolvedVc, ValueToString, ValueToStringRef, Vc, trace::TraceRawVcs,
     turbobail, turbofmt,
@@ -511,10 +511,12 @@ pub struct RealPathResult {
 pub enum RealPathResultError {
     TooManySymlinks,
     CycleDetected,
-    /// See: [LinkContent::NotFound].
+    /// The first symlink that resolution attempted to read no longer exists.
     NotFound,
-    /// See: [LinkContent::Invalid].
-    Invalid,
+    /// Resolution failed after finding a symlink, or the symlink was invalid to begin with.
+    Invalid {
+        reason: RcStr,
+    },
 }
 
 impl RealPathResultError {
@@ -538,13 +540,14 @@ impl RealPathResultError {
                 );
                 turbofmt!("Symlink {orig} is in a symlink loop: {symlinks_dbg}").await?
             }
-            RealPathResultError::Invalid => {
-                turbofmt!("Symlink {orig} is invalid, its target leaves the filesystem root")
-                    .await?
+            RealPathResultError::Invalid { reason } => {
+                turbofmt!("Symlink {orig} could not be resolved: {reason}").await?
             }
             RealPathResultError::NotFound => {
-                turbofmt!("Symlink {orig} is invalid, it points at a file that doesn't exist")
-                    .await?
+                turbofmt!(
+                    "Symlink {orig} could not be read because the symlink itself no longer exists"
+                )
+                .await?
             }
         })
     }
@@ -643,7 +646,16 @@ async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>>
                 }
             }
             Err(parent_error) => {
-                error = parent_error;
+                error = match parent_error {
+                    RealPathResultError::NotFound if !symlinks.is_empty() => {
+                        RealPathResultError::Invalid {
+                            reason: rcstr!(
+                                "a symlink encountered while resolving the path no longer exists"
+                            ),
+                        }
+                    }
+                    error => error,
+                };
                 break;
             }
         }
@@ -657,8 +669,12 @@ async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>>
             //
             // Only report this for a link we actually followed: resolving a path that simply
             // doesn't exist is not an error, it just resolves to itself.
-            if followed_link && matches!(entry_type, FileSystemEntryType::NotFound) {
-                error = RealPathResultError::NotFound;
+            if (followed_link || !symlinks.is_empty())
+                && matches!(entry_type, FileSystemEntryType::NotFound)
+            {
+                error = RealPathResultError::Invalid {
+                    reason: rcstr!("a symlink target does not exist"),
+                };
                 break;
             }
             return Ok(RealPathResult {
@@ -677,11 +693,21 @@ async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>>
                 followed_link = true;
             }
             LinkContent::NotFound => {
-                error = RealPathResultError::NotFound;
+                error = if symlinks.is_empty() {
+                    RealPathResultError::NotFound
+                } else {
+                    RealPathResultError::Invalid {
+                        reason: rcstr!(
+                            "a symlink encountered while resolving the path no longer exists"
+                        ),
+                    }
+                };
                 break;
             }
-            LinkContent::Invalid => {
-                error = RealPathResultError::Invalid;
+            LinkContent::Invalid { reason } => {
+                error = RealPathResultError::Invalid {
+                    reason: reason.clone(),
+                };
                 break;
             }
         }

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -5,7 +5,8 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{Completion, ResolvedVc, TryJoinIterExt, Vc, turbobail};
 
 use crate::{
-    DirectoryContent, DirectoryEntry, FileSystem, FileSystemPath, LinkContent, LinkType, glob::Glob,
+    DirectoryContent, DirectoryEntry, FileSystem, FileSystemEntryType, FileSystemPath, LinkContent,
+    glob::Glob,
 };
 
 #[turbo_tasks::value]
@@ -85,8 +86,11 @@ async fn read_glob_internal(
                         handle_dir(&mut result, entry_path, segment, path).await?;
                     }
                     DirectoryEntry::Symlink(path) => {
-                        if let LinkContent::Link { link_type, .. } = &*path.read_link().await? {
-                            if link_type.contains(LinkType::DIRECTORY) {
+                        // Skip links that leave the filesystem root.
+                        let link_content = path.read_link().await?;
+                        if let LinkContent::Link { target } = &*link_content {
+                            if matches!(target.target_type().await?, FileSystemEntryType::Directory)
+                            {
                                 // Ensure that there are no infinite link loops, but don't resolve
                                 resolve_symlink_safely(entry.clone()).await?;
 

--- a/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
@@ -2,7 +2,10 @@ use anyhow::{Result, bail};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ValueToString, Vc};
 
-use crate::{FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent};
+use crate::{
+    FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent,
+    WriteLinkContent,
+};
 
 #[derive(ValueToString)]
 #[value_to_string(self.name)]
@@ -52,6 +55,11 @@ impl FileSystem for VirtualFileSystem {
     }
 
     #[turbo_tasks::function]
+    fn is_junction_point(&self, _fs_path: FileSystemPath) -> Result<Vc<bool>> {
+        bail!("Reading is not possible on the virtual file system")
+    }
+
+    #[turbo_tasks::function]
     fn raw_read_dir(&self, _fs_path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
         bail!("Reading is not possible on the virtual file system")
     }
@@ -62,7 +70,11 @@ impl FileSystem for VirtualFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
+    fn write_link(
+        &self,
+        _fs_path: FileSystemPath,
+        _target: Vc<WriteLinkContent>,
+    ) -> Result<Vc<()>> {
         bail!("Writing is not possible on the virtual file system")
     }
 

--- a/turbopack/crates/turbo-tasks-fs/src/windows.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/windows.rs
@@ -1,4 +1,61 @@
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsString,
+    io, mem,
+    os::windows::ffi::{OsStrExt, OsStringExt},
+    path::{Component, Path, PathBuf, Prefix},
+    ptr::{null, null_mut},
+};
+
+use omnipath::WinPathExt;
+use windows_sys::Win32::{
+    Foundation::{CloseHandle, INVALID_HANDLE_VALUE},
+    Storage::FileSystem::{
+        CreateFileW, FILE_ATTRIBUTE_TAG_INFO, FILE_FLAG_BACKUP_SEMANTICS,
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        FileAttributeTagInfo, GetFileInformationByHandleEx, OPEN_EXISTING,
+    },
+    System::SystemServices::IO_REPARSE_TAG_MOUNT_POINT,
+};
+
+pub(crate) fn is_link_junction_point(path: &Path) -> io::Result<bool> {
+    let path: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    let handle = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut tag_info = FILE_ATTRIBUTE_TAG_INFO {
+        FileAttributes: 0,
+        ReparseTag: 0,
+    };
+    let result = unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileAttributeTagInfo,
+            (&mut tag_info as *mut FILE_ATTRIBUTE_TAG_INFO).cast(),
+            mem::size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+        )
+    };
+    let error = if result == 0 {
+        Some(io::Error::last_os_error())
+    } else {
+        None
+    };
+    unsafe {
+        CloseHandle(handle);
+    }
+    error.map_or(Ok(tag_info.ReparseTag == IO_REPARSE_TAG_MOUNT_POINT), Err)
+}
 
 /// Converts `path` into the verbatim, drive-letter-case-folded representation used internally by
 /// [`crate::DiskFileSystem`] on Windows.
@@ -8,57 +65,41 @@ use std::path::{Path, PathBuf};
 /// `canonicalize`, does not touch the disk — it resolves neither symlinks nor 8.3 short names. The
 /// drive letter is then upper-cased to match the form `GetFinalPathNameByHandle` (and thus
 /// `canonicalize`) produces.
-///
-/// No-op on non-Windows platforms (returns `path` unchanged).
-pub fn to_verbatim_with_case_folded_disk(path: &Path) -> std::io::Result<PathBuf> {
-    #[cfg(windows)]
-    {
-        use std::{
-            ffi::OsString,
-            os::windows::ffi::{OsStrExt, OsStringExt},
-            path::{Component, Prefix},
-        };
+pub fn to_verbatim_with_case_folded_disk(path: &Path) -> io::Result<PathBuf> {
+    // `to_verbatim` guarantees an absolute, verbatim path from here on, so there's no
+    // non-verbatim case to guard against below.
+    let path = path.to_verbatim()?;
 
-        use omnipath::WinPathExt;
-
-        // `to_verbatim` guarantees an absolute, verbatim path from here on, so there's no
-        // non-verbatim case to guard against below.
-        let path = path.to_verbatim()?;
-
-        // Only `\\?\C:\...` (`VerbatimDisk`) paths carry a drive letter; verbatim UNC
-        // (`\\?\UNC\...`) and other verbatim device paths (`\\?\prefix`) don't, so there's nothing
-        // to case-fold for those.
-        //
-        // We can't read the letter from `VerbatimDisk(disk)` because that value is already
-        // normalized to uppercase, so it wouldn't tell us whether the underlying path needs
-        // rewriting.
-        let is_verbatim_disk = matches!(
-            path.components().next(),
-            Some(Component::Prefix(prefix)) if matches!(prefix.kind(), Prefix::VerbatimDisk(_))
-        );
-        if !is_verbatim_disk {
-            return Ok(path);
-        }
-
-        // The layout is `\\?\C:\...`, so the drive letter is the 5th UTF-16 code unit (index 4)
-        // and is guaranteed to be a-z or A-Z.
-        if let Some(disk) = path.as_os_str().encode_wide().nth(4).map(|disk| disk as u8)
-            && disk.is_ascii_lowercase()
-        {
-            // we must encode/decode because OsString's internal encoding is opaque/unstable
-            let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
-            wide[4] = u16::from(disk.to_ascii_uppercase());
-            return Ok(PathBuf::from(OsString::from_wide(&wide)));
-        }
-
-        Ok(path)
+    // Only `\\?\C:\...` (`VerbatimDisk`) paths carry a drive letter; verbatim UNC
+    // (`\\?\UNC\...`) and other verbatim device paths (`\\?\prefix`) don't, so there's nothing
+    // to case-fold for those.
+    //
+    // We can't read the letter from `VerbatimDisk(disk)` because that value is already
+    // normalized to uppercase, so it wouldn't tell us whether the underlying path needs
+    // rewriting.
+    let is_verbatim_disk = matches!(
+        path.components().next(),
+        Some(Component::Prefix(prefix)) if matches!(prefix.kind(), Prefix::VerbatimDisk(_))
+    );
+    if !is_verbatim_disk {
+        return Ok(path);
     }
 
-    #[cfg(not(windows))]
-    Ok(path.to_path_buf())
+    // The layout is `\\?\C:\...`, so the drive letter is the 5th UTF-16 code unit (index 4)
+    // and is guaranteed to be a-z or A-Z.
+    if let Some(disk) = path.as_os_str().encode_wide().nth(4).map(|disk| disk as u8)
+        && disk.is_ascii_lowercase()
+    {
+        // we must encode/decode because OsString's internal encoding is opaque/unstable
+        let mut wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+        wide[4] = u16::from(disk.to_ascii_uppercase());
+        return Ok(PathBuf::from(OsString::from_wide(&wide)));
+    }
+
+    Ok(path)
 }
 
-#[cfg(all(test, windows))]
+#[cfg(test)]
 mod tests {
     use std::path::Path;
 
@@ -86,5 +127,19 @@ mod tests {
             fold(r"\\?\UNC\server\share\foo"),
             r"\\?\UNC\server\share\foo"
         );
+    }
+
+    #[test]
+    fn identifies_junction_points() {
+        let scratch = tempfile::tempdir().unwrap();
+        let target = scratch.path().join("target");
+        let link = scratch.path().join("link");
+        let file = scratch.path().join("file");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::File::create(&file).unwrap();
+        std::os::windows::fs::junction_point(&target, &link).unwrap();
+
+        assert!(is_link_junction_point(&link).unwrap());
+        assert!(!is_link_junction_point(&file).unwrap());
     }
 }

--- a/turbopack/crates/turbo-tasks-fuzz/src/fs_watcher.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/fs_watcher.rs
@@ -20,7 +20,8 @@ use turbo_tasks::{
 };
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_fs::{
-    DiskFileSystem, File, FileContent, FileSystem, FileSystemPath, LinkContent, LinkType,
+    DiskFileSystem, File, FileContent, FileSystem, FileSystemPath, WriteLinkContent,
+    WriteLinkTarget, WriteLinkTargetType,
 };
 
 // `read_or_write_all_paths_operation` always writes the sentinel values to files/symlinks. We can
@@ -76,12 +77,12 @@ enum SymlinkMode {
 }
 
 impl SymlinkMode {
-    fn to_link_type(self) -> LinkType {
+    fn is_directory(self) -> bool {
         match self {
-            SymlinkMode::File => LinkType::empty(),
-            SymlinkMode::Directory => LinkType::DIRECTORY,
+            SymlinkMode::File => false,
+            SymlinkMode::Directory => true,
             #[cfg(windows)]
-            SymlinkMode::Junction => LinkType::DIRECTORY,
+            SymlinkMode::Junction => true,
         }
     }
 }
@@ -139,8 +140,7 @@ pub async fn run(args: FsWatcher) -> anyhow::Result<()> {
         };
         let track_writes = args.track_writes;
         let symlink_mode = args.symlinks;
-        let symlink_is_directory =
-            symlink_mode.map(|m| m.to_link_type().contains(LinkType::DIRECTORY));
+        let symlink_is_directory = symlink_mode.map(SymlinkMode::is_directory);
 
         let effects_op = extract_effects_operation(read_or_write_all_paths_operation(
             invalidations.clone(),
@@ -348,12 +348,14 @@ async fn write_link(
 ) -> anyhow::Result<()> {
     let path_str = path.path.clone();
     invalidations.0.lock().unwrap().insert(path_str);
-    let link_type = if is_directory {
-        LinkType::DIRECTORY
-    } else {
-        LinkType::empty()
+    let link_content = WriteLinkContent {
+        target: WriteLinkTarget::Relative(target),
+        target_type: if is_directory {
+            WriteLinkTargetType::DirectoryOrJunctionPoint
+        } else {
+            WriteLinkTargetType::FileNonPortable
+        },
     };
-    let link_content = LinkContent::Link { target, link_type };
     let _ = path
         .fs()
         .write_link(path.clone(), link_content.cell())

--- a/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
@@ -13,7 +13,10 @@ use turbo_tasks::{
     read_strongly_consistent_and_apply_effects, take_effects,
 };
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
-use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath, LinkContent, LinkType};
+use turbo_tasks_fs::{
+    DiskFileSystem, FileSystem, FileSystemPath, WriteLinkContent, WriteLinkTarget,
+    WriteLinkTargetType,
+};
 
 #[derive(Args)]
 pub struct SymlinkStress {
@@ -40,6 +43,15 @@ async fn extract_effects_operation(op: OperationVc<()>) -> anyhow::Result<Vc<Eff
 }
 
 pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
+    // Each batch writes `parallelism` distinct symlinks, so there must be enough to go around.
+    if args.parallelism > args.symlink_count {
+        anyhow::bail!(
+            "--parallelism ({}) must not exceed --symlink-count ({}), since a batch cannot write \
+             the same symlink twice",
+            args.parallelism,
+            args.symlink_count,
+        );
+    }
     std::fs::create_dir(&args.fs_root)?;
     let fs_root = args.fs_root.canonicalize()?;
     let _guard = FsCleanup {
@@ -58,7 +70,12 @@ pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
     std::fs::create_dir(&symlinks_dir)?;
 
     let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
-        BackendOptions::default(),
+        BackendOptions {
+            // `noop_backing_storage` is read-only, so asking to persist on shutdown (the default)
+            // just fails with "Cannot perform write operations on a read-only database".
+            storage_mode: None,
+            ..Default::default()
+        },
         noop_backing_storage(),
     ));
 
@@ -102,6 +119,8 @@ pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
         );
 
         let mut rng = rand::rngs::SmallRng::from_rng(&mut rand::rng());
+        // Reused across batches; each batch partially shuffles it to sample distinct symlinks.
+        let mut symlink_indices: Vec<usize> = (0..symlink_count).collect();
         let mut total_writes: u64 = 0;
         let mut last_progress_writes: u64 = 0;
         let start_time = Instant::now();
@@ -113,13 +132,18 @@ pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
                 break;
             }
 
-            // Generate random symlink updates for this batch
-            let updates: Vec<(usize, usize)> = (0..parallelism)
-                .map(|_| {
-                    let symlink_idx = rng.random_range(0..symlink_count);
-                    let target_idx = rng.random_range(0..target_count);
-                    (symlink_idx, target_idx)
-                })
+            // Pick `parallelism` *distinct* symlinks for this batch, via a partial Fisher-Yates
+            // shuffle. They must be distinct because writing two different targets to one path
+            // within a single operation is a conflicting effect: a usage error, not something to
+            // stress test. Sampling without replacement (rather than deduplicating) keeps the
+            // batch size exactly `parallelism`, so the reported concurrency is honest.
+            for i in 0..parallelism {
+                let j = rng.random_range(i..symlink_count);
+                symlink_indices.swap(i, j);
+            }
+            let updates: Vec<(usize, usize)> = symlink_indices[..parallelism]
+                .iter()
+                .map(|&symlink_idx| (symlink_idx, rng.random_range(0..target_count)))
                 .collect();
 
             // Execute writes in parallel via turbo-tasks
@@ -169,17 +193,17 @@ pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[turbo_tasks::function(operation)]
+#[turbo_tasks::function(operation, root)]
 fn disk_file_system_operation(fs_root: RcStr) -> Vc<DiskFileSystem> {
     DiskFileSystem::new(rcstr!("project"), Vc::cell(fs_root))
 }
 
-#[turbo_tasks::function(operation)]
+#[turbo_tasks::function(operation, root)]
 fn disk_file_system_root_operation(fs: ResolvedVc<DiskFileSystem>) -> Vc<FileSystemPath> {
     fs.root()
 }
 
-#[turbo_tasks::function(operation)]
+#[turbo_tasks::function(operation, root)]
 async fn create_initial_symlinks_operation(
     symlinks_dir: FileSystemPath,
     count: usize,
@@ -192,7 +216,7 @@ async fn create_initial_symlinks_operation(
     Ok(())
 }
 
-#[turbo_tasks::function(operation)]
+#[turbo_tasks::function(operation, root)]
 async fn write_symlinks_batch_operation(
     symlinks_dir: FileSystemPath,
     updates: Vec<(usize, usize)>,
@@ -215,9 +239,9 @@ async fn write_symlink(
     target: RcStr,
 ) -> anyhow::Result<()> {
     let symlink_path = symlinks_dir.join(&symlink_idx.to_string())?;
-    let link_content = LinkContent::Link {
-        target,
-        link_type: LinkType::DIRECTORY,
+    let link_content = WriteLinkContent {
+        target: WriteLinkTarget::Relative(target),
+        target_type: WriteLinkTargetType::DirectoryOrJunctionPoint,
     };
     symlink_path
         .fs()

--- a/turbopack/crates/turbo-tasks-macros/src/derive/deterministic_hash_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/deterministic_hash_macro.rs
@@ -10,28 +10,27 @@ use crate::expand::{generate_exhaustive_destructuring, match_expansion};
 ///
 /// This requires that every contained value also implement `DeterministicHash`.
 pub fn derive_deterministic_hash(input: TokenStream) -> TokenStream {
-    let derive_input = parse_macro_input!(input as DeriveInput);
-
-    let ident = &derive_input.ident;
-    let match_hash = match_expansion(
+    let DeriveInput {
         ident,
-        &derive_input.data,
-        &hash_named,
-        &hash_unnamed,
-        &hash_unit,
-    );
-    let discriminant = match derive_input.data {
+        generics,
+        data,
+        ..
+    } = parse_macro_input!(input as DeriveInput);
+
+    let match_hash = match_expansion(&ident, &data, &hash_named, &hash_unnamed, &hash_unit);
+    let discriminant = match data {
         Data::Enum(_) => {
             quote! {
-                turbo_tasks_hash::DeterministicHash::deterministic_hash(&std::mem::discriminant(self), __state__);
+                ::turbo_tasks_hash::DeterministicHash::deterministic_hash(&std::mem::discriminant(self), __state__);
             }
         }
         _ => quote! {},
     };
 
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     quote! {
         #[automatically_derived]
-        impl turbo_tasks_hash::DeterministicHash for #ident {
+        impl #impl_generics ::turbo_tasks_hash::DeterministicHash for #ident #ty_generics #where_clause {
             fn deterministic_hash<H: turbo_tasks_hash::DeterministicHasher>(&self, __state__: &mut H) {
                 #discriminant
                 #match_hash

--- a/turbopack/crates/turbo-unix-path/src/lib.rs
+++ b/turbopack/crates/turbo-unix-path/src/lib.rs
@@ -6,11 +6,11 @@ use std::borrow::Cow;
 /// directory separators with forward slashes on Windows.
 #[inline]
 pub fn sys_to_unix(path: &str) -> Cow<'_, str> {
-    #[cfg(not(target_family = "windows"))]
+    #[cfg(not(windows))]
     {
         Cow::from(path)
     }
-    #[cfg(target_family = "windows")]
+    #[cfg(windows)]
     {
         Cow::Owned(path.replace(std::path::MAIN_SEPARATOR_STR, "/"))
     }
@@ -20,11 +20,11 @@ pub fn sys_to_unix(path: &str) -> Cow<'_, str> {
 /// slash directory separators with backslashes on Windows.
 #[inline]
 pub fn unix_to_sys(path: &str) -> Cow<'_, str> {
-    #[cfg(not(target_family = "windows"))]
+    #[cfg(not(windows))]
     {
         Cow::from(path)
     }
-    #[cfg(target_family = "windows")]
+    #[cfg(windows)]
     {
         Cow::Owned(path.replace('/', std::path::MAIN_SEPARATOR_STR))
     }
@@ -36,10 +36,8 @@ pub fn unix_to_sys(path: &str) -> Cow<'_, str> {
 /// see also [normalize_path] for normalization.
 /// Returns `None` if the joined path would leave the filesystem root.
 pub fn join_path(fs_path: &str, join: &str) -> Option<String> {
-    // Paths that we join are written as source code (eg, `join_path(fs_path, "foo/bar.js")`) and
-    // it's expected that they will never contain a backslash.
     debug_assert!(
-        !join.contains('\\'),
+        !cfg!(windows) || !join.contains('\\'),
         "joined path {join} must not contain a Windows directory '\\', it must be normalized to \
          Unix '/'"
     );

--- a/turbopack/crates/turbopack-core/src/asset.rs
+++ b/turbopack/crates/turbopack-core/src/asset.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{
-    FileContent, FileJsonContent, FileLinesContent, FileSystemPath, LinkContent, LinkType,
+    FileContent, FileJsonContent, FileLinesContent, FileSystemPath, WriteLinkContent,
 };
 use turbo_tasks_hash::{HashAlgorithm, deterministic_hash};
 
@@ -52,10 +52,8 @@ pub trait Asset {
 #[derive(Clone)]
 pub enum AssetContent {
     File(ResolvedVc<FileContent>),
-    // for the relative link, the target is raw value read from the link
-    // for the absolute link, the target is stripped of the root path while reading
-    // See [LinkContent::Link] for more details.
-    Redirect { target: RcStr, link_type: LinkType },
+    /// A symbolic link. See [`WriteLinkContent`] for how it is written.
+    Redirect(WriteLinkContent),
 }
 
 #[turbo_tasks::value_impl]
@@ -69,7 +67,7 @@ impl AssetContent {
     pub fn parse_json(&self) -> Vc<FileJsonContent> {
         match self {
             AssetContent::File(content) => content.parse_json(),
-            AssetContent::Redirect { .. } => {
+            AssetContent::Redirect(..) => {
                 FileJsonContent::unparsable(rcstr!("a redirect can't be parsed as json")).cell()
             }
         }
@@ -79,7 +77,7 @@ impl AssetContent {
     pub fn file_content(&self) -> Vc<FileContent> {
         match self {
             AssetContent::File(content) => **content,
-            AssetContent::Redirect { .. } => FileContent::NotFound.cell(),
+            AssetContent::Redirect(..) => FileContent::NotFound.cell(),
         }
     }
 
@@ -87,7 +85,7 @@ impl AssetContent {
     pub fn lines(&self) -> Vc<FileLinesContent> {
         match self {
             AssetContent::File(content) => content.lines(),
-            AssetContent::Redirect { .. } => FileLinesContent::Unparsable.cell(),
+            AssetContent::Redirect(..) => FileLinesContent::Unparsable.cell(),
         }
     }
 
@@ -95,7 +93,7 @@ impl AssetContent {
     pub fn len(&self) -> Vc<Option<u64>> {
         match self {
             AssetContent::File(content) => content.len(),
-            AssetContent::Redirect { .. } => Vc::cell(None),
+            AssetContent::Redirect(..) => Vc::cell(None),
         }
     }
 
@@ -103,7 +101,7 @@ impl AssetContent {
     pub fn parse_json_with_comments(&self) -> Vc<FileJsonContent> {
         match self {
             AssetContent::File(content) => content.parse_json_with_comments(),
-            AssetContent::Redirect { .. } => {
+            AssetContent::Redirect(..) => {
                 FileJsonContent::unparsable(rcstr!("a redirect can't be parsed as json")).cell()
             }
         }
@@ -115,16 +113,10 @@ impl AssetContent {
             AssetContent::File(file) => {
                 path.write(**file).as_side_effect().await?;
             }
-            AssetContent::Redirect { target, link_type } => {
-                path.write_symbolic_link_dir(
-                    LinkContent::Link {
-                        target: target.clone(),
-                        link_type: *link_type,
-                    }
-                    .cell(),
-                )
-                .as_side_effect()
-                .await?;
+            AssetContent::Redirect(content) => {
+                path.write_link(content.clone().cell())
+                    .as_side_effect()
+                    .await?;
             }
         }
         Ok(())
@@ -134,9 +126,9 @@ impl AssetContent {
     pub async fn hash(&self, salt: Vc<RcStr>, algorithm: HashAlgorithm) -> Result<Vc<RcStr>> {
         Ok(match self {
             AssetContent::File(content) => content.hash(salt, algorithm),
-            AssetContent::Redirect { target, link_type } => Vc::cell(RcStr::from(
+            AssetContent::Redirect(content) => Vc::cell(RcStr::from(
                 // no_hash_salt
-                deterministic_hash(&salt.await?, (target, link_type), algorithm),
+                deterministic_hash(&salt.await?, content, algorithm),
             )),
         })
     }
@@ -154,7 +146,7 @@ impl AssetContent {
     ) -> Result<Vc<Option<RcStr>>> {
         match self {
             AssetContent::File(content) => Ok(content.content_hash(salt, algorithm)),
-            AssetContent::Redirect { .. } => Ok(Vc::cell(None)),
+            AssetContent::Redirect(..) => Ok(Vc::cell(None)),
         }
     }
 }

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -1,7 +1,10 @@
 use anyhow::{Result, bail};
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
-use turbo_tasks_fs::{FileContent, FileSystemEntryType, FileSystemPath, LinkContent};
+use turbo_tasks_fs::{
+    FileContent, FileSystemEntryType, FileSystemPath, LinkContent, LinkTarget, WriteLinkContent,
+    WriteLinkTarget, WriteLinkTargetType,
+};
 
 use crate::{
     asset::{Asset, AssetContent},
@@ -66,11 +69,31 @@ impl Asset for FileSource {
         let file_type = &*self.path.get_type().await?;
         match file_type {
             FileSystemEntryType::Symlink => match &*self.path.read_link().await? {
-                LinkContent::Link { target, link_type } => Ok(AssetContent::Redirect {
-                    target: target.clone(),
-                    link_type: *link_type,
+                LinkContent::Link { target } => {
+                    let write_target = match target {
+                        LinkTarget::Absolute { resolved } => {
+                            WriteLinkTarget::Absolute(resolved.path.clone())
+                        }
+                        LinkTarget::Relative { raw, .. } => WriteLinkTarget::Relative(raw.clone()),
+                    };
+                    let target_fs_path = target.file_system_path();
+                    let write_target_type = match *target_fs_path.get_type().await? {
+                        FileSystemEntryType::Directory => {
+                            WriteLinkTargetType::DirectoryOrJunctionPoint
+                        }
+                        FileSystemEntryType::Symlink
+                            if *target_fs_path.is_junction_point().await? =>
+                        {
+                            WriteLinkTargetType::DirectoryOrJunctionPoint
+                        }
+                        _ => WriteLinkTargetType::FileNonPortable,
+                    };
+                    Ok(AssetContent::Redirect(WriteLinkContent {
+                        target: write_target,
+                        target_type: write_target_type,
+                    })
+                    .cell())
                 }
-                .cell()),
                 _ => bail!("Invalid symlink"),
             },
             FileSystemEntryType::File => {

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -70,22 +70,27 @@ impl Asset for FileSource {
         match file_type {
             FileSystemEntryType::Symlink => match &*self.path.read_link().await? {
                 LinkContent::Link { target } => {
-                    debug_assert!(
-                        !matches!(
-                            *target.file_system_path().get_type().await?,
-                            FileSystemEntryType::Directory
-                        ),
-                        "FileSource cannot represent a symlink to a directory"
-                    );
                     let write_target = match target {
                         LinkTarget::Absolute { resolved } => {
                             WriteLinkTarget::Absolute(resolved.path.clone())
                         }
                         LinkTarget::Relative { raw, .. } => WriteLinkTarget::Relative(raw.clone()),
                     };
+                    let target_fs_path = target.file_system_path();
+                    let write_target_type = match *target_fs_path.get_type().await? {
+                        FileSystemEntryType::Directory => {
+                            WriteLinkTargetType::DirectoryOrJunctionPoint
+                        }
+                        FileSystemEntryType::Symlink
+                            if *target_fs_path.is_junction_point().await? =>
+                        {
+                            WriteLinkTargetType::DirectoryOrJunctionPoint
+                        }
+                        _ => WriteLinkTargetType::FileNonPortable,
+                    };
                     Ok(AssetContent::Redirect(WriteLinkContent {
                         target: write_target,
-                        target_type: WriteLinkTargetType::FileNonPortable,
+                        target_type: write_target_type,
                     })
                     .cell())
                 }

--- a/turbopack/crates/turbopack-core/src/file_source.rs
+++ b/turbopack/crates/turbopack-core/src/file_source.rs
@@ -70,27 +70,22 @@ impl Asset for FileSource {
         match file_type {
             FileSystemEntryType::Symlink => match &*self.path.read_link().await? {
                 LinkContent::Link { target } => {
+                    debug_assert!(
+                        !matches!(
+                            *target.file_system_path().get_type().await?,
+                            FileSystemEntryType::Directory
+                        ),
+                        "FileSource cannot represent a symlink to a directory"
+                    );
                     let write_target = match target {
                         LinkTarget::Absolute { resolved } => {
                             WriteLinkTarget::Absolute(resolved.path.clone())
                         }
                         LinkTarget::Relative { raw, .. } => WriteLinkTarget::Relative(raw.clone()),
                     };
-                    let target_fs_path = target.file_system_path();
-                    let write_target_type = match *target_fs_path.get_type().await? {
-                        FileSystemEntryType::Directory => {
-                            WriteLinkTargetType::DirectoryOrJunctionPoint
-                        }
-                        FileSystemEntryType::Symlink
-                            if *target_fs_path.is_junction_point().await? =>
-                        {
-                            WriteLinkTargetType::DirectoryOrJunctionPoint
-                        }
-                        _ => WriteLinkTargetType::FileNonPortable,
-                    };
                     Ok(AssetContent::Redirect(WriteLinkContent {
                         target: write_target,
-                        target_type: write_target_type,
+                        target_type: WriteLinkTargetType::FileNonPortable,
                     })
                     .cell())
                 }

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -54,9 +54,7 @@ pub async fn content_to_details(content: Vc<AssetContent>) -> Result<Vc<RcStr>> 
             }
             FileContent::NotFound => Vc::cell(rcstr!("not found")),
         },
-        AssetContent::Redirect { target, link_type } => {
-            Vc::cell(format!("redirect to {target} with type {link_type:?}").into())
-        }
+        AssetContent::Redirect(content) => Vc::cell(format!("redirect to {content:?}").into()),
     })
 }
 

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -14,7 +14,7 @@ use turbo_tasks::{
     NonLocalValue, TaskInput, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{
-    FileSystemPath, LinkContent, LinkType, RawDirectoryContent, RawDirectoryEntry,
+    FileSystemEntryType, FileSystemPath, LinkContent, RawDirectoryContent, RawDirectoryEntry,
 };
 use turbo_unix_path::normalize_path;
 
@@ -1606,12 +1606,12 @@ pub async fn read_matches(
                         )),
                         RawDirectoryEntry::Symlink => {
                             let fs_path = parent_fs_path.join(last_segment)?;
-                            let LinkContent::Link { link_type, .. } = &*fs_path.read_link().await?
-                            else {
+                            let LinkContent::Link { target } = &*fs_path.read_link().await? else {
                                 continue;
                             };
                             let path = concat(&prefix, str).into();
-                            if link_type.contains(LinkType::DIRECTORY) {
+                            if matches!(target.target_type().await?, FileSystemEntryType::Directory)
+                            {
                                 results.push((index, PatternMatch::Directory(path, fs_path)));
                             } else {
                                 results.push((index, PatternMatch::File(path, fs_path)))
@@ -1795,10 +1795,13 @@ pub async fn read_matches(
                                 }
                                 if let Some(pos) = pat.match_position(&prefix) {
                                     let fs_path = lookup_dir.join(key)?;
-                                    if let LinkContent::Link { link_type, .. } =
+                                    if let LinkContent::Link { target } =
                                         &*fs_path.read_link().await?
                                     {
-                                        if link_type.contains(LinkType::DIRECTORY) {
+                                        if matches!(
+                                            target.target_type().await?,
+                                            FileSystemEntryType::Directory
+                                        ) {
                                             results.push((
                                                 pos,
                                                 PatternMatch::Directory(
@@ -1817,9 +1820,12 @@ pub async fn read_matches(
                                 prefix.push('/');
                                 if let Some(pos) = pat.match_position(&prefix) {
                                     let fs_path = lookup_dir.join(key)?;
-                                    if let LinkContent::Link { link_type, .. } =
+                                    if let LinkContent::Link { target } =
                                         &*fs_path.read_link().await?
-                                        && link_type.contains(LinkType::DIRECTORY)
+                                        && matches!(
+                                            target.target_type().await?,
+                                            FileSystemEntryType::Directory
+                                        )
                                     {
                                         results.push((
                                             pos,
@@ -1829,9 +1835,12 @@ pub async fn read_matches(
                                 }
                                 if let Some(pos) = pat.could_match_position(&prefix) {
                                     let fs_path = lookup_dir.join(key)?;
-                                    if let LinkContent::Link { link_type, .. } =
+                                    if let LinkContent::Link { target } =
                                         &*fs_path.read_link().await?
-                                        && link_type.contains(LinkType::DIRECTORY)
+                                        && matches!(
+                                            target.target_type().await?,
+                                            FileSystemEntryType::Directory
+                                        )
                                     {
                                         results.push((
                                             pos,

--- a/turbopack/crates/turbopack-core/src/server_fs.rs
+++ b/turbopack/crates/turbopack-core/src/server_fs.rs
@@ -2,6 +2,7 @@ use anyhow::{Result, bail};
 use turbo_tasks::{ValueToString, Vc};
 use turbo_tasks_fs::{
     FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent,
+    WriteLinkContent,
 };
 
 #[turbo_tasks::value]
@@ -30,6 +31,11 @@ impl FileSystem for ServerFileSystem {
     }
 
     #[turbo_tasks::function]
+    fn is_junction_point(&self, _fs_path: FileSystemPath) -> Result<Vc<bool>> {
+        bail!("Reading is not possible from the marker filesystem for the server")
+    }
+
+    #[turbo_tasks::function]
     fn raw_read_dir(&self, _fs_path: FileSystemPath) -> Result<Vc<RawDirectoryContent>> {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
@@ -40,7 +46,11 @@ impl FileSystem for ServerFileSystem {
     }
 
     #[turbo_tasks::function]
-    fn write_link(&self, _fs_path: FileSystemPath, _target: Vc<LinkContent>) -> Result<Vc<()>> {
+    fn write_link(
+        &self,
+        _fs_path: FileSystemPath,
+        _target: Vc<WriteLinkContent>,
+    ) -> Result<Vc<()>> {
         bail!("Writing is not possible to the marker filesystem for the server")
     }
 

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -234,7 +234,7 @@ impl FileHashVersion {
                     .context("file not found")?;
                 Ok(Self::cell(FileHashVersion { hash }))
             }
-            AssetContent::Redirect { .. } => bail!("not a file"),
+            AssetContent::Redirect(..) => bail!("not a file"),
         }
     }
 }

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -378,7 +378,7 @@ pub async fn parse_css(
         let content = source.content();
         let ident_str = &*source.ident().to_string().await?;
         Ok(match &*content.await? {
-            AssetContent::Redirect { .. } => ParseCssResult::Unparsable.cell(),
+            AssetContent::Redirect(..) => ParseCssResult::Unparsable.cell(),
             AssetContent::File(file_content) => match &*file_content.await? {
                 FileContent::NotFound => ParseCssResult::NotFound.cell(),
                 FileContent::Content(file) => match file.content().to_str() {

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -372,7 +372,7 @@ async fn parse_internal(
                 }
             }
         },
-        AssetContent::Redirect { .. } => ParseResult::Unparsable { messages: None }.cell(),
+        AssetContent::Redirect(..) => ParseResult::Unparsable { messages: None }.cell(),
     })
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -4,7 +4,10 @@ use anyhow::{Context, Result};
 use bincode::{Decode, Encode};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToStringRef, Vc, trace::TraceRawVcs};
-use turbo_tasks_fs::{FileSystem, FileSystemPath, LinkType, VirtualFileSystem, rope::RopeBuilder};
+use turbo_tasks_fs::{
+    FileSystem, FileSystemPath, VirtualFileSystem, WriteLinkContent, WriteLinkTarget,
+    WriteLinkTargetType, rope::RopeBuilder,
+};
 use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -508,10 +511,10 @@ impl Asset for ExternalsSymlinkAsset {
         )
         .into();
 
-        Ok(AssetContent::Redirect {
-            target,
-            link_type: LinkType::DIRECTORY,
-        }
+        Ok(AssetContent::Redirect(WriteLinkContent {
+            target: WriteLinkTarget::Relative(target),
+            target_type: WriteLinkTargetType::DirectoryOrJunctionPoint,
+        })
         .cell())
     }
 }

--- a/turbopack/crates/turbopack-test-utils/src/snapshot.rs
+++ b/turbopack/crates/turbopack-test-utils/src/snapshot.rs
@@ -169,9 +169,7 @@ async fn get_contents(file: Vc<AssetContent>) -> Result<Option<String>> {
                 }
             }
         },
-        AssetContent::Redirect { target, link_type } => Some(format!(
-            "Redirect {{ target: {target}, link_type: {link_type:?} }}"
-        )),
+        AssetContent::Redirect(content) => Some(format!("Redirect {content:?}")),
     })
 }
 


### PR DESCRIPTION
Another attempt at cleanup, similar to https://github.com/vercel/next.js/pull/96955.

We need different information to write symlinks or junction points (most notably, if it's a directory or not) than we get when reading symlinks.

We were trying to use the same data structure for both, but this lead us to always call `get_type()` as part of reading a link, which was just silly.

This also meant that `write_link` had to handle `NotFound` and `Invalid`. `NotFound` is somewhat reasonable (just delete the file), but `Invalid` is awkward.