### PR TITLE
fix: drop V8 stack frames from prerender interrupt abort reasons

### DIFF
--- a/packages/next/src/server/app-render/dynamic-rendering.test.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.test.ts
@@ -2,22 +2,45 @@
  * @jest-environment node
  */
 
-import {
-  createPrerenderInterruptedError,
-  isPrerenderInterruptedError,
-} from './dynamic-rendering'
+import { isPrerenderInterruptedError } from './dynamic-rendering'
+import { abortAndThrowOnSynchronousRequestDataAccess } from './dynamic-rendering'
 
-describe('createPrerenderInterruptedError', () => {
-  it('is recognized by isPrerenderInterruptedError and does not keep V8 frames', () => {
-    const error = createPrerenderInterruptedError(
-      'Route / needs to bail out of prerendering at this point because it used Date.now().'
-    )
+function makePrerenderStore() {
+  const controller = new AbortController()
+  return {
+    type: 'prerender',
+    controller,
+    dynamicTracking: {
+      isDebugDynamicAccesses: false,
+      dynamicAccesses: [],
+      syncDynamicErrorWithStack: null,
+      syncDynamicErrorWithStackPostMicrotask: false,
+    },
+    runtimeDataAccessed: { resolve() {} },
+    shouldAttemptStaticPrefetch: null,
+  } as any
+}
 
-    expect(isPrerenderInterruptedError(error)).toBe(true)
-    expect(error.name).toBe('Error')
-    // Assignment materializes the stack as name + message only, dropping the
-    // CallSite frames that would retain the creating closure / render graph.
-    expect(error.stack).toBe(`${error.name}: ${error.message}`)
-    expect(error.stack).not.toMatch(/\n\s+at /)
+describe('prerender interrupt abort reason', () => {
+  it('reuses one Error constructed at module load, not on the render stack', () => {
+    function render() {
+      try {
+        abortAndThrowOnSynchronousRequestDataAccess(
+          '/',
+          'Date.now()',
+          new Error('sync'),
+          makePrerenderStore()
+        )
+      } catch (err) {
+        return err as Error
+      }
+    }
+
+    const first = render()
+    const second = render()
+
+    expect(first).toBe(second)
+    expect(isPrerenderInterruptedError(first)).toBe(true)
+    expect(first.stack).not.toMatch(/at render /)
   })
 })

--- a/packages/next/src/server/app-render/dynamic-rendering.test.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  createPrerenderInterruptedError,
+  isPrerenderInterruptedError,
+} from './dynamic-rendering'
+
+describe('createPrerenderInterruptedError', () => {
+  it('is recognized by isPrerenderInterruptedError and does not keep V8 frames', () => {
+    const error = createPrerenderInterruptedError(
+      'Route / needs to bail out of prerendering at this point because it used Date.now().'
+    )
+
+    expect(isPrerenderInterruptedError(error)).toBe(true)
+    expect(error.name).toBe('Error')
+    // Assignment materializes the stack as name + message only, dropping the
+    // CallSite frames that would retain the creating closure / render graph.
+    expect(error.stack).toBe(`${error.name}: ${error.message}`)
+    expect(error.stack).not.toMatch(/\n\s+at /)
+  })
+})

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -292,15 +292,14 @@ export function trackDynamicDataInDynamicRender(workUnitStore: WorkUnitStore) {
 }
 
 function abortOnSynchronousDynamicDataAccess(
-  route: string,
+  _route: string,
   expression: string,
   prerenderStore: PrerenderStoreModern
 ): void {
-  const reason = `Route ${route} needs to bail out of prerendering at this point because it used ${expression}.`
-
-  const error = createPrerenderInterruptedError(reason)
-
-  prerenderStore.controller.abort(error)
+  // Reuse the module-level reason. Constructing `new Error()` here would
+  // capture Server Component CallSites on the abort reason; a retained
+  // AbortSignal then pins the whole render graph.
+  prerenderStore.controller.abort(prerenderInterruptedError)
 
   const dynamicTracking = prerenderStore.dynamicTracking
   if (dynamicTracking) {
@@ -378,22 +377,19 @@ export function abortAndThrowOnSynchronousRequestDataAccess(
       }
     }
   }
-  throw createPrerenderInterruptedError(
-    `Route ${route} needs to bail out of prerendering at this point because it used ${expression}.`
-  )
+  throw prerenderInterruptedError
 }
 
 const NEXT_PRERENDER_INTERRUPTED = 'NEXT_PRERENDER_INTERRUPTED'
 
-export function createPrerenderInterruptedError(message: string): Error {
-  const error = new Error(message)
-  ;(error as any).digest = NEXT_PRERENDER_INTERRUPTED
-  // Assignment overwrites V8's private CallSite slot. Leaving the lazy stack
-  // intact would let a retained AbortSignal.reason pin the whole render graph
-  // (~1.7MB vs ~1KB). These frames are never read in production.
-  error.stack = `${error.name}: ${error.message}`
-  return error
-}
+// Constructed once at module load. A per-render `new Error()` used as
+// `AbortSignal.reason` captures Server Component frames, so a retained
+// signal pins the render graph. The expression that interrupted the
+// prerender is recorded on `dynamicTracking` instead.
+const prerenderInterruptedError: Error & { digest: string } = Object.assign(
+  new Error('Prerender interrupted.'),
+  { digest: NEXT_PRERENDER_INTERRUPTED }
+)
 
 type DigestError = Error & {
   digest: string

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -385,9 +385,13 @@ export function abortAndThrowOnSynchronousRequestDataAccess(
 
 const NEXT_PRERENDER_INTERRUPTED = 'NEXT_PRERENDER_INTERRUPTED'
 
-function createPrerenderInterruptedError(message: string): Error {
+export function createPrerenderInterruptedError(message: string): Error {
   const error = new Error(message)
   ;(error as any).digest = NEXT_PRERENDER_INTERRUPTED
+  // Assignment overwrites V8's private CallSite slot. Leaving the lazy stack
+  // intact would let a retained AbortSignal.reason pin the whole render graph
+  // (~1.7MB vs ~1KB). These frames are never read in production.
+  error.stack = `${error.name}: ${error.message}`
   return error
 }
 


### PR DESCRIPTION
## For Contributors

### Fixing a bug

- Related issues linked using `fixes #97351`
- Tests added in `packages/next/src/server/app-render/dynamic-rendering.test.ts`

## What?

A prerender interrupt used to `new Error()` during the render and store that object as `AbortSignal.reason`. V8 CallSites on an Error created on the render stack include the Server Component frame, so a retained signal pins the whole render graph (~1.7MB vs ~1KB).

## Why?

#97351. The first version of this PR assigned `error.stack` to drop frames. That is not the right fix — we cannot expect every Error to limit its frames.

## How?

Create one interrupt Error at module load and reuse it for `controller.abort(...)` and the throw. It is still an `Error` with `digest === NEXT_PRERENDER_INTERRUPTED`, so `isPrerenderInterruptedError` is unchanged. The expression that interrupted the prerender is recorded on `dynamicTracking` (with a stack only when `isDebugDynamicAccesses` is on).

Not in this PR: `io-utils` still aborts with a per-render `syncIOError` (a different diagnostic, already stored on `syncDynamicErrorWithStack`), and the `use cache` `AbortSignal.any` listener leak (#97363).

Fixes #97351

<!-- NEXT_JS_LLM -->