### PR TITLE
test: dynamic Pages API route routing with i18n adapter output

### DIFF
--- a/test/production/adapter-i18n-dynamic-api-route/adapter-i18n-dynamic-api-route.test.ts
+++ b/test/production/adapter-i18n-dynamic-api-route/adapter-i18n-dynamic-api-route.test.ts
@@ -1,0 +1,43 @@
+import { nextTestSetup } from 'e2e-utils'
+import type { NextAdapter } from 'next'
+
+// Regression test for https://github.com/vercel/next.js/issues/97231
+// With `i18n` configured, the adapter routing entry for a dynamic Pages Router
+// API route stopped accepting the locale-prefixed pathname that i18n routing
+// resolves to, so deployments served the 404 page instead of the API function.
+describe('adapter i18n dynamic Pages API route', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('matches locale-prefixed requests for dynamic Pages API routes', async () => {
+    const { outputs, routing }: Parameters<NextAdapter['onBuildComplete']>[0] =
+      await next.readJSON('build-complete.json')
+
+    expect(
+      outputs.pagesApi.find((output) => output.pathname === '/api/dynamic/[id]')
+    ).toBeDefined()
+
+    const apiRoute = routing.dynamicRoutes.find(
+      (route) => route.source === '/api/dynamic/[id]'
+    )
+    const pageRoute = routing.dynamicRoutes.find(
+      (route) => route.source === '/blog/[slug]'
+    )
+
+    expect(apiRoute).toBeDefined()
+    expect(pageRoute).toBeDefined()
+
+    const apiRegex = new RegExp(apiRoute.sourceRegex)
+    const pageRegex = new RegExp(pageRoute.sourceRegex)
+
+    // the dynamic page route matches every locale prefix
+    expect(pageRegex.test('/de/blog/hello')).toBe(true)
+    expect(pageRegex.test('/en/blog/hello')).toBe(true)
+
+    // the dynamic API route has to do the same, otherwise the locale-prefixed
+    // pathname falls through to the 404 output
+    expect(apiRegex.test('/de/api/dynamic/123')).toBe(true)
+    expect(apiRegex.test('/en/api/dynamic/123')).toBe(true)
+  })
+})

--- a/test/production/adapter-i18n-dynamic-api-route/my-adapter.mjs
+++ b/test/production/adapter-i18n-dynamic-api-route/my-adapter.mjs
@@ -1,0 +1,12 @@
+import fs from 'fs/promises'
+
+// @ts-check
+/** @type {import('next').NextAdapter} */
+const adapter = {
+  name: 'i18n-dynamic-api-route-adapter',
+  async onBuildComplete(ctx) {
+    await fs.writeFile('build-complete.json', JSON.stringify(ctx, null, 2))
+  },
+}
+
+export default adapter

--- a/test/production/adapter-i18n-dynamic-api-route/next.config.mjs
+++ b/test/production/adapter-i18n-dynamic-api-route/next.config.mjs
@@ -1,0 +1,14 @@
+import Module from 'module'
+
+const require = Module.createRequire(import.meta.url)
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  adapterPath: require.resolve('./my-adapter.mjs'),
+  i18n: {
+    locales: ['de', 'en'],
+    defaultLocale: 'de',
+  },
+}
+
+export default nextConfig

--- a/test/production/adapter-i18n-dynamic-api-route/pages/api/dynamic/[id].ts
+++ b/test/production/adapter-i18n-dynamic-api-route/pages/api/dynamic/[id].ts
@@ -1,0 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json(req.query)
+}

--- a/test/production/adapter-i18n-dynamic-api-route/pages/api/static.ts
+++ b/test/production/adapter-i18n-dynamic-api-route/pages/api/static.ts
@@ -1,0 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json({ ok: true })
+}

--- a/test/production/adapter-i18n-dynamic-api-route/pages/blog/[slug].tsx
+++ b/test/production/adapter-i18n-dynamic-api-route/pages/blog/[slug].tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>blog</p>
+}

--- a/test/production/adapter-i18n-dynamic-api-route/pages/index.tsx
+++ b/test/production/adapter-i18n-dynamic-api-route/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}


### PR DESCRIPTION
## What?

Adds regression coverage for dynamic Pages Router API routes with `i18n`
configured in adapter builds.

Dynamic API routes such as `/api/dynamic/[id]` must retain locale-prefixed
routing information when `i18n` is enabled.

Without this coverage, the regression could cause locale-prefixed API
requests to fall through to the 404 route in deployments.

## Why?

This covers #97231.

The regression was caused by dynamic Pages API routes being excluded from
i18n localization in the adapter build output.

The corresponding production fix is already present in canary via
`2f84a1f288`.

## Test plan

- `adapter-i18n-dynamic-api-route.test.ts`
- `adapter-config-i18n.test.ts`

Both pass with webpack.

The regression test verifies that:

- `/api/dynamic/[id]` is present in `pagesApi`
- the dynamic API route is present in adapter routing metadata
- locale-prefixed `/de/api/dynamic/123` matches
- locale-prefixed `/en/api/dynamic/123` matches
- normal dynamic Pages routes continue to match locale-prefixed paths