### PR TITLE
Add structured agent feedback telemetry

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -24,7 +24,16 @@ import {
   SUPPORTED_TEST_RUNNERS_LIST,
   type NextTestOptions,
 } from '../cli/next-test.js'
-import type { NextTelemetryOptions } from '../cli/next-telemetry.js'
+import {
+  agentFeedbackModels,
+  agentFeedbackOutcomes,
+  agentFeedbackSeverities,
+  agentFeedbackTypes,
+} from '../telemetry/events/agent-feedback'
+import type {
+  NextTelemetryFeedbackOptions,
+  NextTelemetryOptions,
+} from '../cli/next-telemetry.js'
 import type { NextStartOptions } from '../cli/next-start.js'
 import type { NextInfoOptions } from '../cli/next-info.js'
 import type { NextDevOptions } from '../cli/next-dev.js'
@@ -154,6 +163,23 @@ function parseValidInspectAddress(value: string): DebugAddress {
   }
 
   return address
+}
+
+function parseAgentFeedbackInteger(value: string): number {
+  if (value !== '-1' && !/^\d+$/.test(value)) {
+    throw new InvalidArgumentError(
+      `'${value}' is not -1 or a non-negative safe integer.`
+    )
+  }
+
+  const parsedValue = Number(value)
+  if (!Number.isSafeInteger(parsedValue)) {
+    throw new InvalidArgumentError(
+      `'${value}' is not -1 or a non-negative safe integer.`
+    )
+  }
+
+  return parsedValue
 }
 
 const program = new NextRootCommand()
@@ -491,12 +517,12 @@ program
   })
   .usage('[directory] [options]')
 
