### PR TITLE
[no-unsafe-inline] Stop inlining the Turbopack chunk group bootstrap

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1643,6 +1643,7 @@ impl Project {
                 .next_config()
                 .turbo_nested_async_chunking(self.next_mode(), true),
             shared_runtime: self.next_config().turbo_shared_runtime(self.next_mode()),
+            inline_chunk_group_bootstrap: self.next_config().turbo_inline_chunk_group_bootstrap(),
             per_page_module_graph: self.per_page_module_graph(),
             debug_ids: self.next_config().turbopack_debug_ids(),
             worker_asset_prefix: self.next_config().turbopack_worker_asset_prefix(),

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -486,6 +486,7 @@ pub struct ClientChunkingContextOptions {
     pub scope_hoisting: Vc<bool>,
     pub nested_async_chunking: Vc<bool>,
     pub shared_runtime: Vc<bool>,
+    pub inline_chunk_group_bootstrap: Vc<bool>,
     pub per_page_module_graph: Vc<bool>,
     pub debug_ids: Vc<bool>,
     pub worker_asset_prefix: Vc<Option<RcStr>>,
@@ -535,6 +536,7 @@ pub async fn get_client_chunking_context(
         scope_hoisting,
         nested_async_chunking,
         shared_runtime,
+        inline_chunk_group_bootstrap,
         per_page_module_graph,
         debug_ids,
         worker_asset_prefix,
@@ -642,7 +644,8 @@ pub async fn get_client_chunking_context(
             )
             .chunk_content_hashing(ContentHashing::Direct { length: 13 })
             .module_merging(*scope_hoisting.await?)
-            .shared_runtime(*shared_runtime.await?);
+            .shared_runtime(*shared_runtime.await?)
+            .inline_chunk_group_bootstrap(*inline_chunk_group_bootstrap.await?);
     }
 
     Ok(Vc::upcast(builder.build()))

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2690,6 +2690,15 @@ impl NextConfig {
         }))
     }
 
+    /// The inlined chunk-group bootstrap is an inline `<script>`, which a
+    /// Content-Security-Policy without `unsafe-inline` rejects. When
+    /// `experimental.externalBrowserRuntime` is enabled the evaluate chunk is emitted as a
+    /// regular asset instead, at the cost of one extra request per route.
+    #[turbo_tasks::function]
+    pub fn turbo_inline_chunk_group_bootstrap(&self) -> Vc<bool> {
+        Vc::cell(!self.experimental.external_browser_runtime.unwrap_or(false))
+    }
+
     #[turbo_tasks::function]
     pub async fn turbo_nested_async_chunking(
         &self,

--- a/test/e2e/app-dir/external-browser-runtime/external-browser-runtime.test.ts
+++ b/test/e2e/app-dir/external-browser-runtime/external-browser-runtime.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 describe('external-browser-runtime', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
   })
 
@@ -12,14 +12,26 @@ describe('external-browser-runtime', () => {
     // `data-rci` is the "complete boundary" instruction React emits once the
     // Suspense boundary resolves. Its presence is the direct evidence that Fizz
     // switched from its SCRIPT streaming format to the DATA format.
-    //
-    // Asserting on a React-internal attribute is more coupling than we would
-    // like. It is the only signal available today. Once the Flight payload and
-    // `bootstrapScriptContent` also stop being inlined, replace this with the
-    // assertion that actually matters: that the document contains no inline
-    // `<script>` at all.
     expect(html).toContain('<template data-rci=""')
   })
