### PR TITLE
docs: rename Vercel Edge Config to Global Config in redirecting guide

### DIFF
--- a/docs/01-app/02-guides/redirecting.mdx
+++ b/docs/01-app/02-guides/redirecting.mdx
@@ -376,11 +376,11 @@ Consider the following data structure:
 }
 ```
 
-In [Proxy](/docs/app/api-reference/file-conventions/proxy), you can read from a database such as Vercel's [Edge Config](https://vercel.com/docs/global-config/get-started) or [Redis](https://vercel.com/docs/redis), and redirect the user based on the incoming request:
+In [Proxy](/docs/app/api-reference/file-conventions/proxy), you can read from a database such as Vercel's [Global Config](https://vercel.com/docs/global-config/get-started) or [Redis](https://vercel.com/docs/redis), and redirect the user based on the incoming request:
 
 ```ts filename="proxy.ts" switcher
 import { NextResponse, NextRequest } from 'next/server'
-import { get } from '@vercel/edge-config'
+import { get } from '@vercel/global-config'
 
 type RedirectEntry = {
   destination: string
@@ -404,7 +404,7 @@ export async function proxy(request: NextRequest) {
 
 ```js filename="proxy.js" switcher
 import { NextResponse } from 'next/server'
-import { get } from '@vercel/edge-config'
+import { get } from '@vercel/global-config'
 
 export async function proxy(request) {
   const pathname = request.nextUrl.pathname


### PR DESCRIPTION
## What

Vercel's **Edge Config** product is now **Global Config**. This updates the two stale-name occurrences flagged in the redirecting guide.

The URL was already migrated in #96723 (`/docs/edge-config/get-started` → `/docs/global-config/get-started`), but that pass only rewrote link targets — the visible product name and the SDK import in the code samples still said `Edge Config` / `@vercel/edge-config`, so the page read *"Vercel's Edge Config"* while linking to the Global Config docs.

## Changes

`docs/01-app/02-guides/redirecting.mdx`, in *Managing redirects at scale → Creating and storing a redirect map*:

| | Before | After |
| --- | --- | --- |
| Prose | Vercel's [Edge Config] | Vercel's [Global Config] |
| `proxy.ts` / `proxy.js` samples | `import { get } from '@vercel/edge-config'` | `import { get } from '@vercel/global-config'` |

The link target, the neighbouring [Redis](https://vercel.com/docs/redis) link, and the surrounding sentence structure are unchanged.

## Why the package import changed too

The renamed package is published and is the same library — `@vercel/global-config@1.5.1`, from `vercel/storage` at `packages/global-config`, matching `@vercel/edge-config@1.5.1` — and it exports the same `get`. Vercel's own [Global Config quickstart](https://vercel.com/docs/global-config/get-started) now uses `import { get } from '@vercel/global-config'`. Leaving the old specifier would have left the sample importing a legacy package name on a page that calls the product Global Config. `@vercel/edge-config` is not yet formally deprecated on npm, so this is a naming-consistency change rather than a fix for broken code.

## Both flagged pages

Two docs paths were flagged — `/docs/app/guides/redirecting` and `/docs/pages/guides/redirecting` — but they share one source. `docs/02-pages/02-guides/redirecting.mdx` is a generated stub (`source: app/guides/redirecting`, carrying the *DO NOT EDIT* banner), and the affected paragraph is not wrapped in `<AppOnly>`/`<PagesOnly>`, so it renders on both. Editing the App Router source fixes both pages; no separate edit to the Pages file is needed or allowed.

## Verification

- `grep -rn "Edge Config\|edge-config" docs/` → no matches remain.
- `prettier --check` and `alex` pass on both files; the pre-commit `lint-staged` (prettier + eslint) pass ran clean.
- `https://vercel.com/docs/global-config/get-started` → `200`; the old `/docs/edge-config/get-started` → `308`, confirming the link already points at the final target.

Docs-only change; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)