### PR TITLE
[ci] Wait for the `next` version to be available on npm before deploy tests

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -136,6 +136,40 @@ jobs:
           retention-days: 5
           if-no-files-found: error
 
+      # Runs last in setup so the steps above overlap with npm propagation.
+      - name: wait-for-published-next
+        env:
+          # The spec that comes after `next@` when the deploy tests install
+          # it: a dist-tag, an exact version, or a tarball URL.
+          NEXT_VERSION_SPEC: ${{ steps.version.outputs.value }}
+          POLL_TIMEOUT_SECONDS: 900
+          POLL_INTERVAL_SECONDS: 15
+        run: |
+          set -euo pipefail
+
+          if [[ "$NEXT_VERSION_SPEC" == http* ]]; then
+            echo "next@$NEXT_VERSION_SPEC is a tarball URL, skipping npm availability check"
+            exit 0
+          fi
+
+          deadline=$((SECONDS + POLL_TIMEOUT_SECONDS))
+          attempt=1
+          while true; do
+            if resolved="$(pnpm view "next@$NEXT_VERSION_SPEC" version)"; then
+              echo "next@$NEXT_VERSION_SPEC is available on npm (resolved to $resolved, attempt $attempt)"
+              break
+            fi
+
+            if (( SECONDS >= deadline )); then
+              echo "::error::Timed out after ${POLL_TIMEOUT_SECONDS}s waiting for next@$NEXT_VERSION_SPEC to become available on npm"
+              exit 1
+            fi
+
+            echo "next@$NEXT_VERSION_SPEC is not available on npm yet (attempt $attempt), retrying in ${POLL_INTERVAL_SECONDS}s"
+            sleep "$POLL_INTERVAL_SECONDS"
+            attempt=$((attempt + 1))
+          done
+
   test-deploy-webpack:
     name: Run Deploy Tests (Webpack)
     needs: setup


### PR DESCRIPTION

The deploy test jobs in `test_e2e_deploy_release` install the resolved `next` version from npm. When the workflow is triggered by a release, npm may not have propagated the freshly published version yet, which fails fixture installs across all test shards with confusing errors. This is purely an NPM distribution issue. We only create GitHub releases after a successful `npm publish`

This adds a `wait-for-published-next` step at the end of the `setup` job that polls `pnpm view` for the resolved version every 15 seconds for up to 15 minutes and fails with a clear error on timeout. The step runs last in `setup` so checkout, dependency installation, and test-timings fetching overlap with any propagation lag, and as a separate named step its duration is trackable in Datadog. 

Tarball URL inputs skip the check since they are not distributed through npm. We assume these exist when triggered. It would be nice to also poll but I'm not sure that's more common than accidentally using the wrong URL that'll never exist.

## test plan

- [x] [new step succeeds on existing version (`@canary`)](https://github.com/vercel/next.js/actions/runs/32116787756/job/95647991249#step:12:40)
- [x] [new step fails on non-existing version (`@foo`)](https://github.com/vercel/next.js/actions/runs/32116568965/job/95648262235#step:12:561)