### PR TITLE
Trace lazy App Route module loading

### DIFF
--- a/packages/next/src/server/lib/trace/constants.ts
+++ b/packages/next/src/server/lib/trace/constants.ts
@@ -116,6 +116,10 @@ enum AppRouteRouteHandlersSpan {
   runHandler = 'AppRouteRouteHandlers.runHandler',
 }
 
+enum AppRouteRouteModuleSpan {
+  loadUserland = 'AppRouteRouteModule.loadUserland',
+}
+
 enum RouteModuleSpan {
   prepare = 'RouteModule.prepare',
   loadManifests = 'RouteModule.loadManifests',
@@ -142,6 +146,7 @@ type SpanTypes =
   | `${DevBundlerServiceSpan}`
   | `${NodeSpan}`
   | `${AppRouteRouteHandlersSpan}`
+  | `${AppRouteRouteModuleSpan}`
   | `${RouteModuleSpan}`
   | `${ResolveMetadataSpan}`
   | `${MiddlewareSpan}`
@@ -158,6 +163,7 @@ export const NextVanillaSpanAllowlist = new Set([
   RenderSpan.renderDocument,
   NodeSpan.runHandler,
   AppRouteRouteHandlersSpan.runHandler,
+  AppRouteRouteModuleSpan.loadUserland,
   RouteModuleSpan.prepare,
   InstrumentationSpan.loadModule,
   InstrumentationSpan.register,
@@ -191,6 +197,7 @@ export {
   DevBundlerServiceSpan,
   NodeSpan,
   AppRouteRouteHandlersSpan,
+  AppRouteRouteModuleSpan,
   RouteModuleSpan,
   ResolveMetadataSpan,
   MiddlewareSpan,

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -24,6 +24,7 @@ import {
   traceLocalSpan,
 } from './local-span-recorder'
 import {
+  AppRouteRouteModuleSpan,
   AppRenderSpan,
   BaseServerSpan,
   InstrumentationSpan,
@@ -268,6 +269,7 @@ describe('local span recording', () => {
     ])
 
     getTracer().trace(RouteModuleSpan.prepare, () => undefined)
+    getTracer().trace(AppRouteRouteModuleSpan.loadUserland, () => undefined)
     getTracer().trace(RouteModuleSpan.loadManifests, () => undefined)
     getTracer().trace(InstrumentationSpan.register, () => undefined)
     getTracer().trace(InstrumentationSpan.loadModule, () => undefined)
@@ -275,6 +277,7 @@ describe('local span recording', () => {
       NodeSpan.runHandler,
       LoadComponentsSpan.loadRouteModule,
       RouteModuleSpan.prepare,
+      AppRouteRouteModuleSpan.loadUserland,
       InstrumentationSpan.register,
       InstrumentationSpan.loadModule,
     ])
@@ -287,6 +290,7 @@ describe('local span recording', () => {
       NodeSpan.runHandler,
       LoadComponentsSpan.loadRouteModule,
       RouteModuleSpan.prepare,
+      AppRouteRouteModuleSpan.loadUserland,
       InstrumentationSpan.register,
       InstrumentationSpan.loadModule,
       BaseServerSpan.render,

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -22,7 +22,10 @@ import { type HTTP_METHOD, HTTP_METHODS, isHTTPMethod } from '../../web/http'
 import { getImplicitTags, type ImplicitTags } from '../../lib/implicit-tags'
 import { patchFetch } from '../../lib/patch-fetch'
 import { getTracer } from '../../lib/trace/tracer'
-import { AppRouteRouteHandlersSpan } from '../../lib/trace/constants'
+import {
+  AppRouteRouteHandlersSpan,
+  AppRouteRouteModuleSpan,
+} from '../../lib/trace/constants'
 import * as Log from '../../../build/output/log'
 import { autoImplementMethods } from './helpers/auto-implement-methods'
 import {
@@ -281,8 +284,19 @@ export class AppRouteRouteModule extends RouteModule<
     this.resolvedPagePath = resolvedPagePath
     this.nextConfigOutput = nextConfigOutput
     this._getUserland = getUserland
-    this._lazyUserland = new LazyModule(userland, (module) =>
-      this._onUserlandLoaded(module)
+    this._lazyUserland = new LazyModule(
+      () =>
+        getTracer().trace(
+          AppRouteRouteModuleSpan.loadUserland,
+          {
+            spanName: 'load app route module',
+            attributes: {
+              'next.route': this.definition.pathname,
+            },
+          },
+          userland
+        ),
+      (module) => this._onUserlandLoaded(module)
     )
 
     // output:export routes load eagerly, so that errors surface at module

--- a/test/e2e/opentelemetry/instrumentation/app/api/app/[param]/data/route.ts
+++ b/test/e2e/opentelemetry/instrumentation/app/api/app/[param]/data/route.ts
@@ -1,3 +1,6 @@
+// Keep this module asynchronous so tracing covers promise-backed userland loads.
+await Promise.resolve()
+
 export async function GET() {
   return new Response(JSON.stringify({ test: 'data' }))
 }

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -14,6 +14,7 @@ const EXTERNAL = {
 const COLLECTOR_PORT = 9001
 const ROUTE_PREPARATION_COLLECTOR_PORT = 9002
 const INSTRUMENTATION_STARTUP_COLLECTOR_PORT = 9003
+const APP_ROUTE_MODULE_LOADING_COLLECTOR_PORT = 9004
 
 function setup({ useDirectEntrypointHandler, useNodeMiddleware }) {
   let collector: Collector
@@ -1608,6 +1609,139 @@ describe.each(
       useDirectEntrypointHandler: true,
     },
   ].filter(Boolean)
+)(
+  'opentelemetry App Route module loading - $name',
+  ({ useDirectEntrypointHandler }) => {
+    let collector: Collector | undefined
+    const { next, skipped } = nextTestSetup({
+      files: __dirname,
+      skipDeployment: true,
+      skipStart: true,
+      dependencies: require('./package.json').dependencies,
+      ...(!useDirectEntrypointHandler
+        ? {
+            env: {
+              TEST_OTEL_COLLECTOR_PORT: String(
+                APP_ROUTE_MODULE_LOADING_COLLECTOR_PORT
+              ),
+              NEXT_TELEMETRY_DISABLED: '1',
+            },
+          }
+        : {
+            startCommand: 'pnpm start-entrypoint',
+            packageJson: {
+              scripts: {
+                'start-entrypoint':
+                  'pnpm tsx custom-entrypoint-server.ts --without-parent-span',
+              },
+            },
+            serverReadyPattern: /- Local:/,
+            env: {
+              TEST_OTEL_COLLECTOR_PORT: String(
+                APP_ROUTE_MODULE_LOADING_COLLECTOR_PORT
+              ),
+              NEXT_TELEMETRY_DISABLED: '1',
+              NODE_ENV: 'production',
+            },
+          }),
+    })
+
+    if (skipped) {
+      return
+    }
+
+    afterAll(async () => {
+      await collector?.shutdown()
+    })
+
+    it('should trace cold App Route module loading once', async () => {
+      collector = await connectCollector({
+        port: APP_ROUTE_MODULE_LOADING_COLLECTOR_PORT,
+      })
+      await next.start()
+
+      const pathname = '/api/app/param/data'
+      const route = '/api/app/[param]/data'
+      expect((await next.fetch(pathname)).status).toBe(200)
+
+      let coldSpanId: string | undefined
+      await retry(async () => {
+        const spans = collector?.getSpans() ?? []
+        const rootSpan = spans.find(
+          (span) =>
+            span.attributes?.['next.span_type'] ===
+              'BaseServer.handleRequest' &&
+            span.attributes?.['http.target'] === pathname
+        )
+        const moduleLoadSpans = spans.filter(
+          (span) =>
+            span.attributes?.['next.span_type'] ===
+              'AppRouteRouteModule.loadUserland' &&
+            span.attributes?.['next.route'] === route
+        )
+
+        expect(rootSpan).toBeDefined()
+        expect(moduleLoadSpans).toEqual([
+          expect.objectContaining({
+            runtime: 'nodejs',
+            name: 'load app route module',
+            traceId: rootSpan?.traceId,
+            attributes: {
+              'next.route': route,
+              'next.span_category': 'nextjs',
+              'next.span_name': 'load app route module',
+              'next.span_type': 'AppRouteRouteModule.loadUserland',
+            },
+            status: { code: 0 },
+          }),
+        ])
+
+        const moduleLoadSpan = moduleLoadSpans[0]
+        const ancestorIds = new Set<string>()
+        const parentBySpanId = new Map(
+          spans.map((span) => [span.id, span.parentId])
+        )
+        let parentId = moduleLoadSpan.parentId
+        while (parentId) {
+          ancestorIds.add(parentId)
+          parentId = parentBySpanId.get(parentId)
+        }
+        expect(ancestorIds).toContain(rootSpan?.id)
+        coldSpanId = moduleLoadSpan.id
+      })
+
+      expect((await next.fetch(pathname)).status).toBe(200)
+      await retry(async () => {
+        const spans = collector?.getSpans() ?? []
+        expect(
+          spans.filter(
+            (span) =>
+              span.attributes?.['next.span_type'] ===
+                'AppRouteRouteModule.loadUserland' &&
+              span.attributes?.['next.route'] === route
+          )
+        ).toEqual([expect.objectContaining({ id: coldSpanId })])
+        expect(
+          spans.filter(
+            (span) =>
+              span.attributes?.['next.span_type'] ===
+                'BaseServer.handleRequest' &&
+              span.attributes?.['http.target'] === pathname
+          )
+        ).toHaveLength(2)
+      })
+    })
+  }
+)
+
+describe.each(
+  [
+    { name: 'default', useDirectEntrypointHandler: false },
+    isNextStart && {
+      name: 'direct entrypoints',
+      useDirectEntrypointHandler: true,
+    },
+  ].filter(Boolean)
 )('opentelemetry - middleware $name', ({ useDirectEntrypointHandler }) => {
   describe.each(['edge', 'nodejs'])('%s runtime', (runtime) => {
     const {
@@ -2284,6 +2418,7 @@ async function expectTrace(
         (span) =>
           ![
             'LoadComponents.loadRouteModule',
+            'AppRouteRouteModule.loadUserland',
             'RouteModule.prepare',
             'Instrumentation.loadModule',
             'Instrumentation.register',


### PR DESCRIPTION
### What?

Adds a public OpenTelemetry span for the cold evaluation of an App Route's
lazy userland module:

- span type: `AppRouteRouteModule.loadUserland`
- display name: `load app route module`
- route-specific attribute: the normalized `next.route` pattern

### Why?

`LoadComponents.loadRouteModule` measures loading Next.js's compiled route
entry. App Routes then defer the actual userland module behind a
`LazyModule`, so expensive top-level module evaluation can occur after that
existing span has ended and remain invisible in traces.

### How?

The App Route module wraps only its lazy userland factory with the Next.js
tracer. `LazyModule` still memoizes that factory, so each route-module instance
emits one span for its successful cold initialization and warm requests reuse
the initialized value. The HMR getter remains untraced, and the span records no
resolved filename or request URL.

The integration fixture uses top-level await to exercise the asynchronous
module path. Coverage verifies the span is a descendant of the request,
appears exactly once across cold and warm requests, and works with the direct
entrypoint handler.

### Verification

- `pnpm exec jest packages/next/src/server/lib/trace/tracer.test.ts --runInBand`
- `HEADLESS=true pnpm test-dev-turbo test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts -t 'should trace cold App Route module loading'`
- `HEADLESS=true pnpm test-dev-webpack test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts -t 'should trace cold App Route module loading'`
- `HEADLESS=true pnpm test-start-turbo test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts -t 'should trace cold App Route module loading'`
- `HEADLESS=true pnpm test-start-webpack test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts -t 'should trace cold App Route module loading'`
- Exact-head GitHub build-and-test run `31950299347`: 102/102 jobs passed.
- Exact-head Generate Stats run `31950299340`: passed.
