### PR TITLE
fix(eslint-plugin-next): flag `<a>` links to static App Router routes

### DIFF
--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -166,7 +166,9 @@ export function getUrlFromAppDirectory(
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
-          (url) => `^${normalizeAppPath(url)}$`
+          // `href`s are compared after `normalizeURL` (which adds a trailing
+          // slash), so normalize here too or static app routes never match.
+          (url) => `^${normalizeURL(normalizeAppPath(url))}$`
         )
     )
   ).map((urlReg) => {

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -10,6 +10,7 @@ const withCustomPagesDir = path.join(__dirname, 'with-custom-pages-dir')
 const withNestedPagesDir = path.join(__dirname, 'with-nested-pages-dir')
 const withoutPagesDir = path.join(__dirname, 'without-pages-dir')
 const withAppDir = path.join(__dirname, 'with-app-dir')
+const withAppDirStatic = path.join(__dirname, 'with-app-dir-static')
 
 const linters = {
   withoutPages: new Linter({
@@ -18,6 +19,10 @@ const linters = {
   }),
   withApp: new Linter({
     cwd: withAppDir,
+    configType: 'eslintrc',
+  }),
+  withAppStatic: new Linter({
+    cwd: withAppDirStatic,
     configType: 'eslintrc',
   }),
   withNestedPages: new Linter({
@@ -185,6 +190,51 @@ export class Blah extends Head {
 }
 `
 
+const invalidStaticAppRouteCode = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/dashboard'>Dashboard</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+
+const invalidNestedStaticAppRouteCode = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/dashboard/settings'>Settings</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+
+const validMissingStaticAppRouteCode = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/about'>About</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+
 const invalidDynamicCode = `
 import Link from 'next/link';
 
@@ -256,6 +306,39 @@ export class Blah extends Head {
 }
 `
 describe('no-html-link-for-pages', function () {
+  it('invalid static app route with appDir', function () {
+    const [report] = linters.withAppStatic.verify(
+      invalidStaticAppRouteCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/dashboard/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('invalid nested static app route with appDir', function () {
+    const [report] = linters.withAppStatic.verify(
+      invalidNestedStaticAppRouteCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/dashboard/settings/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('valid link to a non-existent static app route', function () {
+    const report = linters.withAppStatic.verify(
+      validMissingStaticAppRouteCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
+  })
+
   it('does not print warning when there are "pages" or "app" directories with rootDir in context settings', function () {
     const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
     linters.withNestedPages.verify(

--- a/test/unit/eslint-plugin-next/with-app-dir-static/app/dashboard/page.tsx
+++ b/test/unit/eslint-plugin-next/with-app-dir-static/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null
+}

--- a/test/unit/eslint-plugin-next/with-app-dir-static/app/dashboard/settings/page.tsx
+++ b/test/unit/eslint-plugin-next/with-app-dir-static/app/dashboard/settings/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null
+}

--- a/test/unit/eslint-plugin-next/with-app-dir-static/app/page.tsx
+++ b/test/unit/eslint-plugin-next/with-app-dir-static/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null
+}


### PR DESCRIPTION
Problem
The no html link for pages lint rule currently misses a pretty straightforward app router case. If /dashboard exists as app/dashboard/page.tsx, an <a href="/dashboard"> should be flagged, but the rule doesnt warn about it

Why

rule builds a list of real routes and uses that list match links. For the App Router route gets turned into ^/dashboard$. The problem is links were normalize before matching so /dashboard becomes /dashboard/. Those two dont line up, so the route never matches.
The Pages Router was already doing this type normalization so it didnt have the same issue The two route builders were just handling urls slightly differently

How

I updated the App Router route builder to run the url through same normalize url function used by link before building regex it keeps both sides consistent and is just a one line change.

This doesnt change the behavior for / or dynamic routes.

Tests

I added a small static only App Router fixture and tests covering:

/dashboard is now flagged when the page exists
/dashboard/settings is also flagged when the page exists
/about is still ignored when there isn't a matching page

So the rule now catches the App Router links it was intended to catch without changing the existing behavior for unrelated routes.