### PR TITLE
fix(turbo-rcstr): make TaggedValue usable on wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10134,7 +10134,6 @@ dependencies = [
  "mockito",
  "quick_cache",
  "reqwest",
- "rustc-hash 2.1.1",
  "rustls",
  "serde",
  "tokio",

--- a/turbopack/crates/turbo-rcstr/Cargo.toml
+++ b/turbopack/crates/turbo-rcstr/Cargo.toml
@@ -28,7 +28,10 @@ napi = { workspace = true, optional = true }
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 scattered-collect = { workspace = true }
 
-[dev-dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+# Only used by the benchmarks, which don't run on wasm. Gated by target so that
+# `cargo test -p turbo-rcstr --lib --target wasm32-wasip1-threads` can build: criterion pulls in
+# rayon, which refuses to compile for wasi, and cargo resolves dev-dependencies even for `--lib`.
 criterion = { workspace = true }
 
 [lints]

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -778,6 +778,65 @@ mod tests {
             }
         };
         assert_eq!(STR, RcStr::from("hello"));
+
+        // A literal one byte past the capacity must not inline, on either width.
+        let too_long = "x".repeat(MAX_INLINE_LEN + 1);
+        assert!(inline_atom(&too_long).is_none());
+    }
+
+    /// The inline capacity must be the same on every target. `turbo-rcstr-macros` runs on the
+    /// *host*, so it decides inline-vs-static using a host-side constant; if the target disagreed,
+    /// the macro would emit `inline_atom(..).unwrap()` for a literal that does not fit and panic at
+    /// runtime. This is the regression guard for that.
+    #[test]
+    #[cfg(not(feature = "atom_size_128"))]
+    fn max_inline_len_is_uniform_across_targets() {
+        assert_eq!(
+            MAX_INLINE_LEN, 7,
+            "MAX_INLINE_LEN must be 7 on every target, including 32-bit/wasm"
+        );
+        assert_eq!(size_of::<crate::tagged_value::TaggedValue>(), 8);
+        // The non-zero niche must survive, or `Option<RcStr>` silently doubles in size.
+        assert_eq!(size_of::<Option<RcStr>>(), size_of::<RcStr>());
+    }
+
+    /// `rcstr!` expands to a `const`, so it must stay const-evaluable on every target. On 32-bit
+    /// this only works because `TaggedValue` holds the address in a real pointer field: a bare
+    /// integer representation would need a pointer→integer cast, which const evaluation forbids,
+    /// and every literal taking the static path would fail with `E0080`.
+    #[test]
+    fn rcstr_macro_is_const_on_every_target() {
+        // Short enough to be stored inline.
+        const SHORT: RcStr = rcstr!("abc");
+        // Longer than the inline capacity, so this takes the static path — the one that needs the
+        // pointer to survive const evaluation.
+        const LONG: RcStr = rcstr!("a string that is definitely not inline");
+
+        assert_eq!(SHORT, RcStr::from("abc"));
+        assert_eq!(LONG, RcStr::from("a string that is definitely not inline"));
+        assert_eq!(SHORT.tag(), INLINE_TAG);
+        assert_eq!(LONG.tag(), STATIC_TAG);
+    }
+
+    /// Round-trips across the inline/static boundary. Lengths 4..=7 are the interesting band: they
+    /// are inline at capacity 7 but would spill to the static path at capacity 3, so this fails if
+    /// the representation ever diverges by target again.
+    #[test]
+    fn round_trip_across_the_inline_boundary() {
+        for len in 0..=9usize {
+            let s = "abcdefghi"[..len].to_string();
+            let r = RcStr::from(s.as_str());
+            assert_eq!(r.as_str(), s, "round trip failed at len {len}");
+            assert_eq!(r.len(), len);
+
+            let expected_inline = len <= MAX_INLINE_LEN;
+            assert_eq!(
+                r.tag() == INLINE_TAG,
+                expected_inline,
+                "len {len} should {} be inline (MAX_INLINE_LEN = {MAX_INLINE_LEN})",
+                if expected_inline { "" } else { "not" }
+            );
+        }
     }
 
     #[test]
@@ -833,6 +892,9 @@ mod tests {
     }
 
     #[test]
