### PR TITLE
fix(codemod): write pnpm overrides to the workspace root

### DIFF
--- a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/README.md
+++ b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/README.md
@@ -1,0 +1,61 @@
+Verifies that on pnpm v11+, upgrading an app that lives inside a pnpm
+workspace writes `@types/react` / `@types/react-dom` overrides to the
+workspace root's `pnpm-workspace.yaml` instead of creating a new one next to
+the app's `package.json`.
+
+A `pnpm-workspace.yaml` is what makes a directory a pnpm workspace root, so
+creating one in `apps/web` would declare a nested workspace root: `apps/web`
+would be cut off from the real root and stop resolving `@fixture/ui`
+(`workspace:*`).
+
+The overrides are scoped to the app with pnpm's `<package>><dependency>`
+selector so sibling packages such as `@fixture/ui` keep their own
+`@types/react` resolution.
+See https://pnpm.io/settings/dependency-resolution#overrides.
+
+Run this fixture with pnpm v11+ on PATH, from the app directory:
+
+```sh
+pnpm test:upgrade-fixture bin/__testfixtures__/pnpm-v11-workspace-overrides/apps/web latest
+```
+
+Expected: no `apps/web/pnpm-workspace.yaml` is created, and the root manifest
+gains scoped overrides.
+
+```diff
+diff --git a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/apps/web/package.json b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/apps/web/package.json
+--- a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/apps/web/package.json
++++ b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/apps/web/package.json
+@@ -6,9 +6,9 @@
+   "dependencies": {
+     "@fixture/ui": "workspace:*",
+-    "next": "14.3.0-canary.44",
+-    "react": "18.2.0",
+-    "react-dom": "18.2.0",
+-    "@types/react": "^18.2.0",
+-    "@types/react-dom": "^18.2.0"
++    "next": "15.0.4-canary.43",
++    "react": "19.0.0",
++    "react-dom": "19.0.0",
++    "@types/react": "19.0.0",
++    "@types/react-dom": "19.0.0"
+   }
+ }
+diff --git a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/pnpm-workspace.yaml b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/pnpm-workspace.yaml
+--- a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/pnpm-workspace.yaml
++++ b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/pnpm-workspace.yaml
+@@ -1,8 +1,11 @@
+ packages:
+   - 'apps/*'
+   - 'packages/*'
+ allowBuilds:
+   sharp: false
+   unrs-resolver: false
++overrides:
++  '@fixture/web>@types/react': 19.0.0
++  '@fixture/web>@types/react-dom': 19.0.0
+```
+
+Note that the comment at the top of `pnpm-workspace.yaml` is dropped: `js-yaml`
+cannot round-trip comments. The upgrade prints a warning saying so, and skips
+the rewrite entirely when the overrides are already up to date.

--- a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/apps/web/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/apps/web/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@fixture/web",
+  "scripts": {
+    "dev": "next dev"
+  },
+  "dependencies": {
+    "@fixture/ui": "workspace:*",
+    "next": "14.3.0-canary.44",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
+  }
+}

--- a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pnpm-v11-workspace-overrides",
+  "private": true,
+  "packageManager": "pnpm@11.5.3"
+}

--- a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/packages/ui/package.json
+++ b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/packages/ui/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixture/ui",
+  "version": "0.0.0",
+  "dependencies": {
+    "@types/react": "^18.2.0"
+  }
+}

--- a/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/pnpm-workspace.yaml
+++ b/packages/next-codemod/bin/__testfixtures__/pnpm-v11-workspace-overrides/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+# The workspace root. `apps/web` must keep resolving `@fixture/ui` from here.
+packages:
+  - 'apps/*'
+  - 'packages/*'
+
+allowBuilds:
+  sharp: false
+  unrs-resolver: false

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -8,6 +8,7 @@ import {
   minor,
 } from 'semver'
 import { execSync } from 'child_process'
