### PR TITLE
docs: app router reference accuracy

### DIFF
--- a/docs/01-app/02-guides/caching-without-cache-components.mdx
+++ b/docs/01-app/02-guides/caching-without-cache-components.mdx
@@ -108,7 +108,7 @@ export const dynamic = 'auto'
 <details>
   <summary>This is an advanced option that should only be used if you specifically need to override the default behavior.</summary>
 
-By default, Next.js **will cache** any `fetch()` requests that are reachable **before** any Request-time APIs are used and **will not cache** `fetch` requests that are discovered **after** Request-time APIs are used.
+A `fetch` request that sets no `cache` option is fetched once during `next build` if it is reachable **before** any Request-time APIs are used, because the route is prerendered up to that point. Requests discovered **after** a Request-time API run on every request.
 
 `fetchCache` allows you to override the default `cache` option of all `fetch` requests in a layout or page.
 

--- a/docs/01-app/02-guides/upgrading/version-16.mdx
+++ b/docs/01-app/02-guides/upgrading/version-16.mdx
@@ -276,7 +276,7 @@ export default nextConfig
 
 ### Turbopack File System Caching
 
-Turbopack stores compiler artifacts on disk between runs, for significantly faster compile times across restarts. Filesystem caching is enabled by default for both `next dev` and `next build`. See [`turbopackFileSystemCache`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) to configure or disable it.
+Turbopack stores compiler artifacts on disk between runs, for significantly faster compile times across restarts. Filesystem caching is enabled by default for both `next dev` and `next build`, through `experimental.turbopackFileSystemCacheForDev` and `experimental.turbopackFileSystemCacheForBuild`. See [Turbopack FileSystem Caching](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) to configure or disable either one.
 
 ## Async Request APIs (Breaking change)
 

--- a/docs/01-app/02-guides/upgrading/version-16.mdx
+++ b/docs/01-app/02-guides/upgrading/version-16.mdx
@@ -1074,7 +1074,7 @@ const nextConfig = {
   },
 }
 
-export default nextConfig
+module.exports = nextConfig
 ```
 
 Evaluate if AMP is still necessary for your use case. Most performance benefits can now be achieved through Next.js's built-in optimizations and modern web standards.

--- a/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
@@ -44,7 +44,7 @@ const nextConfig = {
   cacheComponents: true,
 }
 
-export default nextConfig
+module.exports = nextConfig
 ```
 
 Then add `'use cache: private'` to your function along with a `cacheLife` configuration.

--- a/docs/01-app/03-api-reference/01-directives/use-cache-remote.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache-remote.mdx
@@ -44,7 +44,7 @@ const nextConfig = {
   cacheComponents: true,
 }
 
-export default nextConfig
+module.exports = nextConfig
 ```
 
 Then add `'use cache: remote'` to the functions or components where you've determined remote caching is justified. The handler implementation is configured via [`cacheHandlers`](/docs/app/api-reference/config/next-config-js/cacheHandlers), though hosting providers should typically provide this automatically. If you're self-hosting, see the `cacheHandlers` configuration reference to set up your cache storage.

--- a/docs/01-app/03-api-reference/01-directives/use-cache.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache.mdx
@@ -64,7 +64,8 @@ export async function MyComponent() {
 // Function level
 export async function getData() {
   'use cache'
-  const data = await fetch('/api/data')
+  const res = await fetch('https://api.example.com/data')
+  const data = await res.json()
   return data
 }
 ```
