### PR TITLE
fix(eslint-plugin-next): suppress no-img-element when ImageResponse is imported

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-img-element.ts
+++ b/packages/eslint-plugin-next/src/rules/no-img-element.ts
@@ -3,6 +3,9 @@ import { defineRule } from '../utils/define-rule'
 
 const url = 'https://nextjs.org/docs/messages/no-img-element'
 
+// Packages that export ImageResponse for OG image generation
+const IMAGE_RESPONSE_PACKAGES = ['next/og', '@vercel/og']
+
 export default defineRule({
   meta: {
     docs: {
@@ -24,7 +27,26 @@ export default defineRule({
 
     const isAppDir = /^(src\/)?app\//.test(relativePath)
 
+    // Track whether this file imports ImageResponse from next/og or @vercel/og.
+    // When ImageResponse is used, <img> is the correct API inside the JSX
+    // passed to ImageResponse and next/image cannot be used there.
+    let hasImageResponseImport = false
+
     return {
+      ImportDeclaration(node) {
+        if (!IMAGE_RESPONSE_PACKAGES.includes(node.source.value as string)) {
+          return
+        }
+        const hasImageResponseSpecifier = node.specifiers.some(
+          (specifier) =>
+            specifier.type === 'ImportSpecifier' &&
+            specifier.imported.name === 'ImageResponse'
+        )
+        if (hasImageResponseSpecifier) {
+          hasImageResponseImport = true
+        }
+      },
+
       JSXOpeningElement(node) {
         if (node.name.name !== 'img') {
           return
@@ -45,6 +67,13 @@ export default defineRule({
           /\/opengraph-image|twitter-image|icon\.\w+$/.test(relativePath)
         )
           return
+
+        // If the file imports ImageResponse from next/og or @vercel/og,
+        // <img> is the only valid image element inside the ImageResponse JSX.
+        // See: https://github.com/vercel/next.js/issues/47097
+        if (hasImageResponseImport) {
+          return
+        }
 
         context.report({
           node,

--- a/test/unit/eslint-plugin-next/no-img-element.test.ts
+++ b/test/unit/eslint-plugin-next/no-img-element.test.ts
@@ -94,6 +94,66 @@ export default function Image() {
 `,
       filename: `app/opengraph-image.tsx`,
     },
+    {
+      code: `\
+import { ImageResponse } from "next/og";
+
+export default function handler() {
+  return new ImageResponse(
+    (
+      <img
+        alt="avatar"
+        style={{ borderRadius: "100%" }}
+        width="100%"
+        height="100%"
+        src="https://example.com/image.png"
+      />
+    )
+  );
+}
+`,
+      filename: `app/api/og/route.tsx`,
+    },
+    {
+      code: `\
+import { ImageResponse } from "@vercel/og";
+
+export default function handler() {
+  return new ImageResponse(
+    (
+      <img
+        alt="avatar"
+        style={{ borderRadius: "100%" }}
+        width="100%"
+        height="100%"
+        src="https://example.com/image.png"
+      />
+    )
+  );
+}
+`,
+      filename: `app/api/og/route.tsx`,
+    },
+    {
+      code: `\
+import { ImageResponse } from "next/og";
+
+export default function Image() {
+return new ImageResponse(
+  (
+    <img
+      alt="avatar"
+      style={{ borderRadius: "100%" }}
+      width="100%"
+      height="100%"
+      src="https://example.com/image.png"
+    />
+  )
+);
+}
+`,
+      filename: `some/non-metadata-route-image.tsx`,
+    },
   ],
   invalid: [
     {
@@ -132,23 +192,18 @@ export default function Image() {
     },
     {
       code: `\
-import { ImageResponse } from "next/og";
-
-export default function Image() {
-return new ImageResponse(
-  (
+export default function handler() {
+  return (
     <img
       alt="avatar"
-      style={{ borderRadius: "100%" }}
       width="100%"
       height="100%"
       src="https://example.com/image.png"
     />
-  )
-);
+  );
 }
 `,
-      filename: `some/non-metadata-route-image.tsx`,
+      filename: `app/api/og/route.tsx`,
       errors: [{ message, type: 'JSXOpeningElement' }],
     },
   ],


### PR DESCRIPTION
### What?
Suppresses the `@next/next/no-img-element` ESLint rule warning when a file imports `ImageResponse` from `next/og` or `@vercel/og`.

### Why?
When generating Open Graph images via `ImageResponse`, standard HTML `<img>` elements are required by the image rendering engine (Satori). Next.js's `<Image />` component cannot be used in this context.

Previously, the `no-img-element` rule only exempted exact metadata file names (`opengraph-image.tsx`, `icon.js`, etc.) inside the `app/` directory. If developers created custom OG image route handlers in other routes (e.g. `app/api/og/route.ts` or `pages/api/og.tsx`) or used `@vercel/og`, the linter raised a false-positive warning.

### How?
1. Updated `packages/eslint-plugin-next/src/rules/no-img-element.ts` with an `ImportDeclaration` visitor that sets a flag if `ImageResponse` is imported from `next/og` or `@vercel/og`.
2. When `ImageResponse` is imported in the file, `no-img-element` skips reporting on `<img>` elements.
3. Files without an `ImageResponse` import continue to trigger warnings for raw `<img>` tags as expected.

### Testing
Added test cases to `test/unit/eslint-plugin-next/no-img-element.test.ts` covering:
- Route handler files (`app/api/og/route.tsx`) importing `ImageResponse` from `next/og`
- Files importing `ImageResponse` from `@vercel/og`
- Arbitrary non-metadata filenames importing `ImageResponse`
- Route handler files using `<img>` *without* an `ImageResponse` import (verifying error reporting still works)

Running unit tests:
```bash
PASS ./no-img-element.test.ts
  no-img-element
    eslint
      valid
        ✓ import { Image } from 'next/image'; ...
        ✓ export class MyComponent { ... picture > img ... }
        ✓ export class MyComponent { ... picture > source + img ... }
        ✓ import { ImageResponse } from "next/og"; (icon.js)
        ✓ import { ImageResponse } from "next/og"; (opengraph-image.tsx)
        ✓ import { ImageResponse } from "next/og"; (app/api/og/route.tsx)
        ✓ import { ImageResponse } from "@vercel/og"; (app/api/og/route.tsx)
        ✓ import { ImageResponse } from "next/og"; (some/non-metadata-route-image.tsx)
      invalid
        ✓ MyComponent div > img
        ✓ MyComponent img
        ✓ handler app/api/og/route.tsx without ImageResponse import (triggers warning as expected)

Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
```

Fixes #47097
