### PR TITLE
perf(turbopack): skip ignored files during server tracing

### DIFF
--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -77,6 +77,7 @@ pub(crate) async fn pages_renderer_modules(project_path: FileSystemPath) -> Resu
     let asset_context = Vc::upcast(externals_tracing_module_context(
         get_tracing_compile_time_info(),
         false,
+        None,
     ));
     let next_resolve_origin = Vc::upcast(PlainResolveOrigin::new(
         asset_context,

--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -7,7 +7,8 @@ use next_core::{get_next_package, next_server::get_tracing_compile_time_info};
 use serde_json::json;
 use turbo_tasks::{ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::{
-    DirectoryContent, DirectoryEntry, File, FileContent, FileSystemPath, glob::Glob,
+    DirectoryContent, DirectoryEntry, File, FileContent, FileSystemPath,
+    glob::{Glob, GlobOptions},
 };
 use turbo_tasks_hash::HashAlgorithm;
 use turbopack::externals_tracing_module_context;
@@ -38,6 +39,7 @@ pub(crate) async fn require_hook_modules(project_path: FileSystemPath) -> Result
     let asset_context = Vc::upcast(externals_tracing_module_context(
         get_tracing_compile_time_info(),
         false,
+        None,
     ));
     let next_resolve_origin = Vc::upcast(PlainResolveOrigin::new(
         asset_context,
@@ -285,15 +287,83 @@ impl Asset for ServerNftJsonAsset {
     }
 }
 
+/// The patterns `ignores()` is built from that Next owns, as opposed to the ones a project can
+/// supply. None of them can match an entry request resolved by `entries()`, which is what makes
+/// them safe to apply while the graph is built rather than after it: see `prunable_ignores()`.
+fn next_owned_ignores(ty: &ServerNftType, has_next_support: bool) -> Vec<&'static str> {
+    let mut globs = vec![
+        "**/node_modules/react{,-dom,-server-dom-turbopack}/**/*.development.js",
+        "**/*.d.ts",
+        "**/*.map",
+        "**/next/dist/pages/**/*",
+        "**/next/dist/compiled/next-server/**/*.dev.js",
+        "**/next/dist/compiled/webpack/*",
+        "**/node_modules/webpack5/**/*",
+        "**/next/dist/server/lib/route-resolver*",
+        // The testmode interceptors bundle reads its HTTP parser WASM with a
+        // dynamic path, making the tracer include the bundle's whole
+        // directory. Test proxying is not supported in standalone output, so
+        // keep the parser asset (and the license file picked up by the
+        // directory glob) out of production traces.
+        "**/next/dist/compiled/@mswjs/interceptors/ClientRequest/LICENSE",
+        "**/next/dist/compiled/@mswjs/interceptors/ClientRequest/llhttp/**",
+        "**/next/dist/compiled/semver/semver/**/*.js",
+        "**/next/dist/compiled/jest-worker/**/*",
+        // -- The following were added for Turbopack specifically --
+        // client/components/use-action-queue.ts has a process.env.NODE_ENV guard, but we can't set that due to React: https://github.com/vercel/next.js/pull/75254
+        "**/next/dist/next-devtools/userspace/use-app-dev-rendering-indicator.js",
+        // client/components/app-router.js has a process.env.NODE_ENV guard, but we
+        // can't set that.
+        "**/next/dist/client/dev/hot-reloader/app/hot-reloader-app.js",
+        // server/lib/router-server.js doesn't guard this require:
+        "**/next/dist/server/lib/router-utils/setup-dev-bundler.js",
+        // server/next.js doesn't guard this require
+        "**/next/dist/server/dev/next-dev-server.js",
+        // next/dist/compiled/babel* pulls in this, but we never actually transpile at
+        // deploy-time
+        "**/next/dist/compiled/browserslist/**",
+    ];
+
+    // only ignore image-optimizer code when
+    // this is being handled outside of next-server
+    if has_next_support {
+        globs.extend([
+            "**/node_modules/sharp/**/*",
+            "**/@img/sharp-libvips*/**/*",
+            "**/next/dist/server/image-optimizer.js",
+        ]);
+    }
+
+    if matches!(ty, ServerNftType::Minimal) {
+        globs.extend([
+            "**/next/dist/compiled/edge-runtime/**/*",
+            "**/next/dist/server/web/sandbox/**/*",
+            "**/next/dist/server/post-process.js",
+        ]);
+    }
+
+    globs
+}
+
 #[turbo_tasks::value_impl]
 impl ServerNftJsonAsset {
     #[turbo_tasks::function]
     async fn entries(&self) -> Result<Vc<Modules>> {
         let is_standalone = *self.project.next_config().is_standalone().await?;
 
+        let prune = Glob::alternatives(
+            next_owned_ignores(&self.ty, *self.project.ci_has_next_support().await?)
+                .into_iter()
+                .map(|g| Glob::new(g.into(), GlobOptions::default()))
+                .collect(),
+        )
+        .to_resolved()
+        .await?;
+
         let asset_context = Vc::upcast(externals_tracing_module_context(
             get_tracing_compile_time_info(),
             false,
+            Some((self.project.project_root_path().owned().await?, prune)),
         ));
 
         let project_path = self.project.project_path().owned().await?;
@@ -380,78 +450,24 @@ impl ServerNftJsonAsset {
             }
         }
 
-        let server_ignores_glob = [
-            "**/node_modules/react{,-dom,-server-dom-turbopack}/**/*.development.js",
-            "**/*.d.ts",
-            "**/*.map",
-            "**/next/dist/pages/**/*",
-            "**/next/dist/compiled/next-server/**/*.dev.js",
-            "**/next/dist/compiled/webpack/*",
-            "**/node_modules/webpack5/**/*",
-            "**/next/dist/server/lib/route-resolver*",
-            // The testmode interceptors bundle reads its HTTP parser WASM with a
-            // dynamic path, making the tracer include the bundle's whole
-            // directory. Test proxying is not supported in standalone output, so
-            // keep the parser asset (and the license file picked up by the
-            // directory glob) out of production traces.
-            "**/next/dist/compiled/@mswjs/interceptors/ClientRequest/LICENSE",
-            "**/next/dist/compiled/@mswjs/interceptors/ClientRequest/llhttp/**",
-            "**/next/dist/compiled/semver/semver/**/*.js",
-            "**/next/dist/compiled/jest-worker/**/*",
-            // -- The following were added for Turbopack specifically --
-            // client/components/use-action-queue.ts has a process.env.NODE_ENV guard, but we can't set that due to React: https://github.com/vercel/next.js/pull/75254
-            "**/next/dist/next-devtools/userspace/use-app-dev-rendering-indicator.js",
-            // client/components/app-router.js has a process.env.NODE_ENV guard, but we
-            // can't set that.
-            "**/next/dist/client/dev/hot-reloader/app/hot-reloader-app.js",
-            // server/lib/router-server.js doesn't guard this require:
-            "**/next/dist/server/lib/router-utils/setup-dev-bundler.js",
-            // server/next.js doesn't guard this require
-            "**/next/dist/server/dev/next-dev-server.js",
-            // next/dist/compiled/babel* pulls in this, but we never actually transpile at
-            // deploy-time
-            "**/next/dist/compiled/browserslist/**",
-        ]
-        .into_iter()
-        .chain(additional_ignores.iter().map(|s| s.as_str()))
-        // only ignore image-optimizer code when
-        // this is being handled outside of next-server
-        .chain(if has_next_support {
-            Either::Left(
-                [
-                    "**/node_modules/sharp/**/*",
-                    "**/@img/sharp-libvips*/**/*",
-                    "**/next/dist/server/image-optimizer.js",
-                ]
-                .into_iter(),
-            )
-        } else {
-            Either::Right(std::iter::empty())
-        })
-        .chain(if is_standalone {
-            Either::Left(std::iter::empty())
-        } else {
-            Either::Right(["**/*/next/dist/server/next.js", "**/*/next/dist/bin/next"].into_iter())
-        })
-        .map(|g| Glob::new(g.into(), Default::default()))
-        .collect::<Vec<_>>();
+        // Everything below that `next_owned_ignores` does not cover can match one of the entry
+        // requests `entries()` resolves, so it can only be applied to the finished graph:
+        // `traced_modules_for_entries` inserts entries without consulting the glob (the
+        // `parent == None` arm in `nft.rs`), whereas pruning one would delete it and everything
+        // reachable only through it.
+        let server_ignores_glob = next_owned_ignores(&self.ty, has_next_support)
+            .into_iter()
+            .chain(additional_ignores.iter().map(|s| s.as_str()))
+            .chain(if is_standalone {
+                Either::Left(std::iter::empty())
+            } else {
+                Either::Right(
+                    ["**/*/next/dist/server/next.js", "**/*/next/dist/bin/next"].into_iter(),
+                )
+            })
+            .map(|g| Glob::new(g.into(), Default::default()))
+            .collect::<Vec<_>>();
 
-        Ok(match self.ty {
-            ServerNftType::Full => Glob::alternatives(server_ignores_glob),
-            ServerNftType::Minimal => Glob::alternatives(
-                server_ignores_glob
-                    .into_iter()
-                    .chain(
-                        [
-                            "**/next/dist/compiled/edge-runtime/**/*",
-                            "**/next/dist/server/web/sandbox/**/*",
-                            "**/next/dist/server/post-process.js",
-                        ]
-                        .into_iter()
-                        .map(|g| Glob::new(g.into(), Default::default())),
-                    )
-                    .collect(),
-            ),
-        })
+        Ok(Glob::alternatives(server_ignores_glob))
     }
 }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -2834,7 +2834,7 @@ impl Project {
             .await?;
 
         let asset_context =
-            externals_tracing_module_context(get_tracing_compile_time_info(), false);
+            externals_tracing_module_context(get_tracing_compile_time_info(), false, None);
 
         Ok(Vc::cell(
             cache_handler

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -140,5 +140,6 @@ pub async fn config_tracing_module_context(
             .cell()
             .await?,
         true,
+        None,
     )))
 }

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -12,13 +12,14 @@ pub mod transition;
 
 use anyhow::{Context as _, Result, bail};
 use module_options::{
-    ConfiguredModuleType, ModuleOptions, ModuleOptionsContext, ModuleRuleEffect, ModuleType,
+    ConfiguredModuleType, ModuleOptions, ModuleOptionsContext, ModuleRule, ModuleRuleEffect,
+    ModuleType, RuleCondition,
 };
 pub use runtime_asset_context::get_runtime_asset_context;
 use tracing::{Instrument, field::Empty};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
-use turbo_tasks_fs::FileSystemPath;
+use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 pub use turbopack_core::condition;
 use turbopack_core::{
     asset::Asset,
@@ -908,15 +909,29 @@ async fn process_default_internal(
     Ok(module)
 }
 
+/// `prune` skips matching files as the graph is walked, rather than filtering them out of the
+/// result afterwards.
 #[turbo_tasks::function]
 pub async fn externals_tracing_module_context(
     compile_time_info: Vc<CompileTimeInfo>,
     resolve_typescript: bool,
+    prune: Option<(FileSystemPath, ResolvedVc<Glob>)>,
 ) -> Result<Vc<ModuleAssetContext>> {
     let mut extensions = vec![rcstr!(".js"), rcstr!(".node"), rcstr!(".json")];
     if resolve_typescript {
         extensions.insert(0, rcstr!(".ts"));
     }
+
+    let prune_rules = match prune {
+        Some((base, glob)) => vec![ModuleRule::new(
+            RuleCondition::ResourcePathGlob {
+                base,
+                glob: glob.await?,
+            },
+            vec![ModuleRuleEffect::Ignore],
+        )],
+        None => vec![],
+    };
 
     let resolve_options = ResolveOptionsContext {
         custom_extensions: Some(extensions),
@@ -955,6 +970,7 @@ pub async fn externals_tracing_module_context(
             // node-file-trace.
             environment: None,
             analyze_mode: AnalyzeMode::Tracing,
+            module_rules: prune_rules,
             // Disable tree shaking. Even side-effect-free imports need to be traced, as they will
             // execute at runtime.
             ..Default::default()
@@ -1110,6 +1126,7 @@ impl AssetContext for ModuleAssetContext {
                                         Vc::upcast(externals_tracing_module_context(
                                             *options.compile_time_info,
                                             false,
+                                            None,
                                         )),
                                         // If target is specified, a symlink will be created to
                                         // make the folder


### PR DESCRIPTION
So I was playing around with profiling some very simple next apps when I noticed this. Basically, becauase of how things were set up we were spending a good chunk of our build time analyzing files we were going to reject. I went around and around trying different combinations to make sure we ignore those files (and only the files we should ignore) to speed up build times. Since it is a constant impact, mostly on small projects, but on some, it can make a big difference. I had some adversarial rounds with agents to see if they can break the config in the ways the old comments hints at why we didn't do that. And this final round finally couldn't get it to break.

For a v0-generated Hello World app, compile time is 28.0% faster (+/-1.7%) and a full clean build is 15.9% faster (+/- 1.2%). 