### PR TITLE
docs: mention Valibot as validation library option in forms guides

### DIFF
--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -100,7 +100,7 @@ export async function signup(formData) {}
 
 #### 2. Validate form fields on the server
 
-Use the Server Action to validate the form fields on the server. If your authentication provider doesn't provide form validation, you can use a schema validation library like [Zod](https://zod.dev/) or [Yup](https://github.com/jquense/yup).
+Use the Server Action to validate the form fields on the server. If your authentication provider doesn't provide form validation, you can use a schema validation library like [Zod](https://zod.dev/), [Valibot](https://valibot.dev/) or [Yup](https://github.com/jquense/yup).
 
 Using Zod as an example, you can define a form schema with appropriate error messages:
 

--- a/docs/01-app/02-guides/forms.mdx
+++ b/docs/01-app/02-guides/forms.mdx
@@ -131,7 +131,7 @@ export async function updateUser(userId, formData) {}
 Forms can be validated on the client or server.
 
 - For **client-side validation**, you can use the HTML attributes like `required` and `type="email"` for basic validation.
-- For **server-side validation**, you can use a library like [zod](https://zod.dev/) to validate the form fields. For example:
+- For **server-side validation**, you can use a schema validation library like [Zod](https://zod.dev/) or [Valibot](https://valibot.dev/) to validate the form fields. For example:
 
 ```tsx filename="app/actions.ts" switcher
 'use server'

--- a/docs/02-pages/02-guides/forms.mdx
+++ b/docs/02-pages/02-guides/forms.mdx
@@ -96,7 +96,7 @@ export default function Page() {
 
 We recommend using HTML validation like `required` and `type="email"` for basic client-side form validation.
 
-For more advanced server-side validation, you can use a schema validation library like [zod](https://zod.dev/) to validate the form fields before mutating the data:
+For more advanced server-side validation, you can use a schema validation library like [Zod](https://zod.dev/) or [Valibot](https://valibot.dev/) to validate the form fields before mutating the data:
 
 ```ts filename="pages/api/submit.ts" switcher
 import type { NextApiRequest, NextApiResponse } from 'next'


### PR DESCRIPTION
The forms guides recommend validating with a library like Zod. This broadens the wording to also mention Valibot, which covers the same use case with a smaller bundle footprint. The authentication guide already lists Zod or Yup, so Valibot is added to that list as well. The existing Zod examples are unchanged. I'm the author of Valibot.

- Ran `prettier --check` on the touched files with the repo's pinned version.
