### PR TITLE
fix(next-napi-bindings): detect the target, not the host, in build.rs

### DIFF
--- a/crates/next-napi-bindings/build.rs
+++ b/crates/next-napi-bindings/build.rs
@@ -5,7 +5,13 @@ use serde_json::Value;
 fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-env-changed=CI");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_FAMILY");
+    // Note these have to be read from `CARGO_CFG_*`, not `#[cfg(...)]`: inside a build script,
+    // `#[cfg(...)]` describes the machine *running* the script (the host), not the target being
+    // compiled.
     let is_macos_target = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|value| value == "macos");
+    let is_linux_target = env::var("CARGO_CFG_TARGET_OS").is_ok_and(|value| value == "linux");
+    let is_wasm_target = env::var("CARGO_CFG_TARGET_FAMILY").is_ok_and(|value| value == "wasm");
 
     let nextjs_version = {
         let package_json_path = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -86,8 +92,12 @@ fn main() -> anyhow::Result<()> {
 
     // Resolve a potential linker issue for unit tests on linux
     // https://github.com/napi-rs/napi-rs/issues/1782
-    #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
-    println!("cargo:rustc-link-arg=-Wl,--warn-unresolved-symbols");
+    //
+    // Cross-compiling from Linux to wasm must not pass this: `rust-lld -flavor wasm` rejects it
+    // with `unknown argument: -Wl,--warn-unresolved-symbols`.
+    if is_linux_target && !is_wasm_target {
+        println!("cargo:rustc-link-arg=-Wl,--warn-unresolved-symbols");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
### What?

`crates/next-napi-bindings/build.rs` now decides whether to emit
`-Wl,--warn-unresolved-symbols` from `CARGO_CFG_TARGET_OS` / `CARGO_CFG_TARGET_FAMILY` instead of
from a `#[cfg(...)]` attribute.

### Why?

`#[cfg(...)]` inside a build script is evaluated for the machine that **runs** the script — the host
— not for the target being compiled. The existing `not(target_arch = "wasm32")` guard was therefore
always true on a Linux host, so cross-compiling to wasm still passed the flag and the link died with:

```
rust-lld: error: unknown argument: -Wl,--warn-unresolved-symbols
```

This is a latent bug for any cross-compilation target, not only wasm.

### How?

Cargo sets `CARGO_CFG_*` for the *target*, so the condition is read from the environment instead of
from a compile-time attribute. Behaviour on native Linux is unchanged.

<!-- NEXT_JS_LLM -->
