### PR TITLE
fix: middleware throw + compression resets res.statusCode to 404 after headers sent

### DIFF
--- a/packages/next/src/server/lib/is-response-already-sent.test.ts
+++ b/packages/next/src/server/lib/is-response-already-sent.test.ts
@@ -1,0 +1,32 @@
+import type { ServerResponse } from 'node:http'
+
+import { isResponseAlreadySent } from './is-response-already-sent'
+
+const res = (state: {
+  closed?: boolean
+  finished?: boolean
+  headersSent?: boolean
+}) =>
+  ({
+    closed: false,
+    finished: false,
+    headersSent: false,
+    ...state,
+  }) as unknown as ServerResponse
+
+describe('isResponseAlreadySent', () => {
+  it('true when the response ended or the connection closed', () => {
+    expect(isResponseAlreadySent(res({ finished: true }), undefined)).toBe(true)
+    expect(isResponseAlreadySent(res({ closed: true }), undefined)).toBe(true)
+  })
+
+  it('true when a route reported finished and headers are out, even though res.finished is false (compression defers the real end())', () => {
+    expect(isResponseAlreadySent(res({ headersSent: true }), true)).toBe(true)
+  })
+
+  it('false while nothing was sent, whatever resolveRoutes reported', () => {
+    expect(isResponseAlreadySent(res({}), true)).toBe(false)
+    expect(isResponseAlreadySent(res({}), undefined)).toBe(false)
+    expect(isResponseAlreadySent(res({ headersSent: true }), false)).toBe(false)
+  })
+})

--- a/packages/next/src/server/lib/is-response-already-sent.ts
+++ b/packages/next/src/server/lib/is-response-already-sent.ts
@@ -1,0 +1,28 @@
+import type { ServerResponse } from 'node:http'
+
+/**
+ * Whether a response has already been handled and must not be routed further.
+ *
+ * `res.finished` alone is not enough. The `compression` middleware ends its own
+ * stream from its `res.end()` wrapper, so on a compressed response the real
+ * `end()` is deferred into the zlib stream and `res.finished` is still `false`
+ * once the handler returns -- even though the status line and headers are
+ * already on the wire.
+ *
+ * Routing such a response continues to the 404 fallthrough, which assigns
+ * `res.statusCode = 404`. The wire status is unaffected, but the property is
+ * not: anything reading it on `'finish'` (instrumentation, access logs) then
+ * records a 404 for a response the client received as a 500.
+ *
+ * `finished` is what `resolveRoutes` reported. Neither half works alone:
+ * `finished` is `true` for an ordinary render too, before a byte is written, and
+ * `res.headersSent` is `true` throughout a streaming render that is still
+ * legitimately in progress. Returning early on either would hang the request, so
+ * it takes both -- reported handled, and already committed.
+ */
+export function isResponseAlreadySent(
+  res: ServerResponse,
+  finished: boolean | undefined
+): boolean {
+  return res.closed || res.finished || (Boolean(finished) && res.headersSent)
+}

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -30,6 +30,7 @@ import { pathHasPrefix } from '../../shared/lib/router/utils/path-has-prefix'
 import { removePathPrefix } from '../../shared/lib/router/utils/remove-path-prefix'
 import setupCompression from 'next/dist/compiled/compression'
 import { releaseCompressionStream } from './release-compression-stream'
+import { isResponseAlreadySent } from './is-response-already-sent'
 import { signalFromNodeResponse } from '../web/spec-extension/adapters/next-request'
 import { isNonHtmlSecFetchDest } from './is-non-html-sec-fetch-dest'
 import { parseUrl as parseUrlUtil } from '../../shared/lib/router/utils/parse-url'
@@ -536,7 +537,7 @@ export async function initialize(opts: {
         invokedOutputs,
       })
 
