### PR TITLE
Fix prototype-shadowing in searchParamsToUrlQuery

### DIFF
--- a/packages/next/src/shared/lib/router/utils/querystring.test.ts
+++ b/packages/next/src/shared/lib/router/utils/querystring.test.ts
@@ -1,0 +1,55 @@
+import { searchParamsToUrlQuery, urlQueryToSearchParams } from './querystring'
+
+describe('searchParamsToUrlQuery', () => {
+  it('reads a single parameter and repeats into an array', () => {
+    expect(searchParamsToUrlQuery(new URLSearchParams('a=1'))).toEqual({
+      a: '1',
+    })
+    expect(searchParamsToUrlQuery(new URLSearchParams('a=1&a=2&a=3'))).toEqual({
+      a: ['1', '2', '3'],
+    })
+  })
+
+  it.each(['constructor', 'toString', 'valueOf', 'hasOwnProperty'])(
+    'reads a parameter named %p, which shadows an Object.prototype member',
+    (key) => {
+      // Reading through the prototype chain reported the inherited member as an
+      // already-seen value, so the parameter came back as `[Function, '1']`.
+      expect(searchParamsToUrlQuery(new URLSearchParams(`${key}=1`))).toEqual({
+        [key]: '1',
+      })
+      expect(
+        searchParamsToUrlQuery(new URLSearchParams(`${key}=1&${key}=2`))
+      ).toEqual({ [key]: ['1', '2'] })
+    }
+  )
+
+  it('reads a parameter named __proto__ without moving the prototype', () => {
+    const query = searchParamsToUrlQuery(new URLSearchParams('__proto__=1&a=2'))
+
+    // `query.__proto__ = '1'` hit the inherited setter, so the parameter was
+    // dropped and the object's prototype was replaced instead.
+    expect(Object.keys(query).sort()).toEqual(['__proto__', 'a'])
+    expect(query['__proto__']).toBe('1')
+    expect(Object.getPrototypeOf(query)).toBe(Object.prototype)
+  })
+
+  it('returns an ordinary object, so prototype methods stay callable', () => {
+    // `router.query` is public API and callers do reach for these, e.g.
+    // `compareRouterStates` in ./compare-states.
+    const query = searchParamsToUrlQuery(new URLSearchParams('__proto__=1'))
+
+    expect(query.hasOwnProperty('__proto__')).toBe(true)
+    expect(query.hasOwnProperty('a')).toBe(false)
+  })
+
+  it('round-trips prototype-shadowing names back into search params', () => {
+    const search = '__proto__=1&constructor=2&a=3'
+
+    expect(
+      urlQueryToSearchParams(
+        searchParamsToUrlQuery(new URLSearchParams(search))
+      ).toString()
+    ).toBe(new URLSearchParams(search).toString())
+  })
+})

--- a/packages/next/src/shared/lib/router/utils/querystring.ts
+++ b/packages/next/src/shared/lib/router/utils/querystring.ts
@@ -1,17 +1,46 @@
 import type { ParsedUrlQuery } from 'querystring'
 
+/**
+ * Adds one entry to a query object.
+ *
+ * `query[key] = value` cannot be used: for a `key` of `__proto__` that reaches
+ * the setter inherited from `Object.prototype`, which replaces the object's
+ * prototype instead of adding an entry, and the parameter disappears from the
+ * query altogether. Defining the property keeps the ordinary object shape that
+ * `router.query` consumers rely on, unlike a null-prototype object.
+ */
+function defineQueryValue(
+  query: ParsedUrlQuery,
+  key: string,
+  value: string | string[]
+): void {
+  Object.defineProperty(query, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  })
+}
+
 export function searchParamsToUrlQuery(
   searchParams: URLSearchParams
 ): ParsedUrlQuery {
   const query: ParsedUrlQuery = {}
   for (const [key, value] of searchParams.entries()) {
-    const existing = query[key]
-    if (typeof existing === 'undefined') {
-      query[key] = value
+    // Reading `query[key]` goes through the prototype chain, so a parameter
+    // named after an `Object.prototype` member (`constructor`, `toString`,
+    // `valueOf`, ...) reads back the inherited value and is mistaken for a
+    // parameter that was already seen.
+    const existing = Object.prototype.hasOwnProperty.call(query, key)
+      ? query[key]
+      : undefined
+
+    if (existing === undefined) {
+      defineQueryValue(query, key, value)
     } else if (Array.isArray(existing)) {
       existing.push(value)
     } else {
-      query[key] = [existing, value]
+      defineQueryValue(query, key, [existing, value])
     }
   }
   return query


### PR DESCRIPTION
## What?

Fixes `searchParamsToUrlQuery` handling of search parameter names that collide with properties inherited from `Object.prototype`.

The function currently reads `query[key]` from a regular object to determine whether a parameter has already been added. For keys such as `constructor`, `toString`, `valueOf`, or `hasOwnProperty`, that lookup can resolve an inherited property instead of an existing query parameter.

For example, `?constructor=1` can be interpreted as if `constructor` already existed, producing an incorrect value instead of `"1"`.

`__proto__` is a more problematic case because assigning it through the inherited setter does not create an own query property and can instead change the object's prototype.

This matters for request-controlled input as well. One of the call sites is `server/web/edge-route-module-wrapper.ts`, where `request.nextUrl.searchParams` is converted into route handler params.

## Why?

Search parameter names should be treated as data regardless of whether they happen to match properties on `Object.prototype`.

This change ensures those keys are handled as actual query entries instead of interacting with inherited properties.

I considered using `Object.create(null)` for the resulting query object, which would also match the behavior of Node.js `querystring.parse()`. I avoided that here because `router.query` is a public API and existing code, including `shared/lib/router/utils/compare-states.ts`, expects methods such as `hasOwnProperty` to be available.

I'm happy to switch to a null-prototype object instead if that is preferred, along with updating those expectations.

## Tests

Added coverage for prototype-colliding query parameter names, including:

* `constructor`
* `toString`
* `valueOf`
* `hasOwnProperty`
* `__proto__`

The new regression cases fail on a clean `canary` checkout and pass with this change.

Validated with:

```text
jest packages/next/src/shared/lib/router/ test/unit/
```

118 suites and 1037 tests passing.

Types and Prettier also pass.

I did not run the e2e suite.
