### PR TITLE
Warn and ignore invalid next/head tags

### DIFF
--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -47,6 +47,19 @@ function onlyReactElement(
 }
 
 const METATYPES = ['name', 'httpEquiv', 'charSet', 'itemProp']
+const VALID_HEAD_TAGS = new Set([
+  'base',
+  'link',
+  'meta',
+  'noscript',
+  'script',
+  'style',
+  'title',
+])
+
+function isValidHeadTag(h: React.ReactElement<any>) {
+  return typeof h.type !== 'string' || VALID_HEAD_TAGS.has(h.type)
+}
 
 /*
  returns a function for filtering head child elements
@@ -121,6 +134,16 @@ function reduceComponents(
 ) {
   return headChildrenElements
     .reduce(onlyReactElement, [])
+    .filter((h) => {
+      if (!isValidHeadTag(h)) {
+        warnOnce(
+          `Do not use <${h.type}> in next/head. It will be ignored. See: https://nextjs.org/docs/messages/no-head-element`
+        )
+        return false
+      }
+
+      return true
+    })
     .reverse()
     .concat(defaultHead().reverse())
     .filter(unique())

--- a/test/e2e/next-head/app/pages/invalid-head.js
+++ b/test/e2e/next-head/app/pages/invalid-head.js
@@ -1,0 +1,13 @@
+import Head from 'next/head'
+
+export default function InvalidHeadPage() {
+  return (
+    <div>
+      <Head>
+        <html lang="en" />
+        <title>Invalid Head</title>
+      </Head>
+      <h1>Invalid head example</h1>
+    </div>
+  )
+}

--- a/test/e2e/next-head/index.test.ts
+++ b/test/e2e/next-head/index.test.ts
@@ -67,4 +67,24 @@ describe('next/head', () => {
       'hello'
     )
   })
+
+  it('should warn and ignore invalid head tags', async () => {
+    const browser = await webdriver(next.url, '/invalid-head')
+
+    await browser.waitForElementByCss('h1')
+
+    const browserLogs = await browser.log()
+    const warning = browserLogs.find(({ message }) =>
+      message.includes('Do not use <html> in next/head')
+    )
+
+    expect(warning).toBeTruthy()
+    expect(await browser.eval(() => document.title)).toBe('Invalid Head')
+    expect(
+      await browser.eval(() => document.head.querySelector('title')?.textContent)
+    ).toBe('Invalid Head')
+    expect(
+      await browser.eval(() => document.body.querySelector('html'))
+    ).toBeNull()
+  })
 })

--- a/test/unit/next-head-rendering.test.ts
+++ b/test/unit/next-head-rendering.test.ts
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 import Head from 'next/head'
+import { HeadManagerContext } from 'next/dist/shared/lib/head-manager-context.shared-runtime'
 import React from 'react'
 import ReactDOM from 'react-dom/server'
 
@@ -14,5 +15,45 @@ describe('Rendering next/head', () => {
       )
     )
     expect(html).toContain('hello world')
+  })
+
+  it('should warn and ignore invalid head tags', () => {
+    const updateHead = jest.fn()
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    ReactDOM.renderToString(
+      React.createElement(
+        HeadManagerContext.Provider,
+        {
+          value: {
+            mountedInstances: new Set(),
+            updateHead,
+          },
+        },
+        React.createElement(
+          Head,
+          {},
+          React.createElement('html', { lang: 'en' }),
+          React.createElement('title', {}, 'Invalid Head')
+        )
+      )
+    )
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Do not use <html> in next/head')
+    )
+    expect(updateHead).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'title',
+          props: expect.objectContaining({ children: 'Invalid Head' }),
+        }),
+      ])
+    )
+    expect(updateHead).not.toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ type: 'html' })])
+    )
+
+    warnSpy.mockRestore()
   })
 })


### PR DESCRIPTION
Teach `next/head` to warn once and ignore unsupported intrinsic tags such as `<html>`, instead of letting them reach the head manager and produce confusing runtime behavior.

Impact:
- Prevents invalid head tags from leaking into the rendered head.
- Preserves the valid title/meta path while surfacing a clear warning.

Validation:
- `pnpm testheadless test/unit/next-head-rendering.test.ts`
- 2/2 tests passed