+
+  if (!isNextDev) {
+    // The point of the whole feature: with React's instructions, the Flight
+    // payload, and the chunk-group bootstrap all carried as data, a production
+    // document has no inline script left, so a Content-Security-Policy no longer
+    // needs `unsafe-inline`.
+    //
+    // Development is excluded on purpose. It still inlines the request id that
+    // the dev overlay and HMR socket read, and the dev server is not the target
+    // for CSP hardening.
+    it('emits no inline scripts', async () => {
+      const html = await next.render('/')
+
+      const inlineScripts =
+        html.match(/<script(?![^>]*\ssrc=)[^>]*>[\s\S]*?<\/script>/g) ?? []
+      expect(inlineScripts).toEqual([])
+    })
+  }
 
   it('carries the Flight payload as data instead of inline scripts', async () => {
     const html = await next.render('/')

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -174,6 +174,12 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
+    /// See [`BrowserChunkingContext::inline_chunk_group_bootstrap`].
+    pub fn inline_chunk_group_bootstrap(mut self, inline_chunk_group_bootstrap: bool) -> Self {
+        self.chunking_context.inline_chunk_group_bootstrap = inline_chunk_group_bootstrap;
+        self
+    }
+
     /// Marks this context as being shared by multiple independent module graphs (e.g. per-page
     /// graphs), each of which only sees part of what is written to `chunk_root_path`.
     ///
@@ -362,6 +368,12 @@ pub struct BrowserChunkingContext {
     /// entrypoint's chunk group bootstrap params via
     /// `ChunkGroupResult.chunk_group_bootstrap_params`.
     shared_runtime: bool,
+    /// Whether an entry chunk group's bootstrap params may be returned for the host to inline into
+    /// the HTML instead of emitting the per-route evaluate chunk as an asset. Only consulted when
+    /// `shared_runtime` is enabled. Set this to `false` when the host cannot emit inline scripts,
+    /// for example under a Content-Security-Policy without `unsafe-inline`; the evaluate chunk is
+    /// then emitted as a regular asset, which is also what happens when `shared_runtime` is off.
+    inline_chunk_group_bootstrap: bool,
     /// Whether the runtime chunk is shared with other module graphs using this context.
     /// See [`BrowserChunkingContextBuilder::shared_runtime_chunk`].
     shared_runtime_chunk: bool,
@@ -444,6 +456,7 @@ impl BrowserChunkingContext {
                 enable_dynamic_chunk_content_loading: false,
                 debug_ids: false,
                 shared_runtime: false,
+                inline_chunk_group_bootstrap: true,
                 shared_runtime_chunk: false,
                 environment,
                 runtime_type,
@@ -1022,22 +1035,26 @@ impl ChunkingContext for BrowserChunkingContext {
             // per-route evaluate chunk file. Only `ChunkGroup::Entry` groups (the page/app client
             // entries Next renders into HTML) can be inlined. When `shared_runtime` is disabled the
             // evaluate chunk itself carries the runtime, so it is always emitted as an asset.
+            // `inline_chunk_group_bootstrap` opts out of the inlining while keeping the shared
+            // runtime, for hosts that cannot emit inline scripts.
             let evaluate_chunk = self
                 .generate_evaluate_chunk(ident, other_assets, entries, *module_graph)
                 .to_resolved()
                 .await?;
-            let chunk_group_bootstrap_params =
-                if this.shared_runtime && matches!(chunk_group, ChunkGroup::Entry(_)) {
-                    Some(
-                        evaluate_chunk
-                            .chunk_group_bootstrap_params()
-                            .owned()
-                            .await?,
-                    )
-                } else {
-                    assets.push(ResolvedVc::upcast(evaluate_chunk));
-                    None
-                };
+            let chunk_group_bootstrap_params = if this.shared_runtime
+                && this.inline_chunk_group_bootstrap
+                && matches!(chunk_group, ChunkGroup::Entry(_))
+            {
+                Some(
+                    evaluate_chunk
+                        .chunk_group_bootstrap_params()
+                        .owned()
+                        .await?,
+                )
+            } else {
+                assets.push(ResolvedVc::upcast(evaluate_chunk));
+                None
+            };
 
             // The shared runtime chunk must be the LAST asset of the group. It drains
             // the registration queue set up by the chunks above, so it has to load


### PR DESCRIPTION
With React's instruction set and the Flight payload both carried as data, one inline script was left in a production App Router document: the Turbopack chunk-group bootstrap, which seeds `globalThis[TURBOPACK]` with the page's chunk list so the runtime does not have to fetch it. It is emitted whenever `experimental.turbopackSharedRuntime` is on, which is the default for canary builds, so it affected the default bundler.

Rather than move that payload to a template and apply it from the shared browser runtime asset, this change stops inlining it at all. The browser chunking context gains an `inline_chunk_group_bootstrap` option, and when it is disabled the per-route evaluate chunk is emitted as an ordinary asset instead of having its params hoisted into the HTML. That path is not new: it is exactly what happens when the shared runtime is disabled, which is the case in development. Next.js then produces no `bootstrapScriptContent` for the page, because the existing guard already skips it when the manifest carries no params for the route.

The alternative would have kept the inlining and had the runtime asset push the params instead. That asset is loaded with `async`, so the push would frequently land after the runtime chunk had already resolved the page's chunks, which is the very round trip the inlining exists to avoid. Trading it for one extra request per route is simpler, reuses a well-exercised code path, and does not depend on load order.

The option defaults to inlining, so nothing changes unless `experimental.externalBrowserRuntime` is enabled.

With this the flag delivers what it was named for: a production document contains no inline `<script>` at all, which is now asserted in the test suite. Development is excluded from that assertion, since it still inlines the request id that the dev overlay and HMR socket read, and is not a target for CSP hardening.
