### PR TITLE
Capture initial URL before hydration

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -19,7 +19,7 @@ import {
   type AppRouterActionQueue,
   createMutableActionQueue,
 } from './components/app-router-instance'
-import AppRouter from './components/app-router'
+import AppRouter, { setInitialUrl } from './components/app-router'
 import type { InitialRSCPayload } from '../shared/lib/app-router-types'
 import { createInitialRouterState } from './components/router-reducer/create-initial-router-state'
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
@@ -343,6 +343,24 @@ const reactRootOptions: ReactDOMClient.RootOptions = {
   onUncaughtError,
 }
 
+declare global {
+  interface Window {
+    __next_h?: string
+  }
+}
+
+function getInitialRouterUrl(): URL {
+  let initialUrl: URL
+  try {
+    initialUrl = new URL(window.__next_h ?? window.location.href)
+  } catch {
+    initialUrl = new URL(window.location.href)
+  }
+  // The hash doesn't change what's rendered.
+  initialUrl.hash = window.location.hash
+  return initialUrl
+}
+
 export async function hydrate(
   instrumentationModules: ClientInstrumentationModules,
   assetPrefix: string
@@ -375,13 +393,16 @@ export async function hydrate(
 
   initializeRouterTransitionModules(instrumentationModules)
 
+  const initialUrl = getInitialRouterUrl()
+  setInitialUrl(initialUrl)
+
   const initialTimestamp = Date.now()
   const actionQueue: AppRouterActionQueue = createMutableActionQueue(
     createInitialRouterState({
       navigatedAt: initialTimestamp,
       initialRSCPayload,
       initialFlightStreamForCache,
-      location: window.location,
+      location: initialUrl,
     })
   )
 

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -54,30 +54,18 @@ const globalMutable: {
   pendingMpaPath?: string
 } = {}
 
-// A Back/Forward press before the router's popstate listener exists moves the
-// browser to a different history entry than the one the document was activated
-// on, and the resulting popstate fires with nobody listening. The activation
-// entry is fixed for the document's lifetime and entry keys are stable across
-// replaceState, so until the listener is installed a key mismatch means a
-// traversal went unobserved.
-function hasMissedTraversal(): boolean {
-  if (typeof window.navigation === 'undefined') {
-    return false
-  }
-  const activationEntry = window.navigation.activation?.entry
-  const currentEntry = window.navigation.currentEntry
-  return (
-    activationEntry != null &&
-    currentEntry != null &&
-    activationEntry.key !== currentEntry.key &&
-    // Only entries written by the app router can be restored; on any other
-    // entry the traversal is left unhandled, as before.
-    window.history.state?.__NA === true
-  )
+let initialHref: string | null = null
+
+export function setInitialUrl(url: URL): void {
+  initialHref = createHrefFromUrl(url)
 }
 
-let checkedMissedTraversalBeforeHistoryWrite = false
-let checkedMissedTraversalBeforeReplay = false
+function hasUnhandledHistoryChange(): boolean {
+  return (
+    initialHref !== null &&
+    createHrefFromUrl(new URL(window.location.href)) !== initialHref
+  )
+}
 
 /**
  * Handles a popstate event (or one that was missed before hydration).
@@ -114,14 +102,10 @@ function HistoryUpdater({
 
     const { tree, pushRef, canonicalUrl, renderedSearch } = appRouterState
 
-    if (!checkedMissedTraversalBeforeHistoryWrite) {
-      checkedMissedTraversalBeforeHistoryWrite = true
-      if (hasMissedTraversal()) {
-        // Skip the write: it would overwrite the traversed-to entry's state.
-        // The tree was rendered even though the history write is skipped.
-        setLastCommittedTree(tree)
-        return
-      }
+    if (hasUnhandledHistoryChange()) {
+      // The popstate handler will restore this entry.
+      setLastCommittedTree(tree)
+      return
     }
 
     const appHistoryState: AppHistoryState = {
@@ -422,12 +406,14 @@ function Router({
 
     window.addEventListener('popstate', onPopState)
 
-    if (!checkedMissedTraversalBeforeReplay) {
-      checkedMissedTraversalBeforeReplay = true
-      if (hasMissedTraversal()) {
+    if (hasUnhandledHistoryChange()) {
+      if (window.history.state?.__NA) {
         handlePopState(window.history.state)
+      } else {
+        restore(new URL(window.location.href), undefined)
       }
     }
+    initialHref = null
 
     return () => {
       window.history.pushState = originalPushState

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -24,7 +24,7 @@ export interface InitialRouterStateParameters {
   navigatedAt: number
   initialRSCPayload: InitialRSCPayload
   initialFlightStreamForCache?: ReadableStream<Uint8Array> | null
-  location: Location | null
+  location: URL | null
 }
 
 export function createInitialRouterState({
@@ -61,10 +61,7 @@ export function createInitialRouterState({
   const canonicalUrl =
     // location.href is read as the initial value for canonicalUrl in the browser
     // This is safe to do as canonicalUrl can't be rendered, it's only used to control the history updates in the useEffect further down in this file.
-    location
-      ? // window.location does not have the same type as URL but has all the fields createHrefFromUrl needs.
-        createHrefFromUrl(location)
-      : initialCanonicalUrl
+    location ? createHrefFromUrl(location) : initialCanonicalUrl
 
   // Decode the initial transport tree into the RouteTree type, with the
   // payload's render output embedded on each node. (discoverKnownRoute below

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3514,6 +3514,12 @@ type RSCInitialPayloadPartialDev = {
   c?: InitialRSCPayload['c']
 }
 
+// The URL the document was created for, in case history changes before
+// hydration. `self.navigation` may be a frame or a global with that name.
+// This must never throw since hydration starts in the same script.
+const historyBootstrapScript =
+  'try{self.__next_h=(typeof Navigation=="function"&&self.navigation instanceof Navigation&&self.navigation.activation&&self.navigation.activation.entry&&self.navigation.activation.entry.url)||location.href}catch(e){}'
+
 async function renderToStream(
   requestStore: RequestStore,
   req: BaseNextRequest,
@@ -3624,6 +3630,10 @@ async function renderToStream(
       (bootstrapScriptContent ? `${bootstrapScriptContent};` : '') +
       (await getInstantTestBootstrapScriptContent())
   }
+
+  bootstrapScriptContent =
+    (bootstrapScriptContent ? `${bootstrapScriptContent};` : '') +
+    historyBootstrapScript
 
   // Create the "render route (app)" span manually so we can keep it open during streaming.
   // This is necessary because errors inside Suspense boundaries are reported asynchronously
@@ -4411,15 +4421,21 @@ async function renderToStream(
       let errorBootstrapScriptContent: string | undefined
       if (process.env.__NEXT_DEV_SERVER) {
         errorBootstrapScriptContent = bootstrapScriptContent
-      } else if (
-        buildManifest.pagesChunkGroupBootstrapParams &&
-        buildManifest.chunkLoadingGlobal
-      ) {
-        errorBootstrapScriptContent = getTurbopackChunkGroupBootstrap(
-          buildManifest.pagesChunkGroupBootstrapParams,
-          buildManifest.chunkLoadingGlobal,
-          [UNDERSCORE_NOT_FOUND_ROUTE_ENTRY]
-        )
+      } else {
+        if (
+          buildManifest.pagesChunkGroupBootstrapParams &&
+          buildManifest.chunkLoadingGlobal
+        ) {
+          errorBootstrapScriptContent = getTurbopackChunkGroupBootstrap(
+            buildManifest.pagesChunkGroupBootstrapParams,
+            buildManifest.chunkLoadingGlobal,
+            [UNDERSCORE_NOT_FOUND_ROUTE_ENTRY]
+          )
+        }
+        errorBootstrapScriptContent =
+          (errorBootstrapScriptContent
+            ? `${errorBootstrapScriptContent};`
+            : '') + historyBootstrapScript
       }
 
       if (process.env.__NEXT_USE_NODE_STREAMS) {
@@ -8588,6 +8604,10 @@ async function prerenderToStream(
       bootstrapScriptContent
   }
 
+  bootstrapScriptContent =
+    (bootstrapScriptContent ? `${bootstrapScriptContent};` : '') +
+    historyBootstrapScript
+
   const { reactServerErrorsByDigest } = workStore
   // We don't report errors during prerendering through our instrumentation hooks
   const reportErrors = !experimental.isRoutePPREnabled
@@ -9731,7 +9751,7 @@ async function prerenderToStream(
       UNDERSCORE_NOT_FOUND_ROUTE_ENTRY
     )
 
-    const errorBootstrapScriptContent =
+    let errorBootstrapScriptContent =
       buildManifest.pagesChunkGroupBootstrapParams &&
       buildManifest.chunkLoadingGlobal
         ? getTurbopackChunkGroupBootstrap(
@@ -9740,6 +9760,9 @@ async function prerenderToStream(
             [UNDERSCORE_NOT_FOUND_ROUTE_ENTRY]
           )
         : undefined
+    errorBootstrapScriptContent =
+      (errorBootstrapScriptContent ? `${errorBootstrapScriptContent};` : '') +
+      historyBootstrapScript
 
     if (cacheComponents) {
       const originalFlightPrerenderResult = reactServerPrerenderResult

--- a/test/e2e/app-dir/back-before-hydration-global-error/app/broken/page.tsx
+++ b/test/e2e/app-dir/back-before-hydration-global-error/app/broken/page.tsx
@@ -1,0 +1,6 @@
+import { connection } from 'next/server'
+
+export default async function Broken(): Promise<never> {
+  await connection()
+  throw new Error('broken page')
+}

--- a/test/e2e/app-dir/back-before-hydration-global-error/app/global-error.tsx
+++ b/test/e2e/app-dir/back-before-hydration-global-error/app/global-error.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { Suspense } from 'react'
+import { RouterUrl } from './router-url'
+
+export default function GlobalError() {
+  return (
+    <html lang="en">
+      <body>
+        <Suspense>
+          <RouterUrl />
+        </Suspense>
+        <h1 id="global-error">Global error</h1>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/back-before-hydration-global-error/app/layout.tsx
+++ b/test/e2e/app-dir/back-before-hydration-global-error/app/layout.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react'
+import { RouterUrl } from './router-url'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <Suspense>
+          <RouterUrl />
+        </Suspense>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/back-before-hydration-global-error/app/page.tsx
+++ b/test/e2e/app-dir/back-before-hydration-global-error/app/page.tsx
@@ -4,11 +4,8 @@ export default function Home() {
   return (
     <>
       <h1 id="home">Home</h1>
-      <Link id="to-post" href="/post">
-        To post
-      </Link>
-      <Link id="to-missing" href="/missing">
-        To missing
+      <Link id="to-broken" href="/broken">
+        To broken
       </Link>
     </>
   )

--- a/test/e2e/app-dir/back-before-hydration-global-error/app/router-url.tsx
+++ b/test/e2e/app-dir/back-before-hydration-global-error/app/router-url.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { usePathname, useSearchParams } from 'next/navigation'
+
+// Reports the router's URL once the App Router has installed its history
+// handlers (its effect runs after this child effect). Until then it renders
+// nothing, so a test reading it cannot mistake server HTML for router state.
+export function RouterUrl() {
+  const pathname = usePathname()
+  const search = useSearchParams().toString()
+  const [isRouterReady, setIsRouterReady] = useState(false)
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setIsRouterReady(true), 0)
+    return () => clearTimeout(timeout)
+  }, [])
+
+  if (!isRouterReady) {
+    return null
+  }
+  return (
+    <output id="router-url">{pathname + (search ? `?${search}` : '')}</output>
+  )
+}

--- a/test/e2e/app-dir/back-before-hydration-global-error/back-before-hydration-global-error.test.ts
+++ b/test/e2e/app-dir/back-before-hydration-global-error/back-before-hydration-global-error.test.ts
@@ -1,0 +1,59 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import type * as Playwright from 'playwright'
+
+// A page that throws while its shell renders is served as the global-error
+// document, built by renderToStream's error path. Cache Components rejects
+// such a page at build time, so this suite only runs without it.
+;(process.env.__NEXT_CACHE_COMPONENTS ? describe.skip : describe)(
+  'back navigation before hydration on the global-error document',
+  () => {
+    const { next } = nextTestSetup({ files: __dirname })
+
+    it('replays a traversal after a reload', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        pushErrorAsConsoleLog: true,
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      await browser.elementById('to-broken').click()
+      await browser.elementByCss('#global-error', { waitUntil: false })
+
+      let stalling = true
+      const stalled: Array<() => void> = []
+      await page.route('**/_next/static/**', async (route) => {
+        if (stalling && route.request().resourceType() === 'script') {
+          await new Promise<void>((resolve) => stalled.push(resolve))
+        }
+        await route.continue()
+      })
+      await browser.refresh({ waitUntil: 'commit' })
+      await page.waitForFunction(() => document.readyState !== 'loading')
+      await page.evaluate('window.__stayed = true')
+
+      await browser.back({ waitUntil: 'commit' })
+      expect(new URL(await browser.url()).pathname).toBe('/')
+      stalling = false
+      for (const release of stalled) release()
+
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            'document.getElementById("router-url")?.textContent'
+          )
+        ).toBe('/')
+      })
+      expect(await browser.eval('window.__routerTransitions')).toEqual([
+        'traverse /',
+      ])
+      expect(await browser.eval('window.__stayed')).toBe(true)
+      // The server error and the 500 response are reported as errors.
+      const errors = (await browser.log())
+        .filter((entry) => entry.source === 'error')
+        .map((entry) => entry.message)
+      expect(errors).not.toContainEqual(expect.stringContaining('Hydration'))
+    })
+  }
+)

--- a/test/e2e/app-dir/back-before-hydration-global-error/instrumentation-client.ts
+++ b/test/e2e/app-dir/back-before-hydration-global-error/instrumentation-client.ts
@@ -1,0 +1,7 @@
+;(window as any).__routerTransitions = []
+
+export function onRouterTransitionStart(href: string, navigateType: string) {
+  ;(window as any).__routerTransitions.push(
+    `${navigateType} ${new URL(href, window.location.href).pathname}`
+  )
+}

--- a/test/e2e/app-dir/back-before-hydration/app/missing/page.tsx
+++ b/test/e2e/app-dir/back-before-hydration/app/missing/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function Missing(): never {
+  notFound()
+}

--- a/test/e2e/app-dir/back-before-hydration/app/not-found.tsx
+++ b/test/e2e/app-dir/back-before-hydration/app/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1 id="not-found">Not found</h1>
+}

--- a/test/e2e/app-dir/back-before-hydration/app/tabs/[tab]/page.tsx
+++ b/test/e2e/app-dir/back-before-hydration/app/tabs/[tab]/page.tsx
@@ -1,0 +1,19 @@
+import { SelectDefaultTab } from './select-default-tab'
+
+export function generateStaticParams() {
+  return [{ tab: 'none' }, { tab: 'first' }]
+}
+
+export default async function Tab({
+  params,
+}: {
+  params: Promise<{ tab: string }>
+}) {
+  const { tab } = await params
+  return (
+    <>
+      <h1 id={`tab-${tab}`}>Tab {tab}</h1>
+      {tab === 'none' ? <SelectDefaultTab /> : null}
+    </>
+  )
+}

--- a/test/e2e/app-dir/back-before-hydration/app/tabs/[tab]/select-default-tab.tsx
+++ b/test/e2e/app-dir/back-before-hydration/app/tabs/[tab]/select-default-tab.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { useLayoutEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+// Navigates while hydrating, before the router's own effects have run.
+export function SelectDefaultTab() {
+  const router = useRouter()
+  useLayoutEffect(() => {
+    router.replace('/tabs/first')
+  }, [router])
+  return null
+}

--- a/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
+++ b/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
@@ -158,14 +158,10 @@ describe('back navigation before hydration after reload', () => {
     await retry(async () => {
       expect(await readRouterUrl(browser)).toBe(homePath)
     })
-    // TODO: The router initializes from the traversed-to URL, so the
-    // pathname rendered during hydration does not match the server HTML.
     expect(
       await browser.eval('document.getElementById("server-pathname").__server')
-    ).toBeUndefined()
-    expect(await browser.log()).toContainEqual(
-      expect.objectContaining({ source: 'error' })
-    )
+    ).toBe(true)
+    await expectNoPageErrors(browser)
 
     // History traversal must still work after recovery.
     await browser.forward()
@@ -218,12 +214,28 @@ describe('back navigation before hydration after reload', () => {
     expect(await browser.eval('document.getElementById("post").__server')).toBe(
       true
     )
+    expect(await browser.eval('window.__routerTransitions')).toEqual([])
 
     await browser.elementById('to-home').click()
     await waitForPage(browser, '#home')
     await browser.back()
     await waitForPage(browser, '#post')
     expect(await browser.eval('window.__stayed')).toBe(true)
+    await expectNoPageErrors(browser)
+  })
+
+  // A navigation dispatched while hydrating, before the router's own effect
+  // has run, must not be mistaken for a history change to recover from.
+  it('keeps a navigation made in a layout effect during hydration', async () => {
+    const browser = await next.browser('/tabs/none', {
+      pushErrorAsConsoleLog: true,
+    })
+
+    await waitForPage(browser, '#tab-first')
+    await retry(async () => {
+      expect(await readRouterUrl(browser)).toBe('/tabs/first')
+    })
+    expect(new URL(await browser.url()).pathname).toBe('/tabs/first')
     await expectNoPageErrors(browser)
   })
 
@@ -348,22 +360,15 @@ describe('back navigation before hydration after reload', () => {
       releaseScripts()
 
       await retry(async () => {
-        // The traversal cannot be replayed onto the third-party entry. The
-        // content stays on the reloaded page, like before the fix — and in
-        // particular the router must not reload a page that just loaded.
         expect(await browser.eval('window.__stayed')).toBe(true)
         expect(new URL(await browser.url()).search).toBe('?tp=1')
         expect(await browser.elementByCss('h1').text()).toBe('Post')
-        // TODO: The router never learns about the third-party entry.
-        expect(await readRouterUrl(browser)).toBe(homePath)
+        expect(await readRouterUrl(browser)).toBe(`${homePath}?tp=1`)
       })
-      // TODO: Same hydration mismatch as after any Back before hydration.
-      expect(await browser.log()).toContainEqual(
-        expect.objectContaining({ source: 'error' })
-      )
 
       await browser.elementById('to-home').click()
       await waitForPage(browser, '#home')
+      await expectNoPageErrors(browser)
     })
 
     it('handles a traversal onto a third-party entry', async () => {

--- a/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
+++ b/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
@@ -197,6 +197,32 @@ describe('back navigation before hydration after reload', () => {
     await expectNoPageErrors(browser)
   })
 
+  it('replays a traversal after a reload on a prerendered not-found page', async () => {
+    const { browser, releaseScripts } = await clickThenReloadStalled(
+      homePath,
+      'to-missing',
+      '#not-found'
+    )
+
+    await browser.back({ waitUntil: 'commit' })
+    expect(new URL(await browser.url()).pathname).toBe(homePath)
+    releaseScripts()
+
+    await waitForPage(browser, '#home')
+    await retry(async () => {
+      expect(await readRouterUrl(browser)).toBe(homePath)
+    })
+    expect(await browser.eval('window.__routerTransitions')).toEqual([
+      `traverse ${homePath}`,
+    ])
+    expect(await browser.eval('window.__stayed')).toBe(true)
+    // The 404 response is reported as an error.
+    const errors = (await browser.log())
+      .filter((entry) => entry.source === 'error')
+      .map((entry) => entry.message)
+    expect(errors).not.toContainEqual(expect.stringContaining('Hydration'))
+  })
+
   it('hydrates in place on an ordinary reload', async () => {
     const { browser, page, releaseScripts } = await clickThenReloadStalled(
       homePath,

--- a/test/e2e/app-dir/back-before-hydration/instrumentation-client.ts
+++ b/test/e2e/app-dir/back-before-hydration/instrumentation-client.ts
@@ -1,0 +1,7 @@
+;(window as any).__routerTransitions = []
+
+export function onRouterTransitionStart(href: string, navigateType: string) {
+  ;(window as any).__routerTransitions.push(
+    `${navigateType} ${new URL(href, window.location.href).pathname}`
+  )
+}


### PR DESCRIPTION
Replaces the detection from https://github.com/vercel/next.js/pull/96252.

Right now we only listen to `popstate` after hydration. But `popstate` can fire before hydration, and if we miss it, we show the wrong page. That's what happened before #95682.

In https://github.com/vercel/next.js/pull/96252, we tried to detect whether we're still on the right page when we hydrate, using the Navigation API. This doesn't work in browsers that don't have the Navigation API. It's also a bit silly. We can know where we started by writing it down early, so then there's no need to guess it after the fact.

This PR captures the initial URL in an inline script that runs early. When the router mounts, if the URL is different from the initially captured one, it means the user went somewhere before we were listening. So we don't write to history yet (that would overwrite the entry they're on now), and we instead handle the change the same way we'd handle a `popstate`.

The inline script prefers `navigation.activation.entry.url` but falls back to `location.href` if there's no Navigation API.

Initializing from the captured URL also fixes hydration mismatches. After a Back press, `usePathname` used to hydrate with the URL the user went back to, but the server HTML was for the page they started on. So this caused a hydration mismatch. You can see this fixing the TODOs in the tests from [#97651](https://github.com/vercel/next.js/pull/97651).

This whole fix relies on `bootstrapScriptContent`, which React emits after the shell. Without the Navigation API, a Back press before that script has run is still not handled. To be more resilient there we'd have to inject the script earlier, into the `<head>`. I don't know how to do this correctly, so I haven't tried.

## Test Plan

Old tests still pass on the new mechanism, and the TODOs from [#97651](https://github.com/vercel/next.js/pull/97651) are flipped. Added regression tests for the error documents (`global-error` and a prerendered 404) so we don't forget `bootstrapScriptContent` in those code paths.