### PR TITLE
fix(next/image): don't wedge a transform when its requester aborts

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -57,6 +57,7 @@ const ANIMATABLE_TYPES = [WEBP, PNG, GIF]
 const BYPASS_TYPES = [SVG, ICO, ICNS, BMP, JXL, HEIC]
 const BLUR_IMG_SIZE = 8 // should match `next-image-loader`
 const BLUR_QUALITY = 70 // should match `next-image-loader`
+const INTERNAL_IMAGE_RESPONSE_TIMEOUT_MS = 30_000
 
 let _sharp: typeof import('sharp').default
 
@@ -973,25 +974,6 @@ export async function fetchExternalImage(
   return { buffer, contentType, cacheControl, etag }
 }
 
-/**
- * How long to wait for the internal response to finish streaming before giving
- * up on it. This only ever fires when something has gone wrong: the response is
- * a local file read that is already bounded by `maximumResponseBody`.
- */
-const INTERNAL_IMAGE_RESPONSE_TIMEOUT_MS = 30_000
-
-/**
- * `hasStreamed` settles on the mocked response's `finish`, `end` or `error`
- * event, and nothing guarantees that one of them ever fires — `send` can tear
- * the underlying file stream down without ending the response.
- *
- * That matters more than a single stuck request: `ResponseCache` coalesces
- * every request for a given transform onto one generator, and only releases the
- * key once that generator settles. A generator that never settles therefore
- * leaves its transform permanently unresponsive for every client, until the
- * process restarts. Bounding the wait keeps the key releasable and, just as
- * importantly, makes the failure show up in the logs.
- */
 async function waitForInternalResponse(
   hasStreamed: Promise<boolean>,
   href: string
@@ -1032,14 +1014,8 @@ export async function fetchInternalImage(
   ) => Promise<void>
 ): Promise<ImageUpstream> {
   try {
-    // Coerce HEAD to GET to avoid issues with the image optimizer
     const method = !_req.method || _req.method === 'HEAD' ? 'GET' : _req.method
 
-    // Deliberately not wired to `_req.socket`. This request is shared between
-    // every client waiting on the same transform, so it must not depend on any
-    // one of them staying connected: `send` watches `res.socket` through
-    // `on-finished`, and would destroy the shared stream as soon as the first
-    // requester hung up.
     const mocked = createRequestResponseMocks({
       url: href,
       method,

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -973,6 +973,53 @@ export async function fetchExternalImage(
   return { buffer, contentType, cacheControl, etag }
 }
 
+/**
+ * How long to wait for the internal response to finish streaming before giving
+ * up on it. This only ever fires when something has gone wrong: the response is
+ * a local file read that is already bounded by `maximumResponseBody`.
+ */
+const INTERNAL_IMAGE_RESPONSE_TIMEOUT_MS = 30_000
+
+/**
+ * `hasStreamed` settles on the mocked response's `finish`, `end` or `error`
+ * event, and nothing guarantees that one of them ever fires — `send` can tear
+ * the underlying file stream down without ending the response.
+ *
+ * That matters more than a single stuck request: `ResponseCache` coalesces
+ * every request for a given transform onto one generator, and only releases the
+ * key once that generator settles. A generator that never settles therefore
+ * leaves its transform permanently unresponsive for every client, until the
+ * process restarts. Bounding the wait keeps the key releasable and, just as
+ * importantly, makes the failure show up in the logs.
+ */
+async function waitForInternalResponse(
+  hasStreamed: Promise<boolean>,
+  href: string
+): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      hasStreamed,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => {
+          Log.error(
+            'internal image response never finished streaming for',
+            href
+          )
+          reject(
+            new ImageError(
+              504,
+              '"url" parameter is valid but internal response never finished streaming'
+            )
+          )
+        }, INTERNAL_IMAGE_RESPONSE_TIMEOUT_MS)
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
 export async function fetchInternalImage(
   href: string,
   _req: IncomingMessage,
@@ -988,15 +1035,19 @@ export async function fetchInternalImage(
     // Coerce HEAD to GET to avoid issues with the image optimizer
     const method = !_req.method || _req.method === 'HEAD' ? 'GET' : _req.method
 
+    // Deliberately not wired to `_req.socket`. This request is shared between
+    // every client waiting on the same transform, so it must not depend on any
+    // one of them staying connected: `send` watches `res.socket` through
+    // `on-finished`, and would destroy the shared stream as soon as the first
+    // requester hung up.
     const mocked = createRequestResponseMocks({
       url: href,
       method,
-      socket: _req.socket,
       maximumResponseBody,
     })
 
     await handleRequest(mocked.req, mocked.res, parseReqUrl(href))
-    await mocked.res.hasStreamed
+    await waitForInternalResponse(mocked.res.hasStreamed, href)
 
     if (!mocked.res.statusCode) {
       Log.error('image response failed for', href, mocked.res.statusCode)

--- a/test/unit/image-optimizer/fetch-internal-image.test.ts
+++ b/test/unit/image-optimizer/fetch-internal-image.test.ts
@@ -156,15 +156,11 @@ describe('fetchInternalImage', () => {
   })
 
   describe('when the requester goes away', () => {
-    // The internal request is shared by every client waiting on the same
-    // transform, so it must survive any single one of them disconnecting.
     it('completes even though the requesting socket is already closed', async () => {
       const size = 4 * 1024 * 1024
       const filePath = join(tmpdir(), `fetch-internal-image-disconnect.bin`)
       await fs.writeFile(filePath, Buffer.alloc(size, 1))
 
-      // `send` decides a response is done by watching the socket through
-      // `on-finished`; a disconnected client reports `writable: false`.
       const closedSocket = Object.assign(new EventEmitter(), {
         writable: false,
       })
@@ -197,8 +193,6 @@ describe('fetchInternalImage', () => {
       }
     })
 
-    // Safety net: whatever the reason, the promise has to settle, because
-    // `ResponseCache` only releases the coalesced cache key once it does.
     it('rejects rather than hanging when the response never finishes', async () => {
       jest.useFakeTimers()
 
@@ -211,7 +205,6 @@ describe('fetchInternalImage', () => {
             res.statusCode = 200
             res.getHeader = jest.fn(() => 'image/jpeg')
             res.write(Buffer.alloc(16))
-            // Deliberately never calls `res.end()`.
           }
         )
 

--- a/test/unit/image-optimizer/fetch-internal-image.test.ts
+++ b/test/unit/image-optimizer/fetch-internal-image.test.ts
@@ -3,7 +3,12 @@ import {
   fetchInternalImage,
   ImageError,
 } from 'next/dist/server/image-optimizer'
+import { serveStatic } from 'next/dist/server/serve-static'
 import type { IncomingMessage, ServerResponse } from 'http'
+import { EventEmitter } from 'events'
+import { promises as fs } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 
 describe('fetchInternalImage', () => {
   describe('response size limit', () => {
@@ -147,6 +152,84 @@ describe('fetchInternalImage', () => {
 
       expect(result.buffer).toBeInstanceOf(Buffer)
       expect(result.buffer.length).toBe(maximumResponseBody)
+    })
+  })
+
+  describe('when the requester goes away', () => {
+    // The internal request is shared by every client waiting on the same
+    // transform, so it must survive any single one of them disconnecting.
+    it('completes even though the requesting socket is already closed', async () => {
+      const size = 4 * 1024 * 1024
+      const filePath = join(tmpdir(), `fetch-internal-image-disconnect.bin`)
+      await fs.writeFile(filePath, Buffer.alloc(size, 1))
+
+      // `send` decides a response is done by watching the socket through
+      // `on-finished`; a disconnected client reports `writable: false`.
+      const closedSocket = Object.assign(new EventEmitter(), {
+        writable: false,
+      })
+      const mockReq = {
+        method: 'GET',
+        socket: closedSocket,
+      } as unknown as IncomingMessage
+      const mockRes = {} as ServerResponse
+
+      let hungTimer: ReturnType<typeof setTimeout> | undefined
+      try {
+        const result = await Promise.race([
+          fetchInternalImage(
+            '/test-image.jpg',
+            mockReq,
+            mockRes,
+            50_000_000,
+            (req, res) => serveStatic(req, res, filePath)
+          ),
+          new Promise((resolve) => {
+            hungTimer = setTimeout(() => resolve('hung'), 5_000)
+          }),
+        ])
+
+        expect(result).not.toBe('hung')
+        expect((result as { buffer: Buffer }).buffer.length).toBe(size)
+      } finally {
+        if (hungTimer) clearTimeout(hungTimer)
+        await fs.unlink(filePath).catch(() => {})
+      }
+    })
+
+    // Safety net: whatever the reason, the promise has to settle, because
+    // `ResponseCache` only releases the coalesced cache key once it does.
+    it('rejects rather than hanging when the response never finishes', async () => {
+      jest.useFakeTimers()
+
+      try {
+        const mockReq = { method: 'GET' } as IncomingMessage
+        const mockRes = {} as ServerResponse
+
+        const handleRequest = jest.fn(
+          async (_req: IncomingMessage, res: any) => {
+            res.statusCode = 200
+            res.getHeader = jest.fn(() => 'image/jpeg')
+            res.write(Buffer.alloc(16))
+            // Deliberately never calls `res.end()`.
+          }
+        )
+
+        const pending = fetchInternalImage(
+          '/test-image.jpg',
+          mockReq,
+          mockRes,
+          50_000_000,
+          handleRequest
+        ).catch((e) => e)
+
+        await jest.advanceTimersByTimeAsync(30_000)
+
+        const error = await pending
+        expect(error).toBeInstanceOf(ImageError)
+      } finally {
+        jest.useRealTimers()
+      }
     })
   })
 })


### PR DESCRIPTION
### What

A client aborting a cold `/_next/image` request leaves that exact transform permanently unresponsive for every other client, on self-hosted `next start`, with nothing logged, until the process restarts.

Two changes:

1. **Stop wiring the coalesced internal request to the requester's socket.** `fetchInternalImage` builds its mocks with `socket: _req.socket`. `send` watches `res.socket` through `on-finished`, so when that one client disconnects mid-stream, `send` declares the response finished and destroys the file read stream without ever ending the mock. `hasStreamed` then never settles. Since `ResponseCache` coalesces every request for that cache key onto this one generator and only releases the key in a `finally`, the key stays pending for the lifetime of the process.

2. **Bound the wait on `hasStreamed`.** Even with (1), nothing in the type system or the call chain guarantees the mock is ever ended, and the failure mode is the worst kind: a silent, permanent, per-key outage with no timeout, no log and no recovery short of a restart. A 30 s ceiling makes the generator always settle, so the cache key is always released, and logs the URL when it fires. It cannot trigger in normal operation. the internal response is a local file read already bounded by `maximumResponseBody`.

### Why

(1) removes the cause we know about. (2) contains the class: any future path that fails to end the mock degrades to one failed request plus a log line, instead of a transform that is dead for everyone until someone restarts the server. The reporter of #96538 listed both directions; only the first has been proposed so far.

### Tests

`test/unit/image-optimizer/fetch-internal-image.test.ts`:

- `completes even though the requesting socket is already closed` serves a 4 MB file through the real `serveStatic` with a socket reporting `writable: false`, which is what `send` reads to decide the response is done. Fails on `canary` by hanging until the race's 5 s guard fires.
- `rejects rather than hanging when the response never finishes` a `handleRequest` that writes but never calls `end()`. Asserts the promise settles rather than hanging forever.

```
Test Suites: 11 passed, 11 total
Tests:       139 passed, 139 total
```

### Verification

Beyond the unit tests, end to end on `next start` with `next@16.3.1`: sweeping 84 cold cache keys (14 widths x 6 qualities), aborting each mid-flight and then re-requesting the same URL as a fresh client.

| | permanently hung |
| --- | --- |
| stock, local `/public` images | 6 / 84 |
| stock, external images (`remotePatterns`) | 0 / 84 |
| with change (1), local images | 0 / 84 |

The dead keys all serve again after a restart, confirming this is process state rather than the disk cache. Reproduction, including the negative control: https://github.com/Neeptossss/next-image-abort-hang reported with the production symptoms in #97489.

### Relationship to #96542

#96542 proposes change (1) and reaches the same conclusion independently; the socket-close test here uses the same `writable: false` technique, which is the natural way to drive `send` down that path. This PR adds (2) and the never-finishes test on top. If you would rather take #96542 and handle the safety net separately, that works just as well. happy to close this or rebase it down to only (2).

Fixes #97489
