### PR TITLE
[PPF] Fix incorrect eager hint in incremental PPF

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2689,11 +2689,7 @@ export async function fetchSegmentPrefetchesUsingRuntimeRequest(
 
     // Runtime prefetch responses (PPRRuntime and RuntimeShell requests) are
     // partial when the server marks the response as '~' (Partial).
-    // Full/LoadingBoundary prefetch responses are always complete. This only
-    // describes the FULL payload: shell-tier writes don't consume it — a
-    // shell is partial by construction (RuntimeShell responses omit every
-    // dynamic suspense boundary below the shell stage, regardless of what
-    // the server marker says); see writeResponsePayloadsIntoCache.
+    // Full/LoadingBoundary prefetch responses are always complete.
     const isFullResponsePartial =
       (fetchStrategy === FetchStrategy.PPRRuntime ||
         fetchStrategy === FetchStrategy.RuntimeShell) &&
@@ -2866,12 +2862,11 @@ function writeResponsePayloadsIntoCache(
       }
       return null
     }
-    // No shell exists, and the request wasn't a static shell walk. The full
-    // payload fulfills the spawned entries at the request's own keying —
-    // including for a RuntimeShell request (shell staging not enabled, or
-    // the render wasn't staged), whose response is then conservatively treated
-    // as the shell it asked for: keyed at the shell tier and partial
-    // by construction.
+    // This request either:
+    // - didn't allow recovering a shell (no staged rendering),
+    // - or was a (runtime) shell request, so we already have a shell without recovering anything.
+    // In either case, we don't have anything to consider other than the request itself,
+    // so the payload simply fulfills the spawned entries at the request's own keying.
     fulfilledEntries = writeServerResponseIntoCache(
       now,
       fetchStrategy,
@@ -2882,9 +2877,7 @@ function writeResponsePayloadsIntoCache(
       renderedSearch,
       buildId,
       staleAt,
-      fetchStrategy === FetchStrategy.RuntimeShell
-        ? true
-        : isFullResponsePartial,
+      isFullResponsePartial,
       metadataVaryPath,
       spawnedEntries,
       null,
@@ -2909,7 +2902,7 @@ function writeResponsePayloadsIntoCache(
       renderedSearch,
       buildId,
       staleAt,
-      shellWasRequested ? true : isFullResponsePartial,
+      isFullResponsePartial,
       metadataVaryPath,
       spawnedEntries,
       // The full payload's tier: PPR for a static response, PPRRuntime for

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -306,12 +306,15 @@ import {
   type AdvanceableRenderStage,
 } from './staged-rendering'
 import {
-  anySegmentHasPartialPrefetchingEnabled,
   isPageAllowedToBlock,
   anySegmentNeedsInstantValidationInDev,
   anySegmentNeedsInstantValidationInBuild,
   resolveInstantConfigSamplesForPage,
 } from './instant-validation/instant-config'
+import {
+  routeHasPartialPrefetchingEnabled,
+  resolvePartialPrefetchingConfigForRoute,
+} from './prefetch-config'
 import { warnOnce } from '../../shared/lib/utils/warn-once'
 import {
   createWebDebugChannel,
@@ -750,11 +753,17 @@ async function generateDynamicRSCPayload(
         key: getFlightMetadataKey(requestId),
       })
     )
+    const routePartialPrefetching =
+      await resolvePartialPrefetchingConfigForRoute(
+        loaderTree,
+        ctx.renderOpts.partialPrefetching
+      )
 
     const responseTree = needsFullTree
       ? await createFullTreeForNavigation({
           ctx,
           loaderTree,
+          routePartialPrefetching,
           rscHead,
           injectedCSS: new Set(),
           injectedJS: new Set(),
@@ -765,6 +774,7 @@ async function generateDynamicRSCPayload(
       : await walkTreeWithFlightRouterState({
           ctx,
           loaderTreeToFilter: loaderTree,
+          routePartialPrefetching,
           parentParams: {},
           flightRouterState,
           rscHead,
@@ -1105,8 +1115,10 @@ async function generateStagedDynamicFlightRenderResultNode(
   // is embedded in the RSC payload. This is gated because it adds extra server
   // processing and increases the response payload size.
   if (
-    Boolean(renderOpts.partialPrefetching) ||
-    (await anySegmentHasPartialPrefetchingEnabled(loaderTree))
+    await routeHasPartialPrefetchingEnabled(
+      loaderTree,
+      renderOpts.partialPrefetching
+    )
   ) {
     // Create a mutable cache that gets filled during the dynamic render.
     const prerenderResumeDataCache = createPrerenderResumeDataCache()
@@ -2160,11 +2172,17 @@ async function getRSCPayload(
     serveStreamingMetadata,
   })
 
+  const routePartialPrefetching = await resolvePartialPrefetchingConfigForRoute(
+    tree,
+    ctx.renderOpts.partialPrefetching
+  )
+
   const preloadCallbacks: PreloadCallbacks = []
 
   const initialTree = await createFullComponentTree({
     ctx,
     loaderTree: tree,
+    routePartialPrefetching,
     parentParams: {},
     parentOptionalCatchAllParamName: null,
     parentRuntimePrefetchable: false,
@@ -2358,12 +2376,17 @@ async function getErrorRSCPayload(
     )
   )
 
+  const routePartialPrefetching = await resolvePartialPrefetchingConfigForRoute(
+    tree,
+    ctx.renderOpts.partialPrefetching
+  )
+
   const initialTree = await createFullTransportTreeFromLoaderTree(
     tree,
     errorHints,
     errorPrefetchInliningEnabled,
     ctx.missingPrefetchHintPolicy,
-    ctx.renderOpts.partialPrefetching,
+    routePartialPrefetching,
     getDynamicParamFromSegment,
     query
   )
@@ -3851,8 +3874,10 @@ async function renderToStream(
         // `prefetch` of 'partial' or 'unstable_eager') or globally (the
         // `partialPrefetching` config).
         if (
-          Boolean(renderOpts.partialPrefetching) ||
-          (await anySegmentHasPartialPrefetchingEnabled(tree))
+          await routeHasPartialPrefetchingEnabled(
+            tree,
+            renderOpts.partialPrefetching
+          )
         ) {
           const prerenderResumeDataCache = createPrerenderResumeDataCache()
           requestStore.resumeDataCache = prerenderResumeDataCache
@@ -5289,12 +5314,13 @@ async function getPrefetchingModeForPage(
     process.env.NEXT_PRIVATE_DEBUG_VALIDATION === '1' ? console.log : undefined
 
   // TODO(app-shells): support "unstable_eager"
-  if (renderOpts.partialPrefetching) {
-    debug?.('using prefetching mode Partial because of next.config.js')
-    return PrefetchingMode.Partial
-  }
-  if (await anySegmentHasPartialPrefetchingEnabled(loaderTree)) {
-    debug?.('using prefetching mode Partial because of segment config')
+  if (
+    await routeHasPartialPrefetchingEnabled(
+      loaderTree,
+      renderOpts.partialPrefetching
+    )
+  ) {
+    debug?.('using prefetching mode Partial')
     return PrefetchingMode.Partial
   }
 

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -58,8 +58,10 @@ import {
   getConventionPathByType,
   isNextjsBuiltinFilePath,
 } from './segment-explorer-path'
+import type { ResolvedPartialPrefetching } from './prefetch-config'
 
 type CreateComponentTreeProps = {
+  routePartialPrefetching: ResolvedPartialPrefetching
   loaderTree: LoaderTree
   parentParams: Params
   parentOptionalCatchAllParamName: string | null
@@ -128,6 +130,7 @@ const cacheNodeKey = 'c'
 async function createComponentTreeInternal(
   {
     loaderTree: tree,
+    routePartialPrefetching,
     parentParams,
     parentOptionalCatchAllParamName,
     rootLayoutIncluded,
@@ -143,6 +146,7 @@ async function createComponentTreeInternal(
     hintTree,
   }: {
     loaderTree: LoaderTree
+    routePartialPrefetching: ResolvedPartialPrefetching
     parentParams: Params
     parentOptionalCatchAllParamName: string | null
     rootLayoutIncluded: boolean
@@ -191,7 +195,6 @@ async function createComponentTreeInternal(
     parseLoaderTree(tree)
 
   const prefetchInliningEnabled = Boolean(experimental.prefetchInlining)
-  const partialPrefetching = ctx.renderOpts.partialPrefetching
 
   const {
     layout,
@@ -598,7 +601,7 @@ async function createComponentTreeInternal(
             childHintTree,
             prefetchInliningEnabled,
             ctx.missingPrefetchHintPolicy,
-            partialPrefetching,
+            routePartialPrefetching,
             getDynamicParamFromSegment,
             query,
             rootLayoutIncludedAtThisLevelOrAbove
@@ -620,6 +623,7 @@ async function createComponentTreeInternal(
           childNode = await createComponentTreeInternal(
             {
               loaderTree: parallelRoute,
+              routePartialPrefetching,
               parentParams: currentParams,
               parentOptionalCatchAllParamName: optionalCatchAllParamName,
               rootLayoutIncluded: rootLayoutIncludedAtThisLevelOrAbove,
@@ -739,7 +743,7 @@ async function createComponentTreeInternal(
     hintTree,
     prefetchInliningEnabled,
     ctx.missingPrefetchHintPolicy,
-    partialPrefetching,
+    routePartialPrefetching,
     !rootLayoutIncluded
   )
 

--- a/packages/next/src/server/app-render/create-transport-tree-from-loader-tree.ts
+++ b/packages/next/src/server/app-render/create-transport-tree-from-loader-tree.ts
@@ -15,6 +15,7 @@ import {
 import type { GetDynamicParamFromSegment } from './app-render'
 import { addSearchParamsIfPageSegment } from '../../shared/lib/segment'
 import type { AppSegmentConfig } from '../../build/segment-config/app/app-segment-config'
+import type { ResolvedPartialPrefetching } from './prefetch-config'
 
 export type MissingPrefetchHintPolicy =
   | 'mark-stale'
@@ -61,7 +62,7 @@ export async function computeSegmentPrefetchHints(
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
   missingPrefetchHintPolicy: MissingPrefetchHintPolicy,
-  partialPrefetching: boolean | 'unstable_eager' | undefined,
+  routePartialPrefetching: ResolvedPartialPrefetching,
   // Whether this segment is at or above the root layout (no layout was found
   // above it).
   isRootLayoutOrAbove: boolean
@@ -74,13 +75,15 @@ export async function computeSegmentPrefetchHints(
   // `partialPrefetching` config in next.config.js.
   const mod = layout ? await layout[0]() : page ? await page[0]() : undefined
   const instantConfig = mod ? (mod as AppSegmentConfig).instant : undefined
-  const prefetchConfig =
-    (mod ? (mod as AppSegmentConfig).prefetch : undefined) ??
-    (partialPrefetching === 'unstable_eager'
-      ? 'unstable_eager'
-      : partialPrefetching
-        ? 'partial'
-        : undefined)
+
+  /**
+   * NOTE: Do not use for determining whether Partial Prefetching is on.
+   * we determine that via `routePartialPrefetching`.
+   * */
+  const segmentPrefetchConfig = mod
+    ? (mod as AppSegmentConfig).prefetch
+    : undefined
+
   let prefetchHints = 0
 
   // Union in the precomputed build-time hints (e.g. segment inlining
@@ -130,25 +133,36 @@ export async function computeSegmentPrefetchHints(
     prefetchHints |= PrefetchHint.SubtreeHasInstantFalse
   }
 
-  if (prefetchConfig === 'partial') {
-    prefetchHints |= PrefetchHint.SubtreeHasPartialPrefetching
-  } else if (prefetchConfig === 'unstable_eager') {
-    // Like 'partial' (uses the PPR fetch strategy) but also marks the segment
-    // as eager, so App Shells keeps prefetching it instead of relying on the
-    // shared app shell.
-    prefetchHints |=
-      PrefetchHint.SubtreeHasPartialPrefetching |
-      PrefetchHint.SubtreeHasEagerPrefetch
-  } else if (prefetchConfig === 'force-disabled') {
-    prefetchHints |= PrefetchHint.PrefetchDisabled
+  switch (routePartialPrefetching) {
+    case false: {
+      // This route does not use partial prefetching.
+      // If we're not using App Shells, then all prefetches are speculative/eager.
+      prefetchHints |= PrefetchHint.SubtreeHasEagerPrefetch
+      break
+    }
+    case true: {
+      // This route uses App Shells, either from `partialPrefetching: true` or `prefetch = "partial".
+      prefetchHints |= PrefetchHint.SubtreeHasPartialPrefetching
+      break
+    }
+    case 'unstable_eager': {
+      // This route uses App Shells + eager per-link prefetches, either from
+      // `partialPrefetching: 'unstable_eager'` or `prefetch = "unstable_eager".
+      // Like 'partial' (uses the PPR fetch strategy) but also marks the segment
+      // as eager, so App Shells keeps prefetching it instead of relying on the
+      // shared app shell.
+      prefetchHints |=
+        PrefetchHint.SubtreeHasPartialPrefetching |
+        PrefetchHint.SubtreeHasEagerPrefetch
+      break
+    }
+    default: {
+      routePartialPrefetching satisfies never
+    }
   }
 
-  // Mark the segment as "eager" unless its effective prefetch strategy is
-  // 'partial'. 'unstable_eager' already set the bit above. Under App Shells,
-  // a subtree with no eager segment skips its Speculative prefetch and relies
-  // on the shared app shell instead.
-  if (prefetchConfig !== 'partial') {
-    prefetchHints |= PrefetchHint.SubtreeHasEagerPrefetch
+  if (segmentPrefetchConfig === 'force-disabled') {
+    prefetchHints |= PrefetchHint.PrefetchDisabled
   }
 
   // Check if this segment has a loading boundary
@@ -176,7 +190,7 @@ async function createTransportTreeFromLoaderTreeImpl(
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
   missingPrefetchHintPolicy: MissingPrefetchHintPolicy,
-  partialPrefetching: boolean | 'unstable_eager' | undefined,
+  routePartialPrefetching: ResolvedPartialPrefetching,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   searchParams: any,
   didFindRootLayout: boolean
@@ -190,7 +204,7 @@ async function createTransportTreeFromLoaderTreeImpl(
     hintTree,
     prefetchInliningEnabled,
     missingPrefetchHintPolicy,
-    partialPrefetching,
+    routePartialPrefetching,
     !didFindRootLayout
   )
 
@@ -211,7 +225,7 @@ async function createTransportTreeFromLoaderTreeImpl(
       childHintNode,
       prefetchInliningEnabled,
       missingPrefetchHintPolicy,
-      partialPrefetching,
+      routePartialPrefetching,
       getDynamicParamFromSegment,
       searchParams,
       didFindRootLayout
@@ -254,7 +268,7 @@ export async function createTransportTreeFromLoaderTree(
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
   missingPrefetchHintPolicy: MissingPrefetchHintPolicy,
-  partialPrefetching: boolean | 'unstable_eager' | undefined,
+  routePartialPrefetching: ResolvedPartialPrefetching,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   searchParams: any,
   // Whether a root layout was already found above this loader tree slice, so a
@@ -268,7 +282,7 @@ export async function createTransportTreeFromLoaderTree(
     hintTree,
     prefetchInliningEnabled,
     missingPrefetchHintPolicy,
-    partialPrefetching,
+    routePartialPrefetching,
     getDynamicParamFromSegment,
     searchParams,
     didFindRootLayout
@@ -285,7 +299,7 @@ export async function createFullTransportTreeFromLoaderTree(
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
   missingPrefetchHintPolicy: MissingPrefetchHintPolicy,
-  partialPrefetching: boolean | 'unstable_eager' | undefined,
+  routePartialPrefetching: ResolvedPartialPrefetching,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   searchParams: any
 ): Promise<FullTransportNode> {
@@ -298,7 +312,7 @@ export async function createFullTransportTreeFromLoaderTree(
     hintTree,
     prefetchInliningEnabled,
     missingPrefetchHintPolicy,
-    partialPrefetching,
+    routePartialPrefetching,
     getDynamicParamFromSegment,
     searchParams,
     false
@@ -314,7 +328,7 @@ export async function createRouteTreePrefetch(
   hintTree: PrefetchHints | null,
   prefetchInliningEnabled: boolean,
   missingPrefetchHintPolicy: MissingPrefetchHintPolicy,
-  partialPrefetching: boolean | 'unstable_eager' | undefined,
+  routePartialPrefetching: ResolvedPartialPrefetching,
   getDynamicParamFromSegment: GetDynamicParamFromSegment,
   // See note on createTransportTreeFromLoaderTree's didFindRootLayout.
   didFindRootLayout: boolean = false
@@ -329,7 +343,7 @@ export async function createRouteTreePrefetch(
     hintTree,
     prefetchInliningEnabled,
     missingPrefetchHintPolicy,
-    partialPrefetching,
+    routePartialPrefetching,
     getDynamicParamFromSegment,
     searchParams,
     didFindRootLayout

--- a/packages/next/src/server/app-render/instant-validation/instant-config.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-config.tsx
@@ -50,38 +50,6 @@ export function isFrameworkErrorRoute(route: string | undefined): boolean {
   )
 }
 
-/**
- * Matches any `prefetch` config that enables Partial Prefetching for the
- * segment: 'partial' or 'unstable_eager'. A route with Partial Prefetching
- * enabled also runtime-caches its navigations, so this gates the runtime
- * prefetch spawn.
- */
-export async function anySegmentHasPartialPrefetchingEnabled(
-  tree: LoaderTree
-): Promise<boolean> {
-  const { mod: layoutOrPageMod } = await getLayoutOrPageModule(tree)
-
-  // TODO(restart-on-cache-miss): Does this work correctly for client page/layout modules?
-  const prefetchConfig = layoutOrPageMod
-    ? (layoutOrPageMod as AppSegmentConfig).prefetch
-    : undefined
-  if (prefetchConfig === 'partial' || prefetchConfig === 'unstable_eager') {
-    return true
-  }
-
-  const { parallelRoutes } = parseLoaderTree(tree)
-  for (const parallelRouteKey in parallelRoutes) {
-    const parallelRoute = parallelRoutes[parallelRouteKey]
-    const hasChildPartialPrefetching =
-      await anySegmentHasPartialPrefetchingEnabled(parallelRoute)
-    if (hasChildPartialPrefetching) {
-      return true
-    }
-  }
-
-  return false
-}
-
 export async function isPageAllowedToBlock(tree: LoaderTree): Promise<boolean> {
   const { mod: layoutOrPageMod } = await getLayoutOrPageModule(tree)
 

--- a/packages/next/src/server/app-render/prefetch-config.ts
+++ b/packages/next/src/server/app-render/prefetch-config.ts
@@ -1,0 +1,122 @@
+import type {
+  AppSegmentConfig,
+  Prefetch,
+} from '../../build/segment-config/app/app-segment-config'
+import { parseLoaderTree } from '../../shared/lib/router/utils/parse-loader-tree'
+import type { NextConfigComplete } from '../config-shared'
+import { getLayoutOrPageModule, type LoaderTree } from '../lib/app-dir-module'
+
+/**
+ * Partial Prefetching is enabled if
+ * - `partialPrefetching` is set globally in the config
+ * - a segment included in the route has a `prefetch` config that enables
+ *   Partial Prefetching: 'partial' or 'unstable_eager'.
+ */
+export async function routeHasPartialPrefetchingEnabled(
+  tree: LoaderTree,
+  globalConfig: NextConfigComplete['partialPrefetching'] | undefined
+): Promise<boolean> {
+  const config = await resolvePartialPrefetchingConfigForRoute(
+    tree,
+    globalConfig
+  )
+  return config !== false
+}
+
+export type ResolvedPartialPrefetching = false | true | 'unstable_eager'
+
+/**
+ * Resolves the route-level prefetching strategy.
+ * Segment-level configs get precedence to allow gradual opt-in.
+ * If one segment defines 'partial' and another defines 'unstable_eager',
+ * we prioritize the higher level, i.e. we pick 'unstable_eager'.
+ * If no segment-level configs are found, we fall back to the global config.
+ */
+export async function resolvePartialPrefetchingConfigForRoute(
+  tree: LoaderTree,
+  globalConfig: NextConfigComplete['partialPrefetching'] | undefined
+): Promise<ResolvedPartialPrefetching> {
+  // NOTE: in theory we could cache the whole result, but it's more straightforward to
+  // cache only the part that walks the loader tree, because we can just use a weakmap.
+  const level = await resolvePartialPrefetchingLevelFromSegments(tree)
+  switch (level) {
+    case PartialPrefetchingLevel.Unspecified:
+      // If no segments specified a relevant prefetch config,
+      // we fall back to the global config.
+      return globalConfig ?? false
+    case PartialPrefetchingLevel.Partial:
+      return true
+    case PartialPrefetchingLevel.Eager:
+      return 'unstable_eager'
+  }
+}
+
+const resolvedLevelCache = new WeakMap<LoaderTree, PartialPrefetchingLevel>()
+
+async function resolvePartialPrefetchingLevelFromSegments(tree: LoaderTree) {
+  let result = resolvedLevelCache.get(tree)
+  if (result === undefined) {
+    result = await resolvePartialPrefetchingLevelFromSegmentsImpl(tree)
+    resolvedLevelCache.set(tree, result)
+  }
+  return result
+}
+
+async function resolvePartialPrefetchingLevelFromSegmentsImpl(
+  tree: LoaderTree
+): Promise<PartialPrefetchingLevel> {
+  const { mod: layoutOrPageMod } = await getLayoutOrPageModule(tree)
+
+  const prefetchConfig = getPrefetchConfigFromSegment(layoutOrPageMod)
+  let level = configToLevel(prefetchConfig)
+
+  // We're picking the max value, and this is the highest, so we can exit early.
+  if (level === PartialPrefetchingLevel.Eager) {
+    return level
+  }
+
+  const { parallelRoutes } = parseLoaderTree(tree)
+  for (const parallelRouteKey in parallelRoutes) {
+    const parallelRoute = parallelRoutes[parallelRouteKey]
+    const childValue =
+      await resolvePartialPrefetchingLevelFromSegmentsImpl(parallelRoute)
+    // We're picking the max value, and this is the highest, so we can exit early.
+    level = moreSpecificLevel(level, childValue)
+    if (level === PartialPrefetchingLevel.Eager) {
+      return level
+    }
+  }
+
+  return level
+}
+
+enum PartialPrefetchingLevel {
+  Unspecified = 1,
+  Partial = 2,
+  Eager = 3,
+}
+
+function configToLevel(prefetchConfig: Prefetch): PartialPrefetchingLevel {
+  switch (prefetchConfig) {
+    case 'auto':
+    case 'force-disabled':
+      return PartialPrefetchingLevel.Unspecified
+    case 'partial':
+      return PartialPrefetchingLevel.Partial
+    case 'unstable_eager':
+      return PartialPrefetchingLevel.Eager
+  }
+}
+
+function moreSpecificLevel(
+  left: PartialPrefetchingLevel,
+  right: PartialPrefetchingLevel
+): PartialPrefetchingLevel {
+  return Math.max(left, right)
+}
+
+function getPrefetchConfigFromSegment(
+  layoutOrPageMod: Record<string, any> | undefined
+): Prefetch {
+  return (layoutOrPageMod as AppSegmentConfig | undefined)?.prefetch ?? 'auto'
+}

--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -22,6 +22,7 @@ import type { AppRenderContext } from './app-render'
 import { hasLoadingComponentInTree } from './has-loading-component-in-tree'
 import { addSearchParamsIfPageSegment } from '../../shared/lib/segment'
 import { createComponentTree } from './create-component-tree'
+import type { ResolvedPartialPrefetching } from './prefetch-config'
 
 /**
  * The result of rendering a navigation (or refresh/action) response: the
@@ -46,6 +47,7 @@ export type NavigationResponseTree = {
  */
 export async function walkTreeWithFlightRouterState({
   loaderTreeToFilter,
+  routePartialPrefetching,
   parentParams,
   flightRouterState,
   parentIsInsideSharedLayout,
@@ -60,6 +62,7 @@ export async function walkTreeWithFlightRouterState({
   hintTree,
 }: {
   loaderTreeToFilter: LoaderTree
+  routePartialPrefetching: ResolvedPartialPrefetching
   parentParams: { [key: string]: string | string[] }
   flightRouterState?: FlightRouterState
   rscHead: HeadData
@@ -81,7 +84,6 @@ export async function walkTreeWithFlightRouterState({
     parsedRequestHeaders,
   } = ctx
   const prefetchInliningEnabled = Boolean(experimental.prefetchInlining)
-  const partialPrefetching = ctx.renderOpts.partialPrefetching
 
   const [segment, parallelRoutes, modules] = loaderTreeToFilter
 
@@ -169,7 +171,7 @@ export async function walkTreeWithFlightRouterState({
           hintTree,
           prefetchInliningEnabled,
           ctx.missingPrefetchHintPolicy,
-          partialPrefetching,
+          routePartialPrefetching,
           getDynamicParamFromSegment,
           rootLayoutIncluded
         )
@@ -178,7 +180,7 @@ export async function walkTreeWithFlightRouterState({
           hintTree,
           prefetchInliningEnabled,
           ctx.missingPrefetchHintPolicy,
-          partialPrefetching,
+          routePartialPrefetching,
           getDynamicParamFromSegment,
           query,
           rootLayoutIncluded
@@ -200,7 +202,7 @@ export async function walkTreeWithFlightRouterState({
           hintTree,
           prefetchInliningEnabled,
           ctx.missingPrefetchHintPolicy,
-          partialPrefetching,
+          routePartialPrefetching,
           getDynamicParamFromSegment
         )
       : await createTransportTreeFromLoaderTree(
@@ -208,7 +210,7 @@ export async function walkTreeWithFlightRouterState({
           hintTree,
           prefetchInliningEnabled,
           ctx.missingPrefetchHintPolicy,
-          partialPrefetching,
+          routePartialPrefetching,
           getDynamicParamFromSegment,
           query,
           rootLayoutIncluded
@@ -228,6 +230,7 @@ export async function walkTreeWithFlightRouterState({
       {
         ctx,
         loaderTree: loaderTreeToFilter,
+        routePartialPrefetching,
         parentParams: currentParams,
         parentOptionalCatchAllParamName: null,
         parentRuntimePrefetchable: false,
@@ -286,6 +289,7 @@ export async function walkTreeWithFlightRouterState({
     const subtreeResult = await walkTreeWithFlightRouterState({
       ctx,
       loaderTreeToFilter: parallelRoute,
+      routePartialPrefetching,
       parentParams: currentParams,
       flightRouterState:
         flightRouterState && flightRouterState[1][parallelRouteKey],
@@ -339,6 +343,7 @@ export async function walkTreeWithFlightRouterState({
  */
 export async function createFullTreeForNavigation({
   loaderTree,
+  routePartialPrefetching,
   rscHead,
   injectedCSS,
   injectedJS,
@@ -348,6 +353,7 @@ export async function createFullTreeForNavigation({
   MetadataOutlet,
 }: {
   loaderTree: LoaderTree
+  routePartialPrefetching: ResolvedPartialPrefetching
   flightRouterState?: FlightRouterState
   rscHead: HeadData
   injectedCSS: Set<string>
@@ -368,6 +374,7 @@ export async function createFullTreeForNavigation({
   const tree = await createComponentTree({
     ctx,
     loaderTree,
+    routePartialPrefetching,
     parentParams: {},
     parentOptionalCatchAllParamName: null,
     parentRuntimePrefetchable: false,

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/page.tsx
@@ -127,6 +127,15 @@ export default function Page() {
           </LinkAccordion>
         </li>
       </ul>
+
+      <h2>Complete shell</h2>
+      <ul>
+        <li>
+          <LinkAccordion href="/runtime-shell-complete">
+            Complete runtime shell
+          </LinkAccordion>
+        </li>
+      </ul>
     </main>
   )
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/runtime-shell-complete/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/runtime-shell-complete/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+export const prefetch = 'partial'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<p id="cookie-loading">Loading cookie...</p>}>
+        <CookieDependent />
+      </Suspense>
+    </main>
+  )
+}
+
+async function CookieDependent() {
+  const cookieStore = await cookies()
+  const value = cookieStore.get('testCookie')?.value ?? 'none'
+  return <p id="cookie-value">{`Cookie: ${value}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
@@ -28,20 +28,13 @@ describe('App Shell prefetching', () => {
     // Reveal the LinkAccordion for /posts/1. This caches the App Shell
     // for the route — the param-independent content of the page that's
     // reusable for any /posts/[id].
+    // The route reads request data, so its static-attempt hint is unset
+    // and the prefetch deopts to a runtime request.
     await act(async () => {
       await browser
         .elementByCss('input[data-link-accordion="/posts/1"]')
         .click()
-    }, [
-      // Two runtime responses carry the shell text, in order: the Shell
-      // phase's runtime App Shell request, then the Speculative phase's
-      // batched per-link runtime prefetch. The route reads request data,
-      // so its static-attempt hint is unset and the prefetch deopts to
-      // runtime requests — the runtime-completeness contract of Partial
-      // Prefetching routes.
-      { includes: 'App shell for posts', kind: 'runtime' },
-      { includes: 'App shell for posts', kind: 'runtime' },
-    ])
+    }, [{ includes: 'App shell for posts', kind: 'runtime' }])
 
     await act(async () => {
       // Click the link to /posts/124. This link is rendered with
@@ -107,40 +100,46 @@ describe('App Shell prefetching', () => {
     const act = createRouterAct(page, { includeAppShellRequests: true })
 
     // Reveal /posts/1 (default/auto prefetch). The page itself is partial
-    // (non-eager), but the path segments above it are eager, so the
-    // Speculative pass still walks them. Unlike /partial (covered by the
-    // next test), this route is dynamic — it reads cookies — so its
-    // static-attempt hint is unset and the walked segments deopt to a
-    // per-link runtime prefetch, which serves the whole subtree, page
-    // included.
+    // (non-eager). Unlike /partial (covered by the next test), this route
+    // is dynamic — it reads cookies — so its static-attempt hint is unset
+    // and the walked segments deopt to a runtime shell prefetch.
     await act(async () => {
       await browser
         .elementByCss('input[data-link-accordion="/posts/1"]')
         .click()
-    }, [
-      // Two runtime responses carry the shell text, in order: the Shell
-      // phase's runtime App Shell request, then the Speculative phase's
-      // batched per-link runtime prefetch. The route reads request data,
-      // so its static-attempt hint is unset and the prefetch deopts to
-      // runtime requests — the runtime-completeness contract of Partial
-      // Prefetching routes.
-      { includes: 'App shell for posts', kind: 'runtime' },
-      { includes: 'App shell for posts', kind: 'runtime' },
-    ])
+    }, [{ includes: 'App shell for posts', kind: 'runtime' }])
 
     // Reveal /posts/2 — a different param that shares the same App Shell.
-    // The shell is already cached and is not re-fetched, but the hint-unset
-    // deopt issues a runtime prefetch for the new param's subtree, so the
-    // per-link content for param 2 arrives ahead of any navigation.
-    // Contrast with the /partial route in the next test, whose hint is set:
-    // there the cached shell satisfies the second link with no requests.
-    await act(
-      async () => {
-        await browser
-          .elementByCss('input[data-link-accordion="/posts/2"]')
-          .click()
-      },
-      { includes: 'Post 2', kind: 'runtime' }
+    // The shell is already cached and is not re-fetched.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/posts/2"]')
+        .click()
+    }, 'no-requests')
+
+    await act(async () => {
+      // Click the link to /posts/2. The cached App
+      // Shell should render immediately, before any navigation response
+      // arrives.
+      await browser.elementByCss('a[href="/posts/2"]').click()
+
+      // While the navigation response is blocked (we're still in the
+      // `act` block), the cached App Shell should already be visible.
+      expect(await browser.elementById('shell').text()).toEqual(
+        'App shell for posts'
+      )
+      // Sesssion data (cookies) is not dependent on URL-data, so they are
+      // allowed to be accessed in the shell.
+      expect(await browser.elementById('cookie-value').text()).toEqual(
+        'Cookie: none'
+      )
+    })
+
+    // After the outer act unblocks the navigation, params resolve and the
+    // dynamic content streams in.
+    expect(await browser.elementById('param-value').text()).toEqual('Post 2')
+    expect(await browser.elementById('dynamic-content').text()).toEqual(
+      'Post body for 2'
     )
   })
 
@@ -165,7 +164,7 @@ describe('App Shell prefetching', () => {
           .elementByCss('input[data-link-accordion="/partial/1"]')
           .click()
       },
-      { includes: 'Partial app shell' }
+      { includes: 'Partial app shell', kind: 'static' }
     )
 
     // Reveal /partial/2 — a different param that shares the same app shell. The
@@ -308,7 +307,7 @@ describe('App Shell prefetching', () => {
       await browser
         .elementByCss('input[data-link-accordion="/static-posts/1"]')
         .click()
-    }, [{ includes: 'App shell for static posts' }])
+    }, [{ includes: 'App shell for static posts', kind: 'static' }])
 
     // Click the link to /static-posts/124 — a different param than what
     // was prefetched, rendered with prefetch={false}. The cached App
@@ -351,13 +350,8 @@ describe('App Shell prefetching', () => {
         .elementByCss('input[data-link-accordion="/short-stale/1"]')
         .click()
     }, [
-      // Two runtime responses carry the shell text, in order: the Shell
-      // phase's runtime App Shell request, then the Speculative phase's
-      // batched per-link runtime prefetch. The route reads request data,
-      // so its static-attempt hint is unset and the prefetch deopts to
-      // runtime requests — the runtime-completeness contract of Partial
-      // Prefetching routes.
-      { includes: 'App shell for short-stale', kind: 'runtime' },
+      // The route reads request data, so its static-attempt hint is unset
+      // and the prefetch deopts to a runtime request.
       { includes: 'App shell for short-stale', kind: 'runtime' },
     ])
 
@@ -417,7 +411,7 @@ describe('App Shell prefetching', () => {
       await browser
         .elementByCss('input[data-link-accordion="/static-short-stale/1"]')
         .click()
-    }, [{ includes: 'App shell for static short-stale posts' }])
+    }, [{ includes: 'App shell for static short-stale posts', kind: 'static' }])
 
     await act(async () => {
       // Click the link to /static-short-stale/124 — a different param than
@@ -478,16 +472,8 @@ describe('App Shell prefetching', () => {
           )
           .click()
       }, [
-        // Two runtime responses carry the shell text, in order: the Shell
-        // phase's runtime App Shell request, then the Speculative phase's
-        // batched per-link runtime prefetch. The route reads request data,
-        // so its static-attempt hint is unset and the prefetch deopts to
-        // runtime requests — the runtime-completeness contract of Partial
-        // Prefetching routes.
-        {
-          includes: 'App shell for posts with root param: en',
-          kind: 'runtime',
-        },
+        // The route reads request data, so its static-attempt hint is unset and the prefetch
+        // deopts to a runtime request.
         {
           includes: 'App shell for posts with root param: en',
           kind: 'runtime',
@@ -552,7 +538,12 @@ describe('App Shell prefetching', () => {
             'input[data-link-accordion="/with-root-param/en/static-posts/1"]'
           )
           .click()
-      }, [{ includes: 'App shell for static posts with root param: en' }])
+      }, [
+        {
+          includes: 'App shell for static posts with root param: en',
+          kind: 'static',
+        },
+      ])
 
       // Click the link to /with-root-param/en/static-posts/124 — a different param than what
       // was prefetched, rendered with prefetch={false}. The cached App
@@ -599,15 +590,8 @@ describe('App Shell prefetching', () => {
           )
           .click()
       }, [
-        // Two runtime responses carry the shell text, in order: the Shell
-        // phase's runtime App Shell request, then the Speculative phase's
-        // per-link runtime prefetch (the page reads cookies, so the hint
-        // is unset and the prefetch deopts to a runtime request). Unlike
-        // the /posts routes, no static bundle fetch fires in between: the
-        // page has no non-root params, so its runtime App Shell entry is
-        // already as complete as any static response could be.
-        { includes: 'App shell for page with root param: en' },
-        { includes: 'App shell for page with root param: en' },
+        // The page reads cookies, so the hint is unset and the prefetch deopts to a runtime request.
+        { includes: 'App shell for page with root param: en', kind: 'runtime' },
       ])
 
       await act(async () => {
@@ -664,7 +648,7 @@ describe('App Shell prefetching', () => {
             )
             .click()
         },
-        { includes: 'App shell for page with root param: en' }
+        { includes: 'App shell for page with root param: en', kind: 'static' }
       )
 
       await act(async () => {
@@ -715,16 +699,8 @@ describe('App Shell prefetching', () => {
           )
           .click()
       }, [
-        // Two runtime responses carry the shell text, in order: the Shell
-        // phase's runtime App Shell request, then the Speculative phase's
-        // batched per-link runtime prefetch. The route reads request data,
-        // so its static-attempt hint is unset and the prefetch deopts to
-        // runtime requests — the runtime-completeness contract of Partial
-        // Prefetching routes.
-        {
-          includes: 'App shell for posts with root param: en',
-          kind: 'runtime',
-        },
+        // The route reads request data, so its static-attempt hint is unset
+        // and the prefetch deopts to a runtime request.
         {
           includes: 'App shell for posts with root param: en',
           kind: 'runtime',
@@ -777,16 +753,8 @@ describe('App Shell prefetching', () => {
           )
           .click()
       }, [
-        // Two runtime responses carry the shell text, in order: the Shell
-        // phase's runtime App Shell request, then the Speculative phase's
-        // batched per-link runtime prefetch. The route reads request data,
-        // so its static-attempt hint is unset and the prefetch deopts to
-        // runtime requests — the runtime-completeness contract of Partial
-        // Prefetching routes.
-        {
-          includes: 'App shell for posts with root param: fr',
-          kind: 'runtime',
-        },
+        // The route reads request data, so its static-attempt hint is unset
+        // and the prefetch deopts to a runtime request.
         {
           includes: 'App shell for posts with root param: fr',
           kind: 'runtime',
@@ -837,7 +805,12 @@ describe('App Shell prefetching', () => {
             'input[data-link-accordion="/with-root-param/en/static-posts/1"]'
           )
           .click()
-      }, [{ includes: 'App shell for static posts with root param: en' }])
+      }, [
+        {
+          includes: 'App shell for static posts with root param: en',
+          kind: 'static',
+        },
+      ])
 
       await act(async () => {
         const startingUrl = await browser.url()

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
@@ -70,6 +70,33 @@ describe('App Shell prefetching', () => {
     )
   })
 
+  it('can navigate without extra requests if a runtime app shell is complete', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the link and fetch the shell. The route uses cookies, so this will be
+    // a runtime shell.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/runtime-shell-complete"]')
+        .click()
+    }, [{ includes: 'Cookie: none', kind: 'runtime' }])
+
+    // Navigate. The shell is complete, so this shouldn't require fetching anything else.
+    await act(async () => {
+      await browser.elementByCss('a[href="/runtime-shell-complete"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementById('cookie-value').text()).toEqual(
+      'Cookie: none'
+    )
+  })
+
   it('runtime-prefetches per-link content of a dynamic route whose static-attempt hint is unset', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
@@ -71,12 +71,12 @@ export default function Page() {
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/test-independent-head/a">
+          <LinkAccordion href="/test-independent-head/a" prefetch={true}>
             Independent head A
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/test-independent-head/b">
+          <LinkAccordion href="/test-independent-head/b" prefetch={true}>
             Independent head B
           </LinkAccordion>
         </li>

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/[item]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/[item]/page.tsx
@@ -30,7 +30,7 @@ export default async function Page({
   return (
     <div>
       <p id="page-independent-head">Independent head page</p>
-      <LinkAccordion href={`/test-independent-head/${sibling}`}>
+      <LinkAccordion href={`/test-independent-head/${sibling}`} prefetch={true}>
         Go to {sibling}
       </LinkAccordion>
     </div>

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
@@ -602,13 +602,13 @@ describe('prefetch inlining', () => {
         page = p
       },
     })
-    const act = createRouterAct(page!)
+    const act = createRouterAct(page!, { includeAppShellRequests: true })
 
     // Reveal a default (auto) link to the route. The route is a Partial
     // Prefetching route (the page is partial), so every segment the
     // prefetch walks is held to the runtime-completeness contract — and the
     // route's static-attempt hint is unset because the page reads cookies,
-    // so the walked layout deopts directly to the batched runtime prefetch,
+    // so the walked layout deopts directly to the batched runtime shell,
     // which serves its whole subtree. The inlined layout content arrives in
     // that runtime response. (No static bundle request fires: the Shell
     // phase already runtime-cached every entry in the bundle chain, and a
@@ -625,9 +625,8 @@ describe('prefetch inlining', () => {
       { includes: 'Static layout content', kind: 'runtime' }
     )
 
-    // Reveal a prefetch={true} link to the same route. Everything is
-    // already runtime-cached at the per-link tier by the prefetch above, so
-    // opting in has nothing left to fetch.
+    // Reveal a prefetch={true} link to the same route. The shell is complete,
+    // so a runtime prefetch will not give us any more data and should be skipped.
     await act(async () => {
       await browser
         .elementByCss(
@@ -675,7 +674,7 @@ describe('prefetch inlining', () => {
         page = p
       },
     })
-    const act = createRouterAct(page!)
+    const act = createRouterAct(page!, { includeAppShellRequests: true })
 
     await act(
       async () => {
@@ -776,7 +775,7 @@ describe('prefetch inlining', () => {
         page = p
       },
     })
-    const act = createRouterAct(page!)
+    const act = createRouterAct(page!, { includeAppShellRequests: true })
 
     await act(
       async () => {

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
@@ -808,8 +808,8 @@ describe('prefetch inlining', () => {
     // [item] param and searchParams, making it depend on runtime data.
     //
     // Because the layout reads cookies, the route's static-attempt hint is
-    // unset, so on this Partial Prefetching route every per-link prefetch
-    // deopts its new subtree to the batched runtime prefetch. The head is
+    // unset, so on this Partial Prefetching route every shell and prefetch
+    // deopt its new subtree to a runtime request. The head is
     // param-dependent, so it is NOT part of the reusable App Shell — but
     // whenever a runtime prefetch fires for a segment, the head rides
     // along in the same request. So each prefetched sibling gets its own
@@ -831,22 +831,25 @@ describe('prefetch inlining', () => {
         page = p
       },
     })
-    const act = createRouterAct(page!)
+    const act = createRouterAct(page!, { includeAppShellRequests: true })
 
-    // Prefetch and navigate to route A. This caches the layout, the static
-    // page, and A's head (riding along with the runtime prefetch), and
-    // makes A the current page.
+    // Runtime-prefetch (with prefetch={true}) A.
+    // This caches the layout, the static page, and A's head (riding along with the runtime prefetch).
     await act(async () => {
       await browser
         .elementByCss('input[data-link-accordion="/test-independent-head/a"]')
         .click()
-    })
+    }, [
+      { includes: 'item-layout', kind: 'runtime' },
+      { includes: 'Independent Head Title: a', kind: 'runtime' },
+    ])
+    // Navigate to A. It should be fully prefetched.
     await act(async () => {
       await browser.elementByCss('a[href="/test-independent-head/a"]').click()
     }, 'no-requests')
 
-    // Now we're on route A. Reveal the sibling link to route B. The
-    // layout is shared between A and B, so it's already cached and won't
+    // Now we're on route A. Reveal the sibling link to route B (with prefetch={true}).
+    // The layout is shared between A and B, so it's already cached and won't
     // be re-fetched. The only new segment is the [item] page. On this
     // hint-unset route it deopts to the batched runtime prefetch, and B's
     // param-specific head rides along in the same request — no standalone
@@ -856,9 +859,7 @@ describe('prefetch inlining', () => {
         .elementByCss('input[data-link-accordion="/test-independent-head/b"]')
         .click()
     }, [
-      // The page below the layout arrives via the runtime prefetch.
-      { includes: 'page-independent-head', kind: 'runtime' },
-      // ...and B's head rides along in the same runtime response.
+      // The page and the head arrive in the same runtime response.
       { includes: 'Independent Head Title: b', kind: 'runtime' },
     ])
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts
@@ -510,18 +510,20 @@ describe('runtime prefetching', () => {
       // Clear cookies after the test. This currently doesn't happen automatically.
       await using _ = defer(() => browser.deleteCookies())
 
-      const act = createRouterAct(page)
+      const act = createRouterAct(page, { includeAppShellRequests: true })
 
       await browser.addCookie({ name: 'testCookie', value: 'initialValue' })
 
-      // Reveal the link to trigger a runtime prefetch for the initial cookie value
+      // Reveal the link.
+      // We won't actually perform a runtime prefetch, because the request is
+      // satisfied by the app shell.
       await act(async () => {
         const linkToggle = await browser.elementByCss(
           `input[data-link-accordion="/${prefix}/cookies-only"]`
         )
         await linkToggle.click()
       }, [
-        // Should allow reading cookies
+        // Should allow reading cookies in the app shell
         {
           includes: 'Cookie: initialValue',
         },
@@ -561,11 +563,14 @@ describe('runtime prefetching', () => {
         // Clear cookies after the test. This currently doesn't happen automatically.
         await using _ = defer(() => browser.deleteCookies())
 
-        const act = createRouterAct(page)
+        const act = createRouterAct(page, { includeAppShellRequests: true })
 
         await browser.addCookie({ name: 'testCookie', value: 'initialValue' })
 
-        // Reveal the link to trigger a runtime prefetch for the initial cookie value
+        // Reveal the link.
+        // We won't actually perform a runtime prefetch, because the request is
+        // satisfied by the app shell.
+
         await act(async () => {
           const linkToggle = await browser.elementByCss(
             `input[data-link-accordion="/${prefix}/cookies-only"]`
@@ -1056,11 +1061,13 @@ describe('runtime prefetching', () => {
           page = p
         },
       })
-      const act = createRouterAct(page)
+      const act = createRouterAct(page, { includeAppShellRequests: true })
 
       const STATIC_CONTENT = 'This page errors after a cookies call'
 
-      // Reveal the link to trigger a runtime prefetch
+      // Reveal the link.
+      // We won't actually perform a runtime prefetch, because the request is
+      // satisfied by the app shell.
       await act(async () => {
         const linkToggle = await browser.elementByCss(
           `input[data-link-accordion="/errors/error-after-cookies"]`
@@ -1077,7 +1084,7 @@ describe('runtime prefetching', () => {
         expect(getCliOutput()).toContain('Error: Kaboom')
       }
 
-      // Navigate to the page. We already have the paged cached.
+      // Navigate to the page. We already have the page cached.
       // Even though the render errored, we shouldn't fetch it again.
       await act(async () => {
         await browser

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/speculative-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/speculative-cookies/page.tsx
@@ -7,20 +7,16 @@ import { cookies } from 'next/headers'
 // Prefetching segment, the page requires runtime-completeness during the
 // Speculative phase (which the consuming test enters via a `prefetch={true}`
 // link), and with the hint unset the scheduler skips the static attempt
-// entirely and issues the runtime prefetch directly. Unlike the uses-cookies
-// fixture, the Speculative runtime prefetch RESOLVES the cookies() read, so
-// the cookie-derived content itself arrives in the runtime response.
+// entirely and issues the runtime prefetch directly.
+// It also awaits searchParams so that a speculative prefetch has non-shell
+// contents to resolve.
 export const prefetch = 'partial'
 
-async function CookieContent() {
-  const cookieStore = await cookies()
-  const value = cookieStore.get('testCookie')?.value ?? 'none'
-  return (
-    <div id="speculative-cookie-content">{`Speculative-cookies cookie: ${value}`}</div>
-  )
+type PageProps = {
+  searchParams: Promise<SearchParams>
 }
 
-export default function Page() {
+export default function Page(props: PageProps) {
   return (
     <main>
       <p id="page-content">Speculative-cookies page shell text</p>
@@ -29,8 +25,34 @@ export default function Page() {
           <p id="speculative-cookie-loading">Loading speculative cookie...</p>
         }
       >
-        <CookieContent />
+        <CookieContent {...props} />
       </Suspense>
     </main>
+  )
+}
+
+async function CookieContent(props: PageProps) {
+  const cookieStore = await cookies()
+  const value = cookieStore.get('testCookie')?.value ?? 'none'
+  return (
+    <>
+      <div id="speculative-cookie-content">{`Speculative-cookies cookie: ${value}`}</div>
+      <Suspense
+        fallback={
+          <p id="speculative-search-params-loading">Loading search params...</p>
+        }
+      >
+        <SearchParamsContent {...props} />
+      </Suspense>
+    </>
+  )
+}
+
+type SearchParams = Record<string, string | string[]>
+
+async function SearchParamsContent(props: PageProps) {
+  const searchCount = Object.keys(await props.searchParams).length
+  return (
+    <div id="search-params-content">{`Search params count: ${searchCount}`}</div>
   )
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/prefetch-static-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/prefetch-static-shell.test.ts
@@ -123,11 +123,8 @@ describe('static App Shell prefetch attempt', () => {
         .elementByCss('input[data-link-accordion="/uses-cookies"]')
         .click()
     }, [
-      // The page (the new part) arrives in the runtime shell response.
-      // (The bare cookies() read itself isn't resolved by the runtime
-      // prerender — it stays a hole for the navigation-time dynamic
-      // request — so we only assert on the shell text.)
-      { includes: 'Cookies page shell text', kind: 'runtime' },
+      // Cookies are included in the runtime shell.
+      { includes: 'cookie-content', kind: 'runtime' },
       // No static attempt for the new part: the page content must not
       // arrive in a static per-segment response. (The route tree prefetch
       // is also `kind: 'static'`, but its response doesn't contain rendered
@@ -382,29 +379,15 @@ describe('static App Shell prefetch attempt', () => {
         .elementByCss('input[data-link-accordion="/speculative-cookies"]')
         .click()
     }, [
-      // Two runtime responses arrive, in order, and each resolves the
-      // cookies() read (a runtime prefetch renders with the request's
-      // cookies):
-      //
-      // 1. The Shell phase's runtime shell request — the same direct
-      //    runtime shell behavior the hint-unset tests above exercise,
-      //    except that here the session content resolves instead of
-      //    remaining a hole.
-      { includes: 'Speculative-cookies page shell text', kind: 'runtime' },
+      // 1. Runtime shell (includes cookies)
       { includes: 'Speculative-cookies cookie: none', kind: 'runtime' },
-      // 2. The Speculative phase's runtime prefetch of the page segment,
-      //    which re-delivers the page content. (It fires on top of the
-      //    runtime shell entry because a per-URL runtime prefetch can
-      //    provide content a URL-independent shell response cannot.)
-      { includes: 'Speculative-cookies page shell text', kind: 'runtime' },
-      { includes: 'Speculative-cookies cookie: none', kind: 'runtime' },
+      // 2. Runtime prefetch (includes cookies and search params)
+      { includes: 'Search params count: 0', kind: 'runtime' },
+
       // No static attempt in either phase: the page content must not
       // arrive in ANY static per-segment response. (The server does emit
       // static data for the segment — the shell text is in it — but with
-      // the hint unset nothing fetches it: this blanket rejection
-      // was verified empirically against the full request log. The route
-      // tree prefetch is also kind: 'static', but its response doesn't
-      // contain rendered page content, so it can't match this.)
+      // the hint unset nothing fetches it.
       {
         includes: 'Speculative-cookies page shell text',
         kind: 'static',


### PR DESCRIPTION
Fixes a bug that happens incremental in incremental PPF (via `export const prefetch = 'partial'`) where all segments without a config would incorrectly be marked as requiring a speculative prefetch if `nextConfig.partialPrefetching` was unset.
In practice, this means that `<Link href="/foo">` would act like `<Link href="/foo" prefetch={true}>`, so **it'd always send a per-link runtime prefetch instead of only fetching a shell**.

Also updates many tests that were incorrectly asserting that we should be seeing 2 requests (shell + speculative) instead of just 1, for the shell.

## TLDR

`computeSegmentPrefetchHints` was treating all segments without a `prefetch` config as if they were segments where PPF is disabled and setting `SubtreeHasEagerPrefetch` which is the pre-PPF behavior. this made the router think it should be doing a speculative prefetch for every link despite not having `prefetch={true}` or `unstable_eager` anywhere. Fixed by determining PPF-ness once per route and using that instead of the per-segment config.

## The problem, in detail

<details>
<summary>(Collapsed because it's like a whole screen of text)</summary>

Consider a `/posts/[id]` page:

```
app/
  layout.tsx
  posts/[id]/
    page.tsx
```
we have 4 segments here:
```
/ # layout.tsx
/posts
/posts/[id]
/posts/[id]/__PAGE__ # page.tsx
```

Assuming we don't have a global `partialPrefetching` value set:
- if none of the segments have `export const prefetch = 'partial' | 'unstable_eager'`, then the tree should be marked with a `SubtreeHasEagerPrefetch` hint (and NO `SubtreeHasPartialPrefetching`). This is because the legacy prefetch strategies are conceptual eager (i.e. does not use shells).
- if `page.tsx` has `export const prefetch = 'partial'`, any link to that page should use partial prefetching and ONLY fetch the shell, i.e. we only set `SubtreeHasPartialPrefetching` hint.
- if `page.tsx` has `export const prefetch = 'unstable_eager'`, we want the links to fetch the shell AND do speculative prefetch, i.e. we set `SubtreeHasPartialPrefetching` and `SubtreeHasEagerPrefetch`.

however, `computeSegmentPrefetchHints` was handling `prefetch` incorrectly, and if any segment had an `undefined` prefetch config (or had no module at all, like `/posts` in the example), it'd fall into this codepath
https://github.com/vercel/next.js/blob/c713d48763dd9c9d34fe2b99829cf3f1ada78dc5/packages/next/src/server/app-render/create-transport-tree-from-loader-tree.ts#L146-L152
and set the `SubtreeHasEagerPrefetch` hint (which then gets propagated upwards).

essentially, this means that if there was even single segment *without* `export const prefetch = "partial"` (and no global `partialPrefetching` to use as a default value), we'd do a speculative prefetch for the link.
This is visible in the `prefetch-app-shell` tests, which (confusingly) assert that we should be seeing two requests (shell + prefetch) for a link that really should only be fetching a shell.
https://github.com/vercel/next.js/blob/1c50e09d1dc3f5be50c5e2f9b99816ad47e11f05/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts#L36-L43

</details>

## The solution

the mistake in `computeSegmentPrefetchHints` is that it doesn't consider that partialPrefetching being enabled or not is the property of a whole route tree, and should not be resolved per segment. instead, we should determine it for the whole tree and only do the "not PPF + speculative" combination if PPF is indeed not enabled *anywhere* in the tree.

the new flow implemented here is as follows:
1. first, traverse the loader tree looking for `prefetch` exports. if we only see `prefetch = partial`, use that. if we see prefetch = `unstable_eager` anywhere, use that instead. if we see both, `unstable_eager` wins.
2. if we found no per-segment configs, we fall back to the global `partialPrefetching` config.

notably, this means that:
- `export const prefetch = 'unstable_eager'` overrides `partialPrefetching: true`
- `export const prefetch = 'partial'` overrides `partialPrefetching: 'unstable_eager'`
it makes sense for the segment level config to win, because it's intended for incrementally migrating an app.

after we compute the prefetch strategy for the route, we plumb it through to `computeSegmentPrefetchHints`, and mark the segments appropriately. it still looks at segment-level `prefetch` configs, but only to find `force-disabled` which applies per-segment.