### PR TITLE
build: show non-200 prerender statuses

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3460,6 +3460,7 @@ export default async function build(
                 hasEmptyStaticShell,
                 hasPostponed,
                 hasStaticRsc,
+                prerenderStatus,
               } = routeResult ?? {}
 
               const cacheControl = getCacheControl(
@@ -3482,6 +3483,11 @@ export default async function build(
                 hasPostponed,
                 hasEmptyStaticShell,
                 initialCacheControl: cacheControl,
+                prerenderStatus:
+                  cacheControl.revalidate !== 0 &&
+                  route.pathname !== UNDERSCORE_NOT_FOUND_ROUTE
+                    ? prerenderStatus
+                    : undefined,
               })
 
               // update the page (eg /blog/[slug]) to also have the postpone metadata
@@ -3748,6 +3754,11 @@ export default async function build(
                     // if PPR is turned on and the route contains a dynamic segment,
                     // we assume it'll be partially prerendered
                     hasPostponed: isRoutePPREnabled,
+                    prerenderStatus:
+                      cacheControl.revalidate !== 0 &&
+                      route.pathname !== UNDERSCORE_NOT_FOUND_ROUTE
+                        ? routeResult?.prerenderStatus
+                        : undefined,
                   })
                 }
 

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -218,6 +218,8 @@ export interface PageInfo {
   hasEmptyStaticShell?: boolean
   hasPostponed?: boolean
   isDynamicAppRoute?: boolean
+  /** The HTTP status produced while prerendering this route. */
+  prerenderStatus?: number
 }
 
 export type PageInfos = Map<string, PageInfo>
@@ -262,6 +264,11 @@ function getTreeViewSymbol(
   }
 
   return 'ƒ'