@@ -87,7 +88,10 @@ async function Component({ userId }: { userId: string }) {
   const getData = async (filter: string) => {
     'use cache'
     // Cache key includes both userId (from closure) and filter (argument)
-    return fetch(`/api/users/${userId}/data?filter=${filter}`)
+    const res = await fetch(
+      `https://api.example.com/users/${userId}/data?filter=${filter}`
+    )
+    return res.json()
   }
 
   return getData('active')
@@ -201,10 +205,10 @@ While `use cache` is designed primarily to include uncached data in the static s
 
 With the default in-memory handler, runtime cache behavior depends on your hosting environment:
 
-| Environment     | Runtime Caching Behavior                                                                                                                                          |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Serverless**  | Cache entries typically don't persist across requests (each request can be a different instance), or during revalidation. Build-time caching works normally.      |
-| **Self-hosted** | Cache entries persist across requests. Control cache size with [`cacheMaxMemorySize`](/docs/app/api-reference/config/next-config-js/incrementalCacheHandlerPath). |
+| Environment     | Runtime Caching Behavior                                                                                                                                     |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Serverless**  | Cache entries typically don't persist across requests (each request can be a different instance), or during revalidation. Build-time caching works normally. |
+| **Self-hosted** | Cache entries persist across requests. Control cache size with [`cacheMaxMemorySize`](/docs/app/api-reference/config/next-config-js/cacheMaxMemorySize).     |
 
 For example, in a serverless environment, a cached function shared by two pages executes on each static shell revalidation, whereas in self-hosted or environments with persistent memory, the cached output is reused if it's still fresh.
 
@@ -296,7 +300,8 @@ import { cacheLife } from 'next/cache'
 async function getData() {
   'use cache'
   cacheLife('hours') // Use built-in 'hours' profile
-  return fetch('/api/data')
+  const res = await fetch('https://api.example.com/data')
+  return res.json()
 }
 ```
 
@@ -310,7 +315,8 @@ If you omit `cacheLife`, the `default` profile applies and the lifetime is no lo
 async function getData() {
   'use cache'
   // Implicitly uses the 'default' profile
-  return fetch('/api/data')
+  const res = await fetch('https://api.example.com/data')
+  return res.json()
 }
 ```
 
@@ -326,7 +332,8 @@ import { cacheTag } from 'next/cache'
 async function getProducts() {
   'use cache'
   cacheTag('products')
-  return fetch('/api/products')
+  const res = await fetch('https://api.example.com/products')
+  return res.json()
 }
 ```
 
@@ -371,7 +378,8 @@ Any components imported and nested in `page` file are part of the cache output a
 'use cache'
 
 async function Users() {
-  const users = await fetch('/api/users')
+  const res = await fetch('https://api.example.com/users')
+  const users = await res.json()
   // loop through users
 }
 
@@ -388,7 +396,8 @@ export default async function Page() {
 'use cache'
 
 async function Users() {
-  const users = await fetch('/api/users')
+  const res = await fetch('https://api.example.com/users')
+  const users = await res.json()
   // loop through users
 }
 
@@ -413,7 +422,10 @@ You can use `use cache` at the component level to cache any fetches or computati
 export async function Bookings({ type = 'haircut' }: BookingsProps) {
   'use cache'
   async function getBookingsData() {
-    const data = await fetch(`/api/bookings?type=${encodeURIComponent(type)}`)
+    const response = await fetch(
+      `https://api.example.com/bookings?type=${encodeURIComponent(type)}`
+    )
+    const data = await response.json()
     return data
   }
   return //...
