### PR TITLE
test: improve error-on-next-codemod-comment flakiness

### DIFF
--- a/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
+++ b/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
@@ -71,21 +71,20 @@ describe('app-dir - error-on-next-codemod-comment', () => {
     })
 
     it('should error with inline comment as well', async () => {
-      let originFileContent
-      await next.patchFile('app/page.tsx', (code) => {
-        originFileContent = code
-        return code.replace(
-          '// @next-codemod-error remove jsx of next line',
-          '/* @next-codemod-error remove jsx of next line */'
-        )
-      })
-
-      const browser = await next.browser('/')
-
-      await waitForRedbox(browser)
-
-      // Recover the original file content
-      await next.patchFile('app/page.tsx', originFileContent)
+      await next.patchFile(
+        'app/page.tsx',
+        (code) =>
+          code.replace(
+            '// @next-codemod-error remove jsx of next line',
+            '/* @next-codemod-error remove jsx of next line */'
+          ),
+        async () => {
+          const browser = await next.browser('/')
+          await retry(async () => {
+            await waitForRedbox(browser)
+          }, 10000)
+        }
+      )
     })
 
     it('should disappear the error when you rre the codemod comment', async () => {
@@ -93,21 +92,16 @@ describe('app-dir - error-on-next-codemod-comment', () => {
 
       await waitForRedbox(browser)
 
-      let originFileContent
-      await next.patchFile('app/page.tsx', (code) => {
-        originFileContent = code
-        return code.replace(
-          '// @next-codemod-error remove jsx of next line',
-          ''
-        )
-      })
-
-      await retry(async () => {
-        await waitForNoRedbox(browser)
-      })
-
-      // Recover the original file content
-      await next.patchFile('app/page.tsx', originFileContent)
+      await next.patchFile(
+        'app/page.tsx',
+        (code) =>
+          code.replace('// @next-codemod-error remove jsx of next line', ''),
+        async () => {
+          await retry(async () => {
+            await waitForNoRedbox(browser)
+          }, 10000)
+        }
+      )
     })
 
     it('should disappear the error when you replace with bypass comment', async () => {
@@ -115,18 +109,15 @@ describe('app-dir - error-on-next-codemod-comment', () => {
 
       await waitForRedbox(browser)
 
-      let originFileContent
-      await next.patchFile('app/page.tsx', (code) => {
-        originFileContent = code
-        return code.replace('@next-codemod-error', '@next-codemod-bypass')
-      })
-
-      await retry(async () => {
-        await waitForNoRedbox(browser)
-      })
-
-      // Recover the original file content
-      await next.patchFile('app/page.tsx', originFileContent)
+      await next.patchFile(
+        'app/page.tsx',
+        (code) => code.replace('@next-codemod-error', '@next-codemod-bypass'),
+        async () => {
+          await retry(async () => {
+            await waitForNoRedbox(browser)
+          }, 10000)
+        }
+      )
     })
   } else {
     it('should fail the build with next build', async () => {


### PR DESCRIPTION
example failure: https://github.com/vercel/next.js/actions/runs/32246702678/job/96048986756?pr=90300
datadog: https://app.datadoghq.com/ci/test/runs?query=test_level%3Asuite%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.suite%3A%22app-dir%20-%20error-on-next-codemod-comment%22&agg_m=%40duration&agg_m_source=base&agg_t=avg&fromUser=false&index=citest&viz=stream&start=1786535051579&end=1787139851579&paused=false

1. Use the callback form of `patchFile` for automatic and more robust cleanup
2. Longer `retry` duration in case HMR is slow on CI