### PR TITLE
Add unstable parallel metadata selectors

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -928,7 +928,10 @@ impl ReactServerComponentValidator {
                         possibly_invalid_exports
                             .insert(export_name.clone(), (InvalidExportKind::General, *span));
                     }
-                    "generateMetadata" | "metadata" => {
+                    "generateMetadata"
+                    | "metadata"
+                    | "unstable_selectMetadata"
+                    | "unstable_selectViewport" => {
                         possibly_invalid_exports
                             .insert(export_name.clone(), (InvalidExportKind::Metadata, *span));
                     }
@@ -1034,9 +1037,12 @@ impl ReactServerComponentValidator {
                         );
                     }
                     InvalidExportKind::Metadata => {
-                        // Client entry can't export `generateMetadata` or `metadata`.
+                        // Client entries can't export metadata APIs.
                         if is_client_entry
-                            && (export_name == "generateMetadata" || export_name == "metadata")
+                            && (export_name == "generateMetadata"
+                                || export_name == "metadata"
+                                || export_name == "unstable_selectMetadata"
+                                || export_name == "unstable_selectViewport")
                         {
                             report_error(
                                 &self.app_dir,

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/multiple/output.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/multiple/output.js
@@ -1,5 +1,7 @@
 export const metadata = {};
 export function generateMetadata() {}
+export function unstable_selectMetadata() {}
+export function unstable_selectViewport() {}
 export function getServerSideProps() {}
 export default function() {
     return null;

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/multiple/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/multiple/output.stderr
@@ -17,11 +17,31 @@
  3 | export function generateMetadata() {}
    :                 ^^^^^^^^^^^^^^^^
    `----
-  x "getServerSideProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
+  x You are attempting to export "unstable_selectMetadata" from a component marked with "use client", which is disallowed. "unstable_selectMetadata" must be resolved on the server before the page
+  | component is rendered. Keep your page as a Server Component and move Client Component logic to a separate file. Read more: https://nextjs.org/docs/app/api-reference/functions/generate-
+  | metadata#why-generatemetadata-is-server-component-only
   | 
   | 
    ,-[input.js:5:1]
  4 | 
- 5 | export function getServerSideProps() {}
+ 5 | export function unstable_selectMetadata() {}
+   :                 ^^^^^^^^^^^^^^^^^^^^^^^
+   `----
+  x You are attempting to export "unstable_selectViewport" from a component marked with "use client", which is disallowed. "unstable_selectViewport" must be resolved on the server before the page
+  | component is rendered. Keep your page as a Server Component and move Client Component logic to a separate file. Read more: https://nextjs.org/docs/app/api-reference/functions/generate-
+  | metadata#why-generatemetadata-is-server-component-only
+  | 
+  | 
+   ,-[input.js:7:1]
+ 6 | 
+ 7 | export function unstable_selectViewport() {}
+   :                 ^^^^^^^^^^^^^^^^^^^^^^^
+   `----
+  x "getServerSideProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
+  | 
+  | 
+   ,-[input.js:9:1]
+ 8 | 
+ 9 | export function getServerSideProps() {}
    :                 ^^^^^^^^^^^^^^^^^^
    `----

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/multiple/page.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/multiple/page.js
@@ -2,6 +2,10 @@ export const metadata = {}
 
 export function generateMetadata() {}
 
+export function unstable_selectMetadata() {}
+
+export function unstable_selectViewport() {}
+
 export function getServerSideProps() {}
 
 export default function () {

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -48,7 +48,12 @@ import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-pat
 import { isProxyFile } from '../utils'
 
 const PARSE_PATTERN =
-  /(?<!(_jsx|jsx-))runtime|preferredRegion|getStaticProps|getServerSideProps|generateStaticParams|export const|generateImageMetadata|generateSitemaps|middleware|proxy/
+  /(?<!(_jsx|jsx-))runtime|preferredRegion|getStaticProps|getServerSideProps|generateStaticParams|export const|generateImageMetadata|generateSitemaps|unstable_selectMetadata|unstable_selectViewport|middleware|proxy/
+
+const METADATA_SELECTOR_EXPORTS = new Set([
+  'unstable_selectMetadata',
+  'unstable_selectViewport',
+])
 
 export type ProxyMatcher = {
   regexp: string
@@ -183,6 +188,7 @@ function checkExports(
   generateStaticParams?: boolean
   directives?: Set<string>
   exports?: Set<string>
+  metadataSelectors?: Set<string>
 } {
   const exportsSet = new Set<string>([
     'getStaticProps',
@@ -202,6 +208,7 @@ function checkExports(
     let generateSitemaps: boolean = false
     let generateStaticParams = false
     let exports = new Set<string>()
+    let metadataSelectors = new Set<string>()
     let directives = new Set<string>()
     let hasLeadingNonDirectiveNode = false
 
@@ -228,10 +235,22 @@ function checkExports(
         node.declaration?.type === 'VariableDeclaration'
       ) {
         for (const declaration of node.declaration?.declarations) {
-          if (expectedExports.includes(declaration.id.value)) {
-            exports.add(declaration.id.value)
+          const exportName = declaration.id.value
+          if (expectedExports.includes(exportName)) {
+            exports.add(exportName)
+          }
+          if (METADATA_SELECTOR_EXPORTS.has(exportName)) {
+            metadataSelectors.add(exportName)
           }
         }
+      }
+
+      if (
+        node.type === 'ExportDeclaration' &&
+        node.declaration?.type === 'FunctionDeclaration' &&
+        METADATA_SELECTOR_EXPORTS.has(node.declaration.identifier?.value)
+      ) {
+        metadataSelectors.add(node.declaration.identifier.value)
       }
 
       if (
@@ -268,6 +287,11 @@ function checkExports(
             specifier.orig?.type === 'Identifier'
           ) {
             const value = specifier.orig.value
+            const exportedValue = specifier.exported?.value ?? value
+
+            if (METADATA_SELECTOR_EXPORTS.has(exportedValue)) {
+              metadataSelectors.add(exportedValue)
+            }
 
             if (!getServerSideProps && value === 'getServerSideProps') {
               getServerSideProps = true
@@ -304,6 +328,7 @@ function checkExports(
       generateStaticParams,
       directives,
       exports,
+      metadataSelectors,
     }
   } catch {}
 
@@ -652,7 +677,27 @@ export async function getAppPageStaticInfo({
     generateSitemaps,
     exports,
     directives,
+    metadataSelectors,
   } = checkExports(ast, AppSegmentConfigSchemaKeys, page)
+
+  if (
+    metadataSelectors?.size &&
+    !nextConfig.experimental?.parallelRouteMetadata
+  ) {
+    const relativePath = relative(process.cwd(), pageFilePath)
+    const resolvedPath = relativePath.startsWith('.')
+      ? relativePath
+      : `./${relativePath}`
+    const selectorExports = Array.from(
+      metadataSelectors,
+      (selector) => `\`${selector}\``
+    ).join(' and ')
+    const hasMultipleSelectors = metadataSelectors.size > 1
+
+    Log.warnOnce(
+      `The ${selectorExports} export${hasMultipleSelectors ? 's' : ''} in "${resolvedPath}" require${hasMultipleSelectors ? '' : 's'} \`experimental.parallelRouteMetadata: true\` in next.config.js. ${hasMultipleSelectors ? 'These exports' : 'This export'} will be ignored.`
+    )
+  }
 
   const { type: rsc } = getRSCModuleInformation(content, true)
 

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -46,12 +46,17 @@ function createTypeGuardFile(
     slots?: string[]
   }
 ) {
+  const metadataTypeImports =
+    options.type === 'layout'
+      ? 'MetadataSelector, ResolvingMetadata, ResolvingViewport, ViewportSelector'
+      : 'ResolvingMetadata, ResolvingViewport'
+
   return `// File: ${fullPath}
 import * as entry from '${relativePath}.js'
 ${
   options.type === 'route'
     ? `import type { NextRequest } from 'next/server.js'`
-    : `import type { ResolvingMetadata, ResolvingViewport } from 'next/dist/lib/metadata/types/metadata-interface.js'`
+    : `import type { ${metadataTypeImports} } from 'next/dist/lib/metadata/types/metadata-interface.js'`
 }
 
 import type { InstantConfigForTypeCheckInternal, Prefetch } from 'next/dist/build/segment-config/app/app-segment-config.js'
@@ -90,6 +95,12 @@ checkFields<Diff<{
   generateMetadata?: Function
   viewport?: any
   generateViewport?: Function
+  ${
+    options.type === 'layout'
+      ? `unstable_selectMetadata?: MetadataSelector
+  unstable_selectViewport?: ViewportSelector`
+      : ''
+  }
   `
   }
 }, TEntry, ''>>()

--- a/packages/next/src/lib/metadata/metadata-parallel.tsx
+++ b/packages/next/src/lib/metadata/metadata-parallel.tsx
@@ -57,7 +57,7 @@ export function createMetadataComponents({
     )
       .then(async (resolution) => {
         const selected = await resolution.selectedViewport
-        if (selected.status === 'resolved') {
+        if (selected.status === 'resolved' && selected.value !== undefined) {
           return <>{createViewportElements(selected.value)}</>
         }
         if (
@@ -73,9 +73,12 @@ export function createMetadataComponents({
             selected.status,
             interpolatedParams,
             metadataContext,
-            resolution.selectedKeyPath
+            resolution.selectedViewportKeyPath
           )
-          if (convention.status === 'resolved') {
+          if (
+            convention.status === 'resolved' &&
+            convention.value !== undefined
+          ) {
             return <>{createViewportElements(convention.value)}</>
           }
         }
@@ -202,7 +205,7 @@ async function getResolvedParallelMetadataImpl(
     errorType
   )
   const selected = await resolution.selectedMetadata
-  if (selected.status === 'resolved') {
+  if (selected.status === 'resolved' && selected.value !== undefined) {
     return <>{createMetadataElements(selected.value)}</>
   }
   if (
@@ -218,9 +221,9 @@ async function getResolvedParallelMetadataImpl(
       selected.status,
       interpolatedParams,
       metadataContext,
-      resolution.selectedKeyPath
+      resolution.selectedMetadataKeyPath
     )
-    if (convention.status === 'resolved') {
+    if (convention.status === 'resolved' && convention.value !== undefined) {
       return <>{createMetadataElements(convention.value)}</>
     }
   }

--- a/packages/next/src/lib/metadata/metadata-resolution-primitives.ts
+++ b/packages/next/src/lib/metadata/metadata-resolution-primitives.ts
@@ -4,6 +4,7 @@ import type {
   ResolvedViewport,
   ResolvingMetadata,
   ResolvingViewport,
+  SelectedMetadata,
   Viewport,
   WithStringifiedURLs,
 } from './types/metadata-interface'
@@ -69,31 +70,7 @@ export type MetadataItems = Array<
 
 export type ViewportItems = Array<Viewport | ViewportResolver | null>
 
-type WithSelectedTitle<T> = T extends { title: AbsoluteTemplateString }
-  ? Omit<T, 'title'> & { title: string }
-  : T
-
-/**
- * Metadata that has finished route-level resolution and post-processing. It
- * contains only values that can be turned into metadata elements; it is never
- * used as the parent of another metadata resolver.
- */
-export type SelectedMetadata = Omit<
-  ResolvedMetadata,
-  | 'metadataBase'
-  | 'title'
-  | 'openGraph'
-  | 'twitter'
-  | 'themeColor'
-  | 'colorScheme'
-  | 'viewport'
-> & {
-  title: string | null
-  openGraph: WithSelectedTitle<
-    NonNullable<ResolvedMetadata['openGraph']>
-  > | null
-  twitter: WithSelectedTitle<NonNullable<ResolvedMetadata['twitter']>> | null
-}
+export type { SelectedMetadata } from './types/metadata-interface'
 
 export type TitleTemplates = {
   title: string | null

--- a/packages/next/src/lib/metadata/resolve-metadata-parallel.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata-parallel.ts
@@ -1,8 +1,16 @@
 import type {
   Metadata,
+  MetadataSelection,
+  MetadataSelectionHandle,
+  MetadataSelector,
+  MetadataSelectorResult,
   ResolvedMetadata,
   ResolvedViewport,
   Viewport,
+  ViewportSelection,
+  ViewportSelectionHandle,
+  ViewportSelector,
+  ViewportSelectorResult,
 } from './types/metadata-interface'
 import type { MetadataContext } from './types/resolvers'
 import type { LoaderTree } from '../../server/lib/app-dir-module'
@@ -82,12 +90,15 @@ type RejectedOutcome = {
 type ResolutionOutcome<T> = ResolvedOutcome<T> | RejectedOutcome
 
 type MetadataBranchOutcome =
-  | (ResolvedOutcome<SelectedMetadata> & { warnings: Set<string> })
+  | (ResolvedOutcome<SelectedMetadata | undefined> & {
+      warnings: Set<string>
+    })
   | RejectedOutcome
-type ViewportBranchOutcome = ResolutionOutcome<ResolvedViewport>
+type ViewportBranchOutcome = ResolutionOutcome<ResolvedViewport | undefined>
 
 type MetadataResolution = {
-  selectedKeyPath: string[]
+  selectedMetadataKeyPath: string[]
+  selectedViewportKeyPath: string[]
   selectedMetadata: Promise<MetadataBranchOutcome>
   selectedViewport: Promise<ViewportBranchOutcome>
   outlets: Map<LoaderTree, Promise<null>>
@@ -115,8 +126,30 @@ type MetadataLayer = {
 }
 
 type MetadataBranch = {
-  metadata: Promise<MetadataBranchOutcome>
-  viewport: Promise<ViewportBranchOutcome>
+  metadata: SelectedMetadataBranch | Promise<SelectedMetadataBranch>
+  viewport: SelectedViewportBranch | Promise<SelectedViewportBranch>
+  outletScope: MetadataOutletScope
+  keyPath: string[]
+  definitionDepth: number
+  isBuiltinFallback: boolean
+}
+
+// Keep the fork structure so selector failures can be added to every
+// descendant outlet without flattening and repeatedly copying leaf arrays.
+type MetadataOutletScope = {
+  tree: LoaderTree | null
+  branches: MetadataOutletScope[] | null
+}
+
+type SelectedMetadataBranch = {
+  outcome: Promise<MetadataBranchOutcome>
+  keyPath: string[]
+  definitionDepth: number
+  isBuiltinFallback: boolean
+}
+
+type SelectedViewportBranch = {
+  outcome: Promise<ViewportBranchOutcome>
   keyPath: string[]
   definitionDepth: number
   isBuiltinFallback: boolean
@@ -124,6 +157,8 @@ type MetadataBranch = {
 
 type CollectedMetadata = MetadataLayer & {
   errorLayer: MetadataLayer | null
+  metadataSelector: MetadataSelector | null
+  viewportSelector: ViewportSelector | null
 }
 
 async function collectMetadataAndViewport({
@@ -171,6 +206,16 @@ async function collectMetadataAndViewport({
     shouldResolveViewport && moduleResult.mod
       ? getDefinedViewport(moduleResult.mod, props, { route })
       : null
+  const metadataSelector =
+    moduleResult.modType === 'layout' &&
+    typeof moduleResult.mod?.unstable_selectMetadata === 'function'
+      ? (moduleResult.mod.unstable_selectMetadata as MetadataSelector)
+      : null
+  const viewportSelector =
+    moduleResult.modType === 'layout' &&
+    typeof moduleResult.mod?.unstable_selectViewport === 'function'
+      ? (moduleResult.mod.unstable_selectViewport as ViewportSelector)
+      : null
 
   let errorLayer: MetadataLayer | null = null
   if (errorConvention && tree[2][errorConvention]) {
@@ -195,6 +240,8 @@ async function collectMetadataAndViewport({
     staticFilesMetadata,
     hasStaticFilesMetadata,
     errorLayer,
+    metadataSelector,
+    viewportSelector,
   }
 }
 
@@ -493,14 +540,24 @@ type MetadataTreeState = {
   metadataParent: Promise<MetadataAccumulator>
   viewportParent: Promise<ViewportAccumulator>
   errorLayer: MetadataLayer | null
+  metadataSelector: MetadataSelector | null
+  viewportSelector: ViewportSelector | null
   definitionDepth: number
   keyPath: string[]
 }
 
-type MetadataBranchAtFork = {
-  key: string
-  branch: MetadataBranch
+type SelectableBranch = {
+  keyPath: string[]
+  definitionDepth: number
+  isBuiltinFallback: boolean
 }
+
+type BranchAtFork<T extends SelectableBranch> = {
+  key: string
+  branch: T
+}
+
+type MetadataBranchAtFork = BranchAtFork<MetadataBranch>
 
 function getResolutionStatus(
   reason: unknown
@@ -581,6 +638,44 @@ function createOutletPromise(
   return outlet
 }
 
+function combineOutletPromises(
+  first: Promise<null>,
+  second: Promise<null>
+): Promise<null> {
+  let pending = 2
+  const combined = new Promise<null>((resolve, reject) => {
+    function settle() {
+      if (--pending === 0) resolve(null)
+    }
+
+    first.then(settle, reject)
+    second.then(settle, reject)
+  })
+  combined.catch(() => null)
+  return combined
+}
+
+function attachOutletPromise(
+  scope: MetadataOutletScope,
+  additional: Promise<null>,
+  outlets: Map<LoaderTree, Promise<null>>
+): void {
+  if (scope.tree !== null) {
+    const outlet = outlets.get(scope.tree)
+    if (outlet) {
+      outlets.set(scope.tree, combineOutletPromises(outlet, additional))
+    }
+    return
+  }
+
+  const branches = scope.branches
+  if (branches) {
+    for (const branch of branches) {
+      attachOutletPromise(branch, additional, outlets)
+    }
+  }
+}
+
 function appendTreeRoute(
   parentRoute: string | null,
   segment: string
@@ -629,10 +724,10 @@ function hasStaticMetadataFiles(tree: LoaderTree): boolean {
   )
 }
 
-function selectDefaultMetadataBranch(
-  branches: MetadataBranchAtFork[],
+function selectDefaultMetadataBranch<T extends SelectableBranch>(
+  branches: Array<BranchAtFork<T>>,
   forkDepth: number
-): MetadataBranch {
+): T {
   if (branches.length === 0) {
     throw new InvariantError('Expected at least one metadata branch')
   }
@@ -686,6 +781,342 @@ function selectDefaultMetadataBranch(
   return selected.branch
 }
 
+function isPendingSelection<T>(
+  selection: T | Promise<T>
+): selection is Promise<T> {
+  return typeof (selection as Promise<T>).then === 'function'
+}
+
+function selectDefaultResolvedMetadataBranch(
+  branches: MetadataBranchAtFork[],
+  forkDepth: number
+): SelectedMetadataBranch | Promise<SelectedMetadataBranch> {
+  if (branches.some(({ branch }) => isPendingSelection(branch.metadata))) {
+    return Promise.all(
+      branches.map(async ({ key, branch }) => ({
+        key,
+        branch: await branch.metadata,
+      }))
+    ).then((resolvedBranches) =>
+      selectDefaultMetadataBranch(resolvedBranches, forkDepth)
+    )
+  }
+
+  const resolvedBranches: Array<BranchAtFork<SelectedMetadataBranch>> = []
+  for (const { key, branch } of branches) {
+    resolvedBranches.push({
+      key,
+      branch: branch.metadata as SelectedMetadataBranch,
+    })
+  }
+  return selectDefaultMetadataBranch(resolvedBranches, forkDepth)
+}
+
+function selectDefaultResolvedViewportBranch(
+  branches: MetadataBranchAtFork[],
+  forkDepth: number
+): SelectedViewportBranch | Promise<SelectedViewportBranch> {
+  if (branches.some(({ branch }) => isPendingSelection(branch.viewport))) {
+    return Promise.all(
+      branches.map(async ({ key, branch }) => ({
+        key,
+        branch: await branch.viewport,
+      }))
+    ).then((resolvedBranches) =>
+      selectDefaultMetadataBranch(resolvedBranches, forkDepth)
+    )
+  }
+
+  const resolvedBranches: Array<BranchAtFork<SelectedViewportBranch>> = []
+  for (const { key, branch } of branches) {
+    resolvedBranches.push({
+      key,
+      branch: branch.viewport as SelectedViewportBranch,
+    })
+  }
+  return selectDefaultMetadataBranch(resolvedBranches, forkDepth)
+}
+
+function createMetadataSelection(
+  outcome: MetadataBranchOutcome
+): MetadataSelection {
+  if (outcome.status === 'resolved') {
+    return {
+      status: 'resolved',
+      value: outcome.value,
+    }
+  }
+  return {
+    status: outcome.status,
+    reason: outcome.reason,
+  }
+}
+
+function isObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null
+}
+
+function isMetadataSelection(value: unknown): value is MetadataSelection {
+  if (!isObject(value) || !('status' in value)) return false
+
+  switch (value.status) {
+    case 'resolved':
+    case 'not-found':
+    case 'forbidden':
+    case 'unauthorized':
+    case 'redirect':
+    case 'error':
+      return true
+    default:
+      return false
+  }
+}
+
+function createUserSelectedMetadataBranch(
+  result: SelectedMetadata | MetadataSelection,
+  fallback: SelectedMetadataBranch,
+  definitionDepth: number
+): SelectedMetadataBranch {
+  let outcome: MetadataBranchOutcome
+  if (isMetadataSelection(result)) {
+    outcome =
+      result.status === 'resolved'
+        ? {
+            status: 'resolved',
+            value: result.value,
+            warnings: new Set<string>(),
+          }
+        : {
+            status: result.status,
+            reason: result.reason,
+          }
+  } else {
+    outcome = {
+      status: 'resolved',
+      value: result,
+      warnings: new Set<string>(),
+    }
+  }
+
+  return {
+    outcome: Promise.resolve(outcome),
+    keyPath: fallback.keyPath,
+    definitionDepth,
+    isBuiltinFallback: false,
+  }
+}
+
+function selectMetadataBranchWithUserlandSelector(
+  selector: MetadataSelector,
+  branches: MetadataBranchAtFork[],
+  fallback: Promise<SelectedMetadataBranch>,
+  definitionDepth: number,
+  outletScope: MetadataOutletScope,
+  outlets: Map<LoaderTree, Promise<null>>
+): Promise<SelectedMetadataBranch> {
+  const handles: Record<string, MetadataSelectionHandle> = {}
+  // Preserve branch identity when userland returns a provided handle, its
+  // resolved outcome, or the SelectedMetadata value from that outcome.
+  const branchByHandle = new WeakMap<object, Promise<SelectedMetadataBranch>>()
+  const branchByResult = new WeakMap<object, SelectedMetadataBranch>()
+
+  for (const { key, branch } of branches) {
+    const pendingBranch = Promise.resolve(branch.metadata)
+    const handle = pendingBranch.then(async (selectedBranch) => {
+      const result = createMetadataSelection(await selectedBranch.outcome)
+      branchByResult.set(result, selectedBranch)
+      if (result.status === 'resolved' && isObject(result.value)) {
+        branchByResult.set(result.value, selectedBranch)
+      }
+      return result
+    })
+    handles[key] = handle
+    branchByHandle.set(handle, pendingBranch)
+  }
+
+  let result: MetadataSelectorResult
+  try {
+    result = selector(handles)
+  } catch (reason) {
+    result = Promise.reject(reason)
+  }
+
+  if (isObject(result)) {
+    const selectedBranch = branchByHandle.get(result)
+    if (selectedBranch) return selectedBranch
+  }
+
+  const normalized = Promise.resolve(result).then(async (resolvedResult) => {
+    if (!isObject(resolvedResult)) {
+      throw new InvariantError(
+        'Expected unstable_selectMetadata to return a metadata handle, selection, or SelectedMetadata object'
+      )
+    }
+
+    const selectedBranch = branchByResult.get(resolvedResult)
+    if (selectedBranch) return selectedBranch
+
+    return createUserSelectedMetadataBranch(
+      resolvedResult,
+      await fallback,
+      definitionDepth
+    )
+  })
+
+  const selectorOutlet = normalized.then(() => null)
+  // A selector is associated with the fork rather than one slot. Add its
+  // failure to every descendant outlet so whichever slots render can replay
+  // it through their normal error or navigation handling.
+  attachOutletPromise(outletScope, selectorOutlet, outlets)
+
+  return normalized.catch(async (reason) => {
+    const fallbackBranch = await fallback
+    return {
+      outcome: Promise.resolve(createRejectedOutcome(reason)),
+      keyPath: fallbackBranch.keyPath,
+      definitionDepth,
+      isBuiltinFallback: false,
+    }
+  })
+}
+
+function createViewportSelection(
+  outcome: ViewportBranchOutcome
+): ViewportSelection {
+  if (outcome.status === 'resolved') {
+    return {
+      status: 'resolved',
+      value: outcome.value,
+    }
+  }
+  return {
+    status: outcome.status,
+    reason: outcome.reason,
+  }
+}
+
+function isViewportSelection(value: unknown): value is ViewportSelection {
+  if (!isObject(value) || !('status' in value)) return false
+
+  switch (value.status) {
+    case 'resolved':
+    case 'not-found':
+    case 'forbidden':
+    case 'unauthorized':
+    case 'redirect':
+    case 'error':
+      return true
+    default:
+      return false
+  }
+}
+
+function createUserSelectedViewportBranch(
+  result: ResolvedViewport | ViewportSelection,
+  fallback: SelectedViewportBranch,
+  definitionDepth: number
+): SelectedViewportBranch {
+  let outcome: ViewportBranchOutcome
+  if (isViewportSelection(result)) {
+    outcome =
+      result.status === 'resolved'
+        ? {
+            status: 'resolved',
+            value: result.value,
+          }
+        : {
+            status: result.status,
+            reason: result.reason,
+          }
+  } else {
+    outcome = {
+      status: 'resolved',
+      value: result,
+    }
+  }
+
+  return {
+    outcome: Promise.resolve(outcome),
+    keyPath: fallback.keyPath,
+    definitionDepth,
+    isBuiltinFallback: false,
+  }
+}
+
+function selectViewportBranchWithUserlandSelector(
+  selector: ViewportSelector,
+  branches: MetadataBranchAtFork[],
+  fallback: Promise<SelectedViewportBranch>,
+  definitionDepth: number,
+  outletScope: MetadataOutletScope,
+  outlets: Map<LoaderTree, Promise<null>>
+): Promise<SelectedViewportBranch> {
+  const handles: Record<string, ViewportSelectionHandle> = {}
+  // Preserve branch identity when userland returns a provided handle, its
+  // resolved outcome, or the ResolvedViewport value from that outcome.
+  const branchByHandle = new WeakMap<object, Promise<SelectedViewportBranch>>()
+  const branchByResult = new WeakMap<object, SelectedViewportBranch>()
+
+  for (const { key, branch } of branches) {
+    const pendingBranch = Promise.resolve(branch.viewport)
+    const handle = pendingBranch.then(async (selectedBranch) => {
+      const result = createViewportSelection(await selectedBranch.outcome)
+      branchByResult.set(result, selectedBranch)
+      if (result.status === 'resolved' && isObject(result.value)) {
+        branchByResult.set(result.value, selectedBranch)
+      }
+      return result
+    })
+    handles[key] = handle
+    branchByHandle.set(handle, pendingBranch)
+  }
+
+  let result: ViewportSelectorResult
+  try {
+    result = selector(handles)
+  } catch (reason) {
+    result = Promise.reject(reason)
+  }
+
+  if (isObject(result)) {
+    const selectedBranch = branchByHandle.get(result)
+    if (selectedBranch) return selectedBranch
+  }
+
+  const normalized = Promise.resolve(result).then(async (resolvedResult) => {
+    if (!isObject(resolvedResult)) {
+      throw new InvariantError(
+        'Expected unstable_selectViewport to return a viewport handle, selection, or ResolvedViewport object'
+      )
+    }
+
+    const selectedBranch = branchByResult.get(resolvedResult)
+    if (selectedBranch) return selectedBranch
+
+    return createUserSelectedViewportBranch(
+      resolvedResult,
+      await fallback,
+      definitionDepth
+    )
+  })
+
+  const selectorOutlet = normalized.then(() => null)
+  // A selector is associated with the fork rather than one slot. Add its
+  // failure to every descendant outlet so whichever slots render can replay
+  // it through their normal error or navigation handling.
+  attachOutletPromise(outletScope, selectorOutlet, outlets)
+
+  return normalized.catch(async (reason) => {
+    const fallbackBranch = await fallback
+    return {
+      outcome: Promise.resolve(createRejectedOutcome(reason)),
+      keyPath: fallbackBranch.keyPath,
+      definitionDepth,
+      isBuiltinFallback: false,
+    }
+  })
+}
+
 async function walkMetadataTree(
   context: MetadataTreeContext,
   state: MetadataTreeState
@@ -730,6 +1161,11 @@ async function walkMetadataTree(
     errorConvention: context.errorConvention,
     resolutionTarget: context.resolutionTarget,
   })
+  // The closest selector above a fork wins. Once a fork is reached it is
+  // consumed, and each branch starts looking for the selector for its next
+  // nested fork.
+  const metadataSelector = layer.metadataSelector || state.metadataSelector
+  const viewportSelector = layer.viewportSelector || state.viewportSelector
   let definitionDepth = hasHeadDefinition(layer) ? depth : state.definitionDepth
 
   // Invoke each active generator as soon as this layer is discovered. Its
@@ -813,12 +1249,25 @@ async function walkMetadataTree(
       state.tree,
       createOutletPromise(metadataOutcome, viewportOutcome)
     )
-    return {
-      metadata: metadataOutcome,
-      viewport: viewportOutcome,
+    const branchProperties = {
       keyPath: state.keyPath,
       definitionDepth,
       isBuiltinFallback: isBuiltinFallback(state.tree),
+    }
+    return {
+      metadata: {
+        outcome: metadataOutcome,
+        ...branchProperties,
+      },
+      viewport: {
+        outcome: viewportOutcome,
+        ...branchProperties,
+      },
+      outletScope: {
+        tree: state.tree,
+        branches: null,
+      },
+      ...branchProperties,
     }
   }
 
@@ -846,6 +1295,8 @@ async function walkMetadataTree(
         cloneAtFork && shouldResolveViewport
       ),
       errorLayer,
+      metadataSelector: cloneAtFork ? null : metadataSelector,
+      viewportSelector: cloneAtFork ? null : viewportSelector,
       definitionDepth,
       keyPath: childKeyPath,
     })
@@ -868,7 +1319,54 @@ async function walkMetadataTree(
     })
   }
 
-  return selectDefaultMetadataBranch(childBranches, depth)
+  if (!cloneAtFork) {
+    return childBranches[0].branch
+  }
+
+  const outletBranches: MetadataOutletScope[] = []
+  for (const { branch } of childBranches) {
+    outletBranches.push(branch.outletScope)
+  }
+  const outletScope: MetadataOutletScope = {
+    tree: null,
+    branches: outletBranches,
+  }
+
+  const selectedBranch = selectDefaultMetadataBranch(childBranches, depth)
+  let selectedMetadata = selectDefaultResolvedMetadataBranch(
+    childBranches,
+    depth
+  )
+  let selectedViewport = selectDefaultResolvedViewportBranch(
+    childBranches,
+    depth
+  )
+  if (metadataSelector && cloneAtFork && shouldResolveMetadata) {
+    selectedMetadata = selectMetadataBranchWithUserlandSelector(
+      metadataSelector,
+      childBranches,
+      Promise.resolve(selectedMetadata),
+      depth,
+      outletScope,
+      context.outlets
+    )
+  }
+  if (viewportSelector && cloneAtFork && shouldResolveViewport) {
+    selectedViewport = selectViewportBranchWithUserlandSelector(
+      viewportSelector,
+      childBranches,
+      Promise.resolve(selectedViewport),
+      depth,
+      outletScope,
+      context.outlets
+    )
+  }
+  return {
+    ...selectedBranch,
+    outletScope,
+    metadata: selectedMetadata,
+    viewport: selectedViewport,
+  }
 }
 
 async function resolveMetadataTree(
@@ -909,12 +1407,20 @@ async function resolveMetadataTree(
         viewport: createDefaultViewport(),
       }),
       errorLayer: null,
+      metadataSelector: null,
+      viewportSelector: null,
       definitionDepth: -1,
       keyPath: [],
     }
   )
 
-  const selected = selectedBranch.metadata.then((outcome) => {
+  const selectedMetadataBranch = isPendingSelection(selectedBranch.metadata)
+    ? await selectedBranch.metadata
+    : selectedBranch.metadata
+  const selectedViewportBranch = isPendingSelection(selectedBranch.viewport)
+    ? await selectedBranch.viewport
+    : selectedBranch.viewport
+  const selected = selectedMetadataBranch.outcome.then((outcome) => {
     if (outcome.status === 'resolved') {
       for (const warning of outcome.warnings) {
         Log.warn(warning)
@@ -924,9 +1430,10 @@ async function resolveMetadataTree(
   })
 
   return {
-    selectedKeyPath: selectedBranch.keyPath,
+    selectedMetadataKeyPath: selectedMetadataBranch.keyPath,
+    selectedViewportKeyPath: selectedViewportBranch.keyPath,
     selectedMetadata: selected,
-    selectedViewport: selectedBranch.viewport,
+    selectedViewport: selectedViewportBranch.outcome,
     outlets,
   }
 }

--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -674,6 +674,53 @@ export type WithStringifiedURLs<T> = T extends URL
  */
 type ResolvedMetadata = WithStringifiedURLs<ResolvedMetadataWithURLs>
 
+type WithSelectedTitle<T> = T extends { title: AbsoluteTemplateString }
+  ? Omit<T, 'title'> & { title: string }
+  : T
+
+/**
+ * Metadata that has finished route-level resolution and post-processing. It
+ * contains only values that can be turned into metadata elements; it is never
+ * used as the parent of another metadata resolver.
+ */
+type SelectedMetadata = Omit<
+  ResolvedMetadata,
+  | 'metadataBase'
+  | 'title'
+  | 'openGraph'
+  | 'twitter'
+  | 'themeColor'
+  | 'colorScheme'
+  | 'viewport'
+> & {
+  title: string | null
+  openGraph: WithSelectedTitle<
+    NonNullable<ResolvedMetadata['openGraph']>
+  > | null
+  twitter: WithSelectedTitle<NonNullable<ResolvedMetadata['twitter']>> | null
+}
+
+type MetadataSelection =
+  | {
+      status: 'resolved'
+      value: SelectedMetadata | undefined
+    }
+  | {
+      status: 'not-found' | 'forbidden' | 'unauthorized' | 'redirect' | 'error'
+      reason: unknown
+    }
+
+type MetadataSelectionHandle = Promise<MetadataSelection>
+
+type MetadataSelectorResult =
+  | SelectedMetadata
+  | MetadataSelection
+  | PromiseLike<SelectedMetadata | MetadataSelection>
+
+type MetadataSelector<Slot extends string = string> = (slots: {
+  [Key in 'children' | Slot]: MetadataSelectionHandle
+}) => MetadataSelectorResult
+
 type RobotsRuleBase = {
   allow?: string | string[] | undefined
   disallow?: string | string[] | undefined
@@ -808,13 +855,43 @@ interface ResolvedViewport extends ViewportLayout {
 
 type ResolvingViewport = Promise<ResolvedViewport>
 
+type ViewportSelection =
+  | {
+      status: 'resolved'
+      value: ResolvedViewport | undefined
+    }
+  | {
+      status: 'not-found' | 'forbidden' | 'unauthorized' | 'redirect' | 'error'
+      reason: unknown
+    }
+
+type ViewportSelectionHandle = Promise<ViewportSelection>
+
+type ViewportSelectorResult =
+  | ResolvedViewport
+  | ViewportSelection
+  | PromiseLike<ResolvedViewport | ViewportSelection>
+
+type ViewportSelector<Slot extends string = string> = (slots: {
+  [Key in 'children' | Slot]: ViewportSelectionHandle
+}) => ViewportSelectorResult
+
 export type {
   Metadata,
   ResolvedMetadata,
   ResolvedMetadataWithURLs,
   ResolvingMetadata,
+  SelectedMetadata,
+  MetadataSelection,
+  MetadataSelectionHandle,
+  MetadataSelector,
+  MetadataSelectorResult,
   MetadataRoute,
   Viewport,
   ResolvingViewport,
   ResolvedViewport,
+  ViewportSelection,
+  ViewportSelectionHandle,
+  ViewportSelector,
+  ViewportSelectorResult,
 }

--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -569,6 +569,8 @@ export function generateValidatorFile(
     props: { params: Promise<ParamMap[Route]> } & any,
     parent: ResolvingViewport
   ) => Promise<any> | any
+  unstable_selectMetadata?: MetadataSelector
+  unstable_selectViewport?: ViewportSelector
   metadata?: any
   viewport?: any
 }
@@ -645,6 +647,9 @@ export function generateValidatorFile(
   }
   if (appPageValidations || layoutValidations) {
     nextTypes.push('ResolvingMetadata', 'ResolvingViewport')
+  }
+  if (layoutValidations) {
+    nextTypes.push('MetadataSelector', 'ViewportSelector')
   }
   const nextTypesImport =
     nextTypes.length > 0
@@ -804,6 +809,8 @@ export function generateValidatorFileStrict(
     props: { params: Promise<ParamMap[Route]> } & any,
     parent: ResolvingViewport
   ) => Promise<any> | any
+  unstable_selectMetadata?: MetadataSelector
+  unstable_selectViewport?: ViewportSelector
   metadata?: any
   viewport?: any
 }
@@ -880,6 +887,9 @@ export function generateValidatorFileStrict(
   }
   if (appPageValidations || layoutValidations) {
     nextTypes.push('ResolvingMetadata', 'ResolvingViewport')
+  }
+  if (layoutValidations) {
+    nextTypes.push('MetadataSelector', 'ViewportSelector')
   }
   const nextTypesImport =
     nextTypes.length > 0

--- a/packages/next/src/server/typescript/constant.ts
+++ b/packages/next/src/server/typescript/constant.ts
@@ -19,6 +19,8 @@ export const ALLOWED_EXPORTS = [
   'generateMetadata',
   'viewport',
   'generateViewport',
+  'unstable_selectMetadata',
+  'unstable_selectViewport',
 ]
 
 export const LEGACY_CONFIG_EXPORT = 'config'

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -35,9 +35,18 @@ export type {
   MetadataRoute,
   ResolvedMetadata,
   ResolvingMetadata,
+  SelectedMetadata,
+  MetadataSelection,
+  MetadataSelectionHandle,
+  MetadataSelector,
+  MetadataSelectorResult,
   Viewport,
   ResolvingViewport,
   ResolvedViewport,
+  ViewportSelection,
+  ViewportSelectionHandle,
+  ViewportSelector,
+  ViewportSelectorResult,
 } from './lib/metadata/types/metadata-interface'
 
 export type { Instant } from './build/segment-config/app/app-segment-config'

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/conditional-slot/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/conditional-slot/layout.tsx
@@ -10,6 +10,10 @@ export const metadata = {
 
 export default async function Layout({
   children,
+  error: _error,
+  imageError: _imageError,
+  login: _login,
+  viewportError: _viewportError,
 }: {
   children: ReactNode
   error: ReactNode

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-ancestor/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-ancestor/layout.tsx
@@ -1,0 +1,13 @@
+import type { MetadataSelector, ViewportSelector } from 'next'
+
+export const unstable_selectMetadata: MetadataSelector<'bar' | 'foo'> = ({
+  foo,
+}) => foo
+
+export const unstable_selectViewport: ViewportSelector<'bar' | 'foo'> = ({
+  foo,
+}) => foo
+
+export default function Layout({ children }) {
+  return children
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-ancestor/nested/@bar/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-ancestor/nested/@bar/page.tsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'default lexical bar title',
+}
+
+export const viewport = {
+  colorScheme: 'light' as const,
+}
+
+export default function Page() {
+  return <div>default lexical bar page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-ancestor/nested/@foo/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-ancestor/nested/@foo/page.tsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'ancestor selected foo title',
+}
+
+export const viewport = {
+  colorScheme: 'dark' as const,
+}
+
+export default function Page() {
+  return <div>ancestor selected foo page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-ancestor/nested/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-ancestor/nested/layout.tsx
@@ -1,0 +1,9 @@
+export default function Layout({ children, bar, foo }) {
+  return (
+    <main>
+      {children}
+      {bar}
+      {foo}
+    </main>
+  )
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-ancestor/nested/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-ancestor/nested/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>ancestor selector children page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-error/@slot/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-error/@slot/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>unrendered selector error slot</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-error/error.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-error/error.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Error() {
+  return <div id="selector-error">metadata selector error reached boundary</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-error/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-error/layout.tsx
@@ -1,0 +1,11 @@
+import type { MetadataSelector } from 'next'
+
+export const dynamic = 'force-dynamic'
+
+export const unstable_selectMetadata: MetadataSelector<'slot'> = () => {
+  throw new Error('metadata selector error')
+}
+
+export default function Layout({ children, slot: _slot }) {
+  return children
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-error/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-error/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>selector error children page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-handle/@bar/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-handle/@bar/page.tsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'selected bar title',
+}
+
+export const viewport = {
+  colorScheme: 'dark' as const,
+}
+
+export default function Page() {
+  return <div>selected bar page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-handle/@foo/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-handle/@foo/page.tsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'unselected foo title',
+}
+
+export const viewport = {
+  colorScheme: 'light' as const,
+}
+
+export default function Page() {
+  return <div>unselected foo page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-handle/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-handle/layout.tsx
@@ -1,0 +1,19 @@
+import type { MetadataSelector, ViewportSelector } from 'next'
+
+export const unstable_selectMetadata: MetadataSelector<'bar' | 'foo'> = ({
+  bar,
+}) => bar
+
+export const unstable_selectViewport: ViewportSelector<'bar' | 'foo'> = ({
+  foo,
+}) => foo
+
+export default function Layout({ children, bar, foo }) {
+  return (
+    <main>
+      {children}
+      {bar}
+      {foo}
+    </main>
+  )
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-handle/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-handle/page.tsx
@@ -1,0 +1,7 @@
+export const metadata = {
+  title: 'selector children title',
+}
+
+export default function Page() {
+  return <div>selector children page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-nested/@outerA/@inner/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-nested/@outerA/@inner/page.tsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'nested original title',
+}
+
+export const viewport = {
+  colorScheme: 'light' as const,
+}
+
+export default function Page() {
+  return <div>nested inner page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-nested/@outerA/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-nested/@outerA/layout.tsx
@@ -1,0 +1,40 @@
+import type { MetadataSelector, ViewportSelector } from 'next'
+
+export const unstable_selectMetadata: MetadataSelector<'inner'> = async ({
+  children,
+  inner,
+}) => {
+  const selected = await inner
+  if (selected.status !== 'resolved' || selected.value === undefined) {
+    return children
+  }
+
+  return {
+    ...selected.value,
+    title: 'nested selected title',
+  }
+}
+
+export const unstable_selectViewport: ViewportSelector<'inner'> = async ({
+  children,
+  inner,
+}) => {
+  const selected = await inner
+  if (selected.status !== 'resolved' || selected.value === undefined) {
+    return children
+  }
+
+  return {
+    ...selected.value,
+    colorScheme: 'dark',
+  }
+}
+
+export default function Layout({ children, inner }) {
+  return (
+    <section>
+      {children}
+      {inner}
+    </section>
+  )
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-nested/@outerA/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-nested/@outerA/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>outer A children page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-nested/@outerB/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-nested/@outerB/page.tsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'outer B fallback title',
+}
+
+export const viewport = {
+  colorScheme: 'light' as const,
+}
+
+export default function Page() {
+  return <div>outer B page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-nested/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-nested/layout.tsx
@@ -1,0 +1,25 @@
+import type { MetadataSelector, ViewportSelector } from 'next'
+
+export const unstable_selectMetadata: MetadataSelector<
+  'outerA' | 'outerB'
+> = async ({ outerA, outerB }) => {
+  const selected = await outerA
+  return selected.status === 'resolved' ? selected : outerB
+}
+
+export const unstable_selectViewport: ViewportSelector<
+  'outerA' | 'outerB'
+> = async ({ outerA, outerB }) => {
+  const selected = await outerA
+  return selected.status === 'resolved' ? selected : outerB
+}
+
+export default function Layout({ children, outerA, outerB }) {
+  return (
+    <main>
+      {children}
+      {outerA}
+      {outerB}
+    </main>
+  )
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-nested/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-nested/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>nested selector children page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-not-found/@bar/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-not-found/@bar/page.tsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'fallback after not found title',
+}
+
+export const viewport = {
+  colorScheme: 'dark' as const,
+}
+
+export default function Page() {
+  return <div>fallback after not found page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-not-found/@foo/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-not-found/@foo/page.tsx
@@ -1,0 +1,13 @@
+import { notFound } from 'next/navigation'
+
+export function generateMetadata() {
+  notFound()
+}
+
+export function generateViewport() {
+  notFound()
+}
+
+export default function Page() {
+  return <div id="unrendered-not-found-page">unrendered not found page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-not-found/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-not-found/layout.tsx
@@ -1,0 +1,26 @@
+import type { MetadataSelector, ViewportSelector } from 'next'
+
+export const unstable_selectMetadata: MetadataSelector<'bar' | 'foo'> = async ({
+  bar,
+  foo,
+}) => {
+  const selected = await foo
+  return selected.status === 'not-found' ? bar : foo
+}
+
+export const unstable_selectViewport: ViewportSelector<'bar' | 'foo'> = async ({
+  bar,
+  foo,
+}) => {
+  const selected = await foo
+  return selected.status === 'not-found' ? bar : foo
+}
+
+export default function Layout({ children, bar, foo: _foo }) {
+  return (
+    <main>
+      {children}
+      {bar}
+    </main>
+  )
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-not-found/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-not-found/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>selector not found children page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-resolved/@bar/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-resolved/@bar/page.tsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'resolved fallback bar title',
+}
+
+export const viewport = {
+  colorScheme: 'light' as const,
+}
+
+export default function Page() {
+  return <div>resolved fallback bar page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-resolved/@foo/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-resolved/@foo/page.tsx
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'original foo title',
+}
+
+export const viewport = {
+  colorScheme: 'light' as const,
+}
+
+export default function Page() {
+  return <div>original foo page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-resolved/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-resolved/layout.tsx
@@ -1,0 +1,41 @@
+import type { MetadataSelector, ViewportSelector } from 'next'
+
+export const unstable_selectMetadata: MetadataSelector<'bar' | 'foo'> = async ({
+  bar,
+  foo,
+}) => {
+  const selected = await foo
+  if (selected.status !== 'resolved' || selected.value === undefined) {
+    return bar
+  }
+
+  return {
+    ...selected.value,
+    title: 'rewritten foo title',
+  }
+}
+
+export const unstable_selectViewport: ViewportSelector<'bar' | 'foo'> = async ({
+  bar,
+  foo,
+}) => {
+  const selected = await foo
+  if (selected.status !== 'resolved' || selected.value === undefined) {
+    return bar
+  }
+
+  return {
+    ...selected.value,
+    colorScheme: 'dark',
+  }
+}
+
+export default function Layout({ children, bar, foo }) {
+  return (
+    <main>
+      {children}
+      {bar}
+      {foo}
+    </main>
+  )
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-resolved/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/selector-resolved/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>selector resolved children page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/viewport-selector-error/@slot/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/viewport-selector-error/@slot/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>unrendered viewport selector error slot</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/viewport-selector-error/error.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/viewport-selector-error/error.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export default function Error() {
+  return (
+    <div id="viewport-selector-error">
+      viewport selector error reached boundary
+    </div>
+  )
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/viewport-selector-error/layout.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/viewport-selector-error/layout.tsx
@@ -1,0 +1,11 @@
+import type { ViewportSelector } from 'next'
+
+export const dynamic = 'force-dynamic'
+
+export const unstable_selectViewport: ViewportSelector<'slot'> = () => {
+  throw new Error('viewport selector error')
+}
+
+export default function Layout({ children, slot: _slot }) {
+  return children
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/app/viewport-selector-error/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/app/viewport-selector-error/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>viewport selector error children page</div>
+}

--- a/test/e2e/app-dir/metadata-streaming-parallel-routes/metadata-streaming-parallel-routes.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-parallel-routes/metadata-streaming-parallel-routes.test.ts
@@ -181,6 +181,60 @@ function runMetadataStreamingTests(parallelRouteMetadata: boolean) {
     expect($('title').text()).toBe('bar lexical title')
   })
 
+  it('should allow a layout to select metadata and viewport handles independently', async () => {
+    const $ = await next.render$('/selector-handle')
+    expect($('title').text()).toBe('selected bar title')
+    expect($('meta[name="color-scheme"]').attr('content')).toBe('light')
+  })
+
+  it('should use the closest selector above a fork', async () => {
+    const $ = await next.render$('/selector-ancestor/nested')
+    expect($('title').text()).toBe('ancestor selected foo title')
+    expect($('meta[name="color-scheme"]').attr('content')).toBe('dark')
+  })
+
+  it('should allow a layout to return rewritten selected metadata', async () => {
+    const $ = await next.render$('/selector-resolved')
+    expect($('title').text()).toBe('rewritten foo title')
+    expect($('meta[name="color-scheme"]').attr('content')).toBe('dark')
+  })
+
+  it('should pass a resolved nested selection to the next fork', async () => {
+    const $ = await next.render$('/selector-nested')
+    expect($('title').text()).toBe('nested selected title')
+    expect($('meta[name="color-scheme"]').attr('content')).toBe('dark')
+  })
+
+  it('should expose navigation status without selecting its slot', async () => {
+    const res = await next.fetch('/selector-not-found')
+    const $ = await next.render$('/selector-not-found')
+
+    expect(res.status).toBe(200)
+    expect($('title').text()).toBe('fallback after not found title')
+    expect($('meta[name="color-scheme"]').attr('content')).toBe('dark')
+    expect($('#unrendered-not-found-page').length).toBe(0)
+  })
+
+  it('should replay selector errors through a rendered outlet', async () => {
+    const browser = await next.browser('/selector-error')
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#selector-error').text()).toBe(
+        'metadata selector error reached boundary'
+      )
+    })
+  })
+
+  it('should replay viewport selector errors through a rendered outlet', async () => {
+    const browser = await next.browser('/viewport-selector-error')
+
+    await retry(async () => {
+      expect(
+        await browser.elementByCss('#viewport-selector-error').text()
+      ).toBe('viewport selector error reached boundary')
+    })
+  })
+
   it('should prefer a real named slot over an implicit children fallback', async () => {
     // first page is /parallel-routes-no-children/first,
     // second page is /parallel-routes-no-children/second

--- a/test/production/app-dir/metadata-selectors-without-parallel-route-metadata/app/layout.tsx
+++ b/test/production/app-dir/metadata-selectors-without-parallel-route-metadata/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { MetadataSelector, ViewportSelector } from 'next'
+import type { ReactNode } from 'react'
+
+export const unstable_selectMetadata: MetadataSelector<never> = ({
+  children,
+}) => children
+
+export function unstable_selectViewport({
+  children,
+}: Parameters<ViewportSelector>[0]) {
+  return children
+}
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/metadata-selectors-without-parallel-route-metadata/app/page.tsx
+++ b/test/production/app-dir/metadata-selectors-without-parallel-route-metadata/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/metadata-selectors-without-parallel-route-metadata/metadata-selectors-without-parallel-route-metadata.test.ts
+++ b/test/production/app-dir/metadata-selectors-without-parallel-route-metadata/metadata-selectors-without-parallel-route-metadata.test.ts
@@ -1,0 +1,14 @@
+import { nextTestSetup } from 'e2e-utils'
+import stripAnsi from 'next/dist/compiled/strip-ansi'
+
+describe('metadata-selectors-without-parallel-route-metadata', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('warns that metadata selectors are ignored when parallel metadata is disabled', () => {
+    expect(stripAnsi(next.cliOutput)).toContain(
+      'The `unstable_selectMetadata` and `unstable_selectViewport` exports in "./app/layout.tsx" require `experimental.parallelRouteMetadata: true` in next.config.js. These exports will be ignored.'
+    )
+  })
+})

--- a/test/production/app-dir/metadata-selectors-without-parallel-route-metadata/next.config.js
+++ b/test/production/app-dir/metadata-selectors-without-parallel-route-metadata/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    parallelRouteMetadata: false,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
## Motivation

Parallel-route metadata now has a deterministic default, but a framework heuristic cannot know which slot an application intends to represent in the document head. This is especially important for conditional slots and nested parallel routes.

## What this does

This adds `unstable_selectMetadata` and `unstable_selectViewport` as layout exports. At each parallel-route fork, the closest selector receives the available slots as handles containing each branch's resolution status and postprocessed value. It can select a branch directly or return a rewritten value. Metadata and viewport are selected independently, and the built-in heuristic remains the fallback when no selector is present.

The exports are typed and validated as layout-only server APIs. Until `experimental.parallelRouteMetadata` is enabled, they are ignored and produce a build warning; the next PR in the stack changes that default.

## Review notes

- Selection only determines what contributes to the head. Navigation and regular errors still replay through their slot's `MetadataOutlet`, whether or not that slot was selected.
- Nested forks resolve from the inside out. The closest selector controls a fork, and its result becomes an input to selection at the next fork.
- Returning a rewritten value makes that value a resolved selection for any higher fork.
- The no-selector path preserves eager metadata generation and avoids introducing additional asynchronous selection work.

## Verification

- `pnpm --filter=next types`
- RSC transform error tests
- Metadata selector coverage in development and production with Turbopack and webpack
- Disabled-flag build coverage with Turbopack and webpack

<!-- NEXT_JS_LLM -->
