### PR TITLE
Turbopack: report unsupported external modules as an issue

### DIFF
--- a/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
@@ -92,6 +92,75 @@ describe('ReactRefreshLogBox', () => {
     }
   })
 
+  test('Node.js builtins with node: prefix in client code', async () => {
+    await using sandbox = await createSandbox(
+      next,
+      new Map([
+        [
+          'pages/_app.js',
+          outdent`
+            import 'node:async_hooks'
+
+            export default function App({ Component, pageProps }) {
+              return <Component {...pageProps} />
+            }
+          `,
+        ],
+        [
+          'pages/index.js',
+          outdent`
+            export default function Page() {
+              return <p>index page</p>
+            }
+          `,
+        ],
+      ])
+    )
+    const { browser } = sandbox
+
+    if (isTurbopack) {
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "node:async_hooks is an external module, which is not supported in the browser environment",
+         "environmentLabel": null,
+         "label": "Build Error",
+         "source": "./pages/_app.js (1:1)
+       Error: node:async_hooks is an external module, which is not supported in the browser environment
+       > 1 | import 'node:async_hooks'
+           | ^^^^^^^^^^^^^^^^^^^^^^^^^",
+         "stack": [],
+       }
+      `)
+    } else if (isRspack) {
+      await expect({ browser, next }).toDisplayRedbox(`
+       {
+         "description": "  × Module build failed:",
+         "environmentLabel": null,
+         "label": "Build Error",
+         "source": "node:async_hooks
+         × Module build failed:
+         ╰─▶   × Reading from "node:async_hooks" is not handled by plugins (Unhandled scheme).
+               │ Rspack supports "data:" and "file:" URIs by default.
+               │ You may need an additional plugin to handle "node:" URIs.",
+         "stack": [],
+       }
+      `)
+    } else {
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Module build failed: UnhandledSchemeError: Reading from "node:async_hooks" is not handled by plugins (Unhandled scheme).",
+         "environmentLabel": null,
+         "label": "Build Error",
+         "source": "node:async_hooks
+       Module build failed: UnhandledSchemeError: Reading from "node:async_hooks" is not handled by plugins (Unhandled scheme).
+       Webpack supports "data:" and "file:" URIs by default.
+       You may need an additional plugin to handle "node:" URIs.",
+         "stack": [],
+       }
+      `)
+    }
+  })
+
   test('Module not found', async () => {
     await using sandbox = await createSandbox(next)
     const { browser, session } = sandbox

--- a/turbopack/crates/turbopack-core/src/environment.rs
+++ b/turbopack/crates/turbopack-core/src/environment.rs
@@ -130,6 +130,19 @@ impl Environment {
         })
     }
 
