### PR TITLE
test: Don't wait trying to load non-existing images

### DIFF
--- a/test/production/next-image-legacy/basic/basic.test.ts
+++ b/test/production/next-image-legacy/basic/basic.test.ts
@@ -1,8 +1,20 @@
 import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+import type { Page } from 'playwright'
 
 const emptyImage =
   'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+
+const browserOptions = {
+  beforePageLoad(page: Page) {
+    // Block all image requests to external hosts immediately so we are not introducing flakes due
+    // to long DNS timeouts
+    page.route(
+      /^https:\/\/(?:example\.com|arbitraryurl\.com|example\.vercel\.sh|www\.otherhost\.com)\//,
+      (route) => route.abort()
+    )
+  },
+}
 
 describe('Image Component Tests', () => {
   const { next } = nextTestSetup({
@@ -289,7 +301,7 @@ describe('Image Component Tests', () => {
   describe('SSR Image Component Tests', () => {
     let browser: Playwright
     beforeAll(async () => {
-      browser = await next.browser('/', { waitUntil: 'domcontentloaded' })
+      browser = await next.browser('/', browserOptions)
     })
     runTests(() => browser)
 
@@ -337,9 +349,7 @@ describe('Image Component Tests', () => {
       ).toBe('intrinsic')
     })
     it('should not pass config to custom loader prop', async () => {
-      const loaderBrowser = await next.browser('/loader-prop', {
-        waitUntil: 'domcontentloaded',
-      })
+      const loaderBrowser = await next.browser('/loader-prop', browserOptions)
       expect(
         await loaderBrowser.elementById('loader-prop-img').getAttribute('src')
       ).toBe('https://example.vercel.sh/success/foo.jpg?width=1024')
@@ -356,7 +366,7 @@ describe('Image Component Tests', () => {
   describe('Client-side Image Component Tests', () => {
     let browser: Playwright
     beforeAll(async () => {
-      browser = await next.browser('/', { waitUntil: 'domcontentloaded' })
+      browser = await next.browser('/', browserOptions)
       await browser.waitForElementByCss('#clientlink').click()
     })
     runTests(() => browser)
@@ -404,9 +414,7 @@ describe('Image Component Tests', () => {
   describe('SSR Lazy Loading Tests', () => {
     let browser: Playwright
     beforeAll(async () => {
-      browser = await next.browser('/lazy', {
-        waitUntil: 'domcontentloaded',
-      })
+      browser = await next.browser('/lazy', browserOptions)
     })
     lazyLoadingTests(() => browser)
   })
@@ -414,7 +422,7 @@ describe('Image Component Tests', () => {
   describe('Client-side Lazy Loading Tests', () => {
     let browser: Playwright
     beforeAll(async () => {
-      browser = await next.browser('/', { waitUntil: 'domcontentloaded' })
+      browser = await next.browser('/', browserOptions)
       await browser.waitForElementByCss('#lazylink').click()
       await new Promise((r) => setTimeout(r, 500))
     })

--- a/test/production/next-image-legacy/basic/basic.test.ts
+++ b/test/production/next-image-legacy/basic/basic.test.ts
@@ -289,7 +289,7 @@ describe('Image Component Tests', () => {
   describe('SSR Image Component Tests', () => {
     let browser: Playwright
     beforeAll(async () => {
-      browser = await next.browser('/')
+      browser = await next.browser('/', { waitUntil: 'domcontentloaded' })
     })
     runTests(() => browser)
 
@@ -337,7 +337,9 @@ describe('Image Component Tests', () => {
       ).toBe('intrinsic')
     })
     it('should not pass config to custom loader prop', async () => {
-      const loaderBrowser = await next.browser('/loader-prop')
+      const loaderBrowser = await next.browser('/loader-prop', {
+        waitUntil: 'domcontentloaded',
+      })
       expect(
         await loaderBrowser.elementById('loader-prop-img').getAttribute('src')
       ).toBe('https://example.vercel.sh/success/foo.jpg?width=1024')
@@ -354,7 +356,7 @@ describe('Image Component Tests', () => {
   describe('Client-side Image Component Tests', () => {
     let browser: Playwright
     beforeAll(async () => {
-      browser = await next.browser('/')
+      browser = await next.browser('/', { waitUntil: 'domcontentloaded' })
       await browser.waitForElementByCss('#clientlink').click()
     })
     runTests(() => browser)
@@ -402,7 +404,9 @@ describe('Image Component Tests', () => {
   describe('SSR Lazy Loading Tests', () => {
     let browser: Playwright
     beforeAll(async () => {
-      browser = await next.browser('/lazy')
+      browser = await next.browser('/lazy', {
+        waitUntil: 'domcontentloaded',
+      })
     })
     lazyLoadingTests(() => browser)
   })
@@ -410,7 +414,7 @@ describe('Image Component Tests', () => {
   describe('Client-side Lazy Loading Tests', () => {
     let browser: Playwright
     beforeAll(async () => {
-      browser = await next.browser('/')
+      browser = await next.browser('/', { waitUntil: 'domcontentloaded' })
       await browser.waitForElementByCss('#lazylink').click()
       await new Promise((r) => setTimeout(r, 500))
     })

--- a/test/production/next-image-legacy/custom-resolver/custom-resolver.test.ts
+++ b/test/production/next-image-legacy/custom-resolver/custom-resolver.test.ts
@@ -1,4 +1,16 @@
 import { nextTestSetup, type Playwright } from 'e2e-utils'
+import type { Page } from 'playwright'
+
+const browserOptions = {
+  beforePageLoad(page: Page) {
+    // Block all image requests to external hosts immediately so we are not introducing flakes due
+    // to long DNS timeouts
+    page.route(
+      /^https:\/\/(?:customresolver\.com|arbitraryurl\.com)\//,
+      (route) => route.abort()
+    )
+  },
+}
 
 describe('Custom Resolver Tests', () => {
   const { next } = nextTestSetup({
@@ -29,7 +41,7 @@ describe('Custom Resolver Tests', () => {
   describe('SSR Custom Loader Tests', () => {
     let browser: Playwright
     beforeAll(async () => {
-      browser = await next.browser('/', { waitUntil: 'domcontentloaded' })
+      browser = await next.browser('/', browserOptions)
     })
     runTests(() => browser)
   })
@@ -37,9 +49,7 @@ describe('Custom Resolver Tests', () => {
   describe('Client-side Custom Loader Tests', () => {
     let browser: Playwright
     beforeAll(async () => {
-      browser = await next.browser('/client-side', {
-        waitUntil: 'domcontentloaded',
-      })
+      browser = await next.browser('/client-side', browserOptions)
     })
     runTests(() => browser)
   })

--- a/test/production/next-image-legacy/custom-resolver/custom-resolver.test.ts
+++ b/test/production/next-image-legacy/custom-resolver/custom-resolver.test.ts
@@ -29,7 +29,7 @@ describe('Custom Resolver Tests', () => {
   describe('SSR Custom Loader Tests', () => {
     let browser: Playwright
     beforeAll(async () => {
-      browser = await next.browser('/')
+      browser = await next.browser('/', { waitUntil: 'domcontentloaded' })
     })
     runTests(() => browser)
   })
@@ -37,7 +37,9 @@ describe('Custom Resolver Tests', () => {
   describe('Client-side Custom Loader Tests', () => {
     let browser: Playwright
     beforeAll(async () => {
-      browser = await next.browser('/client-side')
+      browser = await next.browser('/client-side', {
+        waitUntil: 'domcontentloaded',
+      })
     })
     runTests(() => browser)
   })


### PR DESCRIPTION
These tests were timing out because they are suddenly waiting for a very long DNS timeout

- https://github.com/vercel/next.js/actions/runs/32116429187/job/95655640990?pr=90300
- https://github.com/vercel/next.js/actions/runs/32116429187/job/95655640961?pr=90300

https://vercel.slack.com/archives/C04KC8A53T7/p1787044110274679?thread_ts=1787011652.816539&cid=C04KC8A53T7