### PR TITLE
test(router): add unit tests for redirect helpers and router signals

### DIFF
--- a/packages/next/src/client/components/is-next-router-error.test.ts
+++ b/packages/next/src/client/components/is-next-router-error.test.ts
@@ -1,14 +1,74 @@
+import { forbidden } from './forbidden'
 import { isNextRouterError } from './is-next-router-error'
 import { notFound } from './not-found'
+import { permanentRedirect, redirect } from './redirect'
+import { unauthorized } from './unauthorized'
 
 describe('isNextRouterError', () => {
-  it('returns true for a navigation error', () => {
-    let caught
+  const origAuthInterrupts = process.env.__NEXT_EXPERIMENTAL_AUTH_INTERRUPTS
+
+  afterEach(() => {
+    process.env.__NEXT_EXPERIMENTAL_AUTH_INTERRUPTS = origAuthInterrupts
+  })
+
+  it('returns true for a notFound error', () => {
+    let caught: unknown
     try {
       notFound()
     } catch (error) {
       caught = error
     }
     expect(isNextRouterError(caught)).toBe(true)
+  })
+
+  it('returns true for a redirect error', () => {
+    let caught: unknown
+    try {
+      redirect('/target')
+    } catch (error) {
+      caught = error
+    }
+    expect(isNextRouterError(caught)).toBe(true)
+  })
+
+  it('returns true for a permanentRedirect error', () => {
+    let caught: unknown
+    try {
+      permanentRedirect('/target')
+    } catch (error) {
+      caught = error
+    }
+    expect(isNextRouterError(caught)).toBe(true)
+  })
+
+  it('returns true for forbidden and unauthorized errors when authInterrupts enabled', () => {
+    process.env.__NEXT_EXPERIMENTAL_AUTH_INTERRUPTS = 'true'
+
+    let caughtForbidden: unknown
+    try {
+      forbidden()
+    } catch (error) {
+      caughtForbidden = error
+    }
+    expect(isNextRouterError(caughtForbidden)).toBe(true)
+
+    let caughtUnauthorized: unknown
+    try {
+      unauthorized()
+    } catch (error) {
+      caughtUnauthorized = error
+    }
+    expect(isNextRouterError(caughtUnauthorized)).toBe(true)
+  })
+
+  it('returns false for generic errors and non-error values', () => {
+    expect(isNextRouterError(new Error('general error'))).toBe(false)
+    expect(isNextRouterError(new TypeError('type error'))).toBe(false)
+    expect(isNextRouterError(null)).toBe(false)
+    expect(isNextRouterError(undefined)).toBe(false)
+    expect(isNextRouterError('NEXT_REDIRECT')).toBe(false)
+    expect(isNextRouterError({ digest: 'invalid;digest' })).toBe(false)
+    expect(isNextRouterError({})).toBe(false)
+    expect(isNextRouterError(123)).toBe(false)
   })
 })

--- a/packages/next/src/client/components/redirect.test.ts
+++ b/packages/next/src/client/components/redirect.test.ts
@@ -1,14 +1,81 @@
-import { getURLFromRedirectError, redirect } from './redirect'
+import {
+  getRedirectStatusCodeFromError,
+  getRedirectTypeFromError,
+  getURLFromRedirectError,
+  permanentRedirect,
+  redirect,
+} from './redirect'
 import { isRedirectError } from './redirect-error'
+import { RedirectStatusCode } from './redirect-status-code'
 
-describe('test', () => {
-  it('should throw a redirect error', () => {
+describe('redirect', () => {
+  it('should throw a redirect error for temporary redirect', () => {
     try {
       redirect('/dashboard')
       throw new Error('did not throw')
     } catch (err: any) {
       expect(isRedirectError(err)).toBeTruthy()
       expect(getURLFromRedirectError(err)).toEqual('/dashboard')
+      expect(getRedirectTypeFromError(err)).toEqual('replace')
+      expect(getRedirectStatusCodeFromError(err)).toEqual(
+        RedirectStatusCode.TemporaryRedirect
+      )
     }
+  })
+
+  it('should support explicit redirect type push', () => {
+    try {
+      redirect('/profile', 'push')
+      throw new Error('did not throw')
+    } catch (err: any) {
+      expect(isRedirectError(err)).toBeTruthy()
+      expect(getURLFromRedirectError(err)).toEqual('/profile')
+      expect(getRedirectTypeFromError(err)).toEqual('push')
+      expect(getRedirectStatusCodeFromError(err)).toEqual(
+        RedirectStatusCode.TemporaryRedirect
+      )
+    }
+  })
+
+  it('should throw a redirect error for permanentRedirect', () => {
+    try {
+      permanentRedirect('/new-home')
+      throw new Error('did not throw')
+    } catch (err: any) {
+      expect(isRedirectError(err)).toBeTruthy()
+      expect(getURLFromRedirectError(err)).toEqual('/new-home')
+      expect(getRedirectTypeFromError(err)).toEqual('replace')
+      expect(getRedirectStatusCodeFromError(err)).toEqual(
+        RedirectStatusCode.PermanentRedirect
+      )
+    }
+  })
+
+  it('should correctly parse URLs containing semicolons or query parameters', () => {
+    const complexUrl = '/search?q=foo;bar=baz;filter=true'
+    try {
+      redirect(complexUrl)
+      throw new Error('did not throw')
+    } catch (err: any) {
+      expect(isRedirectError(err)).toBeTruthy()
+      expect(getURLFromRedirectError(err)).toEqual(complexUrl)
+    }
+  })
+
+  it('should return null for getURLFromRedirectError on non-redirect error', () => {
+    const genericError = new Error('regular error')
+    expect(getURLFromRedirectError(genericError)).toBeNull()
+    expect(getURLFromRedirectError(null)).toBeNull()
+    expect(getURLFromRedirectError(undefined)).toBeNull()
+  })
+
+  it('should throw when extracting redirect type or status code from non-redirect error', () => {
+    const genericError: any = new Error('regular error')
+    expect(() => getRedirectTypeFromError(genericError)).toThrow(
+      'Not a redirect error'
+    )
+    expect(() => getRedirectStatusCodeFromError(genericError)).toThrow(
+      'Not a redirect error'
+    )
   })
 })


### PR DESCRIPTION
### What?

Adds unit test coverage for router signal errors and redirection helpers in `packages/next/src/client/components/`:
- `packages/next/src/client/components/redirect.test.ts`
- `packages/next/src/client/components/is-next-router-error.test.ts`

### Why?

Previously, `redirect.test.ts` and `is-next-router-error.test.ts` only tested a single basic scenario. This PR expands unit test coverage to ensure resilience for:
1. `permanentRedirect()` status code (`308`) vs `redirect()` status code (`307`).
2. Explicit redirect types (`push` vs default `replace`).
3. Handling URLs with complex query parameters and semicolons.
4. Parsing status codes, types, and URLs from redirect error digests, including fallback behavior for non-redirect errors.
5. Signal error detection in `isNextRouterError` across `notFound()`, `redirect()`, `permanentRedirect()`, `forbidden()`, and `unauthorized()`, while correctly rejecting non-error values and generic errors.

### How?

Expanded the Jest unit test suites for `redirect.test.ts` and `is-next-router-error.test.ts`. All 11 tests pass with 0 ESLint and Prettier warnings.
