### PR TITLE
Test foreground blocking and fallback parameter matching

### DIFF
--- a/test/e2e/app-dir/generate-prerender-matching/fixtures/foreground-policy/app/blocking/[slug]/page.tsx
+++ b/test/e2e/app-dir/generate-prerender-matching/fixtures/foreground-policy/app/blocking/[slug]/page.tsx
@@ -1,0 +1,17 @@
+import { PolicyPage } from '../../policy-page'
+
+export const experimental_paramMatching = {
+  slug: 'blocking',
+} as const
+
+export function generateStaticParams() {
+  return [{ slug: 'seed' }]
+}
+
+export default function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  return <PolicyPage params={params} policy="blocking" />
+}

--- a/test/e2e/app-dir/generate-prerender-matching/fixtures/foreground-policy/app/fallback/[slug]/page.tsx
+++ b/test/e2e/app-dir/generate-prerender-matching/fixtures/foreground-policy/app/fallback/[slug]/page.tsx
@@ -1,0 +1,17 @@
+import { PolicyPage } from '../../policy-page'
+
+export const experimental_paramMatching = {
+  slug: 'fallback',
+} as const
+
+export function generateStaticParams() {
+  return [{ slug: 'seed' }]
+}
+
+export default function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  return <PolicyPage params={params} policy="fallback" />
+}

--- a/test/e2e/app-dir/generate-prerender-matching/fixtures/foreground-policy/app/layout.tsx
+++ b/test/e2e/app-dir/generate-prerender-matching/fixtures/foreground-policy/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/generate-prerender-matching/fixtures/foreground-policy/app/policy-page.tsx
+++ b/test/e2e/app-dir/generate-prerender-matching/fixtures/foreground-policy/app/policy-page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from 'react'
+
+function ShellMarker({ policy }: { policy: 'blocking' | 'fallback' }) {
+  return <p data-shell-marker={policy}>{performance.now().toFixed(3)}</p>
+}
+
+async function Params({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  return <p id="params">{slug}</p>
+}
+
+export function PolicyPage({
+  params,
+  policy,
+}: {
+  params: Promise<{ slug: string }>
+  policy: 'blocking' | 'fallback'
+}) {
+  return (
+    <>
+      <ShellMarker policy={policy} />
+      <Suspense fallback={<p id="shell">waiting for params</p>}>
+        <Params params={params} />
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/generate-prerender-matching/fixtures/foreground-policy/next.config.js
+++ b/test/e2e/app-dir/generate-prerender-matching/fixtures/foreground-policy/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    paramMatching: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/generate-prerender-matching/generate-prerender-matching.test.ts
+++ b/test/e2e/app-dir/generate-prerender-matching/generate-prerender-matching.test.ts
@@ -235,6 +235,52 @@ describe('experimental parameter matching complex route shapes', () => {
   }
 })
 
+describe('experimental parameter matching foreground policy', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: path.join(__dirname, 'fixtures', 'foreground-policy'),
+  })
+
+  if (skipped || isNextDev) {
+    it.skip('only runs against a production route cache', () => {})
+    return
+  }
+
+  function readShellMarker(body: string): string {
+    const match = body.match(/data-shell-marker="[^"]+">([^<]+)</)
+    expect(match).not.toBeNull()
+    return match![1]
+  }
+
+  async function render(pathname: string) {
+    const response = await next.fetch(pathname)
+    expect(response.status).toBe(200)
+    const body = await response.text()
+    expect(body).toContain(`<p id="params">${pathname.split('/').at(-1)}</p>`)
+    return { body, marker: readShellMarker(body) }
+  }
+
+  it('generates a distinct shell before returning a blocking miss', async () => {
+    const first = await render('/blocking/novel-a')
+    const other = await render('/blocking/novel-b')
+
+    expect(other.marker).not.toBe(first.marker)
+    expect(first.body).not.toContain('<p id="shell">waiting for params</p>')
+    expect(other.body).not.toContain('<p id="shell">waiting for params</p>')
+
+    const repeat = await render('/blocking/novel-a')
+    expect(repeat.marker).toBe(first.marker)
+  })
+
+  it('returns the shared build shell for a fallback miss', async () => {
+    const first = await render('/fallback/novel-a')
+    const other = await render('/fallback/novel-b')
+
+    expect(other.marker).toBe(first.marker)
+    expect(first.body).toContain('<p id="shell">waiting for params</p>')
+    expect(other.body).toContain('<p id="shell">waiting for params</p>')
+  })
+})
+
 describe('experimental parameter matching ordering validation', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'invalid-order'),


### PR DESCRIPTION
## Summary

Add test-only production route-cache coverage proving that explicit `blocking` and `fallback` parameter matching policies produce different foreground behavior.

The fixture uses equivalent `/blocking/[slug]` and `/fallback/[slug]` routes. Each shell writes a timestamp marker before a Suspense boundary so the test can distinguish a newly generated parameter-resolved shell from the shared build-time fallback shell.

Depends on #97426 and does not change framework implementation.

## Blocking example

```text
GET /blocking/novel-a -> shell A, no loading boundary
GET /blocking/novel-b -> shell B, no loading boundary
GET /blocking/novel-a -> shell A reused from the route cache
```

The first request for each novel slug waits for its parameter-specific shell to be generated. Different slugs therefore have different markers, and a repeated slug reuses the shell generated for that cache key.

## Fallback example

```text
GET /fallback/novel-a -> shared build shell, "waiting for params"
GET /fallback/novel-b -> same shared build shell, "waiting for params"
```

Both misses immediately receive the generic build-time shell and resume the parameter-dependent UI dynamically. They therefore share a marker and expose the loading boundary even though the completed response includes the requested slug.

These assertions distinguish cache behavior that status-code-only tests cannot observe: both policies ultimately return `200`, but blocking generates before responding while fallback responds from an existing shell.

## Verification

- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/e2e/app-dir/generate-prerender-matching/generate-prerender-matching.test.ts -t "foreground policy"`
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-webpack test/e2e/app-dir/generate-prerender-matching/generate-prerender-matching.test.ts -t "foreground policy"`

<!-- NEXT_JS_LLM -->

