### PR TITLE
Fix webpack client references for hash filenames

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -319,7 +319,7 @@ export class ClientReferenceManifestPlugin {
         let resource =
           mod.type === 'css/mini-extract'
             ? mod.identifier().slice(mod.identifier().lastIndexOf('!') + 1)
-            : mod.resource
+            : mod.resourceResolveData?.path || mod.resource
 
         if (!resource) {
           return

--- a/test/e2e/app-dir/webpack-hash-client-filename/app/counter#client.tsx
+++ b/test/e2e/app-dir/webpack-hash-client-filename/app/counter#client.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function Counter() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <button id="counter" onClick={() => setCount((value) => value + 1)}>
+      count: {count}
+    </button>
+  )
+}

--- a/test/e2e/app-dir/webpack-hash-client-filename/app/layout.tsx
+++ b/test/e2e/app-dir/webpack-hash-client-filename/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/webpack-hash-client-filename/app/page.tsx
+++ b/test/e2e/app-dir/webpack-hash-client-filename/app/page.tsx
@@ -1,0 +1,5 @@
+import Counter from './counter#client'
+
+export default function Page() {
+  return <Counter />
+}

--- a/test/e2e/app-dir/webpack-hash-client-filename/next.config.js
+++ b/test/e2e/app-dir/webpack-hash-client-filename/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/webpack-hash-client-filename/webpack-hash-client-filename.test.ts
+++ b/test/e2e/app-dir/webpack-hash-client-filename/webpack-hash-client-filename.test.ts
@@ -1,0 +1,16 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('webpack-hash-client-filename', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('renders and hydrates a Client Component whose filename contains #', async () => {
+    const browser = await next.browser('/')
+
+    expect(await browser.elementByCss('#counter').text()).toBe('count: 0')
+    await browser.elementByCss('#counter').click()
+
+    expect(await browser.elementByCss('#counter').text()).toBe('count: 1')
+  })
+})


### PR DESCRIPTION
## Summary

Build Webpack Client Reference Manifest keys from `resourceResolveData.path` when available, falling back to `module.resource`.

Webpack treats `#` specially while resolving requests. For a Client Component whose filename contains `#`, the Flight loader and manifest plugin can derive different module keys, causing the App Router build or hydration to miss the client reference.

Use Webpack's resolved filesystem path, matching the key used by the loader. The fixture renders and hydrates a stateful Client Component named `counter#client.tsx`.

## Verification

- `test/e2e/app-dir/webpack-hash-client-filename/webpack-hash-client-filename.test.ts` in dev/start with Webpack
- The same test in dev/start with Turbopack as a control

<!-- NEXT_JS_LLM -->