+}
+
+function getPrerenderStatusAnnotation(pageInfo: PageInfo | undefined): string {
+  const status = pageInfo?.prerenderStatus
+  return status !== undefined && status !== 200 ? ` [status: ${status}]` : ''
 }
 
 export interface RoutesUsingEdgeRuntime {
@@ -389,6 +396,9 @@ export async function printTreeView(
       const hasChildRoutes = Boolean(pageInfo?.ssgPageRoutes?.length)
 
       const displayPath = getTreeViewDisplayPath(item)
+      const prerenderStatusAnnotation = hasChildRoutes
+        ? ''
+        : getPrerenderStatusAnnotation(pageInfo)
 
       if (hasGSPAndRevalidateZero.has(item)) {
         usedSymbols.add('ƒ')
@@ -414,7 +424,7 @@ export async function printTreeView(
       }
 
       messages.push([
-        `${border} ${hasChildRoutes ? ' ' : symbol} ${displayPath}${
+        `${border} ${hasChildRoutes ? ' ' : symbol} ${displayPath}${prerenderStatusAnnotation}${
           totalDuration > MIN_DURATION
             ? ` (${getPrettyDuration(totalDuration)})`
             : ''
@@ -481,12 +491,15 @@ export async function printTreeView(
             const routePageInfo = pageInfos.get(route) ?? pageInfo
             const routeSymbol = getTreeViewSymbol(route, routePageInfo)
             usedSymbols.add(routeSymbol)
+            const childStatusAnnotation = getPrerenderStatusAnnotation(
+              pageInfos.get(route)
+            )
 
             const initialCacheControl =
               pageInfos.get(route)?.initialCacheControl
 
             messages.push([
-              `${contSymbol} ${innerSymbol} ${routeSymbol} ${route}${
+              `${contSymbol} ${innerSymbol} ${routeSymbol} ${route}${childStatusAnnotation}${
                 duration > MIN_DURATION
                   ? ` (${getPrettyDuration(duration)})`
                   : ''

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -848,6 +848,9 @@ async function exportAppImpl(
       if (typeof result.metadata !== 'undefined') {
         info.metadata = result.metadata
       }
+      if (typeof result.prerenderStatus !== 'undefined') {
+        info.prerenderStatus = result.prerenderStatus
+      }
 
       if (typeof result.hasEmptyStaticShell !== 'undefined') {
         info.hasEmptyStaticShell = result.hasEmptyStaticShell

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -252,6 +252,9 @@ export async function exportAppPage(
             segmentPaths: meta.segmentPaths,
             prefetchHints: meta.prefetchHints,
           },
+      // Keep the status available to build diagnostics even when deployment
+      // metadata is filtered in environments without Next.js support.
+      prerenderStatus: status,
       hasEmptyStaticShell: Boolean(postponed) && html === '',
       hasPostponed: Boolean(postponed),
       hasPendingUi: hasPendingUi ?? false,

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -69,6 +69,8 @@ export type ExportRouteResult =
   | {
       cacheControl: CacheControl
       metadata?: Partial<RouteMetadata>
+      /** The HTTP status produced while prerendering this route. */
+      prerenderStatus?: number
       ssgNotFound?: boolean
       hasEmptyStaticShell?: boolean
       hasPostponed?: boolean
@@ -144,6 +146,10 @@ export type ExportAppResult = {
        * The metadata for the page.
        */
       metadata?: Partial<RouteMetadata>
+      /**
+       * The HTTP status produced while prerendering the page.
+       */
+      prerenderStatus?: number
       /**
        * If the page has an empty static shell when using PPR.
        */

--- a/test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts
+++ b/test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts
@@ -69,6 +69,34 @@ describe('build-output-tree-view', () => {
     })
   })
 
+  describe('with a non-200 prerendered app route', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures/prerender-status'),
+      skipStart: true,
+      env: {
+        __NEXT_PRIVATE_DETERMINISTIC_BUILD_OUTPUT: '1',
+      },
+    })
+
+    beforeAll(() => next.build())
+
+    it('shows a known non-200 status on the user route only', () => {
+      const treeView = getTreeView(next.cliOutput)
+
+      expect(treeView).toContain('◐ /error-shell [status: 404]')
+      expect(treeView).toContain('◐ /healthy-shell')
+      expect(treeView).not.toContain('/healthy-shell [status:')
+      expect(treeView).not.toContain('/_not-found [status:')
+    })
+
+    it('does not change the runtime response statuses', async () => {
+      await next.start()
+
+      expect((await next.fetch('/error-shell')).status).toBe(404)
+      expect((await next.fetch('/healthy-shell')).status).toBe(200)
+    })
+  })
+
   describe('with generated app routes that mix static and partial outputs', () => {
     const { next } = nextTestSetup({
       files: path.join(__dirname, '../../../e2e/app-dir/cache-components'),

--- a/test/production/app-dir/build-output-tree-view/fixtures/prerender-status/app/error-shell/page.tsx
+++ b/test/production/app-dir/build-output-tree-view/fixtures/prerender-status/app/error-shell/page.tsx
@@ -1,0 +1,11 @@
+import { notFound } from 'next/navigation'
+import { connection } from 'next/server'
+
+export async function generateMetadata() {
+  await connection()
+  return { title: 'Runtime metadata' }
+}
+
+export default function ErrorShellPage() {
+  return notFound()
+}

--- a/test/production/app-dir/build-output-tree-view/fixtures/prerender-status/app/healthy-shell/page.tsx
+++ b/test/production/app-dir/build-output-tree-view/fixtures/prerender-status/app/healthy-shell/page.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+export async function generateMetadata() {
+  await connection()
+  return { title: 'Runtime metadata' }
+}
+
+async function RuntimeMarker() {
+  await connection()
+  return <span>Runtime content</span>
+}
+
+export default function HealthyShellPage() {
+  return (
+    <p>
+      Healthy shell
+      <Suspense fallback={<span>Loading runtime content</span>}>
+        <RuntimeMarker />
+      </Suspense>
+    </p>
+  )
+}

--- a/test/production/app-dir/build-output-tree-view/fixtures/prerender-status/app/layout.tsx
+++ b/test/production/app-dir/build-output-tree-view/fixtures/prerender-status/app/layout.tsx
@@ -1,0 +1,9 @@
+export default function RootLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/build-output-tree-view/fixtures/prerender-status/app/not-found.tsx
+++ b/test/production/app-dir/build-output-tree-view/fixtures/prerender-status/app/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <p>Not found</p>
+}

--- a/test/production/app-dir/build-output-tree-view/fixtures/prerender-status/app/page.tsx
+++ b/test/production/app-dir/build-output-tree-view/fixtures/prerender-status/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <p>Build-output status test</p>
+}

--- a/test/production/app-dir/build-output-tree-view/fixtures/prerender-status/next.config.js
+++ b/test/production/app-dir/build-output-tree-view/fixtures/prerender-status/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  cacheComponents: true,
+}


### PR DESCRIPTION
## Summary

Surface a non-`200` status that is already known while prerendering an App Router route in the `next build` tree:

```text
◐ /error-shell [status: 404]
```

A partial shell that prerenders to `404` and an otherwise equivalent `200` shell currently both appear as `◐`, so the build summary hides a useful diagnostic even though their runtime response statuses are correct.

This carries the status as diagnostic-only export data and annotates an already-visible user route. The framework-owned `/_not-found` route and successful `200` routes remain unannotated.

This replacement is intentionally narrower than the previous revision: it does not reorder generated-route previews, aggregate hidden statuses, or change runtime responses, cache behavior, deployment metadata, or manifests.

## Verification

- `pnpm build-all`
- `pnpm --filter=next build`
- `HEADLESS=true __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true pnpm test-start-turbo test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts`
- `HEADLESS=true IS_WEBPACK_TEST=1 __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true pnpm test-start-webpack test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts`
- Targeted Prettier and ESLint
- `git diff --check`