+import findUp from 'find-up'
 import path from 'path'
 import pc from 'picocolors'
 import {
@@ -765,7 +766,7 @@ function writeOverridesField(
     // since that's the surface where silently-dropped overrides hurt most.
     const pnpmMajorVersion = getPnpmMajorVersion()
     if (pnpmMajorVersion === null || pnpmMajorVersion >= 11) {
-      writePnpmWorkspaceOverrides(overrides)
+      writePnpmWorkspaceOverrides(overrides, packageJson.name)
       return
     }
 
@@ -811,13 +812,54 @@ function writeOverridesField(
   }
 }
 
-function writePnpmWorkspaceOverrides(overrides: Record<string, string>) {
+/**
+ * Resolve the directory that owns `pnpm-workspace.yaml`.
+ *
+ * pnpm treats the directory containing `pnpm-workspace.yaml` as the workspace
+ * root and only reads settings such as `overrides` from that single file. In a
+ * monorepo the upgrade runs from an app package, so creating a new
+ * `pnpm-workspace.yaml` next to that app's `package.json` would declare a
+ * *nested* workspace root: the app would be cut off from the real root and stop
+ * resolving `workspace:*` dependencies on its sibling packages.
+ *
+ * Walking up mirrors how pnpm itself locates the workspace root. When no
+ * manifest exists anywhere above, the project is standalone and `cwd` is the
+ * correct place to create one.
+ */
+function findPnpmWorkspaceRoot(fromDir: string): string {
+  const workspaceManifest = findUp.sync('pnpm-workspace.yaml', { cwd: fromDir })
+  return workspaceManifest ? path.dirname(workspaceManifest) : fromDir
+}
+
+function writePnpmWorkspaceOverrides(
+  overrides: Record<string, string>,
+  appPackageName: unknown
+) {
   // Deferred require so `js-yaml` is only loaded when we hit the pnpm v11+
   // branch (i.e. not for npm/yarn/bun/pnpm-v10 upgrades). The package is CJS,
   // so a sync `require()` keeps this function synchronous.
   const yaml = require('js-yaml') as typeof import('js-yaml')
 
-  const filePath = path.join(cwd, 'pnpm-workspace.yaml')
+  const workspaceRoot = findPnpmWorkspaceRoot(cwd)
+  const filePath = path.join(workspaceRoot, 'pnpm-workspace.yaml')
+  const isSharedWorkspaceRoot = workspaceRoot !== cwd
+
+  // A shared workspace root's overrides apply to every package in the
+  // workspace, so an unqualified `@types/react` entry would force the upgraded
+  // app's version onto unrelated siblings. pnpm can scope an override to a
+  // single parent package with `<package>><dependency>`, which keeps the
+  // upgrade contained to the app being upgraded.
+  // x-ref: https://pnpm.io/settings/dependency-resolution#overrides
+  let scope: string | null = null
+  if (isSharedWorkspaceRoot) {
+    if (typeof appPackageName === 'string' && appPackageName !== '') {
+      scope = appPackageName
+    } else {
+      console.log(
+        `${pc.yellow('⚠')} The package.json at "${cwd}" has no "name", so the overrides below could not be scoped to it and will apply to every package in the workspace.`
+      )
+    }
+  }
 
   let doc: Record<string, any> = {}
   if (fs.existsSync(filePath)) {
@@ -831,11 +873,37 @@ function writePnpmWorkspaceOverrides(overrides: Record<string, string>) {
   if (!doc.overrides || typeof doc.overrides !== 'object') {
     doc.overrides = {}
   }
-  for (const [key, value] of Object.entries(overrides)) {
+  const changedKeys: string[] = []
+  for (const [dependency, value] of Object.entries(overrides)) {
+    const key = scope === null ? dependency : `${scope}>${dependency}`
+    if (doc.overrides[key] !== value) {
+      changedKeys.push(key)
+    }
     doc.overrides[key] = value
   }
 
+  // `js-yaml` cannot round-trip comments, so re-serializing strips them from a
+  // file we don't own. Skip the write when every override already has the value
+  // we would set — re-running the upgrade shouldn't damage the manifest.
+  if (changedKeys.length === 0) {
+    return
+  }
+
   fs.writeFileSync(filePath, yaml.dump(doc))
+
+  if (isSharedWorkspaceRoot) {
+    console.log(
+      `${pc.yellow('⚠')} pnpm only reads overrides from the workspace root, so ${changedKeys
+        .map((key) => `"${key}"`)
+        .join(
+          ', '
+        )} ${changedKeys.length === 1 ? 'was' : 'were'} written to "${filePath}".` +
+        (scope === null
+          ? ''
+          : `\n  They are scoped to "${scope}" so the rest of the workspace is unaffected.`) +
+        `\n  Comments in that file were not preserved.`
+    )
+  }
 }
 
 function warnDependenciesOutOfRange(


### PR DESCRIPTION
### What?

`next upgrade` created a `pnpm-workspace.yaml` in the directory it was run
from. In a pnpm monorepo that is the app package, so the file now lands in the
workspace root instead, and the `@types/react` / `@types/react-dom` overrides
it writes are scoped to the package being upgraded.

### Why?

The presence of `pnpm-workspace.yaml` is what defines a pnpm workspace root.
Writing one next to an app's `package.json` declared a *nested* root: the app
was cut off from the real one and stopped resolving its `workspace:*`
dependencies on sibling packages.

Overrides in a shared root apply to the whole workspace, so hoisting them
without scoping would force the upgraded app's `@types/react` version onto
unrelated packages.

Introduced in #94690.

### How?

- Walk up from the current directory to the nearest `pnpm-workspace.yaml`,
  the way pnpm locates the workspace root, and write there. With no manifest
  anywhere above, the project is standalone and the file is still created in
  place — unchanged for single-package projects.
- Write scoped keys using pnpm's `<package>><dependency>` selector, e.g.
  `'@fixture/web>@types/react': 19.2.18`, so siblings keep their own
  resolution. Falls back to an unqualified key with a warning if the app's
  `package.json` has no `name`.
- Skip the rewrite when every override already holds the value the upgrade
  would set. `js-yaml` cannot round-trip comments, and re-running the upgrade
  should not repeatedly strip them from a file the tool does not own.
- Warn when writing into a shared root, naming the file, the scope, and the
  lost comments.

Verified on a real 13-package pnpm workspace running pnpm v11.21.0, upgrading
its Next.js app from 16.2.9 to 16.3.1: no `pnpm-workspace.yaml` was created
beside the app, the root manifest gained the scoped overrides, `pnpm install`
completed across all 13 projects, and the app's `node_modules` kept its
workspace symlinks.

```
⚠ pnpm only reads overrides from the workspace root, so "@repo/web>@types/react",
  "@repo/web>@types/react-dom" were written to "<root>/pnpm-workspace.yaml".
  They are scoped to "@repo/web" so the rest of the workspace is unaffected.
  Comments in that file were not preserved.
```

Also verified on a throwaway two-package workspace, where a second run with
unchanged versions wrote nothing and printed no warning, and a run after
clearing the `overrides:` block re-emitted it.

Known limitation, not changed here: an actual write still drops comments from
the manifest. Preserving them means swapping `js-yaml` for `yaml`.

### Fixing a bug

- [x] Related issues linked using `fixes #number`
- [x] Tests added — `bin/__testfixtures__/pnpm-v11-workspace-overrides/`,
      following the existing manual fixture convention in that directory:
      `pnpm test:upgrade-fixture bin/__testfixtures__/pnpm-v11-workspace-overrides/apps/web latest`
- [ ] Errors have a helpful link attached — n/a, no new error



Fixes #98941
