### PR TITLE
fix: report Google Font file fetch failures instead of Module not found

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2854,7 +2854,7 @@ impl NextConfig {
         Ok(FetchClientConfig {
             connect_timeout,
             timeout,
-            max_retries: 1,
+            max_retries: 3,
             ..Default::default()
         }
         .cell())

--- a/crates/next-core/src/next_font/google/mod.rs
+++ b/crates/next-core/src/next_font/google/mod.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{Completion, FxIndexMap, ResolvedVc, Vc};
 use turbo_tasks_env::{CommandLineProcessEnv, ProcessEnv};
-use turbo_tasks_fetch::{FetchClientConfig, HttpResponseBody};
+use turbo_tasks_fetch::{FetchClientConfig, FetchErrorKind, HttpResponseBody};
 use turbo_tasks_fs::{
     DiskFileSystem, File, FileContent, FileSystem, FileSystemPath,
     json::parse_json_with_source_context,
@@ -416,12 +416,19 @@ impl ImportMappingReplacement for NextFontGoogleFontFileReplacer {
 
         // doesn't seem ideal to download the font into a string, but probably doesn't
         // really matter either.
-        let Some(font) =
-            fetch_from_google_fonts(*self.fetch_client, url.into(), font_virtual_path.clone())
-                .await?
+        let Some(font) = fetch_from_google_fonts(
+            *self.fetch_client,
+            url.clone().into(),
+            font_virtual_path.clone(),
+            IssueSeverity::Error,
+        )
+        .await?
         else {
-            return Ok(
-                ImportMapResult::Result(ResolveResult::unresolvable().resolved_cell()).cell(),
+            // Do not turn a failed font-file fetch into `ResolveResult::unresolvable()`,
+            // which surfaces as `Module not found: @vercel/turbopack-next/internal/font/google/font`.
+            bail!(
+                "Failed to fetch Google Font file from `{}`. See the fetch error above for the HTTP status.",
+                url
             );
         };
 
@@ -654,7 +661,13 @@ async fn fetch_real_stylesheet(
     stylesheet_url: RcStr,
     css_virtual_path: FileSystemPath,
 ) -> Result<Option<Vc<RcStr>>> {
-    let body = fetch_from_google_fonts(fetch_client, stylesheet_url, css_virtual_path).await?;
+    let body = fetch_from_google_fonts(
+        fetch_client,
+        stylesheet_url,
+        css_virtual_path,
+        IssueSeverity::Warning,
+    )
+    .await?;
 
     Ok(body.map(|body| body.to_string()))
 }
@@ -663,18 +676,36 @@ async fn fetch_from_google_fonts(
     fetch_client: Vc<FetchClientConfig>,
     url: RcStr,
     virtual_path: FileSystemPath,
+    severity: IssueSeverity,
 ) -> Result<Option<Vc<HttpResponseBody>>> {
     let result = fetch_client
-        .fetch(url, Some(USER_AGENT_FOR_GOOGLE_FONTS))
+        .fetch(url.clone(), Some(USER_AGENT_FOR_GOOGLE_FONTS))
         .await?;
 
     Ok(match *result {
         Ok(r) => Some(*r.await?.body),
         Err(err) => {
-            err.to_issue(IssueSeverity::Warning, virtual_path)
+            err.to_issue(severity, virtual_path)
                 .to_resolved()
                 .await?
                 .emit();
+
+            // When the caller asked for an error (font files), fail with the URL
+            // and status instead of letting the resolver report a missing internal module.
+            if severity == IssueSeverity::Error {
+                let kind = err.await?.kind.await?;
+                match &*kind {
+                    FetchErrorKind::Status(status) => {
+                        bail!(
+                            "Failed to fetch Google Font file from `{}` (HTTP {status})",
+                            url
+                        );
+                    }
+                    _ => {
+                        bail!("Failed to fetch Google Font file from `{}`", url);
+                    }
+                }
+            }
 
             None
         }

--- a/packages/font/src/google/fetch-font-file.ts
+++ b/packages/font/src/google/fetch-font-file.ts
@@ -11,6 +11,14 @@ export async function fetchFontFile(url: string, isDev: boolean) {
     if (url.startsWith('/')) {
       return fs.readFileSync(url)
     }
+    // `null` in the mock map means "this file fetch failed", matching how
+    // stylesheet mocks already encode a failed CSS request.
+    const mocked = require(process.env.NEXT_FONT_GOOGLE_MOCKED_RESPONSES) as
+      | Record<string, unknown>
+      | undefined
+    if (mocked && mocked[url] === null) {
+      throw new Error(`Failed to fetch font file from \`${url}\` (HTTP 404)`)
+    }
     return Buffer.from(url)
   }
 

--- a/test/e2e/next-font/google-font-file-fetch-error.test.ts
+++ b/test/e2e/next-font/google-font-file-fetch-error.test.ts
@@ -1,0 +1,46 @@
+import { FileRef, nextTestSetup } from 'e2e-utils'
+import { join } from 'path'
+
+const mockedGoogleFontResponses = require.resolve(
+  './google-font-mocked-responses.js'
+)
+
+describe('next/font/google font file fetch error', () => {
+  const isDev = (global as any).isNextDev
+
+  if ((global as any).isNextDeploy) {
+    it('should skip next deploy for now', () => {})
+    return
+  }
+
+  const { next } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, 'google-font-file-fetch-error/pages')),
+    },
+    env: {
+      NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,
+    },
+    skipStart: true,
+  })
+
+  it('should name the font file URL and status instead of a missing internal module', async () => {
+    const missingInternalModule =
+      "Can't resolve '@vercel/turbopack-next/internal/font/google/font'"
+
+    if (isDev) {
+      await next.start()
+      await next.browser('/').catch(() => {})
+      expect(next.cliOutput).toInclude(
+        'https://fonts.gstatic.com/s/bitter/v42/this-file-does-not-exist.woff2'
+      )
+      expect(next.cliOutput).not.toInclude(missingInternalModule)
+    } else {
+      await expect(next.start()).rejects.toThrow('next build failed')
+      expect(next.cliOutput).toInclude(
+        'https://fonts.gstatic.com/s/bitter/v42/this-file-does-not-exist.woff2'
+      )
+      expect(next.cliOutput).toMatch(/Failed to fetch .*font file/i)
+      expect(next.cliOutput).not.toInclude(missingInternalModule)
+    }
+  })
+})

--- a/test/e2e/next-font/google-font-file-fetch-error/pages/index.js
+++ b/test/e2e/next-font/google-font-file-fetch-error/pages/index.js
@@ -1,0 +1,11 @@
+import { Bitter } from 'next/font/google'
+
+const bitter = Bitter({ weight: '400', subsets: ['latin'] })
+
+export default function Page() {
+  return (
+    <p id="bitter" className={bitter.className}>
+      {JSON.stringify(bitter)}
+    </p>
+  )
+}

--- a/test/e2e/next-font/google-font-mocked-responses.js
+++ b/test/e2e/next-font/google-font-mocked-responses.js
@@ -1,4 +1,17 @@
 module.exports = {
+  // Stylesheet points at a URL that is not a real gstatic file. Used by
+  // google-font-file-fetch-error.test.ts to pin the Turbopack error path.
+  'https://fonts.googleapis.com/css2?family=Bitter:wght@400&display=swap': `
+@font-face {
+  font-family: 'Bitter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/bitter/v42/this-file-does-not-exist.woff2) format('woff2');
+  unicode-range: U+0000-00FF;
+}
+  `,
+  'https://fonts.gstatic.com/s/bitter/v42/this-file-does-not-exist.woff2': null,
   'https://fonts.googleapis.com/css2?family=Open+Sans:wght@300..800&display=swap': `
 /* cyrillic-ext */
 @font-face {


### PR DESCRIPTION
## For Contributors

### Fixing a bug

- Related issues linked using `fixes #97378`
- Tests added in `test/e2e/next-font/google-font-file-fetch-error.test.ts`

## What?

When Turbopack fails to download a `next/font/google` font *file* (HTTP 404, timeout, etc.), `NextFontGoogleFontFileReplacer` turns that failure into `ResolveResult::unresolvable()`. The build then dies with:

```
Module not found: Can't resolve '@vercel/turbopack-next/internal/font/google/font'
```

The real HTTP status only appears earlier as a warning. Webpack already retries and throws a fetch error that names the URL.

## Why?

A single rotated or 404'd `fonts.gstatic.com` file currently looks like a missing internal module. The warning is easy to miss in a large build, and there is no retry on transient failures.

## How?

- Emit the fetch issue at **Error** severity for font files and `bail!` with the URL and HTTP status instead of returning unresolvable.
- Raise `FetchClientConfig.max_retries` from 1 to 3 so transient 5xx / connect / timeout failures match the webpack `retry(..., 3)` path.
- Let `NEXT_FONT_GOOGLE_MOCKED_RESPONSES` mark a font-file URL as `null` (same convention as a failed stylesheet), so this path can be tested offline.

Stylesheet fetch failures are unchanged: they stay a warning in dev (fallback font) and `GoogleFontsFetchIssue` in build.

Fixes #97378

<!-- NEXT_JS_LLM -->