+    // `STATIC_RCSTRS` is an empty array on wasm (see its definition above), so there is no static
+    // registry for the decoder to resolve against and the value comes back as `DYNAMIC_TAG`.
+    #[cfg_attr(target_family = "wasm", ignore = "no static RcStr registry on wasm")]
     fn test_bincode_roundtrip() {
         use turbo_bincode::{turbo_bincode_decode, turbo_bincode_encode};
 

--- a/turbopack/crates/turbo-rcstr/src/tagged_value.rs
+++ b/turbopack/crates/turbo-rcstr/src/tagged_value.rs
@@ -1,14 +1,45 @@
-#![allow(clippy::missing_transmute_annotations)]
+//! The tagged value that backs [`crate::RcStr`].
+//!
+//! An `RcStr` is a single 8-byte value (16 with `atom_size_128`) that packs a 2-bit tag with a
+//! payload: a pointer to a static or `Arc`'d string, or up to [`MAX_INLINE_LEN`] bytes of string
+//! data stored inline. The tag lives in the low 2 bits of the value's least significant byte,
+//! which is why pointers must be at least 4-byte aligned.
+//!
+//! # Why the narrow-pointer targets use a struct rather than an integer
+//!
+//! `rcstr!` expands to a `const`, so both constructors below have to be usable during const
+//! evaluation. Const evaluation is asymmetric about pointer/integer conversions:
+//!
+//! * **pointer → integer is forbidden.** During const evaluation a pointer is an abstract
+//!   (allocation, offset) pair; the numeric address does not exist yet because the linker chooses
+//!   it. No spelling avoids this — `transmute`, `as`, `expose_provenance` and `repr(C)` union
+//!   punning are all rejected.
+//! * **integer → pointer is allowed.** The result simply carries no provenance, which is fine so
+//!   long as it is never dereferenced.
+//!
+//! On 64-bit targets the payload is a `NonNull`, so [`TaggedValue::new_ptr`] is a pointer→pointer
+//! cast and [`TaggedValue::new_tag`] is an integer→pointer transmute: both permitted. If narrower
+//! targets stored a bare `u64` instead, `new_ptr` would need the one conversion that is impossible
+//! and every `rcstr!` taking the static path would fail to compile with
+//! `error[E0080]: unable to turn pointer into integer`.
+//!
+//! So those targets keep the value 8 bytes wide — giving the same [`MAX_INLINE_LEN`] as
+//! everywhere else — but hold the address in a real pointer field paired with a byte payload. The
+//! payload is sized to the pointer width so there is no padding: padding bytes would be
+//! uninitialised, which would make the whole-value transmute in `new_tag` invalid.
+//!
+//! The field order follows endianness so that the pointer's least significant byte always lands
+//! where the value's least significant byte lives — offset 0 on little-endian, the last byte on
+//! big-endian. That is where [`TaggedValue::tag_byte`] reads the tag. With a fixed field
+//! order, a big-endian dynamic pointer's tag bits would be read out of the payload (always zero)
+//! and misread as `STATIC_TAG`.
+//!
+//! Reading the value back as an integer (`get_ptr`, `get_value`, `tag_byte`) only ever happens at
+//! run time, where pointer → integer is perfectly legal.
 
 use std::{num::NonZeroU8, os::raw::c_void, ptr::NonNull, slice};
 
 use self::raw_types::*;
-#[cfg(not(any(
-    target_pointer_width = "32",
-    target_pointer_width = "16",
-    feature = "atom_size_64",
-    feature = "atom_size_128"
-)))]
 use crate::TAG_MASK;
 
 #[cfg(feature = "atom_size_128")]
@@ -17,23 +48,85 @@ mod raw_types {
     pub type RawTaggedNonZeroValue = std::num::NonZeroU128;
 }
 
+/// The narrow-pointer arm: an 8-byte value built from a real pointer plus a byte payload, so that
+/// both constructors stay const-evaluable. See the module docs.
 #[cfg(all(
