### PR TITLE
test: deflake use-cache-size-zero warm reload

### DIFF
--- a/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
+++ b/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
@@ -24,19 +24,12 @@ describe('use-cache-size-zero', () => {
     expect(await browser.elementByCss('p', { waitUntil: false }).text()).toBe(
       'Loading...'
     )
-    await retry(async () => {
-      expect(
-        await browser.elementByCss('p', { waitUntil: false }).text()
-      ).toBeDateString()
-    })
+    // After observing the streamed fallback, wait for the initial document to
+    // finish loading so the cold request is fully settled before reloading.
     const coldValue = await browser
-      .elementByCss('p', { waitUntil: false })
+      .elementByCss('#value', { waitUntil: 'load' })
       .text()
-
-    // Wait for the cache write to settle before reloading. The generated value
-    // can finish streaming before the backing cache has persisted it, which
-    // would race the reload below and turn the expected warm hit into a miss.
-    await waitFor(2000)
+    expect(coldValue).toBeDateString()
 
     // Warm reload: `cacheMaxMemorySize: 0` still caches in development, so the
     // reload serves the previously cached value fast instead of regenerating

--- a/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
+++ b/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
@@ -49,6 +49,11 @@ describe('use-cache-size-zero', () => {
       const $ = await next.render$('/reload')
       expect($('#value').text()).not.toBe(coldValue)
     })
+
+    // Once independent requests observe convergence, confirm the next browser
+    // reload also exposes a fresh value through the user-visible path.
+    await browser.refresh()
+    expect(await browser.elementById('value').text()).not.toBe(coldValue)
   })
 
   it('shows the Cold cache badge on an initial cold load and not on a warm reload', async () => {

--- a/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
+++ b/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
@@ -33,6 +33,11 @@ describe('use-cache-size-zero', () => {
       .elementByCss('p', { waitUntil: false })
       .text()
 
+    // Wait for the cache write to settle before reloading. The generated value
+    // can finish streaming before the backing cache has persisted it, which
+    // would race the reload below and turn the expected warm hit into a miss.
+    await waitFor(2000)
+
     // Warm reload: `cacheMaxMemorySize: 0` still caches in development, so the
     // reload serves the previously cached value fast instead of regenerating
     // it. The entry keeps its default (non-dynamic) cache life, so it's served

--- a/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
+++ b/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
@@ -4,9 +4,6 @@ import { retry, waitFor, waitForNoErrorToast } from 'next-test-utils'
 describe('use-cache-size-zero', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
-    // Expose completed default-handler writes so the test can synchronize with
-    // background revalidation without relying on an elapsed-time delay.
-    env: { NEXT_PRIVATE_DEBUG_CACHE: '1' },
   })
 
   if (skipped) {
@@ -27,22 +24,12 @@ describe('use-cache-size-zero', () => {
     expect(await browser.elementByCss('p', { waitUntil: false }).text()).toBe(
       'Loading...'
     )
+    // After observing the streamed fallback, wait for the initial document to
+    // finish loading so the cold request is fully settled before reloading.
     const coldValue = await browser
-      .elementByCss('#value', { waitUntil: false })
+      .elementByCss('#value', { waitUntil: 'load' })
       .text()
     expect(coldValue).toBeDateString()
-
-    const completedReloadCacheWrites = () =>
-      next.cliOutput.match(
-        /DefaultCacheHandler: set \["[A-Za-z0-9_-]+","[0-9a-f]+",\["reload"\],"[^"]+"\] done/g
-      )?.length ?? 0
-
-    // The value can finish streaming before the cache handler has persisted
-    // it. Wait for that write before testing the first warm reload.
-    await retry(() => {
-      expect(completedReloadCacheWrites()).toBeGreaterThan(0)
-    }, 10000)
-    const cacheWritesBeforeWarmReload = completedReloadCacheWrites()
 
     // Warm reload: `cacheMaxMemorySize: 0` still caches in development, so the
     // reload serves the previously cached value fast instead of regenerating
@@ -55,17 +42,13 @@ describe('use-cache-size-zero', () => {
       await browser.elementByCss('#value', { waitUntil: false }).text()
     ).toBe(coldValue)
 
-    // That warm reload regenerates a fresh entry in the background. The warm
-    // response can finish before that write, so wait for the handler to commit
-    // another value before checking the next reload.
-    await retry(() => {
-      expect(completedReloadCacheWrites()).toBeGreaterThan(
-        cacheWritesBeforeWarmReload
-      )
-    }, 10000)
-
-    await browser.refresh()
-    expect(await browser.elementById('value').text()).not.toBe(coldValue)
+    // That warm reload regenerates a fresh entry in the background. Poll with
+    // independent requests so we can observe convergence without navigating
+    // away from (and potentially cancelling) the warm browser request.
+    await retry(async () => {
+      const $ = await next.render$('/reload')
+      expect($('#value').text()).not.toBe(coldValue)
+    })
   })
 
   it('shows the Cold cache badge on an initial cold load and not on a warm reload', async () => {

--- a/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
+++ b/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
@@ -4,6 +4,9 @@ import { retry, waitFor, waitForNoErrorToast } from 'next-test-utils'
 describe('use-cache-size-zero', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // Expose completed default-handler writes so the test can synchronize with
+    // background revalidation without relying on an elapsed-time delay.
+    env: { NEXT_PRIVATE_DEBUG_CACHE: '1' },
   })
 
   if (skipped) {
@@ -24,12 +27,22 @@ describe('use-cache-size-zero', () => {
     expect(await browser.elementByCss('p', { waitUntil: false }).text()).toBe(
       'Loading...'
     )
-    // After observing the streamed fallback, wait for the initial document to
-    // finish loading so the cold request is fully settled before reloading.
     const coldValue = await browser
-      .elementByCss('#value', { waitUntil: 'load' })
+      .elementByCss('#value', { waitUntil: false })
       .text()
     expect(coldValue).toBeDateString()
+
+    const completedReloadCacheWrites = () =>
+      next.cliOutput.match(
+        /DefaultCacheHandler: set \["[A-Za-z0-9_-]+","[0-9a-f]+",\["reload"\],"[^"]+"\] done/g
+      )?.length ?? 0
+
+    // The value can finish streaming before the cache handler has persisted
+    // it. Wait for that write before testing the first warm reload.
+    await retry(() => {
+      expect(completedReloadCacheWrites()).toBeGreaterThan(0)
+    }, 10000)
+    const cacheWritesBeforeWarmReload = completedReloadCacheWrites()
 
     // Warm reload: `cacheMaxMemorySize: 0` still caches in development, so the
     // reload serves the previously cached value fast instead of regenerating
@@ -38,23 +51,21 @@ describe('use-cache-size-zero', () => {
     // background revalidation regenerates a fresh entry for the next reload
     // (asserted below).
     await browser.refresh({ waitUntil: 'commit' })
-    await retry(async () => {
-      expect(
-        await browser.elementByCss('p', { waitUntil: false }).text()
-      ).toBeDateString()
-    })
-    expect(await browser.elementByCss('p', { waitUntil: false }).text()).toBe(
-      coldValue
-    )
+    expect(
+      await browser.elementByCss('#value', { waitUntil: false }).text()
+    ).toBe(coldValue)
 
-    // That warm reload regenerated a fresh entry in the background, so a later
-    // reload converges to the new value. Read after "load" here (a plain
-    // refresh) since we want the settled value, not the streaming inspection
-    // above.
-    await retry(async () => {
-      await browser.refresh()
-      expect(await browser.elementById('value').text()).not.toBe(coldValue)
-    })
+    // That warm reload regenerates a fresh entry in the background. The warm
+    // response can finish before that write, so wait for the handler to commit
+    // another value before checking the next reload.
+    await retry(() => {
+      expect(completedReloadCacheWrites()).toBeGreaterThan(
+        cacheWritesBeforeWarmReload
+      )
+    }, 10000)
+
+    await browser.refresh()
+    expect(await browser.elementById('value').text()).not.toBe(coldValue)
   })
 
   it('shows the Cold cache badge on an initial cold load and not on a warm reload', async () => {


### PR DESCRIPTION
## Summary

Keep the first warm reload assertion focused on browser-visible stale-while-revalidate behavior, then poll the route with independent HTTP requests until a later response observes the fresh value. After convergence, perform one final browser reload to confirm the user-visible path also receives an updated value.

This avoids fixed delays, cache debug logging, and repeated browser navigations that can cancel or outpace background regeneration. The convergence poll uses the standard 3-second `retry()` window and returns as soon as freshness is observed; the browser only reloads again after that condition is satisfied.

## Verification

- `__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true NEXT_TEST_CI=true HEADLESS=true pnpm test-dev-webpack test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts`
- `__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true NEXT_TEST_CI=true HEADLESS=true pnpm test-dev-turbo test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts`

<!-- NEXT_JS_LLM -->