### PR TITLE
Improve getStaticPaths error message for invalid catch-all array parameters

### DIFF
--- a/packages/next/src/build/static-paths/pages.ts
+++ b/packages/next/src/build/static-paths/pages.ts
@@ -174,6 +174,15 @@ export async function buildPagesStaticPaths({
           )
         }
 
+        if (repeat && Array.isArray(paramValue)) {
+          const invalidItem = paramValue.find((item) => typeof item !== 'string')
+          if (typeof invalidItem !== 'undefined') {
+            throw new Error(
+              `A required parameter (${validParamKey}) was not provided as an array of strings received ${typeof invalidItem} in getStaticPaths for ${page}`
+            )
+          }
+        }
+
         let replaced = `[${repeat ? '...' : ''}${validParamKey}]`
         if (optional) {
           replaced = `[${replaced}]`

--- a/test/integration/prerender-invalid-catchall-params-array-item/pages/[...slug].js
+++ b/test/integration/prerender-invalid-catchall-params-array-item/pages/[...slug].js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+export async function getStaticPaths() {
+  return { paths: [{ params: { slug: [123] } }], fallback: true }
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      time: (await import('perf_hooks')).performance.now(),
+    },
+  }
+}
+
+export default function Page() {
+  return <div />
+}

--- a/test/integration/prerender-invalid-catchall-params-array-item/test/index.test.ts
+++ b/test/integration/prerender-invalid-catchall-params-array-item/test/index.test.ts
@@ -1,0 +1,21 @@
+/* eslint-env jest */
+
+import { join } from 'path'
+import { nextBuild } from 'next-test-utils'
+
+const appDir = join(__dirname, '..')
+
+describe('Invalid Prerender Catchall Params Array Item', () => {
+  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+    'production mode',
+    () => {
+      it('should fail the build with a clear array item type error', async () => {
+        const out = await nextBuild(appDir, [], { stderr: true })
+        expect(out.stderr).toMatch('Build error occurred')
+        expect(out.stderr).toMatch(
+          'A required parameter (slug) was not provided as an array of strings received number in getStaticPaths for /[...slug]'
+        )
+      })
+    }
+  )
+})


### PR DESCRIPTION
## Fixes
Closes #41281

## Summary
Adds explicit type validation for catch-all dynamic route parameters returned from `getStaticPaths`. When a catch-all parameter array item is not a string (e.g., `{ slug: [123] }`), the build now fails with a clear error message instead of causing cryptic failures during SSR rendering.

## Changes
- **packages/next/src/build/static-paths/pages.ts**: Added validation check that for catch-all array parameters, each item must be a string. Throws descriptive error if validation fails.
- **test/integration/prerender-invalid-catchall-params-array-item/**: Added integration test fixture and test case to verify the error message is clear and helpful.

## Testing
✅ Integration test added and passing:
- Test: `test/integration/prerender-invalid-catchall-params-array-item/test/index.test.ts`
- Fixture: Page with catch-all route returning non-string parameter
- Assertion: Build fails with expected error message: "A required parameter (slug) was not provided as an array of strings received number in getStaticPaths for /[...slug]"

## Related
- Issue: #41281
- User provided clear reproduction case and identified exact code location