### PR TITLE
docs: clarify root layout creation with Turbopack

### DIFF
--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -213,7 +213,7 @@ Both `layout.tsx` and `page.tsx` will be rendered when the user visits the root 
 
 > **Good to know**:
 >
-> - If you forget to create the root layout, Next.js will automatically create this file when running the development server with `next dev`.
+> - When using webpack, Next.js will automatically create the root layout if you forget it when running `next dev`. [Turbopack does not support automatic root layout creation](/docs/app/api-reference/turbopack#framework-and-react-features), so you must create the file manually.
 > - You can optionally use a [`src` folder](/docs/app/api-reference/file-conventions/src-folder) in the root of your project to separate your application's code from configuration files.
 
 </AppOnly>


### PR DESCRIPTION
## Summary

Qualify the installation guide's claim that `next dev` creates a missing root layout.

Webpack development performs that recovery, while the default Turbopack development path does not. The Turbopack reference already documents the limitation, but the installation guide currently makes the promise unconditionally.

State that the automatic creation applies to Webpack and link to the existing Turbopack limitation.

## Verification

- Prettier, ESLint, and `git diff --check`

<!-- NEXT_JS_LLM -->
