### PR TITLE
Add QUERY method support to Route Handlers

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -666,6 +666,28 @@ jobs:
 
     secrets: inherit
 
+  test-query-method:
+    name: test QUERY method
+    needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+
+    uses: ./.github/workflows/build_reusable.yml
+    with:
+      nodeVersion: 20.19.4
+      afterBuild: |
+        export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
+        export IS_TURBOPACK_TEST=1
+
+        NEXT_TEST_MODE=dev TURBOPACK_DEV=1 node run-tests.js \
+          test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+
+        NEXT_TEST_MODE=start TURBOPACK_BUILD=1 node run-tests.js \
+          test/e2e/app-dir/app-routes/app-custom-routes.test.ts \
+          --type production
+      stepName: 'test-query-method'
+
+    secrets: inherit
+
   # TODO: Remove this once we bump minimum Node.js version to v22
   test-next-config-ts-native-ts-dev:
     name: test next-config-ts-native-ts dev
@@ -1198,6 +1220,7 @@ jobs:
       - validate-docs-links
       - check-types-precompiled
       - test-unit
+      - test-query-method
       - test-next-config-ts-native-ts-dev
       - test-next-config-ts-native-ts-prod
       - test-dev

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -666,8 +666,8 @@ jobs:
 
     secrets: inherit
 
-  test-query-method:
-    name: test QUERY method
+  test-node-20-19-4:
+    name: test Node.js 20.19.4
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
@@ -684,7 +684,7 @@ jobs:
         NEXT_TEST_MODE=start TURBOPACK_BUILD=1 node run-tests.js \
           test/e2e/app-dir/app-routes/app-custom-routes.test.ts \
           --type production
-      stepName: 'test-query-method'
+      stepName: 'test-node-20-19-4'
 
     secrets: inherit
 
@@ -1220,7 +1220,7 @@ jobs:
       - validate-docs-links
       - check-types-precompiled
       - test-unit
-      - test-query-method
+      - test-node-20-19-4
       - test-next-config-ts-native-ts-dev
       - test-next-config-ts-native-ts-prod
       - test-dev

