### PR TITLE
feat(next-napi-bindings): build Turbopack for wasm

### DIFF
--- a/crates/next-napi-bindings/Cargo.toml
+++ b/crates/next-napi-bindings/Cargo.toml
@@ -83,24 +83,7 @@ swc_core = { workspace = true, features = [
     "ecma_visit",
 ] }
 
-# Dependencies for the native, non-wasm32 build.
-#
-# SWC's plugin host is native-only: `__plugin_transform_host` turns on `swc/plugin`, which pulls in
-# the plugin runner and compiles SWC's `target_arch = "wasm32"` plugin path, and SWC does not support
-# running wasm plugins from inside wasm (https://github.com/swc-project/swc/issues/3934).
-# `plugin_transform_host_native_filesystem_cache` is a native filesystem cache and cannot apply there
-# either.
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-swc_core = { workspace = true, features = [
-    "__plugin_transform_host",
-    "__plugin_transform_host_schema_v1",
-    "plugin_transform_host_native_filesystem_cache",
-] }
-swc_ecma_react_compiler = { workspace = true }
-turbopack-lightningcss-napi = { workspace = true }
-lightningcss = { workspace = true }
-swc_plugin_backend_wasmtime = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+# Turbopack.
 turbo-rcstr = { workspace = true, features = ["napi"] }
 turbo-tasks = { workspace = true }
 turbo-tasks-backend = { workspace = true }
@@ -109,18 +92,34 @@ turbo-unix-path = { workspace = true }
 next-api = { workspace = true, features = ["worker_pool"] }
 next-build = { workspace = true }
 next-core = { workspace = true }
-
-mdxjs = { workspace = true, features = ["serializable"] }
-
-turbo-tasks-malloc = { workspace = true, default-features = false, features = [
-    "custom_allocator",
-] }
-
 turbopack-core = { workspace = true }
 turbopack-ecmascript-hmr-protocol = { workspace = true }
 turbopack-trace-utils = { workspace = true }
 turbopack-trace-server = { workspace = true }
 turbopack-node = { workspace = true, default-features = false, features = ["worker_pool"] }