-      if (res.closed || res.finished) {
+      if (isResponseAlreadySent(res, finished)) {
         return
       }
 
@@ -822,6 +823,14 @@ export async function initialize(opts: {
         return null
       }
 
+      // Nothing above returned, but the response may still have been sent - an
+      // async res.end() (compression) leaves res.finished false. Rendering a 404
+      // into it would be wasted work, and the assignment would corrupt the status
+      // that instrumentation reads on 'finish'.
+      if (res.headersSent) {
+        return
+      }
+
       const appNotFound = opts.dev
         ? development?.bundler?.serverFields.hasAppNotFound
         : await fsChecker.getItem(UNDERSCORE_NOT_FOUND_ROUTE)
@@ -847,6 +856,14 @@ export async function initialize(opts: {
     try {
       await handleRequest(0)
     } catch (err) {
+      // The response may already be on the wire when this throws, in which case
+      // neither the error render below nor res.end() can do anything but corrupt
+      // it. Log and leave it alone.
+      if (res.headersSent) {
+        console.error(err)
+        return
+      }
+
       try {
         let invokePath = '/500'
         let invokeStatus = '500'

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -652,7 +652,14 @@ export function getResolveRoutes(
               throw e
             }
 
-            if (res.closed || res.finished || !middlewareRes) {
+            // headersSent covers a response whose res.end() was deferred, which
+            // leaves res.finished false even though it has already been sent.
+            if (
+              res.closed ||
+              res.finished ||
+              res.headersSent ||
+              !middlewareRes
+            ) {
               return {
                 parsedUrl,
                 resHeaders,

--- a/test/e2e/middleware-throw-compressed-status/middleware-throw-compressed-status.test.ts
+++ b/test/e2e/middleware-throw-compressed-status/middleware-throw-compressed-status.test.ts
@@ -1,0 +1,46 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+/**
+ * When middleware throws, the router sends a 500. If the client accepts gzip,
+ * compression defers the real res.end(), the router's finished-check misses,
+ * and the router used to fall through to `res.statusCode = 404` on the
+ * already-sent response. The wire keeps the 500, so the corruption is only
+ * visible inside the server process: everything reading res.statusCode on
+ * 'finish' (APM tracers, access logs) records a 404 for a 500 the user saw.
+ *
+ * probe.js is injected into the server process via NODE_OPTIONS and prints the
+ * status observed at 'finish', which is what these tests assert on.
+ */
+describe('middleware throw with a compressed response', () => {
+  const { next, isNextDeploy } = nextTestSetup({
+    files: __dirname,
+    env: {
+      NODE_OPTIONS: '--require ./probe.js',
+    },
+  })
+
+  if (isNextDeploy) {
+    it('skips in deploy mode - the probe cannot be injected', () => {})
+    return
+  }
+
+  it.each(['identity', 'gzip'])(
+    'observes the sent 500 on finish (accept-encoding: %s)',
+    async (acceptEncoding) => {
+      const outputIndex = next.cliOutput.length
+
+      const res = await next.fetch('/', {
+        headers: { 'accept-encoding': acceptEncoding },
+      })
+      expect(res.status).toBe(500)
+
+      await retry(() => {
+        const output = next.cliOutput.slice(outputIndex)
+        expect(output).toContain('PROBE_FINISH_STATUS=')
+        expect(output).toContain('PROBE_FINISH_STATUS=500')
+        expect(output).not.toContain('PROBE_FINISH_STATUS=404')
+      })
+    }
+  )
+})

--- a/test/e2e/middleware-throw-compressed-status/middleware.ts
+++ b/test/e2e/middleware-throw-compressed-status/middleware.ts
@@ -1,0 +1,7 @@
+export default function middleware() {
+  throw new Error('boom from middleware')
+}
+
+export const config = {
+  matcher: '/',
+}

--- a/test/e2e/middleware-throw-compressed-status/pages/_error.js
+++ b/test/e2e/middleware-throw-compressed-status/pages/_error.js
@@ -1,0 +1,20 @@
+// Padded past the compression size threshold. A response too small to compress
+// is ended synchronously and cannot reproduce the deferred-end state.
+const PADDING = Array.from({ length: 200 }, (_, i) => `padding line ${i}`)
+
+function Error({ statusCode }) {
+  return (
+    <main>
+      <h1>{statusCode}</h1>
+      {PADDING.map((line) => (
+        <p key={line}>{line}</p>
+      ))}
+    </main>
+  )
+}
+
+Error.getInitialProps = ({ res, err }) => ({
+  statusCode: res?.statusCode ?? err?.statusCode ?? 500,
+})
+
+export default Error

--- a/test/e2e/middleware-throw-compressed-status/pages/index.js
+++ b/test/e2e/middleware-throw-compressed-status/pages/index.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <p>never reached - middleware throws first</p>
+}

--- a/test/e2e/middleware-throw-compressed-status/probe.js
+++ b/test/e2e/middleware-throw-compressed-status/probe.js
@@ -1,0 +1,12 @@
+// Loaded into the server process via NODE_OPTIONS=--require. Reports the status
+// code visible on the 'finish' event - the value APM tracers and access logs
+// record - which is not observable from outside the process.
+const http = require('http')
+
+const originalEmit = http.ServerResponse.prototype.emit
+http.ServerResponse.prototype.emit = function (event) {
+  if (event === 'finish' && this.req && this.req.url === '/') {
+    process.stdout.write(`PROBE_FINISH_STATUS=${this.statusCode}\n`)
+  }
+  return originalEmit.apply(this, arguments)
+}


### PR DESCRIPTION
## Background story:
We had bad locale handling that made our proxy.ts to throw for some locale cookie values.
Oddly enough, on datadog trace viewer, the nginx and nextjs disagree over the status code!
<img width="360" height="123" alt="Screenshot 2026-08-17 at 23 41 27" src="https://github.com/user-attachments/assets/c91f3599-9eaa-4cb6-9615-9fb3e833c7a7" />

But not always, what made it even more odd.
We are using datadog tracer with a little of custom configs, nothing too fancy.

### So what happened?

Middleware throws + client accepts gzip → router resets res.statusCode
500→404 *after* headers are sent. Wire keeps the 500; anything reading
res.statusCode on 'finish' (APM tracers, access logs) records 404, error:0.

### Why?

compression defers the real res.end() into zlib → res.finished is still
false at the router's guard (res.closed || res.finished) → router keeps
routing the answered request → 404 fallthrough mutates a sent response.
Hit this in production: tens of thousands of user-facing 500s recorded
as 404s, no 5xx monitor fired. Only compressed responses affected —
curl never reproduces it, every browser does.

### How?

- isResponseAlreadySent(): guard now also honours the `finished` flag
  resolveRoutes returns (was proxy-only) paired with res.headersSent —
  either half alone regresses (details in the fix commit)
- res.headersSent guards at the 404 fallthrough and the outer catch
- same addition in resolve-routes' own check
- unit truth-table + e2e probing finish-status inside the server
  process (NODE_OPTIONS=--require); e2e observes 404 without the fix,
  500 with it

Related: #96173 #89091

### Versions

- Next.js: hit on 16.2.11 in production; code unchanged on canary —
  verified on 16.3.1-canary.21 (9e1dc0eb), where the e2e test in this PR
  fails without the fix
- Node.js: v24.14.1 (fix + tests verified locally)