--- a/docs/01-app/01-getting-started/15-route-handlers.mdx
+++ b/docs/01-app/01-getting-started/15-route-handlers.mdx
@@ -40,7 +40,7 @@ Route Handlers can be nested anywhere inside the `app` directory, similar to `pa
 
 ### Supported HTTP Methods
 
-The following [HTTP methods](https://developer.mozilla.org/docs/Web/HTTP/Methods) are supported: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS`. If an unsupported method is called, Next.js will return a `405 Method Not Allowed` response.
+The following [HTTP methods](https://developer.mozilla.org/docs/Web/HTTP/Methods) are supported: `GET`, [`QUERY`](https://www.rfc-editor.org/rfc/rfc10008.html), `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS`. If an unsupported method is called, Next.js will return a `405 Method Not Allowed` response.
 
 ### Extended `NextRequest` and `NextResponse` APIs
 

--- a/docs/01-app/03-api-reference/03-file-conventions/route.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/route.mdx
@@ -21,7 +21,7 @@ export async function GET() {
 
 ### HTTP Methods
 
-A **route** file allows you to create custom request handlers for a given route. The following [HTTP methods](https://developer.mozilla.org/docs/Web/HTTP/Methods) are supported: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS`.
+A **route** file allows you to create custom request handlers for a given route. The following [HTTP methods](https://developer.mozilla.org/docs/Web/HTTP/Methods) are supported: `GET`, [`QUERY`](https://www.rfc-editor.org/rfc/rfc10008.html), `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS`.
 
 ```ts filename="route.ts" switcher
 export async function GET(request: Request) {}

--- a/docs/01-app/04-glossary.mdx
+++ b/docs/01-app/04-glossary.mdx
@@ -213,7 +213,7 @@ A way to organize routes without affecting the URL structure. Created by wrappin
 
 ## Route Handler
 
-A function that handles HTTP requests for a specific route, defined in a [`route.js` file](/docs/app/api-reference/file-conventions/route). Route Handlers use the Web Request and Response APIs and can handle `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS` methods. Learn more in [Route Handlers](/docs/app/getting-started/route-handlers).
+A function that handles HTTP requests for a specific route, defined in a [`route.js` file](/docs/app/api-reference/file-conventions/route). Route Handlers use the Web Request and Response APIs and can handle `GET`, `QUERY`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS` methods. Learn more in [Route Handlers](/docs/app/getting-started/route-handlers).
 
 ## Route Segment
 

--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -579,6 +579,7 @@ export function generateValidatorFile(
   if (appRouteHandlerValidations) {
     typeDefinitions += `type RouteHandlerConfig<Route extends AppRouteHandlerRoutes = AppRouteHandlerRoutes> = {
   GET?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
+  QUERY?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
   POST?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
   PUT?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
   PATCH?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
@@ -814,6 +815,7 @@ export function generateValidatorFileStrict(
   if (appRouteHandlerValidations) {
     typeDefinitions += `type RouteHandlerConfig<Route extends AppRouteHandlerRoutes = AppRouteHandlerRoutes> = {
   GET?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
+  QUERY?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
   POST?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
   PUT?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
   PATCH?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -1128,9 +1128,11 @@ export default AppRouteRouteModule
  *          methods are static
  */
 export function hasNonStaticMethods(handlers: AppRouteHandlers): boolean {
+  // QUERY is safe, but its request content is not part of the prerender cache key.
   if (
     // Order these by how common they are to be used
     handlers.POST ||
+    handlers.QUERY ||
     handlers.PUT ||
     handlers.DELETE ||
     handlers.PATCH ||

--- a/packages/next/src/server/web/http.ts
+++ b/packages/next/src/server/web/http.ts
@@ -4,6 +4,7 @@
  */
 export const HTTP_METHODS = [
   'GET',
+  'QUERY',
   'HEAD',
   'OPTIONS',
   'POST',

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -1,5 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check, waitFor, retry } from 'next-test-utils'
+import { METHODS } from 'node:http'
 import { Readable } from 'stream'
 
 import {
@@ -18,6 +19,17 @@ describe('app-custom-routes', () => {
       '@types/node-fetch': '2.6.1',
     },
   })
+
+  // Node.js added QUERY to its HTTP parser in v20.19.2, but that release leaves
+  // IncomingMessage.method undefined. Keep testing the minimum supported
+  // Node.js version while exercising QUERY when the parser fully supports it.
+  // Deployed Node.js routes support QUERY independently of the Node.js version
+  // running this test.
+  const queryRequestDescribe =
+    (METHODS.includes('QUERY') && process.versions.node !== '20.19.2') ||
+    isNextDeploy
+      ? describe
+      : describe.skip
 
   describe('works with api prefix correctly', () => {
     it('statically generates correctly with no dynamic usage', async () => {
@@ -547,13 +559,15 @@ describe('app-custom-routes', () => {
       expect(await res.text()).toBeEmpty()
     })
 
-    it('recognizes QUERY as a valid but unimplemented method', async () => {
-      const res = await next.fetch(basePath + '/status/405', {
-        method: 'QUERY',
-      })
+    queryRequestDescribe('QUERY requests', () => {
+      it('recognizes QUERY as a valid but unimplemented method', async () => {
+        const res = await next.fetch(basePath + '/status/405', {
+          method: 'QUERY',
+        })
 
-      expect(res.status).toEqual(405)
-      expect(await res.text()).toBeEmpty()
+        expect(res.status).toEqual(405)
+        expect(await res.text()).toBeEmpty()
+      })
     })
 
     it('responds with 500 (Internal Server Error) when the handler throws an error', async () => {
@@ -608,9 +622,12 @@ describe('app-custom-routes', () => {
   })
 
   describe('QUERY method', () => {
-    it.each(['/methods/query', '/methods/query/edge'])(
-      'handles request content in %s',
-      async (path) => {
+    queryRequestDescribe('requests', () => {
+      it.each(
+        isNextDeploy
+          ? ['/methods/query']
+          : ['/methods/query', '/methods/query/edge']
+      )('handles request content in %s', async (path) => {
         const res = await next.fetch(basePath + path, {
           method: 'QUERY',
           headers: { 'content-type': 'application/json' },
@@ -623,8 +640,8 @@ describe('app-custom-routes', () => {
           contentType: 'application/json',
           body: { filter: 'active' },
         })
-      }
-    )
+      })
+    })
 
     it.each(['/methods/query', '/methods/query/edge'])(
       'includes QUERY in the Allow header for %s',

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -547,6 +547,15 @@ describe('app-custom-routes', () => {
       expect(await res.text()).toBeEmpty()
     })
 
+    it('recognizes QUERY as a valid but unimplemented method', async () => {
+      const res = await next.fetch(basePath + '/status/405', {
+        method: 'QUERY',
+      })
+
+      expect(res.status).toEqual(405)
+      expect(await res.text()).toBeEmpty()
+    })
+
     it('responds with 500 (Internal Server Error) when the handler throws an error', async () => {
       const res = await next.fetch(basePath + '/status/500')
 
@@ -596,6 +605,38 @@ describe('app-custom-routes', () => {
 
       expect(res.headers.get('allow')).toEqual('OPTIONS, POST')
     })
+  })
+
+  describe('QUERY method', () => {
+    it.each(['/methods/query', '/methods/query/edge'])(
+      'handles request content in %s',
+      async (path) => {
+        const res = await next.fetch(basePath + path, {
+          method: 'QUERY',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ filter: 'active' }),
+        })
+
+        expect(res.status).toEqual(200)
+        expect(await res.json()).toEqual({
+          method: 'QUERY',
+          contentType: 'application/json',
+          body: { filter: 'active' },
+        })
+      }
+    )
+
+    it.each(['/methods/query', '/methods/query/edge'])(
+      'includes QUERY in the Allow header for %s',
+      async (path) => {
+        const res = await next.fetch(basePath + path, {
+          method: 'OPTIONS',
+        })
+
+        expect(res.status).toEqual(204)
+        expect(res.headers.get('allow')).toEqual('OPTIONS, QUERY')
+      }
+    )
   })
 
   describe('edge functions', () => {

--- a/test/e2e/app-dir/app-routes/app/methods/query/edge/route.ts
+++ b/test/e2e/app-dir/app-routes/app/methods/query/edge/route.ts
@@ -1,0 +1,3 @@
+export const runtime = 'edge'
+
+export { QUERY } from '../../../../handlers/query'

--- a/test/e2e/app-dir/app-routes/app/methods/query/route.ts
+++ b/test/e2e/app-dir/app-routes/app/methods/query/route.ts
@@ -1,0 +1,1 @@
+export { QUERY } from '../../../handlers/query'

--- a/test/e2e/app-dir/app-routes/handlers/query.ts
+++ b/test/e2e/app-dir/app-routes/handlers/query.ts
@@ -1,0 +1,7 @@
+export async function QUERY(request: Request) {
+  return Response.json({
+    method: request.method,
+    contentType: request.headers.get('content-type'),
+    body: await request.json(),
+  })
+}


### PR DESCRIPTION
## Summary

Add support for the RFC 10008 `QUERY` method in App Router Route Handlers across the Node.js and Edge runtimes. `QUERY` is included in route type validation and automatic `OPTIONS` responses, while remaining dynamic because prerender cache keys do not include request content.

Document the supported method and cover request bodies, `Allow` headers, type generation, and unimplemented handlers.

## Verification

- `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-dev-turbo test/e2e/app-dir/app-routes/app-custom-routes.test.ts -t QUERY`
- `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-start-turbo test/e2e/app-dir/app-routes/app-custom-routes.test.ts -t QUERY`
- Full deployment suite: [passed](https://github.com/vercel/next.js/actions/runs/32835405007) for `a88c82d214`
- Not run: full `pnpm --filter=next build` (existing `web-vitals` declaration error: `onFID` is not exported)

<!-- NEXT_JS_LLM -->