+
+mdxjs = { workspace = true, features = ["serializable"] }
+
+swc_ecma_react_compiler = { workspace = true }
+turbopack-lightningcss-napi = { workspace = true }
+lightningcss = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# `swc/plugin` compiles SWC's wasm32 plugin path, and SWC can't run wasm plugins from inside wasm
+# (https://github.com/swc-project/swc/issues/3934). The filesystem cache is native-only too.
+swc_core = { workspace = true, features = [
+    "__plugin_transform_host",
+    "__plugin_transform_host_schema_v1",
+    "plugin_transform_host_native_filesystem_cache",
+] }
+# Can't run inside wasm; see `turbopack-ecmascript-plugins`.
+swc_plugin_backend_wasmtime = { workspace = true }
+# `full` pulls in `process` and `signal`, which don't exist on wasi.
+tokio = { workspace = true, features = ["full"] }
+
+turbo-tasks-malloc = { workspace = true, default-features = false, features = [
+    "custom_allocator",
+] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = "0.60"
@@ -129,9 +128,7 @@ windows-sys = "0.60"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.9", default-features = false, features = ["js"] }
 iana-time-zone = { version = "*", features = ["fallback"] }
-
-mdxjs = { workspace = true }
-
+# `turbo-tasks-malloc`'s `custom_allocator` feature uses mimalloc, which isn't compatible with wasm
 turbo-tasks-malloc = { workspace = true, default-features = false }
 
 # wasi-only dependencies.

--- a/crates/next-napi-bindings/src/lib.rs
+++ b/crates/next-napi-bindings/src/lib.rs
@@ -34,28 +34,22 @@ DEALINGS IN THE SOFTWARE.
 
 use std::sync::Arc;
 
-use napi::bindgen_prelude::create_custom_tokio_runtime;
 use swc_core::{
     base::Compiler,
     common::{FilePathMapping, SourceMap},
 };
 
 pub mod code_frame;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod css;
 pub mod lockfile;
 pub mod mdx;
 pub mod minify;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod next_api;
 pub mod parse;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod react_compiler;
 pub mod rspack;
 pub mod transform;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod turbo_trace_server;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod turbopack;
 pub mod util;
 
@@ -82,6 +76,7 @@ fn init() {
         static LAST_SWC_ATOM_GC_TIME: RefCell<Option<Instant>> = const { RefCell::new(None) };
     }
 
+    use napi::bindgen_prelude::create_custom_tokio_runtime;
     use tokio::runtime::Builder;
     use turbo_tasks::{panic_hooks::handle_panic, parallel::available_parallelism};
     use turbo_tasks_malloc::TurboMalloc;

--- a/crates/next-napi-bindings/src/transform.rs
+++ b/crates/next-napi-bindings/src/transform.rs
@@ -31,7 +31,7 @@ use std::{
     fs::read_to_string,
     panic::{AssertUnwindSafe, catch_unwind},
     rc::Rc,
-    sync::{Arc, LazyLock},
+    sync::LazyLock,
 };
 
 use anyhow::{Context as _, anyhow, bail};
@@ -41,11 +41,10 @@ use next_custom_transforms::chain_transforms::{TransformOptions, custom_before_p
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
     atoms::Atom,
-    base::{Compiler, TransformOutput, config::RuntimeOptions, try_with_handler},
+    base::{Compiler, TransformOutput, try_with_handler},
     common::{FileName, GLOBALS, Mark, comments::SingleThreadedComments, errors::ColorConfig},
     ecma::ast::noop_pass,
 };
-use swc_plugin_backend_wasmtime::WasmtimeRuntime;
 
 use crate::{get_compiler, util::MapErr};
 
@@ -169,8 +168,20 @@ impl Task for TransformTask {
                             let unresolved_mark = Mark::new();
                             let mut options = options.patch(&fm);
                             options.swc.unresolved_mark = Some(unresolved_mark);
-                            options.swc.runtime_options =
-                                RuntimeOptions::default().plugin_runtime(Arc::new(WasmtimeRuntime));
+                            // The wasmtime plugin backend cannot run inside wasm; SWC skips
+                            // plugin transforms on wasm32 for the same reason.
+                            // See https://github.com/swc-project/swc/issues/3934.
+                            #[cfg(not(target_arch = "wasm32"))]
+                            {
+                                use std::sync::Arc;
+
+                                use swc_core::base::config::RuntimeOptions;
+
+                                options.swc.runtime_options = RuntimeOptions::default()
+                                    .plugin_runtime(Arc::new(
+                                        swc_plugin_backend_wasmtime::WasmtimeRuntime,
+                                    ));
+                            }
 
                             let cm = self.c.cm.clone();
                             let file = fm.clone();


### PR DESCRIPTION
### What?

Builds Turbopack for wasm, so the wasm fallback can support Turbopack and not just SWC.

### Why?

`next-napi-bindings` gated every Turbopack dependency behind `cfg(not(target_arch = "wasm32"))`, so the
wasm fallback shipped SWC only. That is the reason issues like #96960 have no answer today: when the
native binding cannot load there is no Turbopack at all.

### How?

Moves the Turbopack dependencies into the shared dependency block, leaving genuinely native-only crates
gated:

- `lightningcss` / `turbopack-lightningcss-napi` and `swc_ecma_react_compiler` back the `css` and
  `react_compiler` modules;
- `swc_plugin_backend_wasmtime` cannot run inside wasm;
- SWC's plugin-host features, gated in the previous layer;
- `tokio`'s `full` feature pulls in `process` and `signal`, which do not exist on wasi, so the wasi build
  gets its own `tokio`.

This is the layer at which `swc` first gets compiled for wasm, which is why the plugin-host gating has
to land **before** it: with that in place, `cargo check -p next-napi-bindings --target
wasm32-wasip1-threads` passes here with no `[patch.crates-io]` override.

### What this does *not* do

It makes Turbopack **compile** for wasm. It does not make it run: still outstanding are the
`env.read_custom_section` loader hook, a wasm `module_init` for the tokio runtime and panic hook, a
host-provided fetch, the persistent cache (WASI preview1 has no file-backed mmap or flock), and file
watching. Shipping is separately blocked on the unreleased emnapi v2.

`turbo-tasks-malloc`'s `custom_allocator` feature also stays off, so there is no per-thread allocation
accounting on wasm and memory figures are absent from traces — an observability gap, not a correctness
one.


<!-- fleet b6d0486f-97c7-42a7-bdaf-3490774cdec3 -->