### PR TITLE
docs: generateMetadata values should be serializable with use cache

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
@@ -421,7 +421,7 @@ export const metadata = {
 > **Good to know**:
 >
 > - `metadataBase` is typically set in root `app/layout.js` to apply to URL-based `metadata` fields across all routes.
-> - When `generateMetadata` uses `'use cache'`, its return value must be serializable. `URL` instances are not supported by Cache Functions, so provide `metadataBase` as a string, such as `url.toString()`. See [`use cache` serialization requirements](/docs/app/api-reference/directives/use-cache#serialization).
+> - When `generateMetadata` uses `'use cache'`, its return value must be serializable. `URL` instances are not supported by Cache Functions, so values such as `metadataBase` should be returned as strings (for example, `url.toString()`). See [`use cache` serialization requirements](/docs/app/api-reference/directives/use-cache#serialization).
 > - All URL-based `metadata` fields that require absolute URLs can be configured with a `metadataBase` option.
 > - `metadataBase` can contain a subdomain e.g. `https://app.acme.com` or base path e.g. `https://acme.com/start/from/here`
 > - If a `metadata` field provides an absolute URL, `metadataBase` will be ignored.

--- a/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
@@ -421,6 +421,7 @@ export const metadata = {
 > **Good to know**:
 >
 > - `metadataBase` is typically set in root `app/layout.js` to apply to URL-based `metadata` fields across all routes.
+> - When `generateMetadata` uses `'use cache'`, its return value must be serializable. `URL` instances are not supported by Cache Functions, so provide `metadataBase` as a string, such as `url.toString()`. See [`use cache` serialization requirements](/docs/app/api-reference/directives/use-cache#serialization).
 > - All URL-based `metadata` fields that require absolute URLs can be configured with a `metadataBase` option.
 > - `metadataBase` can contain a subdomain e.g. `https://app.acme.com` or base path e.g. `https://acme.com/start/from/here`
 > - If a `metadata` field provides an absolute URL, `metadataBase` will be ignored.


### PR DESCRIPTION
### Why?

generateMetadata can be marked with use cache, but Cache Function return values must be serializable. The metadataBase examples use URL objects, so the interaction needs co-located guidance for cached metadata.

### How?

Add a Good to know note that recommends returning metadataBase as a string, such as with url.toString(), and links to the use cache serialization requirements. Runtime behavior is unchanged.

<!-- NEXT_JS_LLM -->