-program
+const telemetryCommand = program
   .command('telemetry')
   .description(
     `Allows you to enable or disable Next.js' ${bold(
       'completely anonymous'
-    )} telemetry collection.`
+    )} telemetry collection and submit anonymous agent feedback.`
   )
   .addArgument(new Argument('[arg]').choices(['disable', 'enable', 'status']))
   .addHelpText('after', `\nLearn more: ${cyan('https://nextjs.org/telemetry')}`)
@@ -509,6 +535,72 @@ program
   .action((arg: string, options: NextTelemetryOptions) =>
     import('../cli/next-telemetry.js').then((mod) =>
       mod.nextTelemetry(options, arg)
+    )
+  )
+
+telemetryCommand
+  .command('feedback')
+  .description('Submit structured, anonymous feedback about an agent run.')
+  .addOption(
+    new Option('--feedback-type <type>', 'The category of feedback.')
+      .choices([...agentFeedbackTypes])
+      .makeOptionMandatory()
+  )
+  .addOption(
+    new Option('--outcome <outcome>', 'The outcome of the agent run.')
+      .choices([...agentFeedbackOutcomes])
+      .makeOptionMandatory()
+  )
+  .addOption(
+    new Option('--severity <severity>', 'The severity of the feedback.')
+      .choices([...agentFeedbackSeverities])
+      .makeOptionMandatory()
+  )
+  .addOption(
+    new Option('--model-provider <provider>', 'The model provider.')
+      .choices(Object.keys(agentFeedbackModels))
+      .default('unknown')
+  )
+  .addOption(
+    new Option('--model <model>', 'The model used by the agent.')
+      .choices(Object.values(agentFeedbackModels).flat())
+      .default('unknown')
+  )
+  .addOption(
+    new Option(
+      '--input-tokens <count>',
+      'The number of input tokens, if known.'
+    )
+      .argParser(parseAgentFeedbackInteger)
+      .default(-1)
+  )
+  .addOption(
+    new Option(
+      '--output-tokens <count>',
+      'The number of output tokens, if known.'
+    )
+      .argParser(parseAgentFeedbackInteger)
+      .default(-1)
+  )
+  .addOption(
+    new Option(
+      '--duration-milliseconds <milliseconds>',
+      'The duration of the agent run, if known.'
+    )
+      .argParser(parseAgentFeedbackInteger)
+      .default(-1)
+  )
+  .addOption(
+    new Option(
+      '--tool-call-count <count>',
+      'The number of tool calls, if known.'
+    )
+      .argParser(parseAgentFeedbackInteger)
+      .default(-1)
+  )
+  .action((options: NextTelemetryFeedbackOptions) =>
+    import('../cli/next-telemetry.js').then((mod) =>
+      mod.nextTelemetryFeedback(options)
     )
   )
 

--- a/packages/next/src/cli/next-telemetry.ts
+++ b/packages/next/src/cli/next-telemetry.ts
@@ -1,11 +1,33 @@
 #!/usr/bin/env node
 
 import { bold, cyan, green, red, yellow } from '../lib/picocolors'
+import { printAndExit } from '../server/lib/utils'
+import {
+  agentFeedbackModels,
+  eventAgentFeedback,
+  type AgentFeedbackModel,
+  type AgentFeedbackModelProvider,
+  type AgentFeedbackOutcome,
+  type AgentFeedbackSeverity,
+  type AgentFeedbackType,
+} from '../telemetry/events/agent-feedback'
 import { Telemetry } from '../telemetry/storage'
 
 export type NextTelemetryOptions = {
   enable?: boolean
   disable?: boolean
+}
+
+export type NextTelemetryFeedbackOptions = {
+  feedbackType: AgentFeedbackType
+  outcome: AgentFeedbackOutcome
+  severity: AgentFeedbackSeverity
+  modelProvider: AgentFeedbackModelProvider
+  model: AgentFeedbackModel
+  inputTokens: number
+  outputTokens: number
+  durationMilliseconds: number
+  toolCallCount: number
 }
 
 const telemetry = new Telemetry({ distDir: process.cwd() })
@@ -50,4 +72,53 @@ const nextTelemetry = (options: NextTelemetryOptions, arg: string) => {
   console.log(`\nLearn more: ${cyan('https://nextjs.org/telemetry')}`)
 }
 
-export { nextTelemetry }
+const nextTelemetryFeedback = async (options: NextTelemetryFeedbackOptions) => {
+  if ((options.modelProvider === 'unknown') !== (options.model === 'unknown')) {
+    printAndExit(
+      'The --model-provider and --model options must be provided together.'
+    )
+  }
+
+  const models = agentFeedbackModels[options.modelProvider]
+  if (!(models as readonly string[]).includes(options.model)) {
+    printAndExit(
+      `The model "${options.model}" is not valid for provider "${options.modelProvider}".`
+    )
+  }
+
+  for (const [name, value] of Object.entries({
+    inputTokens: options.inputTokens,
+    outputTokens: options.outputTokens,
+    durationMilliseconds: options.durationMilliseconds,
+    toolCallCount: options.toolCallCount,
+  })) {
+    if (!Number.isSafeInteger(value) || value < -1) {
+      printAndExit(`${name} must be -1 or a non-negative safe integer.`)
+    }
+  }
+
+  if (!telemetry.isEnabled && !process.env.NEXT_TELEMETRY_DEBUG) {
+    console.log(
+      `Agent feedback was not sent because Next.js telemetry is disabled.`
+    )
+    return
+  }
+
+  await telemetry.record(
+    eventAgentFeedback({
+      feedbackType: options.feedbackType,
+      outcome: options.outcome,
+      severity: options.severity,
+      modelProvider: options.modelProvider,
+      model: options.model,
+      inputTokens: options.inputTokens,
+      outputTokens: options.outputTokens,
+      durationMilliseconds: options.durationMilliseconds,
+      toolCallCount: options.toolCallCount,
+    })
+  )
+
+  console.log('Thank you for your feedback.')
+}
+
+export { nextTelemetry, nextTelemetryFeedback }

--- a/packages/next/src/telemetry/events/agent-feedback.ts
+++ b/packages/next/src/telemetry/events/agent-feedback.ts
@@ -1,0 +1,75 @@
+export const eventNameAgentFeedback = 'NEXT_AGENT_FEEDBACK'
+
+export const agentFeedbackTypes = [
+  'inefficient_task',
+  'excessive_searching',
+  'permissions_denied',
+  'missing_documentation',
+  'broken_documentation_link',
+  'network_failure',
+  'typescript_error',
+  'build_failure',
+  'test_failure_systematic',
+  'lint_failure',
+  'missing_configuration',
+  'unclear_pattern',
+  'timeout',
+  'pnpm_failure',
+  'other',
+] as const
+
+export const agentFeedbackOutcomes = [
+  'blocked',
+  'abandoned',
+  'recovered_with_workaround',
+] as const
+
+export const agentFeedbackSeverities = ['critical', 'warning', 'info'] as const
+
+export const agentFeedbackModels = {
+  openai: ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.5'],
+  anthropic: [
+    'claude-fable-5',
+    'claude-opus-5',
+    'claude-opus-4.8',
+    'claude-sonnet-5',
+  ],
+  google: ['gemini-3.7-flash', 'gemini-3.6-flash', 'gemini-3-pro-preview'],
+  xai: ['grok-4.6', 'grok-4.5'],
+  zai: ['glm-5.3', 'glm-5.2'],
+  moonshot: ['kimi-k3'],
+  alibaba: ['qwen3.8-max', 'qwen3.7-max', 'qwen3.7-plus'],
+  deepseek: ['deepseek-v4-pro', 'deepseek-v4-flash'],
+  minimax: ['minimax-m3'],
+  other: ['other'],
+  unknown: ['unknown'],
+} as const
+
+export type AgentFeedbackType = (typeof agentFeedbackTypes)[number]
+export type AgentFeedbackOutcome = (typeof agentFeedbackOutcomes)[number]
+export type AgentFeedbackSeverity = (typeof agentFeedbackSeverities)[number]
+export type AgentFeedbackModelProvider = keyof typeof agentFeedbackModels
+export type AgentFeedbackModel =
+  (typeof agentFeedbackModels)[AgentFeedbackModelProvider][number]
+
+export type EventAgentFeedback = {
+  feedbackType: AgentFeedbackType
+  outcome: AgentFeedbackOutcome
+  severity: AgentFeedbackSeverity
+  modelProvider: AgentFeedbackModelProvider
+  model: AgentFeedbackModel
+  inputTokens: number
+  outputTokens: number
+  durationMilliseconds: number
+  toolCallCount: number
+}
+
+export function eventAgentFeedback(event: EventAgentFeedback): {
+  eventName: string
+  payload: EventAgentFeedback
+} {
+  return {
+    eventName: eventNameAgentFeedback,
+    payload: event,
+  }
+}

--- a/packages/next/src/telemetry/post-telemetry-payload.test.ts
+++ b/packages/next/src/telemetry/post-telemetry-payload.test.ts
@@ -9,6 +9,7 @@ describe('postNextTelemetryPayload', () => {
 
   afterEach(() => {
     global.fetch = originalFetch
+    jest.restoreAllMocks()
   })
 
   it('sends telemetry payload successfully', async () => {
@@ -85,5 +86,32 @@ describe('postNextTelemetryPayload', () => {
     await postNextTelemetryPayload(payload)
 
     expect(mockFetch).toHaveBeenCalledTimes(2) // Initial try + 1 retry
+  })
+
+  it('combines a provided signal with the telemetry timeout', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: true })
+    global.fetch = mockFetch
+    const timeout = jest.spyOn(AbortSignal, 'timeout')
+    const controller = new AbortController()
+
+    const payload = {
+      meta: {},
+      context: {
+        anonymousId: 'test-id',
+        projectId: 'test-project',
+        sessionId: 'test-session',
+      },
+      events: [],
+    }
+
+    await postNextTelemetryPayload(payload, controller.signal)
+
+    expect(timeout).toHaveBeenCalledWith(5000)
+    const signal = mockFetch.mock.calls[0][1].signal as AbortSignal
+    expect(signal).not.toBe(controller.signal)
+    expect(signal.aborted).toBe(false)
+
+    controller.abort()
+    expect(signal.aborted).toBe(true)
   })
 })

--- a/packages/next/src/telemetry/post-telemetry-payload.ts
+++ b/packages/next/src/telemetry/post-telemetry-payload.ts
@@ -16,8 +16,12 @@ interface Payload {
 }
 
 export function postNextTelemetryPayload(payload: Payload, signal?: any) {
-  if (!signal && 'timeout' in AbortSignal) {
-    signal = AbortSignal.timeout(5000)
+  if ('timeout' in AbortSignal) {
+    const timeoutSignal = AbortSignal.timeout(5000)
+    signal =
+      signal && 'any' in AbortSignal
+        ? AbortSignal.any([signal, timeoutSignal])
+        : signal || timeoutSignal
   }
   return (
     retry(

--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -9,7 +9,6 @@ import { getAnonymousMeta } from './anonymous-meta'
 import * as ciEnvironment from '../server/ci-info'
 import { postNextTelemetryPayload } from './post-telemetry-payload'
 import { getRawProjectId } from './project-id'
-import { AbortController } from 'next/dist/compiled/@edge-runtime/ponyfill'
 import fs from 'fs'
 
 // This is the key that stores whether or not telemetry is enabled or disabled.

--- a/test/e2e/telemetry/telemetry.test.ts
+++ b/test/e2e/telemetry/telemetry.test.ts
@@ -91,6 +91,221 @@ import { findAllTelemetryEvents } from 'next-test-utils'
     })
     expect(stdout).toMatch(/Status: Disabled/)
   })
+
+  it('can submit structured agent feedback', async () => {
+    const { exitCode, stdout, stderr } = await next.runCommand(
+      [
+        'telemetry',
+        'feedback',
+        '--feedback-type',
+        'missing_documentation',
+        '--outcome',
+        'recovered_with_workaround',
+        '--severity',
+        'warning',
+        '--model-provider',
+        'openai',
+        '--model',
+        'gpt-5.6-sol',
+        '--input-tokens',
+        '1000',
+        '--output-tokens',
+        '200',
+        '--duration-milliseconds',
+        '30000',
+        '--tool-call-count',
+        '12',
+      ],
+      {
+        env: {
+          NEXT_TELEMETRY_DEBUG: '1',
+        },
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('Thank you for your feedback.')
+    expect(findAllTelemetryEvents(stderr, 'NEXT_AGENT_FEEDBACK')).toEqual([
+      {
+        feedbackType: 'missing_documentation',
+        outcome: 'recovered_with_workaround',
+        severity: 'warning',
+        modelProvider: 'openai',
+        model: 'gpt-5.6-sol',
+        inputTokens: 1000,
+        outputTokens: 200,
+        durationMilliseconds: 30000,
+        toolCallCount: 12,
+      },
+    ])
+  })
+
+  it('can print agent feedback help', async () => {
+    const { exitCode, stdout } = await next.runCommand([
+      'telemetry',
+      'feedback',
+      '--help',
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('Submit structured, anonymous feedback')
+    expect(stdout).toContain('--feedback-type <type>')
+    expect(stdout).toContain('--model-provider <provider>')
+    expect(stdout).not.toContain('--message')
+  })
+
+  it('uses anonymous defaults for unknown agent run details', async () => {
+    const { exitCode, stderr } = await next.runCommand(
+      [
+        'telemetry',
+        'feedback',
+        '--feedback-type',
+        'other',
+        '--outcome',
+        'blocked',
+        '--severity',
+        'info',
+      ],
+      {
+        env: {
+          NEXT_TELEMETRY_DEBUG: '1',
+        },
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(findAllTelemetryEvents(stderr, 'NEXT_AGENT_FEEDBACK')).toEqual([
+      {
+        feedbackType: 'other',
+        outcome: 'blocked',
+        severity: 'info',
+        modelProvider: 'unknown',
+        model: 'unknown',
+        inputTokens: -1,
+        outputTokens: -1,
+        durationMilliseconds: -1,
+        toolCallCount: -1,
+      },
+    ])
+  })
+
+  it('rejects a model that does not belong to its provider', async () => {
+    const { exitCode, stderr } = await next.runCommand([
+      'telemetry',
+      'feedback',
+      '--feedback-type',
+      'build_failure',
+      '--outcome',
+      'blocked',
+      '--severity',
+      'critical',
+      '--model-provider',
+      'anthropic',
+      '--model',
+      'gpt-5.5',
+    ])
+
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain(
+      'The model "gpt-5.5" is not valid for provider "anthropic".'
+    )
+  })
+
+  it('requires model and provider together', async () => {
+    const { exitCode, stderr } = await next.runCommand([
+      'telemetry',
+      'feedback',
+      '--feedback-type',
+      'other',
+      '--outcome',
+      'blocked',
+      '--severity',
+      'info',
+      '--model-provider',
+      'openai',
+    ])
+
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain(
+      'The --model-provider and --model options must be provided together.'
+    )
+  })
+
+  it.each(['12junk', '1.5', '1e3', '9007199254740992'])(
+    'rejects an invalid numeric field: %s',
+    async (inputTokens) => {
+      const { exitCode, stderr } = await next.runCommand([
+        'telemetry',
+        'feedback',
+        '--feedback-type',
+        'build_failure',
+        '--outcome',
+        'blocked',
+        '--severity',
+        'critical',
+        '--input-tokens',
+        inputTokens,
+      ])
+
+      expect(exitCode).toBe(1)
+      expect(stderr).toContain(
+        `'${inputTokens}' is not -1 or a non-negative safe integer.`
+      )
+    }
+  )
+
+  it('accepts the explicit unknown numeric sentinel', async () => {
+    const { exitCode, stderr } = await next.runCommand(
+      [
+        'telemetry',
+        'feedback',
+        '--feedback-type',
+        'other',
+        '--outcome',
+        'blocked',
+        '--severity',
+        'info',
+        '--input-tokens',
+        '-1',
+      ],
+      {
+        env: {
+          NEXT_TELEMETRY_DEBUG: '1',
+        },
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(findAllTelemetryEvents(stderr, 'NEXT_AGENT_FEEDBACK')[0]).toEqual(
+      expect.objectContaining({ inputTokens: -1 })
+    )
+  })
+
+  it('does not submit agent feedback when telemetry is disabled', async () => {
+    const { exitCode, stdout, stderr } = await next.runCommand(
+      [
+        'telemetry',
+        'feedback',
+        '--feedback-type',
+        'timeout',
+        '--outcome',
+        'abandoned',
+        '--severity',
+        'warning',
+      ],
+      {
+        env: {
+          NEXT_TELEMETRY_DISABLED: '1',
+        },
+      }
+    )
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain(
+      'Agent feedback was not sent because Next.js telemetry is disabled.'
+    )
+    expect(stderr).not.toContain('NEXT_AGENT_FEEDBACK')
+  })
   ;(isNextStart ? describe : describe.skip)('production mode', () => {
     // Tests in this block run a full `next build` per test. With a custom
     // `.babelrc` webpack switches off SWC and the build can take 60s+,


### PR DESCRIPTION
## Summary

- add `next telemetry feedback` for enum/integer-only `NEXT_AGENT_FEEDBACK` events
- validate feedback enums, model/provider pairs, token/duration/tool metrics, and telemetry opt-out behavior
- preserve caller cancellation while applying the existing five-second telemetry timeout

Depends on [vercel/next-telemetry#167](https://github.com/vercel/next-telemetry/pull/167). The receiver must be deployed before this PR merges.

## Verification

- `CI=1 pnpm build-all`
- `pnpm exec jest packages/next/src/telemetry/post-telemetry-payload.test.ts --runInBand`
- `NPM_CONFIG_REGISTRY=https://registry.npmjs.org HEADLESS=true pnpm test-start-turbo test/e2e/telemetry/telemetry.test.ts`
- `NPM_CONFIG_REGISTRY=https://registry.npmjs.org HEADLESS=true pnpm test-start-webpack test/e2e/telemetry/telemetry.test.ts`
- `/Users/marcos/.codex/skills/autoreview/scripts/autoreview --mode branch --base origin/canary --stream-engine-output` (GPT-5.6 Sol + Claude Fable 5: clean)

<!-- NEXT_JS_LLM -->