### PR TITLE
Fix soft navigation leaving previous route metadata in document.head

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -3,6 +3,7 @@ import React, {
   useMemo,
   useInsertionEffect,
   useDeferredValue,
+  Fragment,
 } from 'react'
 import {
   AppRouterContext,
@@ -199,7 +200,16 @@ function Head({
   // We use `useDeferredValue` to handle switching between the prefetched and
   // final values. The second argument is returned on initial render, then it
   // re-renders with the first argument.
-  return useDeferredValue(head, resolvedPrefetchRsc)
+  //
+  // Hoistable metadata (`<meta>`, `<link>`) is inserted into `document.head`
+  // outside the React tree. Swapping the RSC tree without remounting can leave
+  // the previous hoistables mounted alongside the new ones (e.g. both
+  // `og:type=website` from a layout/prefetch shell and `og:type=article` from
+  // the destination). Key by which value is currently shown so the prefetch →
+  // final transition fully releases the old tags. See GitHub #97472.
+  const deferredHead = useDeferredValue(head, resolvedPrefetchRsc)
+  const phase = deferredHead === head ? 'h' : 'p'
+  return <Fragment key={phase}>{deferredHead}</Fragment>
 }
 
 /**

--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/app/layout.tsx
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/app/layout.tsx
@@ -6,6 +6,14 @@ export const metadata = {
   // to this default (or retain the previous route's title) — it must never be
   // dropped to an empty string (which makes the browser tab show the URL).
   title: { default: 'Home Default', template: '%s | Site' },
+  metadataBase: new URL('https://example.com'),
+  openGraph: {
+    type: 'website',
+    siteName: 'Site',
+    title: 'Home Default',
+    description: 'Layout open graph defaults',
+    url: '/',
+  },
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/app/slow/page.tsx
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/app/slow/page.tsx
@@ -6,7 +6,15 @@ import { Suspense } from 'react'
 // part of the prefetchable App Shell and must be fetched on navigation.
 export async function generateMetadata(): Promise<Metadata> {
   await connection()
-  return { title: 'Slow Page' }
+  return {
+    title: 'Slow Page',
+    openGraph: {
+      type: 'article',
+      title: 'Slow Page',
+      description: 'Dynamic article open graph',
+      url: '/slow',
+    },
+  }
 }
 
 async function DynamicContent() {

--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/metadata-soft-nav-cache-components.test.ts
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/metadata-soft-nav-cache-components.test.ts
@@ -55,6 +55,42 @@ describe('metadata-soft-nav-cache-components', () => {
     })
   })
 
+  // Regression for GitHub #97472: after soft nav to an already-prefetched
+  // route with dynamic metadata, hoistable <meta> tags from the prefetch /
+  // layout head must be released — not left mounted next to the destination's
+  // tags (e.g. both og:type=website and og:type=article).
+  it('replaces prefetched open graph tags instead of stacking them', async () => {
+    let page: Playwright.Page = null as any
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    await act(async () => {
+      await browser.elementByCss('input[data-link-accordion="/slow"]').click()
+    })
+
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/slow"]').click()
+      },
+      { includes: 'Slow content' }
+    )
+
+    await browser.waitForElementByCss('#slow-content')
+
+    await retry(async () => {
+      const ogTypes = await browser.eval(() =>
+        [...document.head.querySelectorAll('meta[property="og:type"]')].map(
+          (m) => (m as HTMLMetaElement).content
+        )
+      )
+      expect(ogTypes).toEqual(['article'])
+    })
+  })
+
   it('does not blank a complete static title when navigating to a prefetched route with a dynamic body', async () => {
     let page: Playwright.Page = null as any
     const browser = await next.browser('/', {


### PR DESCRIPTION
## What

After a client soft navigation to an already-prefetched route, the previous route's resolved metadata (`og:*`, `twitter:*`, `description`) could stay mounted in `<head>` next to the new route's tags. Hard loads were always clean. Most visible with cold Vercel `PRERENDER` prefetch responses.

## Why

`Head` uses `useDeferredValue` to show the prefetch/shell head first, then the final head. Hoistable metadata is inserted into `document.head` outside the React tree, so swapping the RSC tree without remounting does not release the old tags.

## How

Key the deferred head by whether the prefetch or final value is showing, so the prefetch → final transition remounts and clears prior hoistables.

## Test plan

- [x] `HEADLESS=true NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/e2e/app-dir/metadata-soft-nav-cache-components/metadata-soft-nav-cache-components.test.ts`
- [ ] Manual: deploy repro from #97472, soft-nav `/` → article while prefetch is cold, assert a single `meta[property="og:type"]`

Fixes #97472