+    /// A short human-readable name of the environment, intended for error messages.
+    #[turbo_tasks::function]
+    pub fn name(&self) -> Vc<RcStr> {
+        Vc::cell(match self.execution {
+            ExecutionEnvironment::NodeJsBuildTime(..) | ExecutionEnvironment::NodeJsLambda(_) => {
+                rcstr!("Node.js")
+            }
+            ExecutionEnvironment::EdgeWorker(_) => rcstr!("edge"),
+            ExecutionEnvironment::Browser(_) => rcstr!("browser"),
+            ExecutionEnvironment::Custom(_) => rcstr!("custom"),
+        })
+    }
+
     #[turbo_tasks::function]
     pub fn node_externals(&self) -> Vc<bool> {
         match self.execution {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -14,7 +14,6 @@ use swc_core::{
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
-    turbobail,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -52,7 +51,9 @@ use crate::{
             EsmExport,
             export::{all_known_export_names, is_export_missing},
         },
-        util::{SpecifiedChunkingType, throw_module_not_found_expr},
+        util::{
+            SpecifiedChunkingType, throw_module_not_found_error_expr, throw_module_not_found_expr,
+        },
     },
     runtime_functions::{TURBOPACK_EXTERNAL_IMPORT, TURBOPACK_EXTERNAL_REQUIRE, TURBOPACK_IMPORT},
     utils::module_id_to_lit,
@@ -870,18 +871,18 @@ impl EsmAssetReference {
                                         request,
                                         ty: ExternalType::EcmaScriptModule,
                                     } => {
-                                        if !*chunking_context
+                                        let call = if !*chunking_context
                                             .environment()
                                             .supports_esm_externals()
                                             .await?
                                         {
-                                            turbobail!(
-                                                "the chunking context ({}) does not support \
-                                                 external modules (esm request: {request})",
-                                                chunking_context.name()
-                                            );
-                                        }
-                                        let call = if import_externals {
+                                            unsupported_external_expr(
+                                                chunking_context,
+                                                &request,
+                                                this.issue_source,
+                                            )
+                                            .await?
+                                        } else if import_externals {
                                             quote!(
                                                 "$turbopack_external_import($id)" as Expr,
                                                 turbopack_external_import: Expr = TURBOPACK_EXTERNAL_IMPORT.into(),
@@ -900,22 +901,24 @@ impl EsmAssetReference {
                                         request,
                                         ty: ExternalType::CommonJs | ExternalType::Url,
                                     } => {
-                                        if !*chunking_context
+                                        let call = if !*chunking_context
                                             .environment()
                                             .supports_commonjs_externals()
                                             .await?
                                         {
-                                            turbobail!(
-                                                "the chunking context ({}) does not support \
-                                                 external modules (request: {request})",
-                                                chunking_context.name()
-                                            );
-                                        }
-                                        let call = quote!(
-                                            "$turbopack_external_require($id, () => require($id), true)" as Expr,
-                                            turbopack_external_require: Expr = TURBOPACK_EXTERNAL_REQUIRE.into(),
-                                            id: Expr = Expr::Lit(request.to_string().into())
-                                        );
+                                            unsupported_external_expr(
+                                                chunking_context,
+                                                &request,
+                                                this.issue_source,
+                                            )
+                                            .await?
+                                        } else {
+                                            quote!(
+                                                "$turbopack_external_require($id, () => require($id), true)" as Expr,
+                                                turbopack_external_require: Expr = TURBOPACK_EXTERNAL_REQUIRE.into(),
+                                                id: Expr = Expr::Lit(request.to_string().into())
+                                            )
+                                        };
                                         (name.sym.as_str().into(), call)
                                     }
                                     // fallback in case we introduce a new `ExternalType`
@@ -956,6 +959,54 @@ impl EsmAssetReference {
 
         Ok(CodeGeneration::empty())
     }
+}
+
+/// The request was resolved to an external module, but the environment that this chunking context
+/// targets can't load external modules at runtime (e.g. a Node.js built-in module that was imported
+/// from code that is bundled for the browser).
+///
+/// Reports this as an issue (pointing at the import in the source code) and returns an expression
+/// that throws when the importing module is evaluated.
+async fn unsupported_external_expr(
+    chunking_context: Vc<Box<dyn ChunkingContext>>,
+    request: &RcStr,
+    issue_source: IssueSource,
+) -> Result<Expr> {
+    let environment = chunking_context.environment().name().owned().await?;
+
+    CodeGenerationIssue {
+        severity: IssueSeverity::Error,
+        title: StyledString::Line(vec![
+            StyledString::Code(request.clone()),
+            StyledString::Text(
+                format!(
+                    " is an external module, which is not supported in the {environment} \
+                     environment"
+                )
+                .into(),
+            ),
+        ])
+        .resolved_cell(),
+        message: StyledString::Text(
+            format!(
+                "External modules are loaded by the runtime instead of being bundled, which the \
+                 {environment} environment can't do — this includes Node.js built-in modules. \
+                 Remove the import from code that is bundled for the {environment} environment, \
+                 or use an alternative that works there."
+            )
+            .into(),
+        )
+        .resolved_cell(),
+        path: issue_source.file_path().await?,
+        source: Some(issue_source),
+    }
+    .resolved_cell()
+    .emit();
+
+    Ok(throw_module_not_found_error_expr(
+        request,
+        &format!("external modules are not supported in the {environment} environment"),
+    ))
 }
 
 fn var_decl_with_span(mut decl: Stmt, span: Span) -> Stmt {

--- a/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/input/index.js
@@ -1,0 +1,3 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+console.log(AsyncLocalStorage)

--- a/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/issues/__l___c_node__c__async_hooks__ is an external modu-4a570b.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/issues/__l___c_node__c__async_hooks__ is an external modu-4a570b.txt
@@ -1,0 +1,10 @@
+error - [code gen] /turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/input/index.js:1:0  node:async_hooks is an external module, which is not supported in the browser environment
+  
+         + v--------------------------------------------------v
+       1 + import { AsyncLocalStorage } from 'node:async_hooks'
+         + ^--------------------------------------------------^
+       2 | 
+       3 | console.log(AsyncLocalStorage)
+       4 | 
+  
+  External modules are loaded by the runtime instead of being bundled, which the browser environment can't do — this includes Node.js built-in modules. Remove the import from code that is bundled for the browser environment, or use an alternative that works there.

--- a/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/output/0_9x_turbopack-tests_tests_snapshot_imports_external_unsupported_input_index_0pl48ad.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/output/0_9x_turbopack-tests_tests_snapshot_imports_external_unsupported_input_index_0pl48ad.js.map
@@ -1,0 +1,5 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": []
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/output/0_9x_turbopack-tests_tests_snapshot_imports_external_unsupported_input_index_0zk5y9y.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/output/0_9x_turbopack-tests_tests_snapshot_imports_external_unsupported_input_index_0zk5y9y.js
@@ -1,0 +1,16 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push(["output/0_9x_turbopack-tests_tests_snapshot_imports_external_unsupported_input_index_0zk5y9y.js",
+"[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/input/index.js [test] (ecmascript)", ((__turbopack_context__) => {
+"use strict";
+
+__turbopack_context__.s([]);
+var __TURBOPACK__url__external__node$3a$async_hooks__ = (()=>{
+    const e = new Error("Cannot find module 'node:async_hooks': external modules are not supported in the browser environment");
+    e.code = 'MODULE_NOT_FOUND';
+    throw e;
+})();
+;
+console.log(__TURBOPACK__url__external__node$3a$async_hooks__["AsyncLocalStorage"]);
+}),
+]);
+
+//# sourceMappingURL=0_9x_turbopack-tests_tests_snapshot_imports_external_unsupported_input_index_0zk5y9y.js.map

--- a/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/output/0_9x_turbopack-tests_tests_snapshot_imports_external_unsupported_input_index_0zk5y9y.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/output/0_9x_turbopack-tests_tests_snapshot_imports_external_unsupported_input_index_0zk5y9y.js.map
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "sources": [],
+  "sections": [
+    {"offset": {"line": 4, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/input/index.js"],"sourcesContent":["import { AsyncLocalStorage } from 'node:async_hooks'\n\nconsole.log(AsyncLocalStorage)\n"],"names":["console","log"],"mappings":";AAAA;;;;;;AAEAA,QAAQC,GAAG,CAAC,sEAAiB"}}]
+}

--- a/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/output/0rv8_turbopack-tests_tests_snapshot_imports_external_unsupported_input_index_0pl48ad.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/output/0rv8_turbopack-tests_tests_snapshot_imports_external_unsupported_input_index_0pl48ad.js
@@ -1,0 +1,5 @@
+(globalThis["TURBOPACK"] || (globalThis["TURBOPACK"] = [])).push([
+    "output/0rv8_turbopack-tests_tests_snapshot_imports_external_unsupported_input_index_0pl48ad.js",
+    {"otherChunks":["output/0_9x_turbopack-tests_tests_snapshot_imports_external_unsupported_input_index_0zk5y9y.js"],"runtimeModuleIds":["[project]/turbopack/crates/turbopack-tests/tests/snapshot/imports/external_unsupported/input/index.js [test] (ecmascript)"]}
+]);
+// Dummy runtime


### PR DESCRIPTION
Turbopack: report unsupported external modules as an issue instead of an internal error

### What?

Replace the internal `turbobail!` that Turbopack hit when an ESM reference resolves
to an external module the target environment can't load (e.g. a Node.js built-in
imported into browser code) with a proper Turbopack issue: an error-severity
`CodeGenerationIssue` pointing at the import, plus code that throws at runtime
when the module is evaluated. Adds `Environment::name()` so the message can name
the target environment (`browser`, `edge`, `Node.js`) instead of the (usually
unnamed) chunking context.

### Why?

Importing a Node.js built-in from browser code, e.g. `import 'node:async_hooks'`
in `pages/_app.js`, failed with:

    Error [TurbopackInternalError]: Failed to write page endpoint /_app
    Caused by:
    - the chunking context (unknown) does not support external modules (request: node:async_hooks)

This looked like a Turbopack bug, gave no file/line, and aborted writing the
whole endpoint instead of surfacing a normal build error.