### PR TITLE
fix(turbo-tasks): compile EventListener::wait on wasm

### DIFF
--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -59,7 +59,10 @@ turbo-tasks-macros = { workspace = true }
 turbo-tasks-malloc = { workspace = true }
 unsize = { workspace = true }
 
-[dev-dependencies]
+# Only used by the benchmarks, which don't run on wasm. Gated by target so that
+# `cargo test -p turbo-tasks --lib --target wasm32-wasip1-threads` can build: criterion pulls in
+# rayon, which refuses to compile for wasi, and cargo resolves dev-dependencies even for `--lib`.
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
 
 [[bench]]

--- a/turbopack/crates/turbo-tasks/src/event.rs
+++ b/turbopack/crates/turbo-tasks/src/event.rs
@@ -11,9 +11,25 @@ use std::{
     time::Duration,
 };
 
-use event_listener::Listener as _;
 #[cfg(feature = "hanging_detection")]
 use tokio::time::{Timeout, timeout};
+
+/// Blocks the current thread until `listener` is notified.
+///
+/// `event-listener` gates its own blocking `wait()` behind `not(target_family = "wasm")`, which
+/// excludes every wasm target even though `wasm32-wasip1-threads` has real threads that can park.
+/// Its native implementation is just "register a waker, then park in a loop", so on wasm we drive
+/// the listener's `Future` to completion with a parking executor, which is the same mechanism.
+fn block_on_listener(listener: event_listener::EventListener) {
+    #[cfg(not(target_family = "wasm"))]
+    {
+        use event_listener::Listener as _;
+
+        listener.wait();
+    }
+    #[cfg(target_family = "wasm")]
+    futures::executor::block_on(listener);
+}
 
 pub trait EventDescriptor {
     #[cfg(feature = "hanging_detection")]
@@ -209,7 +225,7 @@ impl EventListener {
     /// This is the synchronous equivalent of `.await`-ing the `EventListener`.
     /// Only valid in synchronous contexts (e.g. backend operations).
     pub fn wait(self) {
-        self.listener.wait();
+        block_on_listener(self.listener);
     }
 }
 
@@ -294,16 +310,21 @@ impl EventListener {
     pub fn wait(mut self) {
         if let Some(future) = self.future.take() {
             // SAFETY: EventListener is Unpin, so it's safe to move out of the Pin.
-            unsafe { std::pin::Pin::into_inner_unchecked(future) }
-                .into_inner()
-                .wait();
+            block_on_listener(unsafe { std::pin::Pin::into_inner_unchecked(future) }.into_inner());
         }
     }
 }
 
 #[cfg(all(test, not(feature = "hanging_detection")))]
 mod tests {
-    use std::hint::black_box;
+    use std::{
+        hint::black_box,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Instant,
+    };
 
     use tokio::time::{Duration, timeout};
 
@@ -340,5 +361,47 @@ mod tests {
         }));
 
         let _ = black_box(timeout(Duration::from_millis(10), listener)).await;
+    }
+
+    /// `EventListener::wait` has to actually block until another thread notifies the event.
+    ///
+    /// The notification is sent only after a delay, so the waiter is registered and parked first —
+    /// this exercises the parking path rather than the already-notified fast path. The assertions
+    /// are written so that a `wait()` which returned early (or did nothing at all) fails rather
+    /// than silently passing, and a `wait()` which never woke up would hang the test.
+    #[test]
+    fn wait_blocks_until_notified_by_another_thread() {
+        const DELAY: Duration = Duration::from_millis(300);
+        // Allow for timer granularity: assert on a slightly shorter span than we sleep for.
+        const MIN_BLOCKED: Duration = Duration::from_millis(200);
+
+        let event = Arc::new(Event::new(|| || "test event".to_string()));
+        let listener = event.listen();
+
+        let notified = Arc::new(AtomicBool::new(false));
+        let notifier = {
+            let event = event.clone();
+            let notified = notified.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(DELAY);
+                notified.store(true, Ordering::SeqCst);
+                event.notify(1);
+            })
+        };
+
+        let start = Instant::now();
+        listener.wait();
+        let blocked_for = start.elapsed();
+
+        assert!(
+            notified.load(Ordering::SeqCst),
+            "wait() returned before the notifying thread ran"
+        );
+        assert!(
+            blocked_for >= MIN_BLOCKED,
+            "wait() did not block; it returned after {blocked_for:?}"
+        );
+
+        notifier.join().unwrap();
     }
 }


