### PR TITLE
Preserve dynamic params in standalone fallback shells

### DIFF
--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -1474,9 +1474,16 @@ export function createAppPageEntrypoint({
                 )
               : null
 
-          const fallbackRouteParamsForRender =
-            placeholderFallbackRouteParams &&
-            placeholderFallbackRouteParams.length > 0
+          const isProductionFallbackShell =
+            isProduction && getRequestMeta(req, 'renderFallbackShell')
+
+          const fallbackRouteParamsForRender = isProductionFallbackShell
+            ? // The deployment requested the route's generic fallback shell,
+              // so every dynamic param must remain opaque. Placeholder values
+              // only describe params encoded in this particular pathname.
+              prerenderInfo?.fallbackRouteParams
+            : placeholderFallbackRouteParams &&
+                placeholderFallbackRouteParams.length > 0
               ? placeholderFallbackRouteParams
               : prerenderInfo?.fallbackRouteParams
 
@@ -1506,7 +1513,7 @@ export function createAppPageEntrypoint({
             // In production or when debugging the static shell for a
             // non-prerendered URL, use the prerender manifest's fallback route
             // params which correctly identifies which params are unknown.
-            ((isProduction && getRequestMeta(req, 'renderFallbackShell')) ||
+            (isProductionFallbackShell ||
               hasPlaceholderFallbackRouteParams ||
               (isDebugStaticShell && !isPrerendered)) &&
             fallbackRouteParamsForRender

--- a/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/@slot/[...catchAll]/loading.tsx
+++ b/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/@slot/[...catchAll]/loading.tsx
@@ -1,0 +1,3 @@
+export default function SlotLoading() {
+  return <p id="slot-loading">/[...catchAll]</p>
+}

--- a/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/@slot/[...catchAll]/page.tsx
+++ b/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/@slot/[...catchAll]/page.tsx
@@ -1,0 +1,12 @@
+export default async function SlotPage({
+  params,
+}: {
+  params: Promise<{ catchAll: string[] }>
+}) {
+  return (
+    <>
+      <p id="slot-page">/@slot/[...catchAll]</p>
+      <p id="slot-params">{JSON.stringify(await params)}</p>
+    </>
+  )
+}

--- a/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/@slot/default.tsx
+++ b/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/@slot/default.tsx
@@ -1,0 +1,3 @@
+export default function SlotDefault() {
+  return null
+}

--- a/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/@slot/nested/[group]/[...catchAll]/loading.tsx
+++ b/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/@slot/nested/[group]/[...catchAll]/loading.tsx
@@ -1,0 +1,3 @@
+export default function NestedSlotLoading() {
+  return <p id="nested-slot-loading">/@slot/nested/[group]/[...catchAll]</p>
+}

--- a/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/@slot/nested/[group]/[...catchAll]/page.tsx
+++ b/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/@slot/nested/[group]/[...catchAll]/page.tsx
@@ -1,0 +1,12 @@
+export default async function NestedSlotPage({
+  params,
+}: {
+  params: Promise<{ group: string; catchAll: string[] }>
+}) {
+  return (
+    <>
+      <p id="nested-slot-page">/@slot/nested/[group]/[...catchAll]</p>
+      <p id="nested-slot-params">{JSON.stringify(await params)}</p>
+    </>
+  )
+}

--- a/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/default.tsx
+++ b/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/layout.tsx
+++ b/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/layout.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+
+export default function RootLayout({
+  children,
+  slot,
+}: {
+  children: React.ReactNode
+  slot: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <Suspense>
+          <div id="children-slot">{children}</div>
+          <div id="parallel-slot">{slot}</div>
+        </Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/nested/[group]/items/[item]/loading.tsx
+++ b/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/nested/[group]/items/[item]/loading.tsx
@@ -1,0 +1,3 @@
+export default function NestedLoading() {
+  return <p id="nested-loading">/nested/[group]/items/[item]</p>
+}

--- a/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/nested/[group]/items/[item]/page.tsx
+++ b/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/nested/[group]/items/[item]/page.tsx
@@ -1,0 +1,12 @@
+export default async function NestedPage({
+  params,
+}: {
+  params: Promise<{ group: string; item: string }>
+}) {
+  return (
+    <>
+      <p id="nested-page">/nested/[group]/items/[item]</p>
+      <p id="nested-params">{JSON.stringify(await params)}</p>
+    </>
+  )
+}

--- a/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/postpone/isr/[slug]/loading.tsx
+++ b/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/postpone/isr/[slug]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="loading">/postpone/isr/[slug]</p>
+}

--- a/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/postpone/isr/[slug]/page.tsx
+++ b/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/app/postpone/isr/[slug]/page.tsx
@@ -1,0 +1,12 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  return (
+    <>
+      <p id="page">/postpone/isr/[slug]</p>
+      <p id="params">{JSON.stringify(await params)}</p>
+    </>
+  )
+}

--- a/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/next.config.js
+++ b/test/production/app-dir/standalone-fallback-shell-parallel-routes/fixtures/default/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  cacheComponents: true,
+  output: 'standalone',
+  outputFileTracingRoot: process.cwd(),
+  outputFileTracingIncludes: {
+    '/*': ['node_modules/@swc/helpers/**/*'],
+  },
+}

--- a/test/production/app-dir/standalone-fallback-shell-parallel-routes/standalone-fallback-shell-parallel-routes.test.ts
+++ b/test/production/app-dir/standalone-fallback-shell-parallel-routes/standalone-fallback-shell-parallel-routes.test.ts
@@ -1,0 +1,171 @@
+import fs from 'node:fs/promises'
+import type { ChildProcess } from 'node:child_process'
+import { join } from 'node:path'
+import cheerio from 'cheerio'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  fetchViaHTTP,
+  findPort,
+  initNextServerScript,
+  killApp,
+  withInvocationId,
+} from 'next-test-utils'
+
+describe('standalone fallback shells with parallel routes', () => {
+  const { next } = nextTestSetup({
+    files: join(__dirname, 'fixtures/default'),
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  let server: ChildProcess
+  let appPort: number
+
+  beforeAll(async () => {
+    process.env.NOW_BUILDER = '1'
+    process.env.NEXT_PRIVATE_TEST_HEADERS = '1'
+
+    const { exitCode } = await next.build()
+    if (exitCode !== 0) {
+      throw new Error(`next build failed with exit code ${exitCode}`)
+    }
+
+    const serverFilePath = join(next.testDir, '.next/standalone/server.js')
+    await fs.writeFile(
+      serverFilePath,
+      (await fs.readFile(serverFilePath, 'utf8')).replace(
+        'port:',
+        'minimalMode: true, port:'
+      )
+    )
+
+    appPort = await findPort()
+    server = await initNextServerScript(
+      serverFilePath,
+      /- Local:/,
+      {
+        ...process.env,
+        ...next.env,
+        __NEXT_TEST_MODE: 'e2e',
+        PORT: `${appPort}`,
+      },
+      undefined,
+      { cwd: next.testDir }
+    )
+  })
+
+  afterAll(async () => {
+    delete process.env.NOW_BUILDER
+    delete process.env.NEXT_PRIVATE_TEST_HEADERS
+    if (server) await killApp(server)
+  })
+
+  async function fetchGenericFallbackShell(
+    pathname: string,
+    matchedPath: string
+  ) {
+    // These private headers model the request a platform adapter sends when it
+    // asks a standalone server for the generic shell of a dynamic route.
+    return fetchViaHTTP(
+      appPort,
+      pathname,
+      undefined,
+      withInvocationId({
+        headers: {
+          'x-matched-path': matchedPath,
+          'x-now-route-matches': '',
+        },
+      })
+    )
+  }
+
+  it('renders ordinary concrete params normally', async () => {
+    const response = await fetchViaHTTP(appPort, '/postpone/isr/concrete')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-nextjs-postponed')).toBeNull()
+
+    const $ = cheerio.load(await response.text())
+    expect($('#page').text()).toBe('/postpone/isr/[slug]')
+    expect($('#params').text()).toBe('{"slug":"concrete"}')
+    expect($('#slot-page').text()).toBe('/@slot/[...catchAll]')
+    expect($('#slot-params').text()).toBe(
+      '{"catchAll":["postpone","isr","concrete"]}'
+    )
+  })
+
+  it('keeps all unknown sibling params suspended in a generic fallback shell', async () => {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const response = await fetchGenericFallbackShell(
+        '/postpone/isr/[slug]',
+        '/postpone/isr/[slug]'
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('x-nextjs-postponed')).toBe('1')
+
+      const html = await response.text()
+      expect(html).not.toContain('</html>')
+      expect(html).not.toContain('%%drp:')
+
+      const $ = cheerio.load(html)
+      expect({
+        page: $('#page').text(),
+        params: $('#params').text(),
+        slotPage: $('#slot-page').text(),
+        slotParams: $('#slot-params').text(),
+      }).toEqual({
+        page: '',
+        params: '',
+        slotPage: '',
+        slotParams: '',
+      })
+      expect($('#loading').text()).toBe('/postpone/isr/[slug]')
+      expect($('#slot-loading').text()).toBe('/[...catchAll]')
+    }
+  })
+
+  it('keeps all unknown nested params suspended in a generic fallback shell', async () => {
+    const response = await fetchGenericFallbackShell(
+      '/nested/[group]/items/[item]',
+      '/nested/[group]/items/[item]'
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-nextjs-postponed')).toBe('1')
+
+    const $ = cheerio.load(await response.text())
+    expect({
+      page: $('#nested-page').text(),
+      params: $('#nested-params').text(),
+      slotPage: $('#nested-slot-page').text(),
+      slotParams: $('#nested-slot-params').text(),
+    }).toEqual({
+      page: '',
+      params: '',
+      slotPage: '',
+      slotParams: '',
+    })
+    expect($('#nested-loading').text()).toBe('/nested/[group]/items/[item]')
+    expect($('#nested-slot-loading').text()).toBe(
+      '/@slot/nested/[group]/[...catchAll]'
+    )
+  })
+
+  it('renders ordinary nested concrete params normally', async () => {
+    const response = await fetchViaHTTP(appPort, '/nested/team/items/widget')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-nextjs-postponed')).toBeNull()
+
+    const $ = cheerio.load(await response.text())
+    expect($('#nested-page').text()).toBe('/nested/[group]/items/[item]')
+    expect($('#nested-params').text()).toBe('{"group":"team","item":"widget"}')
+    expect($('#nested-slot-page').text()).toBe(
+      '/@slot/nested/[group]/[...catchAll]'
+    )
+    expect($('#nested-slot-params').text()).toBe(
+      '{"group":"team","catchAll":["items","widget"]}'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Use the route's complete fallback-param set when a production deployment requests a generic fallback shell.

For a route with dynamic segments and a sibling parallel slot, pathname-derived placeholder params describe only the concrete request path. Reusing that partial set while producing a generic fallback shell can make another dynamic param appear concrete and leak the wrong slot content into the shell.

Detect the production `renderFallbackShell` request once and use `prerenderInfo.fallbackRouteParams` for the render. The generated production suite compares generic sibling and nested shells with ordinary concrete controls.

## Verification

- `pnpm test-start-turbo test/production/app-dir/standalone-fallback-shell-parallel-routes/standalone-fallback-shell-parallel-routes.test.ts` (4/4)
- `pnpm test-start-webpack test/production/app-dir/standalone-fallback-shell-parallel-routes/standalone-fallback-shell-parallel-routes.test.ts` (4/4)

<!-- NEXT_JS_LLM -->