-    any(
-        target_pointer_width = "32",
-        target_pointer_width = "16",
-        feature = "atom_size_64"
-    ),
+    any(target_pointer_width = "32", target_pointer_width = "16"),
     not(feature = "atom_size_128")
 ))]
 mod raw_types {
+    use std::ptr::NonNull;
+
     pub type RawTaggedValue = u64;
-    pub type RawTaggedNonZeroValue = std::num::NonZeroU64;
+
+    /// Padding that brings the value up to 8 bytes, sized so that there is none left over.
+    #[cfg(target_pointer_width = "32")]
+    pub type Payload = [u8; 4];
+    #[cfg(target_pointer_width = "16")]
+    pub type Payload = [u8; 6];
+
+    // Both layouts are declared unconditionally so that the layout assertions for *both* are
+    // compiled on every target; only the alias below is conditional. Otherwise the big-endian
+    // invariant would never be checked on a little-endian host.
+    //
+    // `align(8)` is required, not cosmetic: a pointer field only forces 4-byte (or 2-byte)
+    // alignment, but the value is read back as a `u64` to extract the tag, and wasm traps on an
+    // unaligned 64-bit load with `RuntimeError: operation does not support unaligned accesses`.
+    // Aligning to the width of the integer view keeps that read legal without adding padding.
+    #[repr(C, align(8))]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub struct RawLittle {
+        pub ptr: NonNull<()>,
+        pub pad: Payload,
+    }
+
+    #[repr(C, align(8))]
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub struct RawBig {
+        pub pad: Payload,
+        pub ptr: NonNull<()>,
+    }
+
+    #[cfg(target_endian = "little")]
+    pub type RawTaggedNonZeroValue = RawLittle;
+    #[cfg(target_endian = "big")]
+    pub type RawTaggedNonZeroValue = RawBig;
+
+    // The pointer's least significant byte must coincide with the value's least significant byte.
+    const _: () = assert!(
+        std::mem::offset_of!(RawLittle, ptr) == 0,
+        "little-endian: the pointer must start at offset 0"
+    );
+    const _: () = assert!(
+        std::mem::offset_of!(RawBig, ptr) == std::mem::size_of::<Payload>(),
+        "big-endian: the pointer must follow the payload"
+    );
+    // No padding: `new_tag` transmutes the whole value, and padding bytes are uninitialised.
+    // With `align(8)` and a payload sized to the pointer width, the fields fill the value exactly.
+    const _: () = assert!(
+        std::mem::size_of::<RawLittle>()
+            == std::mem::size_of::<NonNull<()>>() + std::mem::size_of::<Payload>(),
+        "the layout must not contain padding"
+    );
+    const _: () = assert!(
+        std::mem::size_of::<RawBig>()
+            == std::mem::size_of::<NonNull<()>>() + std::mem::size_of::<Payload>(),
+        "the layout must not contain padding"
+    );
+    // The integer view of the value must be legal to load, i.e. at least as aligned as a `u64`.
+    const _: () = assert!(
+        std::mem::align_of::<RawLittle>() >= std::mem::align_of::<u64>(),
+        "the value is read back as a u64, which wasm requires to be aligned"
+    );
+    const _: () = assert!(
+        std::mem::align_of::<RawBig>() >= std::mem::align_of::<u64>(),
+        "the value is read back as a u64, which wasm requires to be aligned"
+    );
 }
 
 #[cfg(not(any(
     target_pointer_width = "32",
     target_pointer_width = "16",
