### PR TITLE
[no-unsafe-inline] Carry the Flight payload as data instead of inline scripts

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1463,6 +1463,37 @@ impl AppEndpoint {
             None
         };
 
+        // Like the polyfill, this is a pre-compiled asset distributed as part of next and served
+        // as-is rather than bundled. React only publishes it on the experimental channel, which
+        // `experimental.externalBrowserRuntime` opts into.
+        let external_browser_runtime_output_asset =
+            if matches!(this.ty, AppEndpointType::Page { .. })
+                && *project
+                    .next_config()
+                    .enable_external_browser_runtime()
+                    .await?
+            {
+                let next_package = get_next_package(project.project_path().owned().await?).await?;
+                let external_browser_runtime_source = FileSource::new(next_package.join(
+                    "dist/compiled/react-dom-experimental/unstable_server-external-runtime.js",
+                )?);
+
+                let external_browser_runtime_output_asset = ResolvedVc::upcast(
+                    SingleFileEcmascriptOutput::new(
+                        *client_chunking_context,
+                        Vc::upcast(external_browser_runtime_source),
+                    )
+                    .to_resolved()
+                    .await?,
+                );
+
+                client_assets.insert(external_browser_runtime_output_asset);
+
+                Some(external_browser_runtime_output_asset)
+            } else {
+                None
+            };
+
         // Compile any service workers registered via `navigator.serviceWorker.register(new
         // URL(...), { scope })` reachable from this endpoint.
         client_assets.extend(
@@ -1497,6 +1528,7 @@ impl AppEndpoint {
                 pages: Default::default(),
                 root_main_files: client_shared_chunks,
                 polyfill_files: polyfill_output_asset.into_iter().collect(),
+                external_browser_runtime_file: external_browser_runtime_output_asset,
                 root_main_files_per_page,
                 pages_chunk_group_bootstrap_params: client_chunk_group_bootstrap_params
                     .map(|params| {

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1286,6 +1286,8 @@ impl PageEndpoint {
             client_relative_path,
             pages,
             polyfill_files: Default::default(),
+            // App Router only for now; the Pages Router still inlines React's instructions.
+            external_browser_runtime_file: None,
             root_main_files: Default::default(),
             root_main_files_per_page: Default::default(),
             pages_chunk_group_bootstrap_params,

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1385,6 +1385,9 @@ pub struct ExperimentalConfig {
     // rename explicitly so it deserializes from the public `blockingSSR` field.
     #[serde(rename = "blockingSSR")]
     blocking_ssr: Option<bool>,
+    /// Streams React's instruction set as data plus a standalone browser runtime
+    /// asset instead of inline `<script>` tags.
+    external_browser_runtime: Option<bool>,
     /// @internal Used by the Next.js internals only.
     trust_host_header: Option<bool>,
 
@@ -2422,6 +2425,11 @@ impl NextConfig {
     #[turbo_tasks::function]
     pub fn enable_blocking_ssr(&self) -> Vc<bool> {
         Vc::cell(self.experimental.blocking_ssr.unwrap_or(false))
+    }
+
+    #[turbo_tasks::function]
+    pub fn enable_external_browser_runtime(&self) -> Vc<bool> {
+        Vc::cell(self.experimental.external_browser_runtime.unwrap_or(false))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -102,12 +102,17 @@ pub async fn get_next_client_import_map(
             let taint = *next_config.enable_taint().await?;
             let transition_indicator = *next_config.enable_transition_indicator().await?;
             let gesture_transition = *next_config.enable_gesture_transition().await?;
-            let react_channel =
-                if blocking_ssr || taint || transition_indicator || gesture_transition {
-                    "-experimental"
-                } else {
-                    ""
-                };
+            let external_browser_runtime = *next_config.enable_external_browser_runtime().await?;
+            let react_channel = if blocking_ssr
+                || taint
+                || transition_indicator
+                || gesture_transition
+                || external_browser_runtime
+            {
+                "-experimental"
+            } else {
+                ""
+            };
 
             import_map.insert_exact_alias(
                 rcstr!("react"),
@@ -887,7 +892,13 @@ async fn apply_vendored_react_aliases_server(
     let taint = *next_config.enable_taint().await?;
     let transition_indicator = *next_config.enable_transition_indicator().await?;
     let gesture_transition = *next_config.enable_gesture_transition().await?;
-    let react_channel = if blocking_ssr || taint || transition_indicator || gesture_transition {
+    let external_browser_runtime = *next_config.enable_external_browser_runtime().await?;
+    let react_channel = if blocking_ssr
+        || taint
+        || transition_indicator
+        || gesture_transition
+        || external_browser_runtime
+    {
         "-experimental"
     } else {
         ""

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -32,6 +32,9 @@ pub struct BuildManifest {
     pub client_relative_path: FileSystemPath,
 
     pub polyfill_files: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
+    /// The standalone browser runtime that applies React's instruction set when
+    /// `experimental.externalBrowserRuntime` is enabled. `None` otherwise.
+    pub external_browser_runtime_file: Option<ResolvedVc<Box<dyn OutputAsset>>>,
     pub root_main_files: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
     #[bincode(with = "turbo_bincode::indexmap")]
     pub pages: FxIndexMap<RcStr, ResolvedVc<OutputAssets>>,
@@ -74,6 +77,7 @@ impl OutputAssetsReference for BuildManifest {
             .flatten()
             .chain(root_main_files)
             .chain(self.polyfill_files.iter().copied())
+            .chain(self.external_browser_runtime_file)
             .chain(per_page_files)
             .collect();
 
@@ -103,6 +107,8 @@ impl Asset for BuildManifest {
             pub dev_files: Vec<RcStr>,
             pub amp_dev_files: Vec<RcStr>,
             pub polyfill_files: Vec<RcStr>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub external_browser_runtime_file: Option<RcStr>,
             pub low_priority_files: Vec<RcStr>,
             pub root_main_files: Vec<RcStr>,
             pub pages: FxIndexMap<RcStr, Vec<RcStr>>,
@@ -150,6 +156,22 @@ impl Asset for BuildManifest {
             })
             .try_join()
             .await?;
+
+        let external_browser_runtime_file: Option<RcStr> = match self.external_browser_runtime_file
+        {
+            Some(chunk) => {
+                let chunk_path = chunk.path().await?;
+                Some(
+                    client_relative_path
+                        .get_path_to(&chunk_path)
+                        .context(
+                            "failed to resolve client-relative path to external browser runtime",
+                        )?
+                        .into(),
+                )
+            }
+            None => None,
+        };
 
         let root_main_files: Vec<RcStr> = self
             .root_main_files
@@ -203,6 +225,7 @@ impl Asset for BuildManifest {
         let manifest = SerializedBuildManifest {
             pages: FxIndexMap::from_iter(pages),
             polyfill_files,
+            external_browser_runtime_file,
             root_main_files,
             root_main_files_tree: FxIndexMap::from_iter(root_main_files_tree),
             pages_chunk_group_bootstrap_params: self

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1474,5 +1474,6 @@
   "1473": "Invariant: image cache entry \"%s\" is empty",
   "1474": "Invariant: cannot write an empty buffer to the image cache",
   "1475": "Invariant: no direct app page entry found for %s",
-  "1476": "Not implemented: this behavior is not yet supported when `experimental.concurrentRouterQueue` is enabled."
+  "1476": "Not implemented: this behavior is not yet supported when `experimental.concurrentRouterQueue` is enabled.",
+  "1477": "`experimental.externalBrowserRuntime` is enabled but the runtime asset is missing from the build manifest. This usually means `.next` was produced by a build that did not have the flag enabled. Rebuild the app."
 }

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -173,6 +173,8 @@ export function getDefineEnv({
       config.experimental.turbopackSharedRuntime
     ),
     'process.env.__NEXT_CACHE_COMPONENTS': isCacheComponentsEnabled,
+    'process.env.__NEXT_EXTERNAL_BROWSER_RUNTIME':
+      config.experimental.externalBrowserRuntime === true,
     'process.env.__NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS': Boolean(
       config.experimental.cachedNavigations
     ),

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -958,6 +958,8 @@ export function createAppPageEntrypoint({
                 nextConfig.experimental.disableResumeDataCacheCompression ??
                 false,
               exposeTestingApi,
+              externalBrowserRuntime:
+                nextConfig.experimental.externalBrowserRuntime === true,
             },
 
             waitUntil: ctx.waitUntil,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -191,6 +191,8 @@ async function requestHandler(
           nextConfig.cacheComponents === true &&
           (pageRouteModule.isDev === true ||
             nextConfig.experimental.exposeTestingApiInProductionBuild === true),
+        externalBrowserRuntime:
+          nextConfig.experimental.externalBrowserRuntime === true,
       },
 
       incrementalCache: await pageRouteModule.getIncrementalCache(

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -19,6 +19,8 @@ import {
 } from './utils'
 import type { CustomRoutes } from '../lib/load-custom-routes.js'
 import {
+  CLIENT_STATIC_FILES_RUNTIME_EXTERNAL_BROWSER_RUNTIME,
+  CLIENT_STATIC_FILES_RUNTIME_EXTERNAL_BROWSER_RUNTIME_SYMBOL,
   CLIENT_STATIC_FILES_RUNTIME_MAIN,
   CLIENT_STATIC_FILES_RUNTIME_MAIN_APP,
   CLIENT_STATIC_FILES_RUNTIME_POLYFILLS_SYMBOL,
@@ -2183,6 +2185,27 @@ export default async function getBaseWebpackConfig(
           minimize: false,
           info: {
             [CLIENT_STATIC_FILES_RUNTIME_POLYFILLS_SYMBOL]: 1,
+            // This file is already minified
+            minimized: true,
+          },
+        }),
+      isClient &&
+        hasAppDir &&
+        config.experimental.externalBrowserRuntime === true &&
+        new CopyFilePlugin({
+          // React only publishes this standalone runtime on the experimental
+          // channel, which `experimental.externalBrowserRuntime` opts into via
+          // `needsExperimentalReact`. It is served as-is rather than bundled.
+          filePath: require.resolve(
+            '../compiled/react-dom-experimental/unstable_server-external-runtime'
+          ),
+          cacheKey: process.env.__NEXT_VERSION as string,
+          name: `static/chunks/${CLIENT_STATIC_FILES_RUNTIME_EXTERNAL_BROWSER_RUNTIME}${
+            dev ? '' : '-[hash]'
+          }.js`,
+          minimize: false,
+          info: {
+            [CLIENT_STATIC_FILES_RUNTIME_EXTERNAL_BROWSER_RUNTIME_SYMBOL]: 1,
             // This file is already minified
             minimized: true,
           },

--- a/packages/next/src/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/build-manifest-plugin.ts
@@ -6,6 +6,7 @@ import {
   BUILD_MANIFEST,
   MIDDLEWARE_BUILD_MANIFEST,
   CLIENT_STATIC_FILES_PATH,
+  CLIENT_STATIC_FILES_RUNTIME_EXTERNAL_BROWSER_RUNTIME_SYMBOL,
   CLIENT_STATIC_FILES_RUNTIME_MAIN,
   CLIENT_STATIC_FILES_RUNTIME_MAIN_APP,
   CLIENT_STATIC_FILES_RUNTIME_POLYFILLS_SYMBOL,
@@ -181,6 +182,15 @@ export default class BuildManifestPlugin {
           )
         })
         .map((v) => v.name)
+
+      // `CopyFilePlugin` emits at most one of these, and only when
+      // `experimental.externalBrowserRuntime` is enabled.
+      assetMap.externalBrowserRuntimeFile = compilationAssets.find(
+        (p) =>
+          p.name.endsWith('.js') &&
+          p.info &&
+          CLIENT_STATIC_FILES_RUNTIME_EXTERNAL_BROWSER_RUNTIME_SYMBOL in p.info
+      )?.name
 
       assetMap.devFiles = getEntrypointFiles(
         entrypoints.get(CLIENT_STATIC_FILES_RUNTIME_REACT_REFRESH)

--- a/packages/next/src/cli/internal/static-routes-info.ts
+++ b/packages/next/src/cli/internal/static-routes-info.ts
@@ -599,10 +599,15 @@ function collectAppClientFiles(
   // app-page. Both bundlers list them in the global `build-manifest.json`
   // under `rootMainFiles`. Turbopack also writes a per-route
   // `build-manifest.json` containing the same files; webpack does not.
-  const globalBm = readJsonFile<{ rootMainFiles?: string[] }>(
-    path.join(distDir, 'build-manifest.json')
-  )
+  const globalBm = readJsonFile<{
+    rootMainFiles?: string[]
+    externalBrowserRuntimeFile?: string
+  }>(path.join(distDir, 'build-manifest.json'))
   for (const chunk of globalBm?.rootMainFiles ?? []) addClientChunk(chunk, sets)
+  // Present only when `experimental.externalBrowserRuntime` is enabled.
+  if (globalBm?.externalBrowserRuntimeFile) {
+    addClientChunk(globalBm.externalBrowserRuntimeFile, sets)
+  }
 }
 
 /**

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -155,14 +155,89 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
   initialServerDataWriter = ctr
 }
 
+let stopFlightTemplateCollector: (() => void) | null = null
+
 // When `DOMContentLoaded`, we can close all pending writers to finish hydration.
 const DOMContentLoaded = function () {
+  // Must run before the writer is closed, otherwise a payload the observer has
+  // not delivered yet would be dropped.
+  if (stopFlightTemplateCollector !== null) {
+    stopFlightTemplateCollector()
+    stopFlightTemplateCollector = null
+  }
   if (initialServerDataWriter && !initialServerDataFlushed) {
     initialServerDataWriter.close()
     initialServerDataFlushed = true
     initialServerDataBuffer = undefined
   }
   initialServerDataLoaded = true
+}
+
+// Kept in sync with `FLIGHT_DATA_ATTRIBUTE` in
+// packages/next/src/server/app-render/use-flight-response.tsx
+const FLIGHT_TEMPLATE_SELECTOR = 'template[data-next-flight]'
+
+/**
+ * With `experimental.externalBrowserRuntime` the server writes each Flight
+ * payload as an inert `<template>` instead of an inline `<script>`, so that a
+ * Content-Security-Policy does not need `unsafe-inline`. Nothing executes those
+ * templates, so we collect them here: once for whatever the parser has already
+ * produced, then continuously as the rest of the document streams in.
+ *
+ * This deliberately lives in the client bundle rather than in the shared browser
+ * runtime asset. This module is the only consumer of the payload queue and it
+ * closes the stream on `DOMContentLoaded`, which `async` scripts do not block —
+ * collecting from a separate async script would race that close and drop data.
+ *
+ * Returns a function that performs a final sweep and stops observing.
+ */
+function createFlightTemplateCollector(): () => void {
+  const handled = new WeakSet<Element>()
+
+  function handle(element: Element) {
+    if (handled.has(element)) {
+      return
+    }
+    handled.add(element)
+
+    const payload = element.getAttribute('data-next-flight')
+    if (payload === null) {
+      return
+    }
+    nextServerDataCallback(JSON.parse(payload) as FlightSegment)
+  }
+
+  // `querySelectorAll` yields document order, which is the order the server
+  // wrote the payloads in. The bootstrap payload is written first, so it is
+  // always handled before any data payload.
+  function collect(root: ParentNode) {
+    root.querySelectorAll(FLIGHT_TEMPLATE_SELECTOR).forEach(handle)
+  }
+
+  collect(document)
+
+  const observer = new MutationObserver((records) => {
+    for (const record of records) {
+      record.addedNodes.forEach((node) => {
+        if (node.nodeType !== Node.ELEMENT_NODE) {
+          return
+        }
+        const element = node as Element
+        if (element.matches(FLIGHT_TEMPLATE_SELECTOR)) {
+          handle(element)
+        } else {
+          // The parser can append a subtree that contains the template.
+          collect(element)
+        }
+      })
+    }
+  })
+  observer.observe(document.documentElement, { childList: true, subtree: true })
+
+  return function stop() {
+    collect(document)
+    observer.disconnect()
+  }
 }
 
 // It's possible that the DOM is already loaded.
@@ -182,6 +257,10 @@ nextServerDataLoadingGlobal.length = 0
 
 // Patch its push method so subsequent chunks are handled (but not actually pushed to the array).
 nextServerDataLoadingGlobal.push = nextServerDataCallback
+
+if (process.env.__NEXT_EXTERNAL_BROWSER_RUNTIME) {
+  stopFlightTemplateCollector = createFlightTemplateCollector()
+}
 
 let readable: ReadableStream<Uint8Array> = new ReadableStream({
   start(controller) {

--- a/packages/next/src/compiled/react-dom-experimental/unstable_server-external-runtime.js
+++ b/packages/next/src/compiled/react-dom-experimental/unstable_server-external-runtime.js
@@ -1,0 +1,504 @@
+(function () {
+  function handleExistingNodes(target) {
+    target = target.querySelectorAll("template");
+    for (var i = 0; i < target.length; i++) handleNode(target[i]);
+  }
+  function installFizzInstrObserver(target) {
+    function handleMutations(mutations) {
+      for (var i = 0; i < mutations.length; i++)
+        for (
+          var addedNodes = mutations[i].addedNodes, j = 0;
+          j < addedNodes.length;
+          j++
+        )
+          addedNodes[j].parentNode && handleNode(addedNodes[j]);
+    }
+    var fizzInstrObserver = new MutationObserver(handleMutations);
+    fizzInstrObserver.observe(target, { childList: !0 });
+    window.addEventListener("DOMContentLoaded", function () {
+      handleMutations(fizzInstrObserver.takeRecords());
+      fizzInstrObserver.disconnect();
+    });
+  }
+  function handleNode(node_) {
+    if (1 === node_.nodeType && node_.dataset) {
+      var dataset = node_.dataset;
+      null != dataset.rxi
+        ? ($RX(
+            dataset.bid,
+            dataset.dgst,
+            dataset.msg,
+            dataset.stck,
+            dataset.cstck
+          ),
+          node_.remove())
+        : null != dataset.rri
+          ? ($RR(dataset.bid, dataset.sid, JSON.parse(dataset.sty)),
+            node_.remove())
+          : null != dataset.rci
+            ? ($RC(dataset.bid, dataset.sid), node_.remove())
+            : null != dataset.rsi &&
+              ($RS(dataset.sid, dataset.pid), node_.remove());
+    }
+  }
+  var $RT;
+  var $RM = new Map();
+  var $RB = [];
+  var $RX = function (
+    suspenseBoundaryID,
+    errorDigest,
+    errorMsg,
+    errorStack,
+    errorComponentStack
+  ) {
+    var suspenseIdNode = document.getElementById(suspenseBoundaryID);
+    suspenseIdNode &&
+      ((suspenseBoundaryID = suspenseIdNode.previousSibling),
+      (suspenseBoundaryID.data = "$!"),
+      (suspenseIdNode = suspenseIdNode.dataset),
+      null != errorDigest && (suspenseIdNode.dgst = errorDigest),
+      errorMsg && (suspenseIdNode.msg = errorMsg),
+      errorStack && (suspenseIdNode.stck = errorStack),
+      errorComponentStack && (suspenseIdNode.cstck = errorComponentStack),
+      suspenseBoundaryID._reactRetry && suspenseBoundaryID._reactRetry());
+  };
+  var $RV = function (revealBoundaries, batch) {
+    function applyViewTransitionName(element, classAttributeName) {
+      var className = element.getAttribute(classAttributeName);
+      className &&
+        ((classAttributeName = element.style),
+        restoreQueue.push(
+          element,
+          classAttributeName.viewTransitionName,
+          classAttributeName.viewTransitionClass
+        ),
+        "auto" !== className &&
+          (classAttributeName.viewTransitionClass = className),
+        (element = element.getAttribute("vt-name")) ||
+          (element = "_T_" + autoNameIdx++ + "_"),
+        (element =
+          CSS.escape(element) !== element
+            ? "r-" + btoa(element).replace(/=/g, "")
+            : element),
+        (classAttributeName.viewTransitionName = element),
+        (shouldStartViewTransition = !0));
+    }
+    var shouldStartViewTransition = !1,
+      autoNameIdx = 0,
+      restoreQueue = [];
+    try {
+      var existingTransition = document.__reactViewTransition;
+      if (existingTransition) {
+        existingTransition.finished.finally($RV.bind(null, batch));
+        return;
+      }
+      var appearingViewTransitions = new Map();
+      for (
+        existingTransition = 1;
+        existingTransition < batch.length;
+        existingTransition += 2
+      )
+        for (
+          var appearingElements =
+              batch[existingTransition].querySelectorAll("[vt-share]"),
+            j = 0;
+          j < appearingElements.length;
+          j++
+        ) {
+          var appearingElement = appearingElements[j];
+          appearingViewTransitions.set(
+            appearingElement.getAttribute("vt-name"),
+            appearingElement
+          );
+        }
+      var suspenseyImages = [];
+      for (
+        appearingElements = 0;
+        appearingElements < batch.length;
+        appearingElements += 2
+      ) {
+        var suspenseIdNode = batch[appearingElements],
+          parentInstance = suspenseIdNode.parentNode;
+        if (parentInstance) {
+          var parentRect = parentInstance.getBoundingClientRect();
+          if (
+            parentRect.left ||
+            parentRect.top ||
+            parentRect.width ||
+            parentRect.height
+          ) {
+            appearingElement = suspenseIdNode;
+            for (existingTransition = 0; appearingElement; ) {
+              if (8 === appearingElement.nodeType) {
+                var data = appearingElement.data;
+                if ("/$" === data)
+                  if (0 === existingTransition) break;
+                  else existingTransition--;
+                else
+                  ("$" !== data &&
+                    "$?" !== data &&
+                    "$~" !== data &&
+                    "$!" !== data) ||
+                    existingTransition++;
+              } else if (1 === appearingElement.nodeType) {
+                j = appearingElement;
+                var exitName = j.getAttribute("vt-name"),
+                  pairedElement = appearingViewTransitions.get(exitName);
+                applyViewTransitionName(
+                  j,
+                  pairedElement ? "vt-share" : "vt-exit"
+                );
+                pairedElement &&
+                  (applyViewTransitionName(pairedElement, "vt-share"),
+                  appearingViewTransitions.set(exitName, null));
+                for (
+                  var disappearingElements = j.querySelectorAll("[vt-share]"),
+                    j$1 = 0;
+                  j$1 < disappearingElements.length;
+                  j$1++
+                ) {
+                  var disappearingElement = disappearingElements[j$1],
+                    name = disappearingElement.getAttribute("vt-name"),
+                    appearingElement$2 = appearingViewTransitions.get(name);
+                  appearingElement$2 &&
+                    (applyViewTransitionName(disappearingElement, "vt-share"),
+                    applyViewTransitionName(appearingElement$2, "vt-share"),
+                    appearingViewTransitions.set(name, null));
+                }
+                var relayExitElements = j.querySelectorAll("[vt-parent-exit]");
+                for (j = 0; j < relayExitElements.length; j++)
+                  applyViewTransitionName(
+                    relayExitElements[j],
+                    "vt-parent-exit"
+                  );
+              }
+              appearingElement = appearingElement.nextSibling;
+            }
+            for (
+              var contentNode$4 = batch[appearingElements + 1],
+                enterElement = contentNode$4.firstElementChild;
+              enterElement;
+
+            ) {
+              null !==
+                appearingViewTransitions.get(
+                  enterElement.getAttribute("vt-name")
+                ) && applyViewTransitionName(enterElement, "vt-enter");
+              var relayEnterElements =
+                enterElement.querySelectorAll("[vt-parent-enter]");
+              for (
+                appearingElement = 0;
+                appearingElement < relayEnterElements.length;
+                appearingElement++
+              )
+                applyViewTransitionName(
+                  relayEnterElements[appearingElement],
+                  "vt-parent-enter"
+                );
+              enterElement = enterElement.nextElementSibling;
+            }
+            appearingElement = parentInstance;
+            do
+              for (
+                var childElement = appearingElement.firstElementChild;
+                childElement;
+
+              ) {
+                var updateClassName = childElement.getAttribute("vt-update");
+                updateClassName &&
+                  "none" !== updateClassName &&
+                  !restoreQueue.includes(childElement) &&
+                  applyViewTransitionName(childElement, "vt-update");
+                childElement = childElement.nextElementSibling;
+              }
+            while (
+              (appearingElement = appearingElement.parentNode) &&
+              1 === appearingElement.nodeType &&
+              "none" !== appearingElement.getAttribute("vt-update")
+            );
+            var appearingImages = contentNode$4.querySelectorAll(
+              'img[src]:not([loading="lazy"])'
+            );
+            suspenseyImages.push.apply(suspenseyImages, appearingImages);
+          }
+        }
+      }
+      if (shouldStartViewTransition) {
+        var transition = (document.__reactViewTransition =
+          document.startViewTransition({
+            update: function () {
+              revealBoundaries(batch);
+              for (
+                var blockingPromises = [
+                    document.documentElement.clientHeight,
+                    document.fonts.ready
+                  ],
+                  $jscomp$loop$9 = {},
+                  i$6 = 0;
+                i$6 < suspenseyImages.length;
+                $jscomp$loop$9 = {
+                  $jscomp$loop$prop$suspenseyImage$10:
+                    $jscomp$loop$9.$jscomp$loop$prop$suspenseyImage$10
+                },
+                  i$6++
+              )
+                if (
+                  (($jscomp$loop$9.$jscomp$loop$prop$suspenseyImage$10 =
+                    suspenseyImages[i$6]),
+                  !$jscomp$loop$9.$jscomp$loop$prop$suspenseyImage$10.complete)
+                ) {
+                  var rect =
+                    $jscomp$loop$9.$jscomp$loop$prop$suspenseyImage$10.getBoundingClientRect();
+                  0 < rect.bottom &&
+                    0 < rect.right &&
+                    rect.top < window.innerHeight &&
+                    rect.left < window.innerWidth &&
+                    ((rect = new Promise(
+                      (function ($jscomp$loop$9) {
+                        return function (resolve) {
+                          $jscomp$loop$9.$jscomp$loop$prop$suspenseyImage$10.addEventListener(
+                            "load",
+                            resolve
+                          );
+                          $jscomp$loop$9.$jscomp$loop$prop$suspenseyImage$10.addEventListener(
+                            "error",
+                            resolve
+                          );
+                        };
+                      })($jscomp$loop$9)
+                    )),
+                    blockingPromises.push(rect));
+                }
+              return Promise.race([
+                Promise.all(blockingPromises),
+                new Promise(function (resolve) {
+                  var currentTime = performance.now();
+                  setTimeout(
+                    resolve,
+                    2300 > currentTime && 2e3 < currentTime
+                      ? 2300 - currentTime
+                      : 500
+                  );
+                })
+              ]);
+            },
+            types: []
+          }));
+        transition.ready.finally(function () {
+          for (var i$7 = restoreQueue.length - 3; 0 <= i$7; i$7 -= 3) {
+            var element = restoreQueue[i$7],
+              elementStyle = element.style;
+            elementStyle.viewTransitionName = restoreQueue[i$7 + 1];
+            elementStyle.viewTransitionClass = restoreQueue[i$7 + 1];
+            "" === element.getAttribute("style") &&
+              element.removeAttribute("style");
+          }
+        });
+        transition.finished.finally(function () {
+          document.__reactViewTransition === transition &&
+            (document.__reactViewTransition = null);
+        });
+        $RB = [];
+        return;
+      }
+    } catch (x) {}
+    revealBoundaries(batch);
+  }.bind(null, function (batch) {
+    $RT = performance.now();
+    for (var i = 0; i < batch.length; i += 2) {
+      var suspenseIdNode = batch[i],
+        contentNode = batch[i + 1];
+      null !== contentNode.parentNode &&
+        contentNode.parentNode.removeChild(contentNode);
+      var parentInstance = suspenseIdNode.parentNode;
+      if (parentInstance) {
+        var suspenseNode = suspenseIdNode.previousSibling,
+          depth = 0;
+        do {
+          if (suspenseIdNode && 8 === suspenseIdNode.nodeType) {
+            var data = suspenseIdNode.data;
+            if ("/$" === data || "/&" === data)
+              if (0 === depth) break;
+              else depth--;
+            else
+              ("$" !== data &&
+                "$?" !== data &&
+                "$~" !== data &&
+                "$!" !== data &&
+                "&" !== data) ||
+                depth++;
+          }
+          data = suspenseIdNode.nextSibling;
+          parentInstance.removeChild(suspenseIdNode);
+          suspenseIdNode = data;
+        } while (suspenseIdNode);
+        for (; contentNode.firstChild; )
+          parentInstance.insertBefore(contentNode.firstChild, suspenseIdNode);
+        suspenseNode.data = "$";
+        suspenseNode._reactRetry &&
+          requestAnimationFrame(suspenseNode._reactRetry);
+      }
+    }
+    batch.length = 0;
+  });
+  var $RC = function (suspenseBoundaryID, contentID) {
+    if ((contentID = document.getElementById(contentID)))
+      (suspenseBoundaryID = document.getElementById(suspenseBoundaryID))
+        ? ((suspenseBoundaryID.previousSibling.data = "$~"),
+          $RB.push(suspenseBoundaryID, contentID),
+          2 === $RB.length &&
+            ("number" !== typeof $RT
+              ? requestAnimationFrame($RV.bind(null, $RB))
+              : ((suspenseBoundaryID = performance.now()),
+                (suspenseBoundaryID =
+                  2300 > suspenseBoundaryID && 2e3 < suspenseBoundaryID
+                    ? 2300 - suspenseBoundaryID
+                    : $RT + 300 - suspenseBoundaryID),
+                setTimeout($RV.bind(null, $RB), suspenseBoundaryID))))
+        : contentID.parentNode.removeChild(contentID);
+  };
+  var $RR = function (suspenseBoundaryID, contentID, stylesheetDescriptors) {
+    function cleanupWith(cb) {
+      this._p = null;
+      cb();
+    }
+    for (
+      var precedences = new Map(),
+        thisDocument = document,
+        lastResource,
+        node,
+        nodes = thisDocument.querySelectorAll(
+          "link[data-precedence],style[data-precedence]"
+        ),
+        styleTagsToHoist = [],
+        i$8 = 0;
+      (node = nodes[i$8++]);
+
+    )
+      "not all" === node.getAttribute("media")
+        ? styleTagsToHoist.push(node)
+        : ("LINK" === node.tagName && $RM.set(node.getAttribute("href"), node),
+          precedences.set(node.dataset.precedence, (lastResource = node)));
+    nodes = 0;
+    node = [];
+    var precedence, resourceEl;
+    for (i$8 = !0; ; ) {
+      if (i$8) {
+        var stylesheetDescriptor = stylesheetDescriptors[nodes++];
+        if (!stylesheetDescriptor) {
+          i$8 = !1;
+          nodes = 0;
+          continue;
+        }
+        var avoidInsert = !1,
+          j = 0;
+        var href = stylesheetDescriptor[j++];
+        if ((resourceEl = $RM.get(href))) {
+          var attr = resourceEl._p;
+          avoidInsert = !0;
+        } else {
+          resourceEl = thisDocument.createElement("link");
+          resourceEl.href = href;
+          resourceEl.rel = "stylesheet";
+          for (
+            resourceEl.dataset.precedence = precedence =
+              stylesheetDescriptor[j++];
+            (attr = stylesheetDescriptor[j++]);
+
+          )
+            resourceEl.setAttribute(attr, stylesheetDescriptor[j++]);
+          attr = resourceEl._p = new Promise(function (resolve, reject) {
+            resourceEl.onload = cleanupWith.bind(resourceEl, resolve);
+            resourceEl.onerror = cleanupWith.bind(resourceEl, reject);
+          });
+          $RM.set(href, resourceEl);
+        }
+        href = resourceEl.getAttribute("media");
+        !attr || (href && !window.matchMedia(href).matches) || node.push(attr);
+        if (avoidInsert) continue;
+      } else {
+        resourceEl = styleTagsToHoist[nodes++];
+        if (!resourceEl) break;
+        precedence = resourceEl.getAttribute("data-precedence");
+        resourceEl.removeAttribute("media");
+      }
+      avoidInsert = precedences.get(precedence) || lastResource;
+      avoidInsert === lastResource && (lastResource = resourceEl);
+      precedences.set(precedence, resourceEl);
+      avoidInsert
+        ? avoidInsert.parentNode.insertBefore(
+            resourceEl,
+            avoidInsert.nextSibling
+          )
+        : ((avoidInsert = thisDocument.head),
+          avoidInsert.insertBefore(resourceEl, avoidInsert.firstChild));
+    }
+    if ((stylesheetDescriptors = document.getElementById(suspenseBoundaryID)))
+      stylesheetDescriptors.previousSibling.data = "$~";
+    Promise.all(node).then(
+      $RC.bind(null, suspenseBoundaryID, contentID),
+      $RX.bind(null, suspenseBoundaryID, "CSS failed to load")
+    );
+  };
+  var $RS = function (containerID, placeholderID) {
+    containerID = document.getElementById(containerID);
+    placeholderID = document.getElementById(placeholderID);
+    for (
+      containerID.parentNode.removeChild(containerID);
+      containerID.firstChild;
+
+    )
+      placeholderID.parentNode.insertBefore(
+        containerID.firstChild,
+        placeholderID
+      );
+    placeholderID.parentNode.removeChild(placeholderID);
+  };
+  (function () {
+    addEventListener("submit", function (event) {
+      if (!event.defaultPrevented) {
+        var form = event.target,
+          submitter = event.submitter,
+          action = form.action,
+          formDataSubmitter = submitter;
+        if (submitter) {
+          var submitterAction = submitter.getAttribute("formAction");
+          null != submitterAction &&
+            ((action = submitterAction), (formDataSubmitter = null));
+        }
+        "javascript:throw new Error('React form unexpectedly submitted.')" ===
+          action &&
+          (event.preventDefault(),
+          (event = new FormData(form, formDataSubmitter)),
+          (action = form.ownerDocument || form),
+          (action.$$reactFormReplay = action.$$reactFormReplay || []).push(
+            form,
+            submitter,
+            event
+          ));
+      }
+    });
+  })();
+  var entries = performance.getEntriesByType
+    ? performance.getEntriesByType("paint")
+    : [];
+  0 < entries.length
+    ? ($RT = entries[0].startTime)
+    : requestAnimationFrame(function () {
+        $RT = performance.now();
+      });
+  if (null != document.body)
+    "loading" === document.readyState &&
+      installFizzInstrObserver(document.body),
+      handleExistingNodes(document.body);
+  else {
+    var domBodyObserver = new MutationObserver(function () {
+      null != document.body &&
+        ("loading" === document.readyState &&
+          installFizzInstrObserver(document.body),
+        handleExistingNodes(document.body),
+        domBodyObserver.disconnect());
+    });
+    domBodyObserver.observe(document.documentElement, { childList: !0 });
+  }
+})();

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -532,6 +532,8 @@ async function exportAppImpl(
         nextConfig.experimental.disableResumeDataCacheCompression ?? false,
       exposeTestingApi:
         nextConfig.experimental.exposeTestingApiInProductionBuild === true,
+      externalBrowserRuntime:
+        nextConfig.experimental.externalBrowserRuntime === true,
     },
     reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
   }

--- a/packages/next/src/lib/needs-experimental-react.ts
+++ b/packages/next/src/lib/needs-experimental-react.ts
@@ -2,9 +2,18 @@ import type { NextConfig } from '../server/config-shared'
 
 // Keep in sync with Turbopack's experimental React switch: file://./../../../../crates/next-core/src/next_import_map.rs
 export function needsExperimentalReact(config: NextConfig) {
-  const { blockingSSR, taint, transitionIndicator, gestureTransition } =
-    config.experimental || {}
+  const {
+    blockingSSR,
+    taint,
+    transitionIndicator,
+    gestureTransition,
+    externalBrowserRuntime,
+  } = config.experimental || {}
   return Boolean(
-    blockingSSR || taint || transitionIndicator || gestureTransition
+    blockingSSR ||
+      taint ||
+      transitionIndicator ||
+      gestureTransition ||
+      externalBrowserRuntime
   )
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -153,6 +153,7 @@ import {
 } from './walk-tree-with-flight-router-state'
 import { createFullComponentTree, getRootParams } from './create-component-tree'
 import { getAssetQueryString } from './get-asset-query-string'
+import { getExternalBrowserRuntimeSrc } from './get-external-browser-runtime-src'
 import {
   getClientReferenceManifest,
   getServerModuleMap,
@@ -3557,6 +3558,14 @@ async function renderToStream(
         nonce,
       }))
 
+  const externalRuntimeSrc = getExternalBrowserRuntimeSrc(
+    ctx,
+    buildManifest,
+    experimental.externalBrowserRuntime,
+    assetPrefix,
+    subresourceIntegrityManifest
+  )
+
   const [preinitScripts, bootstrapScript] = getRequiredScripts(
     buildManifest,
     // Why is assetPrefix optional on renderOpts?
@@ -4145,6 +4154,7 @@ async function renderToStream(
           maxHeadersLength: reactMaxHeadersLength,
           bootstrapScriptContent,
           bootstrapScripts: [bootstrapScript],
+          unstable_externalRuntimeSrc: externalRuntimeSrc,
           formState,
         }
 
@@ -4285,6 +4295,7 @@ async function renderToStream(
           maxHeadersLength: reactMaxHeadersLength,
           bootstrapScriptContent,
           bootstrapScripts: [bootstrapScript],
+          unstable_externalRuntimeSrc: externalRuntimeSrc,
           formState,
         }
 
@@ -4452,6 +4463,7 @@ async function renderToStream(
                 nonce,
                 bootstrapScriptContent: errorBootstrapScriptContent,
                 bootstrapScripts: [errorBootstrapScript],
+                unstable_externalRuntimeSrc: externalRuntimeSrc,
                 formState,
               },
               { waitForAllReady }
@@ -4548,6 +4560,7 @@ async function renderToStream(
                 nonce,
                 bootstrapScriptContent: errorBootstrapScriptContent,
                 bootstrapScripts: [errorBootstrapScript],
+                unstable_externalRuntimeSrc: externalRuntimeSrc,
                 formState,
               }
             )
@@ -8511,6 +8524,14 @@ async function prerenderToStream(
         nonce,
       }))
 
+  const externalRuntimeSrc = getExternalBrowserRuntimeSrc(
+    ctx,
+    buildManifest,
+    experimental.externalBrowserRuntime,
+    assetPrefix,
+    subresourceIntegrityManifest
+  )
+
   const [preinitScripts, bootstrapScript] = getRequiredScripts(
     buildManifest,
     // Why is assetPrefix optional on renderOpts?
@@ -8913,6 +8934,7 @@ async function prerenderToStream(
             },
             bootstrapScriptContent,
             bootstrapScripts: [bootstrapScript],
+            unstable_externalRuntimeSrc: externalRuntimeSrc,
           }
         )
 
@@ -9369,6 +9391,7 @@ async function prerenderToStream(
                 maxHeadersLength: reactMaxHeadersLength,
                 bootstrapScriptContent,
                 bootstrapScripts: [bootstrapScript],
+                unstable_externalRuntimeSrc: externalRuntimeSrc,
               }
             )
 
@@ -9576,6 +9599,7 @@ async function prerenderToStream(
           nonce,
           bootstrapScriptContent,
           bootstrapScripts: [bootstrapScript],
+          unstable_externalRuntimeSrc: externalRuntimeSrc,
         },
         { waitForAllReady: true }
       )
@@ -9877,6 +9901,7 @@ async function prerenderToStream(
                 nonce,
                 bootstrapScriptContent: errorBootstrapScriptContent,
                 bootstrapScripts: [errorBootstrapScript],
+                unstable_externalRuntimeSrc: externalRuntimeSrc,
                 formState,
                 signal: errorClientReactController.signal,
                 onError: (clientError: unknown, errorInfo: ErrorInfo) => {
@@ -10121,6 +10146,7 @@ async function prerenderToStream(
           nonce,
           bootstrapScriptContent: errorBootstrapScriptContent,
           bootstrapScripts: [errorBootstrapScript],
+          unstable_externalRuntimeSrc: externalRuntimeSrc,
           formState,
         },
         { waitForAllReady: true }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3558,10 +3558,11 @@ async function renderToStream(
         nonce,
       }))
 
+  const { externalBrowserRuntime } = experimental
   const externalRuntimeSrc = getExternalBrowserRuntimeSrc(
     ctx,
     buildManifest,
-    experimental.externalBrowserRuntime,
+    externalBrowserRuntime,
     assetPrefix,
     subresourceIntegrityManifest
   )
@@ -4058,7 +4059,8 @@ async function renderToStream(
             const inlinedDataStream = createNodeInlinedDataStream(
               reactServerResult.tee(),
               nonce,
-              formState
+              formState,
+              externalBrowserRuntime
             )
 
             // End the span since there's no async rendering in this path
@@ -4112,7 +4114,8 @@ async function renderToStream(
               inlinedDataStream: createNodeInlinedDataStream(
                 reactServerResult.consume(),
                 nonce,
-                formState
+                formState,
+                externalBrowserRuntime
               ),
               getServerInsertedHTML,
               getServerInsertedMetadata,
@@ -4179,7 +4182,8 @@ async function renderToStream(
           inlinedDataStream: createNodeInlinedDataStream(
             reactServerResult.consume(),
             nonce,
-            formState
+            formState,
+            externalBrowserRuntime
           ),
           waitForAllReady,
           allReady,
@@ -4200,7 +4204,8 @@ async function renderToStream(
             const inlinedDataStream = createWebInlinedDataStream(
               reactServerResult.tee(),
               nonce,
-              formState
+              formState,
+              externalBrowserRuntime
             )
 
             // End the span since there's no async rendering in this path
@@ -4254,7 +4259,8 @@ async function renderToStream(
               inlinedDataStream: createWebInlinedDataStream(
                 reactServerResult.consume(),
                 nonce,
-                formState
+                formState,
+                externalBrowserRuntime
               ),
               getServerInsertedHTML,
               getServerInsertedMetadata,
@@ -4315,7 +4321,8 @@ async function renderToStream(
           inlinedDataStream: createWebInlinedDataStream(
             reactServerResult.consume(),
             nonce,
-            formState
+            formState,
+            externalBrowserRuntime
           ),
           waitForAllReady,
           allReady,
@@ -4480,7 +4487,8 @@ async function renderToStream(
               // render
               reactServerResult.consume(),
               nonce,
-              formState
+              formState,
+              externalBrowserRuntime
             ),
             waitForAllReady,
             deploymentId: ctx.sharedContext.deploymentId,
@@ -4576,7 +4584,8 @@ async function renderToStream(
               // render
               reactServerResult.consume(),
               nonce,
-              formState
+              formState,
+              externalBrowserRuntime
             ),
             waitForAllReady,
             deploymentId: ctx.sharedContext.deploymentId,
@@ -8379,6 +8388,7 @@ async function continueStaticPrerenderWithInlinedData(
   reactServerResult: ReactServerPrerenderResult,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
   createInlinedDataStream: typeof createWebInlinedDataStream,
+  externalBrowserRuntime: boolean,
   formState: unknown | null,
   nonce: string | undefined,
   getServerInsertedHTML: () => Promise<string>,
@@ -8419,7 +8429,8 @@ async function continueStaticPrerenderWithInlinedData(
     const inlinedDataStream = createInlinedDataStream(
       emptyReactServerResult.consumeAsStream(),
       nonce,
-      formState
+      formState,
+      externalBrowserRuntime
     )
     return continueStaticFallbackPrerender(htmlStream, {
       inlinedDataStream,
@@ -8432,7 +8443,8 @@ async function continueStaticPrerenderWithInlinedData(
   const inlinedDataStream = createInlinedDataStream(
     reactServerResult.consumeAsStream(),
     nonce,
-    formState
+    formState,
+    externalBrowserRuntime
   )
   return continueStaticPrerender(htmlStream, {
     inlinedDataStream,
@@ -8524,10 +8536,11 @@ async function prerenderToStream(
         nonce,
       }))
 
+  const { externalBrowserRuntime } = experimental
   const externalRuntimeSrc = getExternalBrowserRuntimeSrc(
     ctx,
     buildManifest,
-    experimental.externalBrowserRuntime,
+    externalBrowserRuntime,
     assetPrefix,
     subresourceIntegrityManifest
   )
@@ -9518,6 +9531,7 @@ async function prerenderToStream(
         reactServerResult,
         fallbackRouteParams,
         createInlinedDataStream,
+        externalBrowserRuntime,
         formState,
         nonce,
         getServerInsertedHTML,
@@ -9629,7 +9643,8 @@ async function prerenderToStream(
           inlinedDataStream: createInlinedDataStream(
             reactServerResult.consumeAsStream(),
             nonce,
-            formState
+            formState,
+            externalBrowserRuntime
           ),
           waitForAllReady: true,
           getServerInsertedHTML,
@@ -10045,6 +10060,7 @@ async function prerenderToStream(
           originalFlightPrerenderResult,
           fallbackRouteParams,
           createInlinedDataStream,
+          externalBrowserRuntime,
           formState,
           nonce,
           getServerInsertedHTML,
@@ -10172,7 +10188,8 @@ async function prerenderToStream(
           inlinedDataStream: createInlinedDataStream(
             reactServerPrerenderResult.consumeAsStream(),
             nonce,
-            formState
+            formState,
+            externalBrowserRuntime
           ),
           waitForAllReady: true,
           getServerInsertedHTML: makeGetServerInsertedHTML({

--- a/packages/next/src/server/app-render/get-external-browser-runtime-src.ts
+++ b/packages/next/src/server/app-render/get-external-browser-runtime-src.ts
@@ -1,0 +1,46 @@
+import type { DeepReadonly } from '../../shared/lib/deep-readonly'
+import type { BuildManifest } from '../get-page-files'
+import type { AppRenderContext } from './app-render'
+import { getAssetQueryString } from './get-asset-query-string'
+
+/**
+ * Resolves the `unstable_externalRuntimeSrc` value for React's Fizz options.
+ *
+ * When set, React streams its instruction set as `<template data-rci="" …>`
+ * elements instead of inline `<script>` tags, and emits a single
+ * `<script src async>` for this runtime itself. It also stops injecting its
+ * inline form-replaying runtime, since the external runtime covers it.
+ *
+ * Returns `undefined` when the feature is off, which leaves React on its default
+ * inline-script format. Only pass the result to `renderToReadableStream` and
+ * `prerender`: `resume` deliberately does not accept it, because the streaming
+ * format is carried in the postponed state's resumable state and the prerendered
+ * shell already contains the `<script src>`.
+ */
+export function getExternalBrowserRuntimeSrc(
+  ctx: AppRenderContext,
+  buildManifest: DeepReadonly<BuildManifest>,
+  externalBrowserRuntime: boolean,
+  assetPrefix: string,
+  subresourceIntegrityManifest: DeepReadonly<Record<string, string>> | undefined
+): { src: string; integrity: string | undefined } | undefined {
+  if (!externalBrowserRuntime) {
+    return undefined
+  }
+
+  const file = buildManifest.externalBrowserRuntimeFile
+  if (file === undefined) {
+    // Deliberately fatal rather than falling back to inline scripts. Silently
+    // reverting would serve a document that needs `unsafe-inline` to an app
+    // configured on the assumption that it does not.
+    throw new Error(
+      '`experimental.externalBrowserRuntime` is enabled but the runtime asset is missing from the build manifest. ' +
+        'This usually means `.next` was produced by a build that did not have the flag enabled. Rebuild the app.'
+    )
+  }
+
+  return {
+    src: `${assetPrefix}/_next/${file}${getAssetQueryString(ctx, false)}`,
+    integrity: subresourceIntegrityManifest?.[file],
+  }
+}

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -33,10 +33,10 @@ import { ENCODED_TAGS } from '../stream-utils/encoded-tags'
 import { createNodeBufferedTransformStream } from '../stream-utils/node-buffered-transform-stream'
 import { MISSING_ROOT_TAGS_ERROR } from '../../shared/lib/errors/constants'
 import {
-  htmlEscapeAttributeString,
-  htmlEscapeJsonString,
-} from '../../shared/lib/htmlescape'
-import { createInlinedDataReadableStream } from './use-flight-response'
+  createFlightMarkup,
+  createInlinedDataReadableStream,
+  type FlightMarkup,
+} from './use-flight-response'
 import {
   ReplayableNodeStream,
   type AnyStream as AnyStreamType,
@@ -924,51 +924,41 @@ export async function streamToString(stream: AnyStream): Promise<string> {
 export function createWebInlinedDataStream(
   source: AnyStream,
   nonce: string | undefined,
-  formState: unknown | null
+  formState: unknown | null,
+  externalBrowserRuntime: boolean
 ): AnyStream {
   const webSource = nodeReadableToWebReadableStream(source)
-  const webResult = createInlinedDataReadableStream(webSource, nonce, formState)
+  const webResult = createInlinedDataReadableStream(
+    webSource,
+    nonce,
+    formState,
+    externalBrowserRuntime
+  )
   return webToReadable(webResult)
 }
 
 export function createNodeInlinedDataStream(
   source: AnyStream,
   nonce: string | undefined,
-  formState: unknown | null
+  formState: unknown | null,
+  externalBrowserRuntime: boolean
 ): AnyStream {
-  const startScriptTag = nonce
-    ? `<script nonce="${htmlEscapeAttributeString(nonce)}">`
-    : '<script>'
+  const markup = createFlightMarkup(nonce, externalBrowserRuntime)
 
   const dataStream = webToReadable(source)
   const pt = new PassThrough()
 
-  // Write initial bootstrap instructions
-  let scriptContents = `(self.__next_f=self.__next_f||[]).push(${htmlEscapeJsonString(
-    JSON.stringify([INLINE_FLIGHT_PAYLOAD_BOOTSTRAP])
-  )})`
-  if (formState != null) {
-    scriptContents += `;self.__next_f.push(${htmlEscapeJsonString(
-      JSON.stringify([INLINE_FLIGHT_PAYLOAD_FORM_STATE, formState])
-    )})`
-  }
-  pt.push(Buffer.from(`${startScriptTag}${scriptContents}</script>`))
+  pt.push(Buffer.from(markup.initial(formState)))
 
-  // Pull from the flight data stream and wrap each chunk in a <script> tag
-  pullFlightData(dataStream, pt, startScriptTag)
+  pullFlightData(dataStream, pt, markup)
 
   return pt
 }
 
-const INLINE_FLIGHT_PAYLOAD_BOOTSTRAP = 0
-const INLINE_FLIGHT_PAYLOAD_DATA = 1
-const INLINE_FLIGHT_PAYLOAD_FORM_STATE = 2
-const INLINE_FLIGHT_PAYLOAD_BINARY = 3
-
 async function pullFlightData(
   dataStream: Readable,
   output: PassThrough,
-  startScriptTag: string
+  markup: FlightMarkup
 ): Promise<void> {
   function waitForReadableOrEnd(): Promise<void> {
     if (dataStream.readableLength > 0 || dataStream.readableEnded) {
@@ -998,25 +988,9 @@ async function pullFlightData(
     while (true) {
       const chunk: Buffer | null = dataStream.read()
       if (chunk !== null) {
-        let htmlInlinedData: string
-        if (isUtf8(chunk)) {
-          const decodedString = chunk.toString('utf-8')
-          htmlInlinedData = htmlEscapeJsonString(
-            JSON.stringify([INLINE_FLIGHT_PAYLOAD_DATA, decodedString])
-          )
-        } else {
-          const base64 = Buffer.from(
-            chunk.buffer,
-            chunk.byteOffset,
-            chunk.byteLength
-          ).toString('base64')
-          htmlInlinedData = htmlEscapeJsonString(
-            JSON.stringify([INLINE_FLIGHT_PAYLOAD_BINARY, base64])
-          )
-        }
         output.push(
           Buffer.from(
-            `${startScriptTag}self.__next_f.push(${htmlInlinedData})</script>`
+            markup.data(isUtf8(chunk) ? chunk.toString('utf-8') : chunk)
           )
         )
         continue

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -194,19 +194,22 @@ export async function processPrelude(
 export function createWebInlinedDataStream(
   source: AnyStream,
   nonce: string | undefined,
-  formState: unknown | null
+  formState: unknown | null,
+  externalBrowserRuntime: boolean
 ): AnyStream {
   return createInlinedDataReadableStream(
     source as ReadableStream<Uint8Array>,
     nonce,
-    formState
+    formState,
+    externalBrowserRuntime
   )
 }
 
 export function createNodeInlinedDataStream(
   _source: AnyStream,
   _nonce: string | undefined,
-  _formState: unknown | null
+  _formState: unknown | null,
+  _externalBrowserRuntime: boolean
 ): AnyStream {
   throw new Error('not implemented')
 }

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -188,6 +188,12 @@ export interface RenderOptsPartial {
      * drives instant navigation tests.
      */
     exposeTestingApi: boolean
+
+    /**
+     * Whether React should stream its instruction set as data, applied by the
+     * standalone browser runtime asset, instead of as inline `<script>` tags.
+     */
+    externalBrowserRuntime: boolean
   }
   postponed?: string
 

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -164,11 +164,10 @@ export function getFlightStream<T>(
 export function createInlinedDataReadableStream(
   flightStream: ReadableStream<Uint8Array>,
   nonce: string | undefined,
-  formState: unknown | null
+  formState: unknown | null,
+  externalBrowserRuntime: boolean
 ): ReadableStream<Uint8Array> {
-  const startScriptTag = nonce
-    ? `<script nonce="${htmlEscapeAttributeString(nonce)}">`
-    : '<script>'
+  const markup = createFlightMarkup(nonce, externalBrowserRuntime)
 
   const flightReader = flightStream.getReader()
   const decoder = new TextDecoder('utf-8', { fatal: true })
@@ -177,7 +176,7 @@ export function createInlinedDataReadableStream(
     type: 'bytes',
     start(controller) {
       try {
-        writeInitialInstructions(controller, startScriptTag, formState)
+        writeInitialInstructions(controller, markup, formState)
       } catch (error) {
         // during encoding or enqueueing forward the error downstream
         controller.error(error)
@@ -193,14 +192,10 @@ export function createInlinedDataReadableStream(
 
             // The chunk cannot be decoded as valid UTF-8 string as it might
             // have arbitrary binary data.
-            writeFlightDataInstruction(
-              controller,
-              startScriptTag,
-              decodedString
-            )
+            writeFlightDataInstruction(controller, markup, decodedString)
           } catch {
             // The chunk cannot be decoded as valid UTF-8 string.
-            writeFlightDataInstruction(controller, startScriptTag, value)
+            writeFlightDataInstruction(controller, markup, value)
           }
         }
 
@@ -220,54 +215,106 @@ export function createInlinedDataReadableStream(
 
 function writeInitialInstructions(
   controller: ReadableStreamDefaultController,
-  scriptStart: string,
+  markup: FlightMarkup,
   formState: unknown | null
 ) {
-  let scriptContents = `(self.__next_f=self.__next_f||[]).push(${htmlEscapeJsonString(
-    JSON.stringify([INLINE_FLIGHT_PAYLOAD_BOOTSTRAP])
-  )})`
-
-  if (formState != null) {
-    scriptContents += `;self.__next_f.push(${htmlEscapeJsonString(
-      JSON.stringify([INLINE_FLIGHT_PAYLOAD_FORM_STATE, formState])
-    )})`
-  }
-
-  controller.enqueue(encoder.encode(`${scriptStart}${scriptContents}</script>`))
+  controller.enqueue(encoder.encode(markup.initial(formState)))
 }
 
 function writeFlightDataInstruction(
   controller: ReadableStreamDefaultController,
-  scriptStart: string,
+  markup: FlightMarkup,
   chunk: string | Uint8Array
 ) {
-  let htmlInlinedData: string
+  controller.enqueue(encoder.encode(markup.data(chunk)))
+}
 
-  if (typeof chunk === 'string') {
-    htmlInlinedData = htmlEscapeJsonString(
-      JSON.stringify([INLINE_FLIGHT_PAYLOAD_DATA, chunk])
-    )
-  } else {
-    // The chunk cannot be embedded as a UTF-8 string in the script tag.
-    // Instead let's inline it in base64.
-    // Credits to Devon Govett (devongovett) for the technique.
-    // https://github.com/devongovett/rsc-html-stream
-    const base64 =
-      typeof Buffer !== 'undefined'
-        ? Buffer.from(
-            chunk.buffer,
-            chunk.byteOffset,
-            chunk.byteLength
-          ).toString('base64')
-        : btoa(String.fromCodePoint(...chunk))
-    htmlInlinedData = htmlEscapeJsonString(
-      JSON.stringify([INLINE_FLIGHT_PAYLOAD_BINARY, base64])
-    )
+/**
+ * The attribute that carries one Flight payload when
+ * `experimental.externalBrowserRuntime` is enabled. Kept in sync with the
+ * collector in `packages/next/src/client/app-index.tsx`.
+ */
+export const FLIGHT_DATA_ATTRIBUTE = 'data-next-flight'
+
+export type FlightMarkup = {
+  initial: (formState: unknown | null) => string
+  data: (chunk: string | Uint8Array) => string
+}
+
+function encodeBinaryChunk(chunk: Uint8Array): string {
+  // The chunk cannot be embedded as a UTF-8 string, so inline it as base64.
+  // Credits to Devon Govett (devongovett) for the technique.
+  // https://github.com/devongovett/rsc-html-stream
+  return typeof Buffer !== 'undefined'
+    ? Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength).toString(
+        'base64'
+      )
+    : btoa(String.fromCodePoint(...chunk))
+}
+
+/**
+ * Builds the HTML that carries the Flight payload to the browser.
+ *
+ * By default each payload is an inline `<script>` that pushes onto
+ * `self.__next_f`, which requires a CSP to allow `unsafe-inline` (or a nonce).
+ * With `experimental.externalBrowserRuntime` each payload is instead an inert
+ * `<template>` carrying the same JSON in an attribute, collected by
+ * `app-index.tsx` and pushed onto the same queue. The payload shape is identical
+ * in both modes, so the client-side consumer is unchanged.
+ */
+export function createFlightMarkup(
+  nonce: string | undefined,
+  externalBrowserRuntime: boolean
+): FlightMarkup {
+  const startScriptTag = nonce
+    ? `<script nonce="${htmlEscapeAttributeString(nonce)}">`
+    : '<script>'
+
+  if (externalBrowserRuntime) {
+    const template = (payload: unknown[]): string =>
+      `<template ${FLIGHT_DATA_ATTRIBUTE}="${htmlEscapeAttributeString(
+        JSON.stringify(payload)
+      )}"></template>`
+
+    return {
+      initial(formState) {
+        let html = template([INLINE_FLIGHT_PAYLOAD_BOOTSTRAP])
+        if (formState != null) {
+          html += template([INLINE_FLIGHT_PAYLOAD_FORM_STATE, formState])
+        }
+        return html
+      },
+      data(chunk) {
+        return typeof chunk === 'string'
+          ? template([INLINE_FLIGHT_PAYLOAD_DATA, chunk])
+          : template([INLINE_FLIGHT_PAYLOAD_BINARY, encodeBinaryChunk(chunk)])
+      },
+    }
   }
 
-  controller.enqueue(
-    encoder.encode(
-      `${scriptStart}self.__next_f.push(${htmlInlinedData})</script>`
-    )
-  )
+  return {
+    initial(formState) {
+      let scriptContents = `(self.__next_f=self.__next_f||[]).push(${htmlEscapeJsonString(
+        JSON.stringify([INLINE_FLIGHT_PAYLOAD_BOOTSTRAP])
+      )})`
+
+      if (formState != null) {
+        scriptContents += `;self.__next_f.push(${htmlEscapeJsonString(
+          JSON.stringify([INLINE_FLIGHT_PAYLOAD_FORM_STATE, formState])
+        )})`
+      }
+
+      return `${startScriptTag}${scriptContents}</script>`
+    },
+    data(chunk) {
+      const htmlInlinedData = htmlEscapeJsonString(
+        JSON.stringify(
+          typeof chunk === 'string'
+            ? [INLINE_FLIGHT_PAYLOAD_DATA, chunk]
+            : [INLINE_FLIGHT_PAYLOAD_BINARY, encodeBinaryChunk(chunk)]
+        )
+      )
+      return `${startScriptTag}self.__next_f.push(${htmlInlinedData})</script>`
+    },
+  }
 }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -625,6 +625,8 @@ export default abstract class Server<
           (this.dev === true ||
             this.nextConfig.experimental.exposeTestingApiInProductionBuild ===
               true),
+        externalBrowserRuntime:
+          this.nextConfig.experimental.externalBrowserRuntime === true,
       },
       onInstrumentationRequestError:
         this.instrumentationOnRequestError.bind(this),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -306,6 +306,7 @@ export const experimentalSchema = {
     .optional(),
   taint: z.boolean().optional(),
   blockingSSR: z.boolean().optional(),
+  externalBrowserRuntime: z.boolean().optional(),
   prerenderEarlyExit: z.boolean().optional(),
   proxyTimeout: z.number().gte(0).optional(),
   rootParams: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1158,6 +1158,30 @@ export interface ExperimentalConfig {
   blockingSSR?: boolean
 
   /**
+   * Streams React's instruction set for the `app` directory as data instead of
+   * as inline `<script>` tags. React emits `<template data-rci="" …>` elements,
+   * and a standalone runtime script, served as a static asset from
+   * `/_next/static/chunks`, collects them with a `MutationObserver` and applies
+   * the instructions. This also removes React's inline form-replaying runtime.
+   *
+   * The goal is a document with no inline scripts, so a Content-Security-Policy
+   * can drop `unsafe-inline` without a per-response nonce (which is
+   * incompatible with static generation). Note that this alone is not
+   * sufficient yet: the Flight payload and the bootstrap script are still
+   * inlined.
+   *
+   * This feature is currently only available in React's experimental release
+   * channel, so enabling it opts the `app` directory into `react@experimental`
+   * (the same channel used by `taint`, `transitionIndicator`,
+   * `gestureTransition`, and `blockingSSR`).
+   *
+   * This is an opt-in only. Setting it to `false` does not disable the
+   * experimental channel when another feature (such as `taint`,
+   * `transitionIndicator`, or `gestureTransition`) requires it.
+   */
+  externalBrowserRuntime?: boolean
+
+  /**
    * Uninstalls all "unhandledRejection" and "uncaughtException" listeners from
    * the global process so that we can override the behavior, which in some
    * runtimes is to exit the process.
@@ -2438,6 +2462,7 @@ export interface NextConfigRuntime {
     | 'exposeTestingApiInProductionBuild'
     | 'instantInsights'
     | 'requestInsights'
+    | 'externalBrowserRuntime'
   > & {
     // Pick on @internal fields generates invalid .d.ts files
     /** @internal */
@@ -2506,6 +2531,7 @@ export function getNextConfigRuntime(
     exposeTestingApiInProductionBuild: ex.exposeTestingApiInProductionBuild,
     instantInsights: ex.instantInsights,
     requestInsights: ex.requestInsights,
+    externalBrowserRuntime: ex.externalBrowserRuntime,
 
     trustHostHeader: ex.trustHostHeader,
     isExperimentalCompile: ex.isExperimentalCompile,

--- a/packages/next/src/server/get-page-files.ts
+++ b/packages/next/src/server/get-page-files.ts
@@ -4,6 +4,10 @@ import { normalizePagePath } from '../shared/lib/page-path/normalize-page-path'
 export type BuildManifest = {
   devFiles: readonly string[]
   polyfillFiles: readonly string[]
+  // The standalone browser runtime that applies React's instruction set when
+  // `experimental.externalBrowserRuntime` is enabled. Absent otherwise. There is
+  // at most one, so this is a single path rather than a list.
+  externalBrowserRuntimeFile?: string
   lowPriorityFiles: readonly string[]
   rootMainFiles: readonly string[]
   // this is a separate field for flying shuttle to allow

--- a/packages/next/src/shared/lib/constants.ts
+++ b/packages/next/src/shared/lib/constants.ts
@@ -154,6 +154,11 @@ export const CLIENT_STATIC_FILES_RUNTIME_POLYFILLS = 'polyfills'
 export const CLIENT_STATIC_FILES_RUNTIME_POLYFILLS_SYMBOL = Symbol(
   CLIENT_STATIC_FILES_RUNTIME_POLYFILLS
 )
+// static/chunks/external-browser-runtime.js
+export const CLIENT_STATIC_FILES_RUNTIME_EXTERNAL_BROWSER_RUNTIME =
+  'external-browser-runtime'
+export const CLIENT_STATIC_FILES_RUNTIME_EXTERNAL_BROWSER_RUNTIME_SYMBOL =
+  Symbol(CLIENT_STATIC_FILES_RUNTIME_EXTERNAL_BROWSER_RUNTIME)
 export const DEFAULT_RUNTIME_WEBPACK = 'webpack-runtime'
 export const EDGE_RUNTIME_WEBPACK = 'edge-runtime-webpack'
 export const STATIC_PROPS_ID = '__N_SSG'

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -428,6 +428,10 @@ export class TurbopackManifestLoader {
       if (m.rootMainFiles.length) manifest.rootMainFiles = m.rootMainFiles
       // polyfillFiles should always be the same, so we can overwrite instead of actually merging
       if (m.polyfillFiles.length) manifest.polyfillFiles = m.polyfillFiles
+      // Same reasoning: every App Router page emits the identical runtime asset.
+      if (m.externalBrowserRuntimeFile) {
+        manifest.externalBrowserRuntimeFile = m.externalBrowserRuntimeFile
+      }
       if (m.rootMainFilesTree) {
         Object.assign(manifest.rootMainFilesTree!, m.rootMainFilesTree)
       }

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1660,7 +1660,12 @@ export async function copy_vendor_react(task_) {
       'cjs/react-dom-server.bun.production.min.js',
       'cjs/react-dom-test-utils.development.js',
       'cjs/react-dom-test-utils.production.min.js',
-      'unstable_server-external-runtime.js',
+      // `unstable_server-external-runtime.js` is deliberately kept. It is the
+      // standalone browser runtime that applies Fizz's instruction set when
+      // `unstable_externalRuntimeSrc` is set, and it is served as a static
+      // asset rather than bundled. React only publishes it on the experimental
+      // channel, so it is absent from the `react-dom` copy and present in the
+      // `react-dom-experimental` one.
     ]
     for (const item of itemsToRemove) {
       yield rmrf(join(reactDomCompiledDir, item))

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -243,6 +243,7 @@
       "test/e2e/app-dir/root-layout-render-once/index.test.ts",
       "test/e2e/app-dir/root-layout/root-layout.test.ts",
       "test/e2e/app-dir/rsc-basic/rsc-basic-blocking-ssr.test.ts",
+      "test/e2e/app-dir/rsc-basic/rsc-basic-external-browser-runtime.test.ts",
       "test/e2e/app-dir/rsc-basic/rsc-basic-react-experimental.test.ts",
       "test/e2e/app-dir/rsc-basic/rsc-basic.test.ts",
       "test/e2e/app-dir/scss/hmr-module/hmr-module.test.ts",

--- a/test/e2e/app-dir/external-browser-runtime/app/counter.tsx
+++ b/test/e2e/app-dir/external-browser-runtime/app/counter.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useState } from 'react'
+
+// Exists purely to prove hydration ran: the count only changes if the client
+// bundle attached its event handlers.
+export function Counter() {
+  const [count, setCount] = useState(0)
+  return (
+    <button id="counter" onClick={() => setCount((c) => c + 1)}>
+      count: {count}
+    </button>
+  )
+}

--- a/test/e2e/app-dir/external-browser-runtime/app/layout.tsx
+++ b/test/e2e/app-dir/external-browser-runtime/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/external-browser-runtime/app/page.tsx
+++ b/test/e2e/app-dir/external-browser-runtime/app/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import { Counter } from './counter'
+
+async function Slow() {
+  // Dynamic access lives inside the boundary so the shell can still be
+  // prerendered. With Cache Components that makes this a PPR route: the shell is
+  // prerendered and this subtree is resumed per request, which exercises React's
+  // `resume` path. Without Cache Components the whole route is dynamic. Either
+  // way the shell flushes before this resolves, so React has to stream a
+  // "complete boundary" instruction, which is what the external runtime applies.
+  await connection()
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  return <p id="slow">slow content</p>
+}
+
+export default function Page() {
+  return (
+    <>
+      <p id="shell">hello world</p>
+      <Suspense fallback={<p id="fallback">loading...</p>}>
+        <Slow />
+      </Suspense>
+      <Counter />
+    </>
+  )
+}

--- a/test/e2e/app-dir/external-browser-runtime/external-browser-runtime.test.ts
+++ b/test/e2e/app-dir/external-browser-runtime/external-browser-runtime.test.ts
@@ -1,0 +1,68 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('external-browser-runtime', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('streams React instructions as data instead of inline scripts', async () => {
+    const html = await next.render('/')
+
+    // `data-rci` is the "complete boundary" instruction React emits once the
+    // Suspense boundary resolves. Its presence is the direct evidence that Fizz
+    // switched from its SCRIPT streaming format to the DATA format.
+    //
+    // Asserting on a React-internal attribute is more coupling than we would
+    // like. It is the only signal available today. Once the Flight payload and
+    // `bootstrapScriptContent` also stop being inlined, replace this with the
+    // assertion that actually matters: that the document contains no inline
+    // `<script>` at all.
+    expect(html).toContain('<template data-rci=""')
+  })
+
+  it('loads the runtime as a static asset', async () => {
+    const $ = await next.render$('/')
+
+    // React emits the runtime as an async script in the head. The filename is
+    // not asserted on: webpack names it readably while Turbopack uses an opaque
+    // content hash, so the asset is identified by what it contains instead.
+    const srcs = $('head script[src]')
+      .map((_, el) => $(el).attr('src'))
+      .get()
+    expect(srcs.length).toBeGreaterThan(0)
+
+    const responses = await Promise.all(
+      srcs.map(async (src) => {
+        const res = await next.fetch(new URL(src, 'http://n').pathname)
+        return { src, status: res.status, body: await res.text() }
+      })
+    )
+
+    // `installFizzInstrObserver` is the runtime's entry point: it attaches the
+    // MutationObserver that picks up React's `<template data-r*i>` elements.
+    const runtimes = responses.filter((r) =>
+      r.body.includes('installFizzInstrObserver')
+    )
+    expect(runtimes).toHaveLength(1)
+    expect(runtimes[0].status).toBe(200)
+  })
+
+  it('reveals suspended content and hydrates', async () => {
+    const browser = await next.browser('/')
+
+    // The boundary content only appears if the external runtime picked up the
+    // `data-rci` template and ran the instruction.
+    await retry(async () => {
+      expect(await browser.elementByCss('#slow').text()).toBe('slow content')
+    })
+
+    expect(await browser.elementByCss('#shell').text()).toBe('hello world')
+
+    // Proves hydration attached handlers.
+    await browser.elementByCss('#counter').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('#counter').text()).toBe('count: 1')
+    })
+  })
+})

--- a/test/e2e/app-dir/external-browser-runtime/external-browser-runtime.test.ts
+++ b/test/e2e/app-dir/external-browser-runtime/external-browser-runtime.test.ts
@@ -21,6 +21,15 @@ describe('external-browser-runtime', () => {
     expect(html).toContain('<template data-rci=""')
   })
 
+  it('carries the Flight payload as data instead of inline scripts', async () => {
+    const html = await next.render('/')
+
+    expect(html).toContain('<template data-next-flight="')
+    // The inline `self.__next_f.push(...)` scripts are what the templates
+    // replace, so none should remain.
+    expect(html).not.toContain('self.__next_f')
+  })
+
   it('loads the runtime as a static asset', async () => {
     const $ = await next.render$('/')
 

--- a/test/e2e/app-dir/external-browser-runtime/next.config.js
+++ b/test/e2e/app-dir/external-browser-runtime/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    externalBrowserRuntime: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/rsc-basic/rsc-basic-external-browser-runtime.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic-external-browser-runtime.test.ts
@@ -1,0 +1,81 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('react@experimental - externalBrowserRuntime', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    overrideFiles: {
+      'next.config.js': `
+        module.exports = {
+          experimental: {
+            externalBrowserRuntime: true,
+          }
+        }
+      `,
+    },
+  })
+
+  // React gates the Fizz external runtime behind `enableFizzExternalRuntime`,
+  // which is only enabled in its experimental build. On the canary channel
+  // `createRenderState` hardcodes `externalRuntimeScript: null`, so passing
+  // `unstable_externalRuntimeSrc` would be a silent no-op. The flag therefore has
+  // to opt into `react@experimental`, and this asserts that it does.
+  it('should opt into the react@experimental channel when externalBrowserRuntime is enabled', async () => {
+    const resPages$ = await next.render$('/app-react')
+    const [
+      ssrReact,
+      ssrReactDOM,
+      ssrClientReact,
+      ssrClientReactDOM,
+      ssrClientReactDOMServer,
+    ] = [
+      resPages$('#react').text(),
+      resPages$('#react-dom').text(),
+      resPages$('#client-react').text(),
+      resPages$('#client-react-dom').text(),
+      resPages$('#client-react-dom-server').text(),
+    ]
+    expect({
+      ssrReact,
+      ssrReactDOM,
+      ssrClientReact,
+      ssrClientReactDOM,
+      ssrClientReactDOMServer,
+    }).toEqual({
+      ssrReact: expect.stringMatching('-experimental-'),
+      ssrReactDOM: expect.stringMatching('-experimental-'),
+      ssrClientReact: expect.stringMatching('-experimental-'),
+      ssrClientReactDOM: expect.stringMatching('-experimental-'),
+      ssrClientReactDOMServer: expect.stringMatching('-experimental-'),
+    })
+
+    const browser = await next.browser('/app-react')
+    const [
+      browserReact,
+      browserReactDOM,
+      browserClientReact,
+      browserClientReactDOM,
+      browserClientReactDOMServer,
+    ] = await browser.eval(`
+      [
+        document.querySelector('#react').innerText,
+        document.querySelector('#react-dom').innerText,
+        document.querySelector('#client-react').innerText,
+        document.querySelector('#client-react-dom').innerText,
+        document.querySelector('#client-react-dom-server').innerText,
+      ]
+    `)
+    expect({
+      browserReact,
+      browserReactDOM,
+      browserClientReact,
+      browserClientReactDOM,
+      browserClientReactDOMServer,
+    }).toEqual({
+      browserReact: expect.stringMatching('-experimental-'),
+      browserReactDOM: expect.stringMatching('-experimental-'),
+      browserClientReact: expect.stringMatching('-experimental-'),
+      browserClientReactDOM: expect.stringMatching('-experimental-'),
+      browserClientReactDOMServer: expect.stringMatching('-experimental-'),
+    })
+  })
+})


### PR DESCRIPTION
Next.js inlines the Flight payload as a stream of `<script>self.__next_f.push(...)</script>` tags, which is the second reason an App Router document needs `unsafe-inline` in its Content-Security-Policy. With `experimental.externalBrowserRuntime` each payload is now written as an inert `<template data-next-flight="...">` carrying the same JSON, and `app-index.tsx` collects those templates and feeds them to the same queue. The payload shape is unchanged, so the consumer that decodes bootstrap, data, form state, and binary segments is untouched.

The collector lives in the client bundle rather than in the shared browser runtime asset that the previous change introduced, which means this adds no additional asset and no additional script tag. That placement is deliberate: the asset is loaded with `async`, `async` scripts do not block `DOMContentLoaded`, and `DOMContentLoaded` is when `app-index.tsx` closes the inline Flight stream. Collecting from a separate async script would therefore race that close and silently drop payloads on a slow or cold cache, surfacing as a hydration failure. This module is the only consumer of the queue, so collecting here removes the race entirely.

Collection happens in two parts, mirroring how React's own external runtime works: one sweep over whatever the parser has already produced, then a `MutationObserver` for payloads that arrive as the rest of the document streams in. A final sweep runs when the stream is about to be closed, because a payload the observer has not delivered yet would otherwise be lost.

The two writers had each grown their own copy of the payload encoding, including the base64 fallback for chunks that are not valid UTF-8. Both now share a single `createFlightMarkup` helper that owns both the inline-script and the template form, so the two wire formats cannot drift apart.
