### PR TITLE
perf(app-render): preinit root main chunks with fetchPriority high

### DIFF
--- a/packages/next/src/server/app-render/required-scripts.tsx
+++ b/packages/next/src/server/app-render/required-scripts.tsx
@@ -51,6 +51,7 @@ export function getRequiredScripts(
           integrity: preinitScriptCommands[i + 1],
           crossOrigin,
           nonce,
+          fetchPriority: 'high',
         })
       }
     }
@@ -68,6 +69,7 @@ export function getRequiredScripts(
           as: 'script',
           nonce,
           crossOrigin,
+          fetchPriority: 'high',
         })
       }
     }


### PR DESCRIPTION
fixes #97531

Chrome 139+ enables the Blink feature kLowPriorityAsyncScriptExecution by default, which delays execution of cross-site classic async scripts. 

With `assetPrefix` pointing at a CDN on a different domain, every chunk script App Router emits is affected and React hydration stalls waiting on them.

This PR fixes #97531 by setting fetchPriority on next's chunk JS to opt out the execution delay.

Chrome's documented opt-out is fetchpriority="high"; ReactDOM.preinit already accepts fetchPriority in PreinitOptions.
