### PR TITLE
fix(turbo-tasks-fs): create symlinks through the WASI API on wasi

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/disk.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/disk.rs
@@ -1371,8 +1371,10 @@ impl FileSystem for DiskFileSystem {
                                 })?;
                                 has_old_content = false;
                             }
-                            #[cfg(not(windows))]
+                            #[cfg(all(not(windows), not(target_os = "wasi")))]
                             let io_result = std::os::unix::fs::symlink(&target, &**full_path);
+                            #[cfg(target_os = "wasi")]
+                            let io_result = std::os::wasi::fs::symlink_path(&target, &**full_path);
                             #[cfg(windows)]
                             let io_result = if is_directory {
                                 std::os::windows::fs::junction_point(&target, &**full_path)

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -10,6 +10,8 @@
 // Junction points are used on Windows. We could use a third-party crate for this if the junction
 // API isn't eventually stabilized.
 #![cfg_attr(windows, feature(junction_point))]
+// `std::os::wasi::fs::symlink_path`, used to create symlinks on wasi, is still unstable.
+#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 #![allow(clippy::mutable_key_type)]
 


### PR DESCRIPTION
### What?

`turbo-tasks-fs` creates symlinks through `std::os::wasi::fs::symlink_path` when targeting wasi.

### Why?

`std::os::unix` does not exist on wasi, so `disk.rs`'s symlink creation failed to compile:

```
error[E0433]: cannot find `unix` in `os`
    --> turbopack/crates/turbo-tasks-fs/src/disk.rs:1375
```

### How?

A `cfg(target_os = "wasi")` arm calls the WASI equivalent, which takes the same `(target, link)`
argument order. That API is still behind the unstable `wasi_ext` feature, enabled for the wasi target
only via `cfg_attr`. The Windows junction-point path and the unix path are unchanged.

<!-- NEXT_JS_LLM -->