-    feature = "atom_size_64",
     feature = "atom_size_128"
 )))]
 mod raw_types {
@@ -42,6 +135,19 @@ mod raw_types {
 }
 
 pub(crate) const MAX_INLINE_LEN: usize = std::mem::size_of::<TaggedValue>() - 1;
+
+// The inline capacity must not depend on the target, or `turbo-rcstr-macros` (which runs on the
+// host) could not decide inline-vs-static on the target's behalf.
+#[cfg(not(feature = "atom_size_128"))]
+const _: () = assert!(
+    std::mem::size_of::<TaggedValue>() == 8,
+    "TaggedValue must be 8 bytes on every target so MAX_INLINE_LEN is uniformly 7"
+);
+#[cfg(feature = "atom_size_128")]
+const _: () = assert!(
+    std::mem::size_of::<TaggedValue>() == 16 && MAX_INLINE_LEN == 15,
+    "atom_size_128 must stay a 16-byte value with 15 inline bytes"
+);
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
@@ -52,13 +158,37 @@ pub(crate) struct TaggedValue {
 impl TaggedValue {
     #[inline(always)]
     pub const fn new_ptr<T>(value: NonNull<T>) -> Self {
-        #[cfg(any(
-            target_pointer_width = "32",
-            target_pointer_width = "16",
-            feature = "atom_size_64",
-            feature = "atom_size_128"
+        // A pointer → pointer cast, which const evaluation permits. See the module docs for why
+        // the narrow-pointer arm cannot store a bare integer here.
+        #[cfg(all(
+            any(target_pointer_width = "32", target_pointer_width = "16"),
+            not(feature = "atom_size_128")
         ))]
+        {
+            #[cfg(target_endian = "little")]
+            {
+                Self {
+                    value: RawTaggedNonZeroValue {
+                        ptr: value.cast(),
+                        pad: [0; std::mem::size_of::<Payload>()],
+                    },
+                }
+            }
+            #[cfg(target_endian = "big")]
+            {
+                Self {
+                    value: RawTaggedNonZeroValue {
+                        pad: [0; std::mem::size_of::<Payload>()],
+                        ptr: value.cast(),
+                    },
+                }
+            }
+        }
+
+        #[cfg(feature = "atom_size_128")]
         unsafe {
+            // `atom_size_128` keeps its integer representation, so this arm still cannot be used
+            // in a const context. It is not enabled anywhere in this workspace.
             let value: std::num::NonZeroUsize = std::mem::transmute(value);
             Self {
                 value: RawTaggedNonZeroValue::new_unchecked(value.get() as _),
@@ -68,7 +198,6 @@ impl TaggedValue {
         #[cfg(not(any(
             target_pointer_width = "32",
             target_pointer_width = "16",
-            feature = "atom_size_64",
             feature = "atom_size_128"
         )))]
         {
@@ -80,30 +209,34 @@ impl TaggedValue {
 
     #[inline(always)]
     pub const fn new_tag(value: NonZeroU8) -> Self {
+        // An integer → pointer transmute, which const evaluation permits.
         let value = value.get() as RawTaggedValue;
         Self {
             #[allow(clippy::transmute_int_to_non_zero)]
-            value: unsafe { std::mem::transmute(value) },
+            value: unsafe { std::mem::transmute::<RawTaggedValue, RawTaggedNonZeroValue>(value) },
         }
     }
 
     #[inline(always)]
     pub fn get_ptr(&self) -> *const c_void {
-        #[cfg(any(
-            target_pointer_width = "32",
-            target_pointer_width = "16",
-            feature = "atom_size_64",
-            feature = "atom_size_128"
+        #[cfg(all(
+            any(target_pointer_width = "32", target_pointer_width = "16"),
+            not(feature = "atom_size_128")
         ))]
         {
-            use crate::TAG_MASK;
-
+            // The tag lives in the low bits of the pointer itself (`DYNAMIC_TAG` sets one), so
+            // mask it before use — otherwise a dynamic string's `Arc` is dereferenced two bytes
+            // off, which traps on wasm as an unaligned atomic access.
+            // Reading the address is fine here: this only ever runs at run time.
+            (self.value.ptr.as_ptr() as usize & !(TAG_MASK as usize)) as _
+        }
+        #[cfg(feature = "atom_size_128")]
+        {
             (self.value.get() as usize & !(TAG_MASK as usize)) as _
         }
         #[cfg(not(any(
             target_pointer_width = "32",
             target_pointer_width = "16",
-            feature = "atom_size_64",
             feature = "atom_size_128"
         )))]
         {
@@ -113,7 +246,26 @@ impl TaggedValue {
 
     #[inline(always)]
     fn get_value(&self) -> RawTaggedValue {
-        unsafe { std::mem::transmute(Some(self.value)) }
+        #[cfg(all(
+            any(target_pointer_width = "32", target_pointer_width = "16"),
+            not(feature = "atom_size_128")
+        ))]
+        {
+            // The layout is guaranteed padding-free and 8-aligned above, so reading the whole
+            // value as an integer is well defined. Again, run time only.
+            unsafe { std::mem::transmute::<RawTaggedNonZeroValue, RawTaggedValue>(self.value) }
+        }
+        #[cfg(not(all(
+            any(target_pointer_width = "32", target_pointer_width = "16"),
+            not(feature = "atom_size_128")
+        )))]
+        {
+            unsafe {
+                std::mem::transmute::<Option<RawTaggedNonZeroValue>, RawTaggedValue>(Some(
+                    self.value,
+                ))
+            }
+        }
     }
 
     #[inline(always)]


