### PR TITLE
fix(third-parties): add SSR window check to sendGAEvent and sendGTMEvent

### DIFF
--- a/packages/third-parties/src/google/ga.tsx
+++ b/packages/third-parties/src/google/ga.tsx
@@ -57,6 +57,10 @@ export function GoogleAnalytics(props: GAParams) {
 }
 
 export function sendGAEvent(..._args: Object[]) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
   if (currDataLayerName === undefined) {
     console.warn(`@next/third-parties: GA has not been initialized`)
     return

--- a/packages/third-parties/src/google/gtm.tsx
+++ b/packages/third-parties/src/google/gtm.tsx
@@ -75,6 +75,10 @@ export function GoogleTagManager(props: GTMParams) {
 }
 
 export const sendGTMEvent = (data: Object, dataLayerName?: string) => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
   // special case if we are sending events before GTM init and we have custom dataLayerName
   const dataLayer = dataLayerName || currDataLayerName
   // define dataLayer so we can still queue up events before GTM init


### PR DESCRIPTION
### What?

Adds SSR safety checks (`typeof window === 'undefined'`) to `sendGAEvent` and `sendGTMEvent` in `@next/third-parties/google`.

### Why?

If `sendGAEvent` or `sendGTMEvent` is imported and called during Server-Side Rendering (SSR) or within a shared utility executing on the server, attempting to access `window` throws a runtime exception:
`ReferenceError: window is not defined`.

### How?

Added `if (typeof window === 'undefined') return` guards before accessing the global `window` object in:
- `packages/third-parties/src/google/ga.tsx`
- `packages/third-parties/src/google/gtm.tsx`