@@ -428,7 +440,10 @@ interface BookingsProps {
 export async function Bookings({ type = 'haircut' }) {
   'use cache'
   async function getBookingsData() {
-    const data = await fetch(`/api/bookings?type=${encodeURIComponent(type)}`)
+    const response = await fetch(
+      `https://api.example.com/bookings?type=${encodeURIComponent(type)}`
+    )
+    const data = await response.json()
     return data
   }
   return //...
@@ -443,7 +458,8 @@ Since you can add `use cache` to any asynchronous function, you aren't limited t
 export async function getData() {
   'use cache'
 
-  const data = await fetch('/api/data')
+  const res = await fetch('https://api.example.com/data')
+  const data = await res.json()
   return data
 }
 ```
@@ -452,7 +468,8 @@ export async function getData() {
 export async function getData() {
   'use cache'
 
-  const data = await fetch('/api/data')
+  const res = await fetch('https://api.example.com/data')
+  const data = await res.json()
   return data
 }
 ```
@@ -485,7 +502,8 @@ async function CacheComponent({
   children: ReactNode
 }) {
   'use cache'
-  const cachedData = await fetch('/api/cached-data')
+  const res = await fetch('https://api.example.com/cached-data')
+  const cachedData = await res.json()
   return (
     <div>
       {header}
@@ -513,7 +531,8 @@ async function CacheComponent({
   children, // children: another slot for nested composition
 }) {
   'use cache'
-  const cachedData = await fetch('/api/cached-data')
+  const res = await fetch('https://api.example.com/cached-data')
+  const cachedData = await res.json()
   return (
     <div>
       {header}

--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -239,7 +239,7 @@ An integer between `1` and `100` that sets the quality of the optimized image. H
 <Image quality={75} />
 ```
 
-If you’ve configured [qualities](#qualities) in `next.config.js`, the value must match one of the allowed entries.
+If you’ve configured [qualities](#qualities) in `next.config.js`, a value outside that list is coerced to the closest allowed entry. For example, with `qualities: [50, 75, 100]`, a `quality` of `80` is served as `75`. Development logs a warning so you can add the value to the allowlist.
 
 > **Good to know**: If the original image is already low quality, setting a high quality value will increase the file size without improving appearance.
 
@@ -1069,7 +1069,7 @@ export default function MyImage() {
 }
 ```
 
-When using `fill`, the parent element must have `position: relative` or `display: block`. This is necessary for the proper rendering of the image element in that layout mode.
+When using `fill`, the parent element must be positioned, with `position: relative`, `fixed`, or `absolute`. The image itself uses `position: absolute`, so it sizes against the nearest positioned ancestor.
 
 ```jsx
 <div style={{ position: 'relative' }}>

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/sitemap.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/sitemap.mdx
@@ -389,7 +389,7 @@ export default async function sitemap(props) {
 }
 ```
 
-Your generated sitemaps will be available at `/.../sitemap/[id]`. For example, `/product/sitemap/1.xml`.
+Your generated sitemaps will be available at `/.../sitemap/[id].xml`. For example, `/product/sitemap/1.xml`.
 
 See the [`generateSitemaps` API reference](/docs/app/api-reference/functions/generate-sitemaps) for more information.
 
@@ -413,6 +413,8 @@ type Sitemap = Array<{
   alternates?: {
     languages?: Languages<string>
   }
+  images?: string[]
+  videos?: Videos[]
 }>
 ```
 

--- a/docs/01-app/03-api-reference/04-functions/cacheLife.mdx
+++ b/docs/01-app/03-api-reference/04-functions/cacheLife.mdx
@@ -34,7 +34,7 @@ const nextConfig = {
   cacheComponents: true,
 }
 
-export default nextConfig
+module.exports = nextConfig
 ```
 
 `cacheLife` can only be used within a cache directive scope.

--- a/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
@@ -33,7 +33,7 @@ const nextConfig = {
   cacheComponents: true,
 }
 
-export default nextConfig
+module.exports = nextConfig
 ```
 
 The `cacheTag` function takes one or more string values.

--- a/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
@@ -44,7 +44,7 @@ import { cacheTag } from 'next/cache'
 export async function getData() {
   'use cache'
   cacheTag('my-data')
-  const data = await fetch('/api/data')
+  const data = await fetch('https://api.example.com/data')
   return data
 }
 ```
@@ -55,7 +55,7 @@ import { cacheTag } from 'next/cache'
 export async function getData() {
   'use cache'
   cacheTag('my-data')
-  const data = await fetch('/api/data')
+  const data = await fetch('https://api.example.com/data')
   return data
 }
 ```
@@ -118,7 +118,9 @@ export async function Bookings({ type = 'haircut' }: BookingsProps) {
   cacheTag('bookings-data')
 
   async function getBookingsData() {
-    const data = await fetch(`/api/bookings?type=${encodeURIComponent(type)}`)
+    const data = await fetch(
+      `https://api.example.com/bookings?type=${encodeURIComponent(type)}`
+    )
     return data
   }
 
@@ -134,7 +136,9 @@ export async function Bookings({ type = 'haircut' }) {
   cacheTag('bookings-data')
 
   async function getBookingsData() {
-    const data = await fetch(`/api/bookings?type=${encodeURIComponent(type)}`)
+    const data = await fetch(
+      `https://api.example.com/bookings?type=${encodeURIComponent(type)}`
+    )
     return data
   }
 
@@ -156,7 +160,10 @@ interface BookingsProps {
 export async function Bookings({ type = 'haircut' }: BookingsProps) {
   async function getBookingsData() {
     'use cache'
-    const data = await fetch(`/api/bookings?type=${encodeURIComponent(type)}`)
+    const response = await fetch(
+      `https://api.example.com/bookings?type=${encodeURIComponent(type)}`
+    )
+    const data = await response.json()
     cacheTag('bookings-data', data.id)
     return data
   }
@@ -170,7 +177,10 @@ import { cacheTag } from 'next/cache'
 export async function Bookings({ type = 'haircut' }) {
   async function getBookingsData() {
     'use cache'
-    const data = await fetch(`/api/bookings?type=${encodeURIComponent(type)}`)
+    const response = await fetch(
+      `https://api.example.com/bookings?type=${encodeURIComponent(type)}`
+    )
+    const data = await response.json()
     cacheTag('bookings-data', data.id)
     return data
   }

--- a/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/cacheTag.mdx
@@ -44,7 +44,8 @@ import { cacheTag } from 'next/cache'
 export async function getData() {
   'use cache'
   cacheTag('my-data')
-  const data = await fetch('https://api.example.com/data')
+  const res = await fetch('https://api.example.com/data')
+  const data = await res.json()
   return data
 }
 ```
@@ -55,7 +56,8 @@ import { cacheTag } from 'next/cache'
 export async function getData() {
   'use cache'
   cacheTag('my-data')
-  const data = await fetch('https://api.example.com/data')
+  const res = await fetch('https://api.example.com/data')
+  const data = await res.json()
   return data
 }
 ```
@@ -118,9 +120,10 @@ export async function Bookings({ type = 'haircut' }: BookingsProps) {
   cacheTag('bookings-data')
 
   async function getBookingsData() {
-    const data = await fetch(
+    const response = await fetch(
       `https://api.example.com/bookings?type=${encodeURIComponent(type)}`
     )
+    const data = await response.json()
     return data
   }
 
@@ -136,9 +139,10 @@ export async function Bookings({ type = 'haircut' }) {
   cacheTag('bookings-data')
 
   async function getBookingsData() {
-    const data = await fetch(
+    const response = await fetch(
       `https://api.example.com/bookings?type=${encodeURIComponent(type)}`
     )
+    const data = await response.json()
     return data
   }
 

--- a/docs/01-app/03-api-reference/04-functions/fetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/fetch.mdx
@@ -98,7 +98,7 @@ fetch(url, { signal })
 
 ## Troubleshooting
 
-### Fetch default `auto no store` and `cache: 'no-store'` not showing fresh data in development
+### Fetch default `auto no cache` and `cache: 'no-store'` not showing fresh data in development
 
 Next.js caches `fetch` responses in Server Components across Hot Module Replacement (HMR) in local development for faster responses and to reduce costs for billed API calls.
 

--- a/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
@@ -383,7 +383,6 @@ export const metadata = {
 <meta name="generator" content="Next.js" />
 <meta name="keywords" content="Next.js,React,JavaScript" />
 <meta name="referrer" content="origin-when-cross-origin" />
-<meta name="color-scheme" content="dark" />
 <meta name="creator" content="Jiachi Liu" />
 <meta name="publisher" content="Sebastian Markbåge" />
 <meta name="format-detection" content="telephone=no, address=no, email=no" />
@@ -1124,7 +1123,7 @@ The following metadata types do not currently have built-in support. However, th
 | `<style>`                     | Learn more about [styling in Next.js](/docs/app/getting-started/css).                                                                                                                                                                        |
 | `<script>`                    | Learn more about [using scripts](/docs/app/guides/scripts).                                                                                                                                                                                  |
 | `<link rel="stylesheet" />`   | `import` stylesheets directly in the layout or page itself.                                                                                                                                                                                  |
-| `<link rel="preload />`       | Use [ReactDOM preload method](#link-relpreload)                                                                                                                                                                                              |
+| `<link rel="preload" />`      | Use [ReactDOM preload method](#link-relpreload)                                                                                                                                                                                              |
 | `<link rel="preconnect" />`   | Use [ReactDOM preconnect method](#link-relpreconnect)                                                                                                                                                                                        |
 | `<link rel="dns-prefetch" />` | Use [ReactDOM prefetchDNS method](#link-reldns-prefetch)                                                                                                                                                                                     |
 
@@ -1422,5 +1421,5 @@ export const metadata = {
 | Version   | Changes                                                                                                                                                 |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `v15.2.0` | Introduced streaming support to `generateMetadata`.                                                                                                     |
-| `v13.2.0` | `viewport`, `themeColor`, and `colorScheme` deprecated in favor of the [`viewport` configuration](/docs/app/api-reference/functions/generate-viewport). |
+| `v14.0.0` | `viewport`, `themeColor`, and `colorScheme` deprecated in favor of the [`viewport` configuration](/docs/app/api-reference/functions/generate-viewport). |
 | `v13.2.0` | `metadata` and `generateMetadata` introduced.                                                                                                           |

--- a/docs/01-app/03-api-reference/04-functions/updateTag.mdx
+++ b/docs/01-app/03-api-reference/04-functions/updateTag.mdx
@@ -121,7 +121,7 @@ export async function createPost(formData) {
 ### Error when used outside Server Actions
 
 ```ts filename="app/api/posts/route.ts" switcher
-import { updateTag } from 'next/cache'
+import { revalidateTag, updateTag } from 'next/cache'
 
 export async function POST() {
   // This will throw an error

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx
@@ -471,7 +471,7 @@ For a full explanation of the tag architecture (including soft tags and multi-in
 
 ## Soft Tags
 
-Soft tags are implicit tags that Next.js automatically generates based on the route path. For example, the route `/blog/hello` generates soft tags for `/`, `/blog`, `/blog/hello`, and their corresponding layout entries. These tags are prefixed internally with `_N_T_`.
+Soft tags are implicit tags that Next.js automatically generates based on the route path. Every segment in the path gets a layout tag, plus the leaf route itself. For example, the route `/blog/hello` generates soft tags for `/layout`, `/blog/layout`, `/blog/hello/layout`, and `/blog/hello`. These tags are prefixed internally with `_N_T_`.
 
 Soft tags enable [`revalidatePath()`](/docs/app/api-reference/functions/revalidatePath) to work through the same tag-based cache system. When `revalidatePath('/blog/hello')` is called, it invalidates all cache entries associated with that path's soft tags.
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheLife.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheLife.mdx
@@ -54,7 +54,8 @@ import { cacheLife } from 'next/cache'
 export async function getCachedData() {
   'use cache'
   cacheLife('blog')
-  const data = await fetch('/api/data')
+  const res = await fetch('https://api.example.com/data')
+  const data = await res.json()
   return data
 }
 ```
@@ -65,7 +66,8 @@ import { cacheLife } from 'next/cache'
 export async function getCachedData() {
   'use cache'
   cacheLife('blog')
-  const data = await fetch('/api/data')
+  const res = await fetch('https://api.example.com/data')
+  const data = await res.json()
   return data
 }
 ```

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheMaxMemorySize.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheMaxMemorySize.mdx
@@ -1,0 +1,36 @@
+---
+title: cacheMaxMemorySize
+description: Configure the size of the in-memory cache that Next.js keeps in each server instance.
+---
+
+{/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
+`cacheMaxMemorySize` sets the size, in bytes, of the in-memory cache each Next.js server instance keeps. It defaults to 50 MB.
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheMaxMemorySize: 50 * 1024 * 1024, // 50 MB, the default
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  cacheMaxMemorySize: 50 * 1024 * 1024, // 50 MB, the default
+}
+
+module.exports = nextConfig
+```
+
+The option sizes two separate caches:
+
+- The server cache that stores prerendered pages, route handler responses, and optimized images. Set this to `0` when adopting a [custom `cacheHandler`](/docs/app/api-reference/config/next-config-js/incrementalCacheHandlerPath), so reads go to your store rather than a per-instance copy.
+- The built-in handler behind [`'use cache'`](/docs/app/api-reference/directives/use-cache). If you register your own handler through [`cacheHandlers`](/docs/app/api-reference/config/next-config-js/cacheHandlers), that handler manages its own memory and this option no longer applies to it.
+
+Setting `cacheMaxMemorySize: 0` disables both in-memory caches. It is also a way to mimic how `use cache` behaves in a serverless environment, where entries rarely survive between requests.
+
+> **Good to know**: `next dev` keeps its own in-memory cache regardless of this option, so reloads stay fast. Production honors the configured value exactly.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/images.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/images.mdx
@@ -156,8 +156,8 @@ export default function gumletLoader({ src, width, quality }) {
 // Docs: https://support.imageengine.io/hc/en-us/articles/360058880672-Directives
 export default function imageengineLoader({ src, width, quality }) {
   const compression = 100 - (quality || 50)
-  const params = [`w_${width}`, `cmpr_${compression}`)]
-  return `https://example.com${src}?imgeng=/${params.join('/')`
+  const params = [`w_${width}`, `cmpr_${compression}`]
+  return `https://example.com${src}?imgeng=/${params.join('/')}`
 }
 ```
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/incrementalCacheHandlerPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/incrementalCacheHandlerPath.mdx
@@ -6,7 +6,7 @@ description: Configure the Next.js cache used for storing and revalidating data 
 
 You can configure the Next.js cache location if you want to persist cached pages and data to durable storage, or share the cache across multiple containers or instances of your Next.js application.
 
-> **Good to know**: The `cacheHandler` (singular) configuration is specifically used by Next.js for server cache operations such as storing and revalidating ISR, route handler responses, and optimized images. It is **not** used by `'use cache'` directives. For `'use cache'` directives, use [`cacheHandlers`](/docs/app/api-reference/config/next-config-js/cacheHandlers) (plural) instead.
+> **Good to know**: The `cacheHandler` (singular) configuration is specifically used by Next.js for server cache operations such as storing and revalidating ISR, route handler responses, and optimized images. It is **not** used by `'use cache'` directives. For `'use cache'` directives, use [`cacheHandlers`](/docs/app/api-reference/config/next-config-js/cacheHandlers) (plural) instead. [`cacheMaxMemorySize`](/docs/app/api-reference/config/next-config-js/cacheMaxMemorySize) is separate from both, and sizes the in-memory cache for each.
 
 ```js filename="next.config.js"
 module.exports = {

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/staticGeneration.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/staticGeneration.mdx
@@ -29,7 +29,7 @@ const nextConfig = {
   },
 }
 
-export default nextConfig
+module.exports = nextConfig
 ```
 
 ## Config Options

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/taint.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/taint.mdx
@@ -63,7 +63,7 @@ In this case, the `getUserDetails` function returns data about a given user. We 
 ```ts switcher
 import { experimental_taintObjectReference } from 'react'
 
-function getUserDetails(id: string): UserDetails {
+async function getUserDetails(id: string): Promise<UserDetails> {
   const user = await db.queryUserById(id)
 
   experimental_taintObjectReference(
@@ -78,7 +78,7 @@ function getUserDetails(id: string): UserDetails {
 ```js switcher
 import { experimental_taintObjectReference } from 'react'
 
-function getUserDetails(id) {
+async function getUserDetails(id) {
   const user = await db.queryUserById(id)
 
   experimental_taintObjectReference(
@@ -158,7 +158,7 @@ We can taint the `config.SERVICE_API_KEY` value.
 ```ts switcher
 import { experimental_taintUniqueValue } from 'react'
 
-function getSystemConfig(): SystemConfig {
+async function getSystemConfig(): Promise<SystemConfig> {
   const config = await config.getConfigDetails()
 
   experimental_taintUniqueValue(
@@ -174,7 +174,7 @@ function getSystemConfig(): SystemConfig {
 ```js switcher
 import { experimental_taintUniqueValue } from 'react'
 
-function getSystemConfig() {
+async function getSystemConfig() {
   const config = await config.getConfigDetails()
 
   experimental_taintUniqueValue(

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/taint.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/taint.mdx
@@ -151,7 +151,7 @@ export async function ContactPage({ params }) {
 
 ### Tainting a unique value
 
-In this case, we can access the server configuration by awaiting calls to `config.getConfigDetails`. However, the system configuration contains the `SERVICE_API_KEY` that we don't want to expose to clients.
+In this case, we can access the server configuration by awaiting calls to `configService.getConfigDetails`. However, the system configuration contains the `SERVICE_API_KEY` that we don't want to expose to clients.
 
 We can taint the `config.SERVICE_API_KEY` value.
 
@@ -159,7 +159,7 @@ We can taint the `config.SERVICE_API_KEY` value.
 import { experimental_taintUniqueValue } from 'react'
 
 async function getSystemConfig(): Promise<SystemConfig> {
-  const config = await config.getConfigDetails()
+  const config = await configService.getConfigDetails()
 
   experimental_taintUniqueValue(
     'Do not pass configuration tokens to the client',
@@ -175,7 +175,7 @@ async function getSystemConfig(): Promise<SystemConfig> {
 import { experimental_taintUniqueValue } from 'react'
 
 async function getSystemConfig() {
-  const config = await config.getConfigDetails()
+  const config = await configService.getConfigDetails()
 
   experimental_taintUniqueValue(
     'Do not pass configuration tokens to the client',

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -7,7 +7,7 @@ description: Configure Next.js with Turbopack-specific options
 
 The `turbopack` option lets you customize [Turbopack](/docs/app/api-reference/turbopack) to transform different files and change how modules are resolved.
 
-> **Good to know**: The `turbopack` option was previously named `experimental.turbo` in Next.js versions 13.0.0 to 15.2.x. The `experimental.turbo` option will be removed in Next.js 16.
+> **Good to know**: The `turbopack` option was previously named `experimental.turbo` in Next.js versions 13.0.0 to 15.2.x, an option which still works as an alias, but new configuration should use the top-level `turbopack` option.
 >
 > If you are using an older version of Next.js, run `npx @next/codemod@latest next-experimental-turbo-to-turbopack .` to automatically migrate your configuration.
 

--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -93,22 +93,20 @@ See the [Building guide](/docs/app/guides/building) to learn how to read the out
 
 The following options are available for the `next build` command:
 
-| Option                             | Description                                                                                                                                                                        |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-h, --help`                       | Show all available options.                                                                                                                                                        |
-| `[directory]`                      | A directory on which to build the application. If not provided, the current directory will be used.                                                                                |
-| `--turbopack`                      | Force enable [Turbopack](/docs/app/api-reference/turbopack) (enabled by default). Also available as `--turbo`.                                                                     |
-| `--webpack`                        | Build using Webpack.                                                                                                                                                               |
-| `-d` or `--debug`                  | Enables a more verbose build output. With this flag enabled additional build output like rewrites, redirects, and headers will be shown.                                           |
-|                                    |
-| `--profile`                        | Enables production [profiling for React](https://react.dev/reference/react/Profiler).                                                                                              |
-| `--no-lint`                        | Disables linting. _Note: linting will be removed from `next build` in Next 16. If you're using Next 15.5+ with a linter other than `eslint`, linting during build will not occur._ |
-| `--no-mangling`                    | Disables [mangling](https://en.wikipedia.org/wiki/Name_mangling). This may affect performance and should only be used for debugging purposes.                                      |
-| `--experimental-app-only`          | Builds only App Router routes.                                                                                                                                                     |
-| `--experimental-build-mode [mode]` | Uses an experimental build mode. (choices: "compile", "generate", default: "default")                                                                                              |
-| `--debug-prerender`                | Debug prerender errors in development.                                                                                                                                             |
-| `--debug-build-paths=<patterns>`   | Build only specific routes for debugging.                                                                                                                                          |
-| `--experimental-cpu-prof`          | Enables CPU profiling using V8's inspector. Profiles are saved to `.next-profiles/` on exit.                                                                                       |
+| Option                             | Description                                                                                                                                   |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-h, --help`                       | Show all available options.                                                                                                                   |
+| `[directory]`                      | A directory on which to build the application. If not provided, the current directory will be used.                                           |
+| `--turbopack`                      | Force enable [Turbopack](/docs/app/api-reference/turbopack) (enabled by default). Also available as `--turbo`.                                |
+| `--webpack`                        | Build using Webpack.                                                                                                                          |
+| `-d` or `--debug`                  | Enables a more verbose build output. With this flag enabled additional build output like rewrites, redirects, and headers will be shown.      |
+| `--profile`                        | Enables production [profiling for React](https://react.dev/reference/react/Profiler).                                                         |
+| `--no-mangling`                    | Disables [mangling](https://en.wikipedia.org/wiki/Name_mangling). This may affect performance and should only be used for debugging purposes. |
+| `--experimental-app-only`          | Builds only App Router routes.                                                                                                                |
+| `--experimental-build-mode [mode]` | Uses an experimental build mode. (choices: "compile", "generate", default: "default")                                                         |
+| `--debug-prerender`                | Debug prerender errors in development.                                                                                                        |
+| `--debug-build-paths=<patterns>`   | Build only specific routes for debugging.                                                                                                     |
+| `--experimental-cpu-prof`          | Enables CPU profiling using V8's inspector. Profiles are saved to `.next-profiles/` on exit.                                                  |
 
 ### `next start` options
 


### PR DESCRIPTION
- Adding docs/01-app/03-api-reference/05-config/01-next-config-js/cacheMaxMemorySize.mdx
- Various use cache snippet fixes
- Break nuance for fetch default
- Point to correct turbopack cache flags