### PR DESCRIPTION
### What?

Makes `turbo-rcstr`'s tagged value work on wasm — and on any target whose pointer is narrower than the
value — **without changing the representation or the inline capacity on any target**. `RcStr` stays 8
bytes wide everywhere, `MAX_INLINE_LEN` stays 7 everywhere, and `rcstr!` stays a `const`.

### Why?

`TaggedValue` stored a `NonNull<()>` on 64-bit but a bare `NonZeroU64` when
`target_pointer_width = "32"`. `rcstr!` expands to a `const`, so both constructors must be usable
during const evaluation — and with integer storage `new_ptr` needs a pointer→integer cast, which
const-eval forbids. Every `rcstr!` taking the static path failed to compile:

```
error[E0080]: unable to turn pointer into integer
```

Concretely, `cargo check -p turbopack-core --target wasm32-wasip1-threads` reported **4** of these
before this change and **0** after.

### How?

The fix rests on an asymmetry in const evaluation:

| direction | const-eval | why |
|---|---|---|
| pointer → integer | **forbidden** | a pointer is an abstract (allocation, offset) pair; its numeric address doesn't exist until the linker assigns one |
| integer → pointer | allowed | the result carries no provenance, which is fine as long as it is never dereferenced |

64-bit already only needs the legal directions: `new_ptr` is pointer→pointer, `new_tag` is
integer→pointer. So rather than narrow the value on other targets, they now store a struct that keeps
a **real pointer field**:

```rust
#[repr(C, align(8))]
struct RawLittle { ptr: NonNull<()>, pad: [u8; PAD] }
```

`new_ptr` stores the pointer as a pointer; `new_tag` transmutes an integer into the struct. Reading the
value back as an integer (`get_ptr`, `get_value`, `tag_byte`) only happens at **run time**, where
pointer→integer is perfectly legal.

Three details are load-bearing, and each has a static assertion:

- **`align(8)`** — a pointer field alone would align the struct to 4 on wasm32, and reading the value
  as a `u64` then traps with `RuntimeError: operation does not support unaligned accesses`.
- **No padding** — the byte payload is sized to the pointer width, because padding bytes are
  uninitialised and would make the whole-value transmute in `new_tag` invalid.
- **Endian-dependent field order** — the pointer's least-significant byte must land where the value's
  least-significant byte lives (offset 0 little-endian, last byte big-endian), since that is where the
  tag is read from. Both layouts are declared unconditionally so the big-endian assertion still
  compiles (and was verified to fail when deliberately broken) on a little-endian host.

A union satisfies both constructors too, but unions carry no niche in rustc, so `Option<RcStr>` would
grow to 16 bytes. The struct keeps it at 8 — also asserted.

### Testing

- `turbo-rcstr`: **11 passed** on host, **10 passed / 1 ignored** on `wasm32-wasip1-threads`
  (the ignored one needs the static-`RcStr` registry, which depends on the link-section loader hook).
- Round-trips every `rcstr!` length from 0 to 9 on both targets, covering both sides of the inline
  boundary and the static path.
- Each of the new static assertions was verified to **fail** when deliberately broken, including the
  big-endian layout one.
- `MAX_INLINE_LEN == 7` asserted on host and wasm.
- The five `const … = rcstr!(…)` sites in the tree — including two `pub const`s in `turbopack-core` —
  are untouched and still compile as `const`.
- `atom_size_128` still builds; its pre-existing const limitation is unchanged and out of scope.
- `cargo fmt --check`, and clippy `-D warnings` for the host and for `wasm32-wasip1-threads`.

Big-endian and 16-bit are compile-checked and assertion-protected, but not runtime-exercised — no such
target is available here.

<!-- NEXT_JS_LLM -->


<!-- fleet b6d0486f-97c7-42a7-bdaf-3490774cdec3 -->