### PR TITLE
fix: server actions fail when page URL has Basic Auth credentials

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -148,7 +148,20 @@ async function fetchServerAction(
 
   let res: Response
   try {
-    res = await fetch(state.canonicalUrl, { method: 'POST', headers, body })
+    // Resolve the relative `canonicalUrl` against the origin rather than
+    // letting the browser resolve it against the document's base URL. If the
+    // page was opened with credentials in the URL
+    // (`http://user:pass@host/...`), the base URL retains the userinfo, and
+    // constructing a Request from it throws:
+    // "Request cannot be constructed from a URL that includes credentials".
+    // `location.origin` never contains userinfo. Note that `location` is
+    // shadowed by a local binding later in this function, so `window` is
+    // referenced explicitly.
+    res = await fetch(new URL(state.canonicalUrl, window.location.origin), {
+      method: 'POST',
+      headers,
+      body,
+    })
     // If the fetch succeeds while we're in the offline state, notify the
     // offline module so it can short-circuit the polling loop.
     if (process.env.__NEXT_USE_OFFLINE) {

--- a/test/e2e/app-dir/server-action-basic-auth/app/actions.ts
+++ b/test/e2e/app-dir/server-action-basic-auth/app/actions.ts
@@ -1,0 +1,5 @@
+'use server'
+
+export async function double(value: number) {
+  return value * 2
+}

--- a/test/e2e/app-dir/server-action-basic-auth/app/layout.tsx
+++ b/test/e2e/app-dir/server-action-basic-auth/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/server-action-basic-auth/app/page.tsx
+++ b/test/e2e/app-dir/server-action-basic-auth/app/page.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useState } from 'react'
+import { double } from './actions'
+
+export default function Page() {
+  const [result, setResult] = useState('initial')
+  const [error, setError] = useState('none')
+
+  return (
+    <>
+      <p id="result">{result}</p>
+      <p id="error">{error}</p>
+      <button
+        id="run"
+        onClick={async () => {
+          try {
+            setResult(String(await double(1)))
+          } catch (err) {
+            setError(String(err))
+          }
+        }}
+      >
+        run action
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/server-action-basic-auth/middleware.ts
+++ b/test/e2e/app-dir/server-action-basic-auth/middleware.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+const USER = 'admin'
+const PASSWORD = 'secret'
+
+export function middleware(request: NextRequest) {
+  const authorization = request.headers.get('authorization')
+
+  if (authorization) {
+    const [scheme, encoded] = authorization.split(' ')
+
+    if (scheme === 'Basic' && encoded) {
+      const [user, password] = atob(encoded).split(':')
+
+      if (user === USER && password === PASSWORD) {
+        return NextResponse.next()
+      }
+    }
+  }
+
+  return new NextResponse('Authentication required', {
+    status: 401,
+    headers: { 'WWW-Authenticate': 'Basic realm="protected"' },
+  })
+}
+
+export const config = {
+  matcher: ['/((?!_next).*)'],
+}

--- a/test/e2e/app-dir/server-action-basic-auth/next.config.js
+++ b/test/e2e/app-dir/server-action-basic-auth/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/server-action-basic-auth/server-action-basic-auth.test.ts
+++ b/test/e2e/app-dir/server-action-basic-auth/server-action-basic-auth.test.ts
@@ -1,0 +1,29 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import webdriver from 'next-webdriver'
+
+describe('server-action-basic-auth', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should run a server action when the page URL contains basic auth credentials', async () => {
+    const url = new URL(next.url)
+    url.username = 'admin'
+    url.password = 'secret'
+
+    const browser = await webdriver(url.toString(), '/')
+
+    // The browser strips the credentials from `location.href`, but keeps them
+    // in the document's base URL, which is what relative fetches resolve
+    // against. Without that, this test would pass even without the fix.
+    expect(await browser.eval('document.baseURI')).toContain('admin:secret@')
+
+    await browser.elementByCss('#run').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#error').text()).toBe('none')
+      expect(await browser.elementByCss('#result').text()).toBe('2')
+    })
+  })
+})


### PR DESCRIPTION
When a page is opened with HTTP Basic Auth credentials in the URL
(`http://user:pass@host/...`), invoking a Server Action throws
`Request cannot be constructed from a URL that includes credentials`.
`fetchServerAction` fetches the relative `state.canonicalUrl`, which the
browser resolves against the credentialed document URL. Resolve against
`window.location.origin` (no userinfo) instead. Includes an e2e test.

Closes #76942