### PR DESCRIPTION
### What?

Gives `turbo_tasks::EventListener::wait` a working blocking implementation on wasm targets, instead
of failing to compile there.

Also moves `criterion` to a non-wasm dev-dependency, which is what makes
`cargo test -p turbo-tasks --lib --target wasm32-wasip1-threads` buildable at all — see *How?*.

### Why?

`event-listener` gates its blocking `wait()` / `wait_timeout()` / `wait_deadline()` behind
`#[cfg(all(feature = "std", not(target_family = "wasm")))]`, so they are unavailable on **every**
wasm target — even `wasm32-wasip1-threads`, which has real threads that can park. That made
`EventListener::wait` fail to compile.

This is load-bearing rather than a corner case: `wait()` backs the priority runner's task barriers
(six call sites in `turbopack/crates/turbo-tasks/src/priority_runner.rs`) and
`turbopack/crates/turbo-tasks/src/scope.rs`. Anything that merely compiled while `wait()` was
unusable would be hollow.

### How?

`event-listener`'s own native implementation (`wait_internal` → `wait_with_parker`) is just "register
an unparker as the listener's task, then `Parker::park()` in a loop". `EventListener` already
implements `Future`, so on wasm the same thing is expressed one level up:

```rust
fn block_on_listener(listener: event_listener::EventListener) {
    #[cfg(not(target_family = "wasm"))]
    { use event_listener::Listener as _; listener.wait(); }
    #[cfg(target_family = "wasm")]
    futures::executor::block_on(listener);
}
```

`futures` is already a dependency of this crate, `executor` is one of its default features, and
`futures-executor` is already in the wasm dependency graph, so nothing new is pulled in. Native
targets keep calling `event-listener` directly, so their behaviour and fast path are untouched.

Both `wait()` implementations — the default one and the `hanging_detection` one — route through that
single helper, so the two cannot drift apart and the target `cfg` exists in exactly one place.

**Verification.** A new test registers a listener, spawns a thread that sleeps before notifying, then
waits — so the listener parks first and the parking path is exercised rather than the
already-notified fast path. It asserts both that the notifier ran *and* that time actually elapsed,
so a `wait()` that returned early fails instead of silently passing.

It passes natively, and the wasm code path was executed under wasmtime with real wasi threads on
`wasm32-wasip1-threads`: the waiter blocked **300.9 ms** against a 300 ms notifier delay and was
woken by the other thread. As a control, a deliberately non-blocking variant returns in ~1 µs and
fails the assertions.

Two notes on the surrounding tooling:

- `criterion` is used only by the `[[bench]]` targets, but it pulls in `rayon`, which refuses to
  compile for wasi, and cargo resolves dev-dependencies even for `cargo test --lib`. Gating it to
  non-wasm targets is semantically right (the benchmarks don't run on wasm) and unblocks wasm test
  binaries for this crate generally. Native benchmarks are unaffected.
- The test binary now *builds* for wasm but cannot be instantiated by a plain runtime, because
  `turbo-tasks` imports `env.read_custom_section` for its link-time task registries and no CLI
  runtime provides it. That hook is tracked separately; until it exists, the runtime evidence above
  comes from a standalone binary that copies the helper's wasm body verbatim against the same
  `event-listener` and `futures` versions.

<!-- NEXT_JS_LLM -->
