### PR TITLE
[test] Drop the dead `sqlite3` build approval from the `sharp-basic` suite

### DIFF
--- a/test/production/sharp-basic/sharp-basic.test.ts
+++ b/test/production/sharp-basic/sharp-basic.test.ts
@@ -6,11 +6,6 @@ describe('sharp support with hasNextSupport', () => {
     dependencies: {
       sharp: 'latest',
     },
-    packageJson: {
-      pnpm: {
-        onlyBuiltDependencies: ['sqlite3'],
-      },
-    },
     env: {
       NOW_BUILDER: '1',
     },


### PR DESCRIPTION
This suite doesn't use `sqlite3`.