### PR TITLE
refactor(turbopack-cli-utils): replace crossterm with owo-colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,31 +1928,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
-name = "crossterm"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio 0.8.11",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4683,18 +4658,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -5206,7 +5169,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio 1.2.0",
+ "mio",
  "notify-types",
  "walkdir",
  "windows-sys 0.60.2",
@@ -7478,27 +7441,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio 0.8.11",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9506,7 +9448,7 @@ checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -10202,6 +10144,7 @@ dependencies = [
  "mockito",
  "quick_cache",
  "reqwest",
+ "rustc-hash 2.1.1",
  "rustls",
  "serde",
  "tokio",
@@ -10502,7 +10445,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "crossterm",
  "owo-colors",
  "rustc-hash 2.1.1",
  "serde",

--- a/turbopack/crates/turbopack-cli-utils/Cargo.toml
+++ b/turbopack/crates/turbopack-cli-utils/Cargo.toml
@@ -17,7 +17,6 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-crossterm = "0.26.0"
 owo-colors = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -9,7 +9,6 @@ use std::{
 
 use anyhow::Result;
 use async_trait::async_trait;
-use crossterm::style::{StyledContent, Stylize};
 use owo_colors::{OwoColorize as _, Style};
 use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_rcstr::RcStr;
@@ -558,15 +557,11 @@ fn make_relative_to_cwd<'a>(path: &'a str, project_dir: &Path, cwd: &Path) -> Co
     }
 }
 
-fn show_all_message(label: &str, size: usize) -> StyledContent<String> {
+fn show_all_message(label: &str, size: usize) -> String {
     show_all_message_with_shown_count(label, size, DEFAULT_SHOW_COUNT)
 }
 
-fn show_all_message_with_shown_count(
-    label: &str,
-    size: usize,
-    shown: usize,
-) -> StyledContent<String> {
+fn show_all_message_with_shown_count(label: &str, size: usize, shown: usize) -> String {
     if shown == 0 {
         format!(
             "... [{} {label}] are hidden, run with {} to show them",
@@ -574,6 +569,7 @@ fn show_all_message_with_shown_count(
             "--show-all".bright_green()
         )
         .bold()
+        .to_string()
     } else {
         format!(
             "... [{} more {label}] are hidden, run with {} to show all",
@@ -581,6 +577,7 @@ fn show_all_message_with_shown_count(
             "--show-all".bright_green()
         )
         .bold()
+        .to_string()
     }
 }
 


### PR DESCRIPTION
### What?

`turbopack-cli-utils` uses `owo-colors` instead of `crossterm` for issue formatting.

### Why?

Two reasons:

- `crossterm` 0.26 has no wasm backend, and fails to compile for wasm with 8 errors inside the crate
  itself.
- It was pulling its weight for very little: the only uses were `StyledContent` and `Stylize` in
  `issue.rs`, and `owo-colors` — already a dependency of that same file — covers all of them.

### How?

Swap the trait usage over and return `String` from `show_all_message` rather than
`StyledContent<String>`. Rendered output is unchanged.

This also removes `crossterm`, `crossterm_winapi`, `mio 0.8`, `signal-hook` and `signal-hook-mio`
from `Cargo.lock` (and lets cargo drop the `mio 1.2` disambiguation, since only one `mio` remains).

<!-- NEXT_JS_LLM -->
