### PR TITLE
test: update React 18 redbox snapshot

### DIFF
--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -124,7 +124,7 @@ describe('Client Navigation rendering', () => {
     test('getInitialProps circular structure', async () => {
       const browser = await next.browser('/circular-json-error')
 
-      if (isReact18 && isTurbopack) {
+      if (isReact18) {
         await expect(browser).toDisplayRedbox(`
          {
            "code": "E490",


### PR DESCRIPTION
## Summary

Update the circular getInitialProps redbox snapshot selection for all React 18 test runs.

This matches the `new Promise <anonymous>` stack frame observed in the React 18 webpack canary CI group.

## Verification

- `HEADLESS=true IS_WEBPACK_TEST=1 NEXT_TEST_MODE=dev NEXT_TEST_REACT_VERSION="18.3.1" __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true NEXT_TEST_PREFER_OFFLINE=1 pnpm test-dev-webpack test/development/pages-dir/client-navigation/rendering.test.ts -t "getInitialProps circular structure"`
- `pnpm build-all` (blocked by the existing `web-vitals` missing `onFID` type error)

<!-- NEXT_JS_LLM -->