### PR TITLE
build: add an opt-in patch for swc's wasm32 plugin host

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,7 @@ build/** linguist-generated=false
 
 # Custom merge driver for auto-generated errors.json
 packages/next/errors.json merge=errors-json
+
+# Patch files are unified diffs: a context line for a blank line is a single space, so whitespace
+# checks flag them and "fixing" the whitespace would corrupt the patch.
+*.patch -whitespace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,31 +1928,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
-name = "crossterm"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio 0.8.11",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4683,18 +4658,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -5206,7 +5169,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio 1.2.0",
+ "mio",
  "notify-types",
  "walkdir",
  "windows-sys 0.60.2",
@@ -7478,27 +7441,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio 0.8.11",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9506,7 +9448,7 @@ checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -10202,6 +10144,7 @@ dependencies = [
  "mockito",
  "quick_cache",
  "reqwest",
+ "rustc-hash 2.1.1",
  "rustls",
  "serde",
  "tokio",
@@ -10502,7 +10445,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "crossterm",
  "owo-colors",
  "rustc-hash 2.1.1",
  "serde",

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -88,7 +88,7 @@ use turbopack_core::{
         VersionState, VersionedContent,
     },
 };
-#[cfg(feature = "process_pool")]
+#[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
 use turbopack_node::child_process_backend;
 use turbopack_node::execution_context::ExecutionContext;
 #[cfg(feature = "worker_pool")]
@@ -1266,7 +1266,7 @@ impl Project {
         let node_backend = match strategy {
             #[cfg(feature = "worker_pool")]
             TurbopackPluginRuntimeStrategy::WorkerThreads => worker_threads_backend(),
-            #[cfg(feature = "process_pool")]
+            #[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
             TurbopackPluginRuntimeStrategy::ChildProcesses => child_process_backend(),
         };
 

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -923,7 +923,7 @@ pub enum ModuleIds {
 pub enum TurbopackPluginRuntimeStrategy {
     #[cfg(feature = "worker_pool")]
     WorkerThreads,
-    #[cfg(feature = "process_pool")]
+    #[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
     ChildProcesses,
 }
 
@@ -2589,9 +2589,14 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub fn turbopack_plugin_runtime_strategy(&self) -> Vc<TurbopackPluginRuntimeStrategy> {
-        #[cfg(feature = "process_pool")]
+        // Child processes cannot be spawned from inside wasm, so worker threads are the only
+        // available runtime there.
+        #[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
         let default = TurbopackPluginRuntimeStrategy::ChildProcesses;
-        #[cfg(all(feature = "worker_pool", not(feature = "process_pool")))]
+        #[cfg(all(
+            feature = "worker_pool",
+            any(not(feature = "process_pool"), target_family = "wasm")
+        ))]
         let default = TurbopackPluginRuntimeStrategy::WorkerThreads;
 
         self.experimental

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -1,36 +1,51 @@
 use anyhow::Result;
-use bincode::{Decode, Encode};
-use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc, trace::TraceRawVcs};
+#[cfg(not(target_family = "wasm"))]
+use turbo_tasks::ResolvedVc;
+use turbo_tasks::Vc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::ModuleRule;
+#[cfg(not(target_family = "wasm"))]
 use turbopack_ecmascript::{CustomTransformer, TransformPlugin};
 
 use crate::next_config::NextConfig;
 
-/// A wrapper around [`serde_json::Value`] that implements [`turbo_tasks::TaskInput`].
-///
-/// [`serde_json::Value`] does not implement [`std::hash::Hash`], so we implement it manually by
-/// hashing the serialized JSON string.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, Encode, Decode)]
-pub struct JsonValue(#[bincode(with = "turbo_bincode::serde_self_describing")] serde_json::Value);
+// Everything below only backs the native implementation of `get_swc_ecma_transform_rule_impl`; on
+// wasm that function is a stub, because SWC wasm plugins need the wasmtime backend.
+#[cfg(not(target_family = "wasm"))]
+mod native_types {
+    use bincode::{Decode, Encode};
+    use serde::{Deserialize, Serialize};
+    use turbo_tasks::trace::TraceRawVcs;
 
-impl std::hash::Hash for JsonValue {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        serde_json::to_string(&self.0)
-            .expect("JSON serialization should never fail")
-            .hash(state);
+    /// A wrapper around [`serde_json::Value`] that implements [`turbo_tasks::TaskInput`].
+    ///
+    /// [`serde_json::Value`] does not implement [`std::hash::Hash`], so we implement it manually by
+    /// hashing the serialized JSON string.
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, TraceRawVcs, Encode, Decode)]
+    pub struct JsonValue(
+        #[bincode(with = "turbo_bincode::serde_self_describing")] pub serde_json::Value,
+    );
+
+    impl std::hash::Hash for JsonValue {
+        fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+            serde_json::to_string(&self.0)
+                .expect("JSON serialization should never fail")
+                .hash(state);
+        }
+    }
+
+    // Manual impl because `serde_json::Value` doesn't implement `TaskInput`, but `JsonValue` can
+    // never contain any `Vc` types.
+    impl turbo_tasks::TaskInput for JsonValue {
+        fn is_transient(&self) -> bool {
+            false
+        }
     }
 }
 
-// Manual impl because `serde_json::Value` doesn't implement `TaskInput`, but `JsonValue` can
-// never contain any `Vc` types.
-impl turbo_tasks::TaskInput for JsonValue {
-    fn is_transient(&self) -> bool {
-        false
-    }
-}
+#[cfg(not(target_family = "wasm"))]
+pub use native_types::JsonValue;
 
 pub async fn get_swc_ecma_transform_plugin_rule(
     next_config: Vc<NextConfig>,
@@ -45,6 +60,19 @@ pub async fn get_swc_ecma_transform_plugin_rule(
     }
 }
 
+/// SWC wasm plugins are not available when Next.js itself is built for wasm: executing them needs
+/// the wasmtime backend, which cannot be hosted inside wasm. SWC skips plugin transforms on wasm32
+/// for the same reason, see <https://github.com/swc-project/swc/issues/3934>.
+#[cfg(target_family = "wasm")]
+pub async fn get_swc_ecma_transform_rule_impl(
+    _project_path: FileSystemPath,
+    _plugin_configs: &[(RcStr, serde_json::Value)],
+    _enable_mdx_rs: bool,
+) -> Result<Option<ModuleRule>> {
+    Ok(None)
+}
+
+#[cfg(not(target_family = "wasm"))]
 pub async fn get_swc_ecma_transform_rule_impl(
     project_path: FileSystemPath,
     plugin_configs: &[(RcStr, serde_json::Value)],
@@ -148,6 +176,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
     )))
 }
 
+#[cfg(not(target_family = "wasm"))]
 #[turbo_tasks::function]
 fn swc_ecma_transform_plugins_transform_plugin(
     plugins: Vec<(

--- a/crates/next-napi-bindings/Cargo.toml
+++ b/crates/next-napi-bindings/Cargo.toml
@@ -86,13 +86,8 @@ swc_core = { workspace = true, features = [
     "plugin_transform_host_native_filesystem_cache",
 ] }
 
-# Dependencies for the native, non-wasm32 build.
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-swc_ecma_react_compiler = { workspace = true }
-turbopack-lightningcss-napi = { workspace = true }
-lightningcss = { workspace = true }
-swc_plugin_backend_wasmtime = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
+# Turbopack. These are built for wasm too, so that the wasm fallback can support Turbopack and not
+# just SWC.
 turbo-rcstr = { workspace = true, features = ["napi"] }
 turbo-tasks = { workspace = true }
 turbo-tasks-backend = { workspace = true }
@@ -101,18 +96,32 @@ turbo-unix-path = { workspace = true }
 next-api = { workspace = true, features = ["worker_pool"] }
 next-build = { workspace = true }
 next-core = { workspace = true }
-
-mdxjs = { workspace = true, features = ["serializable"] }
-
-turbo-tasks-malloc = { workspace = true, default-features = false, features = [
-    "custom_allocator",
-] }
-
 turbopack-core = { workspace = true }
 turbopack-ecmascript-hmr-protocol = { workspace = true }
 turbopack-trace-utils = { workspace = true }
 turbopack-trace-server = { workspace = true }
 turbopack-node = { workspace = true, default-features = false, features = ["worker_pool"] }
+
+mdxjs = { workspace = true, features = ["serializable"] }
+
+# Dependencies for the native, non-wasm32 build.
+#
+# - `lightningcss` / `turbopack-lightningcss-napi` and `swc_ecma_react_compiler` back the `css` and
+#   `react_compiler` modules, which are native-only.
+# - `swc_plugin_backend_wasmtime` cannot run inside wasm; see
+#   `turbopack-ecmascript-plugins`.
+# - `tokio`'s `full` feature pulls in `process` and `signal`, which do not exist on wasi. The wasi
+#   build gets its own `tokio` below.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+swc_ecma_react_compiler = { workspace = true }
+turbopack-lightningcss-napi = { workspace = true }
+lightningcss = { workspace = true }
+swc_plugin_backend_wasmtime = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+
+turbo-tasks-malloc = { workspace = true, default-features = false, features = [
+    "custom_allocator",
+] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = "0.60"
@@ -122,8 +131,8 @@ windows-sys = "0.60"
 getrandom = { version = "0.2.9", default-features = false, features = ["js"] }
 iana-time-zone = { version = "*", features = ["fallback"] }
 
-mdxjs = { workspace = true }
-
+# TODO: `turbo-tasks-malloc`'s `custom_allocator` feature is not enabled on wasm, so `TurboMalloc`'s
+# per-thread accounting (`thread_stop` / `thread_park`) is unavailable there.
 turbo-tasks-malloc = { workspace = true, default-features = false }
 
 # wasi-only dependencies.

--- a/crates/next-napi-bindings/build.rs
+++ b/crates/next-napi-bindings/build.rs
@@ -86,8 +86,17 @@ fn main() -> anyhow::Result<()> {
 
     // Resolve a potential linker issue for unit tests on linux
     // https://github.com/napi-rs/napi-rs/issues/1782
-    #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
-    println!("cargo:rustc-link-arg=-Wl,--warn-unresolved-symbols");
+    //
+    // Note this has to be decided from `CARGO_CFG_*`, not `#[cfg(...)]`: inside a build script,
+    // `#[cfg(...)]` describes the machine *running* the script (the host), not the target being
+    // compiled. Cross-compiling from Linux to wasm would therefore still pass this flag, and
+    // `rust-lld -flavor wasm` rejects it with `unknown argument:
+    // -Wl,--warn-unresolved-symbols`.
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux")
+        && env::var("CARGO_CFG_TARGET_FAMILY").as_deref() != Ok("wasm")
+    {
+        println!("cargo:rustc-link-arg=-Wl,--warn-unresolved-symbols");
+    }
 
     Ok(())
 }

--- a/crates/next-napi-bindings/src/lib.rs
+++ b/crates/next-napi-bindings/src/lib.rs
@@ -34,28 +34,26 @@ DEALINGS IN THE SOFTWARE.
 
 use std::sync::Arc;
 
-use napi::bindgen_prelude::create_custom_tokio_runtime;
 use swc_core::{
     base::Compiler,
     common::{FilePathMapping, SourceMap},
 };
 
 pub mod code_frame;
+// Backed by lightningcss, which is native-only.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod css;
 pub mod lockfile;
 pub mod mdx;
 pub mod minify;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod next_api;
 pub mod parse;
+// Backed by swc_ecma_react_compiler, which is native-only.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod react_compiler;
 pub mod rspack;
 pub mod transform;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod turbo_trace_server;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod turbopack;
 pub mod util;
 
@@ -82,6 +80,7 @@ fn init() {
         static LAST_SWC_ATOM_GC_TIME: RefCell<Option<Instant>> = const { RefCell::new(None) };
     }
 
+    use napi::bindgen_prelude::create_custom_tokio_runtime;
     use tokio::runtime::Builder;
     use turbo_tasks::{panic_hooks::handle_panic, parallel::available_parallelism};
     use turbo_tasks_malloc::TurboMalloc;

--- a/crates/next-napi-bindings/src/transform.rs
+++ b/crates/next-napi-bindings/src/transform.rs
@@ -31,7 +31,7 @@ use std::{
     fs::read_to_string,
     panic::{AssertUnwindSafe, catch_unwind},
     rc::Rc,
-    sync::{Arc, LazyLock},
+    sync::LazyLock,
 };
 
 use anyhow::{Context as _, anyhow, bail};
@@ -41,10 +41,13 @@ use next_custom_transforms::chain_transforms::{TransformOptions, custom_before_p
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
     atoms::Atom,
-    base::{Compiler, TransformOutput, config::RuntimeOptions, try_with_handler},
+    base::{Compiler, TransformOutput, try_with_handler},
     common::{FileName, GLOBALS, Mark, comments::SingleThreadedComments, errors::ColorConfig},
     ecma::ast::noop_pass,
 };
+// The wasmtime plugin backend cannot run inside wasm; SWC skips plugin transforms on wasm32
+// for the same reason. See https://github.com/swc-project/swc/issues/3934.
+#[cfg(not(target_arch = "wasm32"))]
 use swc_plugin_backend_wasmtime::WasmtimeRuntime;
 
 use crate::{get_compiler, util::MapErr};
@@ -169,8 +172,15 @@ impl Task for TransformTask {
                             let unresolved_mark = Mark::new();
                             let mut options = options.patch(&fm);
                             options.swc.unresolved_mark = Some(unresolved_mark);
-                            options.swc.runtime_options =
-                                RuntimeOptions::default().plugin_runtime(Arc::new(WasmtimeRuntime));
+                            #[cfg(not(target_arch = "wasm32"))]
+                            {
+                                use std::sync::Arc;
+
+                                use swc_core::base::config::RuntimeOptions;
+
+                                options.swc.runtime_options = RuntimeOptions::default()
+                                    .plugin_runtime(Arc::new(WasmtimeRuntime));
+                            }
 
                             let cm = self.c.cm.clone();
                             let file = fm.clone();

--- a/patches/rust/README.md
+++ b/patches/rust/README.md
@@ -1,0 +1,54 @@
+# Rust crate patches
+
+Patches for crates.io dependencies that need a fix which has not been released yet.
+
+The `.patch` files next to this README are **not** applied automatically, and they do not affect a
+normal `cargo build`. Cargo has no support for patch files, and a `[patch.crates-io]` entry in the
+root `Cargo.toml` would have to point at a directory that does not exist in a fresh checkout, which
+would break every build. So instead:
+
+1. `scripts/patch-rust-crate.mjs` copies the crate's source out of the cargo registry into
+   `target/patched-crates/<name>-<version>/` and applies `patches/rust/<name>@<version>.patch`.
+2. The build that needs the patch passes the resulting directory to cargo explicitly:
+
+   ```sh
+   SWC_DIR="$(node ./scripts/patch-rust-crate.mjs swc 74.0.0)"
+   cargo check -p next-napi-bindings --target wasm32-wasip1-threads \
+     --config "patch.crates-io.swc.path=\"$SWC_DIR\""
+   ```
+
+Builds that don't pass `--config` resolve the crate from the registry as usual.
+
+> **`Cargo.lock` is rewritten by a patched build.** Pointing `[patch]` at a path makes the crate a
+> path dependency, so cargo drops its `source` and `checksum` from the lockfile. That change must not
+> be committed — restore it afterwards:
+>
+> ```sh
+> git checkout -- Cargo.lock
+> ```
+>
+> `--locked` is not an alternative: the patch legitimately requires a lockfile change, so cargo would
+> refuse to run at all.
+
+Prefer this over vendoring or a git fork when the fix is small and expected to land upstream soon:
+the patch file is the diff you send upstream, and deleting it once the fix is released is a one-line
+change.
+
+## Current patches
+
+### `swc@74.0.0.patch`
+
+Makes `swc`'s `cfg(all(feature = "plugin", target_arch = "wasm32"))` code path compile. That path
+has apparently never been built by anyone, and has two errors:
+
+- `RustPlugins::apply_inner` returns `n` where the signature is `Result<Program, anyhow::Error>`.
+- `transform_metadata_context` is unused on wasm32, and the crate sets `#![deny(unused)]`.
+
+Needed because anything enabling `swc_core`'s `__plugin_transform_host` — which
+`turbopack-ecmascript-plugins`, and therefore `next-core`, does — otherwise fails to compile for
+wasm. Used by the `test-next-napi-bindings-wasi` CI job.
+
+Note SWC deliberately skips wasm plugin transforms on wasm32 (see
+[swc#3934](https://github.com/swc-project/swc/issues/3934)), so this only fixes compilation; SWC
+wasm plugins are still unavailable in a wasm build of Next.js. Delete this patch once the fixes are
+released upstream.

--- a/patches/rust/swc@74.0.0.patch
+++ b/patches/rust/swc@74.0.0.patch
@@ -1,0 +1,33 @@
+diff --git a/src/config/mod.rs b/src/config/mod.rs
+index 3a0a6d6..31ab6cb 100644
+--- a/src/config/mod.rs
++++ b/src/config/mod.rs
+@@ -806,11 +806,15 @@ impl Options {
+ 
+         #[cfg(feature = "plugin")]
+         let plugin_transforms: Box<dyn Pass> = {
++            // Only the embedded (non-wasm32) runtime consumes the metadata context; the wasm32
++            // path below skips plugin transforms entirely.
++            #[cfg(not(target_arch = "wasm32"))]
+             let transform_filename = match base {
+                 FileName::Real(path) => path.as_os_str().to_str().map(String::from),
+                 FileName::Custom(filename) => Some(filename.to_owned()),
+                 _ => None,
+             };
++            #[cfg(not(target_arch = "wasm32"))]
+             let transform_metadata_context = Arc::new(TransformPluginMetadataContext::new(
+                 transform_filename,
+                 self.env_name.to_owned(),
+diff --git a/src/plugin.rs b/src/plugin.rs
+index a3bed74..b95b671 100644
+--- a/src/plugin.rs
++++ b/src/plugin.rs
+@@ -195,7 +195,7 @@ impl RustPlugins {
+     #[cfg_attr(debug_assertions, tracing::instrument(level = "info", skip_all))]
+     fn apply_inner(&mut self, n: Program) -> Result<Program, anyhow::Error> {
+         // [TODO]: unimplemented
+-        n
++        Ok(n)
+     }
+ }
+ 

--- a/scripts/patch-rust-crate.mjs
+++ b/scripts/patch-rust-crate.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Materialize a patched copy of a crates.io crate so cargo can be pointed at it with
+// `--config 'patch.crates-io.<name>.path="<dir>"'`.
+//
+// Why this exists: some crates need a local fix that has not been released yet. Cargo has no
+// support for patch files, and a `[patch.crates-io]` entry in Cargo.toml would have to name a
+// directory that does not exist in a fresh checkout, breaking every normal build. So instead the
+// patch lives in `patches/rust/<name>@<version>.patch`, this script applies it to a copy of the
+// registry source under `target/patched-crates/`, and only the builds that need it pass the
+// `--config` flag. Builds that do not pass the flag are completely unaffected.
+//
+// Usage:
+//   node scripts/patch-rust-crate.mjs swc 74.0.0
+//
+// Prints the absolute path of the patched crate on stdout, so a caller can do:
+//   DIR=$(node scripts/patch-rust-crate.mjs swc 74.0.0)
+//   cargo check --config "patch.crates-io.swc.path=\"$DIR\""
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import { cpSync, existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const NEXT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+const [name, version] = process.argv.slice(2)
+if (!name || !version) {
+  console.error('usage: node scripts/patch-rust-crate.mjs <crate> <version>')
+  process.exit(1)
+}
+
+const patchFile = join(NEXT_DIR, 'patches', 'rust', `${name}@${version}.patch`)
+if (!existsSync(patchFile)) {
+  console.error(`no patch file at ${patchFile}`)
+  process.exit(1)
+}
+
+// `cargo fetch` guarantees the crate source is unpacked in the registry cache.
+execFileSync('cargo', ['fetch', '--quiet'], { cwd: NEXT_DIR, stdio: 'inherit' })
+
+const cargoHome =
+  process.env.CARGO_HOME ?? join(process.env.HOME ?? '', '.cargo')
+const registrySrc = join(cargoHome, 'registry', 'src')
+if (!existsSync(registrySrc)) {
+  console.error(`no cargo registry source directory at ${registrySrc}`)
+  process.exit(1)
+}
+
+// The registry directory name embeds a hash that varies by cargo version and index protocol, so
+// discover it rather than hard-coding it.
+const sourceDir = readdirSync(registrySrc)
+  .map((entry) => join(registrySrc, entry, `${name}-${version}`))
+  .find((candidate) => existsSync(candidate))
+
+if (!sourceDir) {
+  console.error(
+    `could not find ${name}-${version} under ${registrySrc}; run \`cargo fetch\` first`
+  )
+  process.exit(1)
+}
+
+const outDir = join(NEXT_DIR, 'target', 'patched-crates', `${name}-${version}`)
+rmSync(outDir, { recursive: true, force: true })
+mkdirSync(dirname(outDir), { recursive: true })
+cpSync(sourceDir, outDir, { recursive: true })
+
+// The registry copy is read-only.
+execFileSync('chmod', ['-R', 'u+w', outDir])
+
+// `git apply` resolves the paths in a patch relative to the top level of the enclosing repository,
+// not to the working directory — and `target/` is inside this repository. Running it from the repo
+// root with `--directory` is therefore the only reliable form: with `cwd` set to the copy instead,
+// git prints "Skipped patch" and still exits 0, silently leaving the crate unpatched.
+const applied = spawnSync(
+  'git',
+  [
+    'apply',
+    '--verbose',
+    `--directory=${relative(NEXT_DIR, outDir)}`,
+    relative(NEXT_DIR, patchFile),
+  ],
+  { cwd: NEXT_DIR, encoding: 'utf8' }
+)
+
+// `--verbose` reports progress on stderr.
+const applyOutput = `${applied.stdout ?? ''}${applied.stderr ?? ''}`
+process.stderr.write(applyOutput)
+
+// Guard against the silent skip described above: git exits 0 in that case, so the exit status alone
+// is not enough to know the patch landed.
+if (
+  applied.status !== 0 ||
+  applyOutput.includes('Skipped patch') ||
+  !applyOutput.includes('cleanly')
+) {
+  console.error(`failed to apply ${patchFile} to ${outDir}`)
+  process.exit(1)
+}
+
+console.log(outDir)

--- a/turbopack/crates/turbo-rcstr/Cargo.toml
+++ b/turbopack/crates/turbo-rcstr/Cargo.toml
@@ -23,8 +23,10 @@ turbo-bincode = { workspace = true }
 turbo-rcstr-macros = { path = "../turbo-rcstr-macros" }
 unty = { workspace = true }
 
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
+# napi v3 supports `wasm32-wasip1-threads`, so this is not restricted to native targets.
 napi = { workspace = true, optional = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 scattered-collect = { workspace = true }
 
 [dev-dependencies]

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -602,10 +602,7 @@ impl ShrinkToFit for RcStr {
     fn shrink_to_fit(&mut self) {}
 }
 
-#[cfg(all(feature = "napi", target_family = "wasm"))]
-compile_error!("The napi feature cannot be enabled for wasm targets");
-
-#[cfg(all(feature = "napi", not(target_family = "wasm")))]
+#[cfg(feature = "napi")]
 mod napi_impl {
     use napi::{
         bindgen_prelude::{FromNapiValue, ToNapiValue, TypeName, ValidateNapiValue},

--- a/turbopack/crates/turbo-rcstr/src/tagged_value.rs
+++ b/turbopack/crates/turbo-rcstr/src/tagged_value.rs
@@ -3,8 +3,20 @@
 use std::{num::NonZeroU8, os::raw::c_void, ptr::NonNull, slice};
 
 use self::raw_types::*;
+// On 32-bit targets the tagged value is a `u64`, which means `new_ptr` has to cast the pointer
+// to an integer. That is not permitted in a `const` context, and `rcstr!` expands to a
+// `const`, so every `rcstr!` with a non-inline string would fail to compile with
+// `error[E0080]: unable to turn pointer into integer`.
+//
+// wasm is 32-bit but has no use for the wider tag space, so give it the same pointer-based
+// representation 64-bit targets use. `MAX_INLINE_LEN` drops from 7 to 3 there, so slightly
+// more strings take the static path, but `rcstr!` keeps working and behaves identically on
+// every target.
+//
+// Native 32-bit targets still select the `u64` representation and still cannot use `rcstr!`;
+// fixing that needs the same treatment (or a representation that avoids the cast entirely).
 #[cfg(not(any(
-    target_pointer_width = "32",
+    all(target_pointer_width = "32", not(target_family = "wasm")),
     target_pointer_width = "16",
     feature = "atom_size_64",
     feature = "atom_size_128"
@@ -19,7 +31,7 @@ mod raw_types {
 
 #[cfg(all(
     any(
-        target_pointer_width = "32",
+        all(target_pointer_width = "32", not(target_family = "wasm")),
         target_pointer_width = "16",
         feature = "atom_size_64"
     ),
@@ -31,7 +43,7 @@ mod raw_types {
 }
 
 #[cfg(not(any(
-    target_pointer_width = "32",
+    all(target_pointer_width = "32", not(target_family = "wasm")),
     target_pointer_width = "16",
     feature = "atom_size_64",
     feature = "atom_size_128"
@@ -53,7 +65,7 @@ impl TaggedValue {
     #[inline(always)]
     pub const fn new_ptr<T>(value: NonNull<T>) -> Self {
         #[cfg(any(
-            target_pointer_width = "32",
+            all(target_pointer_width = "32", not(target_family = "wasm")),
             target_pointer_width = "16",
             feature = "atom_size_64",
             feature = "atom_size_128"
@@ -66,7 +78,7 @@ impl TaggedValue {
         }
 
         #[cfg(not(any(
-            target_pointer_width = "32",
+            all(target_pointer_width = "32", not(target_family = "wasm")),
             target_pointer_width = "16",
             feature = "atom_size_64",
             feature = "atom_size_128"
@@ -90,7 +102,7 @@ impl TaggedValue {
     #[inline(always)]
     pub fn get_ptr(&self) -> *const c_void {
         #[cfg(any(
-            target_pointer_width = "32",
+            all(target_pointer_width = "32", not(target_family = "wasm")),
             target_pointer_width = "16",
             feature = "atom_size_64",
             feature = "atom_size_128"
@@ -101,7 +113,7 @@ impl TaggedValue {
             (self.value.get() as usize & !(TAG_MASK as usize)) as _
         }
         #[cfg(not(any(
-            target_pointer_width = "32",
+            all(target_pointer_width = "32", not(target_family = "wasm")),
             target_pointer_width = "16",
             feature = "atom_size_64",
             feature = "atom_size_128"

--- a/turbopack/crates/turbo-tasks-fetch/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fetch/Cargo.toml
@@ -61,6 +61,11 @@ webpki-root-certs = "1"
 [target.'cfg(all(windows, target_arch = "aarch64"))'.dependencies]
 reqwest = { workspace = true, features = ["native-tls"] }
 
+# On wasm there is no usable HTTP client (see `src/wasm_reqwest.rs`), so `reqwest` is not a
+# dependency there and the local stand-in is used instead. It only needs a hash map.
+[target.'cfg(target_family = "wasm")'.dependencies]
+rustc-hash = { workspace = true }
+
 [dev-dependencies]
 mockito = { version = "1.7.0", default-features = false }
 tokio = { workspace = true, features = ["full"] }

--- a/turbopack/crates/turbo-tasks-fetch/src/client.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/client.rs
@@ -14,6 +14,9 @@ use turbo_tasks::{
     ResolvedVc, Vc, duration_span, util::StaticOrArc,
 };
 
+// Route every `reqwest::…` path in this module to the local stand-in on wasm.
+#[cfg(target_family = "wasm")]
+use crate::wasm_reqwest as reqwest;
 use crate::{FetchError, FetchResult, HttpResponse, HttpResponseBody};
 
 const MAX_CLIENTS: usize = 16;

--- a/turbopack/crates/turbo-tasks-fetch/src/error.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/error.rs
@@ -5,6 +5,10 @@ use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::issue::{Issue, IssueSeverity, IssueStage, StyledString};
 
+// Route every `reqwest::…` path in this module to the local stand-in on wasm.
+#[cfg(target_family = "wasm")]
+use crate::wasm_reqwest as reqwest;
+
 #[derive(Debug)]
 #[turbo_tasks::value(shared)]
 pub enum FetchErrorKind {

--- a/turbopack/crates/turbo-tasks-fetch/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/lib.rs
@@ -5,6 +5,10 @@
 mod client;
 mod error;
 mod response;
+// A non-functional stand-in for `reqwest` on wasm; see the module docs for why reqwest cannot be
+// used there.
+#[cfg(target_family = "wasm")]
+mod wasm_reqwest;
 
 pub use crate::{
     client::{

--- a/turbopack/crates/turbo-tasks-fetch/src/wasm_reqwest.rs
+++ b/turbopack/crates/turbo-tasks-fetch/src/wasm_reqwest.rs
@@ -1,0 +1,170 @@
+//! A non-functional stand-in for the parts of `reqwest`'s API this crate uses, so that
+//! `turbo-tasks-fetch` compiles for wasm targets.
+//!
+//! **Every request made through this module fails.** It exists to make the crate compile, not to
+//! provide HTTP on wasm.
+//!
+//! `reqwest` cannot be used on wasm here. Its only wasm backend targets
+//! `wasm32-unknown-unknown` and is built on the browser `fetch` API via `wasm-bindgen`. Under
+//! `wasm32-wasip1-threads` that backend is still selected (it keys off `target_arch = "wasm32"`),
+//! and it is both API-incompatible (no `ClientBuilder::connect_timeout`, no
+//! `ClientBuilder::timeout`, no `Error::is_connect`) and — fatally — `!Send`, which `turbo-tasks`
+//! requires of every task future. WASI preview1 has no sockets to build a native client on either.
+//!
+//! TODO: replace this with a real HTTP client provided by the host — for wasm builds of the
+//! Next.js bindings that means a napi callback into the JS `fetch` — kept behind the existing
+//! [`crate::FetchClientConfig`] interface. Until then the only consumer, `next/font/google`, cannot
+//! work on wasm.
+
+use std::{fmt, time::Duration};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub struct Error;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("HTTP requests are not supported on wasm targets")
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl Error {
+    pub fn is_connect(&self) -> bool {
+        false
+    }
+
+    pub fn is_timeout(&self) -> bool {
+        false
+    }
+
+    pub fn is_request(&self) -> bool {
+        true
+    }
+
+    pub fn status(&self) -> Option<StatusCode> {
+        None
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StatusCode(u16);
+
+impl StatusCode {
+    pub fn as_u16(self) -> u16 {
+        self.0
+    }
+
+    pub fn is_server_error(self) -> bool {
+        (500..600).contains(&self.0)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Client;
+
+impl Client {
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder
+    }
+
+    pub fn get(&self, _url: &str) -> RequestBuilder {
+        RequestBuilder
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ClientBuilder;
+
+impl ClientBuilder {
+    pub fn connect_timeout(self, _timeout: Duration) -> Self {
+        self
+    }
+
+    pub fn timeout(self, _timeout: Duration) -> Self {
+        self
+    }
+
+    pub fn build(self) -> Result<Client> {
+        Ok(Client)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RequestBuilder;
+
+impl RequestBuilder {
+    pub fn header(self, _name: &str, _value: &str) -> Self {
+        self
+    }
+
+    pub fn try_clone(&self) -> Option<Self> {
+        Some(RequestBuilder)
+    }
+
+    /// Always fails: there is no HTTP client on wasm.
+    pub async fn send(self) -> Result<Response> {
+        Err(Error)
+    }
+}
+
+#[derive(Debug)]
+pub struct Response {
+    headers: header::HeaderMap,
+}
+
+impl Response {
+    pub fn error_for_status(self) -> Result<Self> {
+        Err(Error)
+    }
+
+    pub fn status(&self) -> StatusCode {
+        StatusCode(0)
+    }
+
+    pub fn headers(&self) -> &header::HeaderMap {
+        &self.headers
+    }
+
+    pub async fn bytes(self) -> Result<Vec<u8>> {
+        Err(Error)
+    }
+}
+
+pub mod header {
+    use rustc_hash::FxHashMap;
+
+    pub const CACHE_CONTROL: &str = "cache-control";
+
+    #[derive(Clone, Debug, Default)]
+    pub struct HeaderValue(String);
+
+    impl HeaderValue {
+        pub fn from_static(value: &'static str) -> Self {
+            HeaderValue(value.to_string())
+        }
+
+        pub fn to_str(&self) -> Result<&str, std::str::Utf8Error> {
+            Ok(&self.0)
+        }
+    }
+
+    #[derive(Clone, Debug, Default)]
+    pub struct HeaderMap(FxHashMap<String, HeaderValue>);
+
+    impl HeaderMap {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        pub fn insert(&mut self, name: &str, value: HeaderValue) -> Option<HeaderValue> {
+            self.0.insert(name.to_ascii_lowercase(), value)
+        }
+
+        pub fn get(&self, name: &str) -> Option<&HeaderValue> {
+            self.0.get(&name.to_ascii_lowercase())
+        }
+    }
+}

--- a/turbopack/crates/turbo-tasks-fs/src/disk.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/disk.rs
@@ -1371,8 +1371,12 @@ impl FileSystem for DiskFileSystem {
                                 })?;
                                 has_old_content = false;
                             }
-                            #[cfg(not(windows))]
+                            // `std::os::unix` does not exist on wasi; the equivalent lives in
+                            // `std::os::wasi::fs` and takes the same (target, link) argument order.
+                            #[cfg(all(not(windows), not(target_os = "wasi")))]
                             let io_result = std::os::unix::fs::symlink(&target, &**full_path);
+                            #[cfg(target_os = "wasi")]
+                            let io_result = std::os::wasi::fs::symlink_path(&target, &**full_path);
                             #[cfg(windows)]
                             let io_result = if is_directory {
                                 std::os::windows::fs::junction_point(&target, &**full_path)

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -10,6 +10,8 @@
 // Junction points are used on Windows. We could use a third-party crate for this if the junction
 // API isn't eventually stabilized.
 #![cfg_attr(windows, feature(junction_point))]
+// `std::os::wasi::fs::symlink_path`, used to create symlinks on wasi, is still unstable.
+#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 #![allow(clippy::mutable_key_type)]
 

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -59,7 +59,10 @@ turbo-tasks-macros = { workspace = true }
 turbo-tasks-malloc = { workspace = true }
 unsize = { workspace = true }
 
-[dev-dependencies]
+# Only used by the benchmarks, which don't run on wasm. Gated by target so that
+# `cargo test -p turbo-tasks --lib --target wasm32-wasip1-threads` can build: criterion pulls in
+# rayon, which refuses to compile for wasi, and cargo resolves dev-dependencies even for `--lib`.
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
 
 [[bench]]

--- a/turbopack/crates/turbo-tasks/src/event.rs
+++ b/turbopack/crates/turbo-tasks/src/event.rs
@@ -11,9 +11,25 @@ use std::{
     time::Duration,
 };
 
-use event_listener::Listener as _;
 #[cfg(feature = "hanging_detection")]
 use tokio::time::{Timeout, timeout};
+
+/// Blocks the current thread until `listener` is notified.
+///
+/// `event-listener` gates its own blocking `wait()` behind `not(target_family = "wasm")`, which
+/// excludes every wasm target even though `wasm32-wasip1-threads` has real threads that can park.
+/// Its native implementation is just "register a waker, then park in a loop", so on wasm we drive
+/// the listener's `Future` to completion with a parking executor, which is the same mechanism.
+fn block_on_listener(listener: event_listener::EventListener) {
+    #[cfg(not(target_family = "wasm"))]
+    {
+        use event_listener::Listener as _;
+
+        listener.wait();
+    }
+    #[cfg(target_family = "wasm")]
+    futures::executor::block_on(listener);
+}
 
 pub trait EventDescriptor {
     #[cfg(feature = "hanging_detection")]
@@ -209,7 +225,7 @@ impl EventListener {
     /// This is the synchronous equivalent of `.await`-ing the `EventListener`.
     /// Only valid in synchronous contexts (e.g. backend operations).
     pub fn wait(self) {
-        self.listener.wait();
+        block_on_listener(self.listener);
     }
 }
 
@@ -294,16 +310,21 @@ impl EventListener {
     pub fn wait(mut self) {
         if let Some(future) = self.future.take() {
             // SAFETY: EventListener is Unpin, so it's safe to move out of the Pin.
-            unsafe { std::pin::Pin::into_inner_unchecked(future) }
-                .into_inner()
-                .wait();
+            block_on_listener(unsafe { std::pin::Pin::into_inner_unchecked(future) }.into_inner());
         }
     }
 }
 
 #[cfg(all(test, not(feature = "hanging_detection")))]
 mod tests {
-    use std::hint::black_box;
+    use std::{
+        hint::black_box,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Instant,
+    };
 
     use tokio::time::{Duration, timeout};
 
@@ -340,5 +361,47 @@ mod tests {
         }));
 
         let _ = black_box(timeout(Duration::from_millis(10), listener)).await;
+    }
+
+    /// `EventListener::wait` has to actually block until another thread notifies the event.
+    ///
+    /// The notification is sent only after a delay, so the waiter is registered and parked first —
+    /// this exercises the parking path rather than the already-notified fast path. The assertions
+    /// are written so that a `wait()` which returned early (or did nothing at all) fails rather
+    /// than silently passing, and a `wait()` which never woke up would hang the test.
+    #[test]
+    fn wait_blocks_until_notified_by_another_thread() {
+        const DELAY: Duration = Duration::from_millis(300);
+        // Allow for timer granularity: assert on a slightly shorter span than we sleep for.
+        const MIN_BLOCKED: Duration = Duration::from_millis(200);
+
+        let event = Arc::new(Event::new(|| || "test event".to_string()));
+        let listener = event.listen();
+
+        let notified = Arc::new(AtomicBool::new(false));
+        let notifier = {
+            let event = event.clone();
+            let notified = notified.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(DELAY);
+                notified.store(true, Ordering::SeqCst);
+                event.notify(1);
+            })
+        };
+
+        let start = Instant::now();
+        listener.wait();
+        let blocked_for = start.elapsed();
+
+        assert!(
+            notified.load(Ordering::SeqCst),
+            "wait() returned before the notifying thread ran"
+        );
+        assert!(
+            blocked_for >= MIN_BLOCKED,
+            "wait() did not block; it returned after {blocked_for:?}"
+        );
+
+        notifier.join().unwrap();
     }
 }

--- a/turbopack/crates/turbopack-cli-utils/Cargo.toml
+++ b/turbopack/crates/turbopack-cli-utils/Cargo.toml
@@ -17,7 +17,6 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-crossterm = "0.26.0"
 owo-colors = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -9,7 +9,6 @@ use std::{
 
 use anyhow::Result;
 use async_trait::async_trait;
-use crossterm::style::{StyledContent, Stylize};
 use owo_colors::{OwoColorize as _, Style};
 use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_rcstr::RcStr;
@@ -558,15 +557,11 @@ fn make_relative_to_cwd<'a>(path: &'a str, project_dir: &Path, cwd: &Path) -> Co
     }
 }
 
-fn show_all_message(label: &str, size: usize) -> StyledContent<String> {
+fn show_all_message(label: &str, size: usize) -> String {
     show_all_message_with_shown_count(label, size, DEFAULT_SHOW_COUNT)
 }
 
-fn show_all_message_with_shown_count(
-    label: &str,
-    size: usize,
-    shown: usize,
-) -> StyledContent<String> {
+fn show_all_message_with_shown_count(label: &str, size: usize, shown: usize) -> String {
     if shown == 0 {
         format!(
             "... [{} {label}] are hidden, run with {} to show them",
@@ -574,6 +569,7 @@ fn show_all_message_with_shown_count(
             "--show-all".bright_green()
         )
         .bold()
+        .to_string()
     } else {
         format!(
             "... [{} more {label}] are hidden, run with {} to show all",
@@ -581,6 +577,7 @@ fn show_all_message_with_shown_count(
             "--show-all".bright_green()
         )
         .bold()
+        .to_string()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
@@ -41,7 +41,12 @@ swc_core = { workspace = true, features = [
   "__plugin_transform_host",
   "__plugin_transform_host_schema_v1",
 ] }
-swc_plugin_backend_wasmtime = { workspace = true }
 swc_emotion = { workspace = true }
 swc_relay = { workspace = true }
+
+# wasmtime cannot be hosted inside wasm (no JIT, and `wasi-common` needs native filesystem APIs),
+# so the SWC wasm-plugin backend is native-only. SWC's own wasm32 path skips plugin transforms too,
+# see https://github.com/swc-project/swc/issues/3934.
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+swc_plugin_backend_wasmtime = { workspace = true }
 

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/mod.rs
@@ -3,4 +3,6 @@ pub mod emotion;
 pub mod relay;
 pub mod styled_components;
 pub mod styled_jsx;
+// Requires the wasmtime plugin backend, which cannot run inside wasm.
+#[cfg(not(target_family = "wasm"))]
 pub mod swc_ecma_transform_plugins;

--- a/turbopack/crates/turbopack-node/src/backend.rs
+++ b/turbopack/crates/turbopack-node/src/backend.rs
@@ -30,7 +30,7 @@ mod sealed {
 #[turbo_tasks::value_impl]
 impl sealed::Sealed for crate::worker_pool::WorkerThreadsBackend {}
 
-#[cfg(feature = "process_pool")]
+#[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
 #[turbo_tasks::value_impl]
 impl sealed::Sealed for crate::process_pool::ChildProcessesBackend {}
 

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -20,7 +20,9 @@ pub mod evaluate;
 pub mod execution_context;
 mod format;
 mod pool_stats;
-#[cfg(feature = "process_pool")]
+// The child-process pool needs `tokio::process` and a TCP listener, neither of which exists on
+// wasi, so `process_pool` is inert on wasm and `worker_pool` is the only available backend there.
+#[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
 pub mod process_pool;
 pub mod source_map;
 pub mod transforms;
@@ -28,7 +30,7 @@ pub mod transforms;
 pub mod worker_pool;
 
 pub use backend::{CreatePoolFuture, CreatePoolOptions, NodeBackend};
-#[cfg(feature = "process_pool")]
+#[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
 pub fn child_process_backend() -> Vc<Box<dyn NodeBackend>> {
     Vc::upcast(process_pool::ChildProcessesBackend.cell())
 }

--- a/turbopack/crates/turbopack-trace-utils/src/exit.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/exit.rs
@@ -19,8 +19,12 @@ impl<T> Drop for ExitGuard<T> {
 
 impl<T: Send + 'static> ExitGuard<T> {
     /// Drop a guard when Ctrl-C is pressed or the [ExitGuard] is dropped.
+    ///
+    /// On wasm targets there is no Ctrl-C to listen for (`tokio::signal` does not exist on wasi),
+    /// so the guard is only dropped when the [ExitGuard] itself is dropped.
     pub fn new(guard: T) -> Result<Self> {
         let guard = Arc::new(Mutex::new(Some(guard)));
+        #[cfg(not(target_family = "wasm"))]
         {
             let guard = guard.clone();
             tokio::spawn(async move {
@@ -58,11 +62,16 @@ impl ExitHandler {
     /// [`ExitHandler::new_receiver`] instead.
     ///
     /// This may listen for other signals, like `SIGTERM` or `SIGPIPE` in the future.
+    ///
+    /// On wasm targets there are no process signals, so nothing is ever run: the returned handler
+    /// only fires through [`ExitReceiver::run_exit_handler`], which this function has no way to
+    /// reach. wasm callers should use [`ExitHandler::new_receiver`].
     pub fn listen() -> &'static Arc<ExitHandler> {
         let (handler, receiver) = Self::new_receiver();
         if GLOBAL_EXIT_HANDLER.set(handler).is_err() {
             panic!("ExitHandler::listen must only be called once");
         }
+        #[cfg(not(target_family = "wasm"))]
         tokio::spawn(async move {
             tokio::signal::ctrl_c()
                 .await
@@ -70,6 +79,8 @@ impl ExitHandler {
             receiver.run_exit_handler().await;
             std::process::exit(0);
         });
+        #[cfg(target_family = "wasm")]
+        drop(receiver);
         GLOBAL_EXIT_HANDLER.get().expect("value is set")
     }
 


### PR DESCRIPTION
### What?

Adds an opt-in mechanism for patching a crates.io dependency — `patches/rust/`, a
`scripts/patch-rust-crate.mjs` helper and a README — plus the first patch, for `swc` 74.0.0.

### Why?

`swc` 74.0.0's `cfg(all(feature = "plugin", target_arch = "wasm32"))` path has apparently never been
compiled by anyone. It has two errors:

- `RustPlugins::apply_inner` returns `n` where the signature is `Result<Program, anyhow::Error>`
- a variable is unused in that arm, and the crate sets `#![deny(unused)]`

Anything enabling `swc_core`'s `__plugin_transform_host` — `turbopack-ecmascript-plugins`, and
therefore `next-core` — consequently cannot build for wasm at all.

Cargo has no support for patch files, and a `[patch.crates-io]` entry in the root `Cargo.toml` would
have to name a directory that does not exist in a fresh checkout, which would break **every** build.

### How?

The patch stays a file. `scripts/patch-rust-crate.mjs` copies the crate out of the cargo registry
into `target/patched-crates/` and applies it; only the builds that need it pass
`--config 'patch.crates-io.swc.path="<dir>"'`. Builds that do not pass the flag resolve the crate
from the registry exactly as before, so nothing else is affected.

Two details worth knowing:

- The script applies the patch **from the repository root with `--directory`**. Run from inside
  `target/`, `git apply` resolves paths against the enclosing repository, prints `Skipped patch` and
  still exits 0 — silently leaving the crate unpatched. The script also asserts the patch applied so
  that cannot pass unnoticed.
- Patch files are exempted from whitespace checks in `.gitattributes`: a unified diff's context line
  for a blank line is a single space, so whitespace tooling flags them and "fixing" them would
  corrupt the patch. The repository's existing pnpm patches have the same property.

The patch is intended to be temporary — delete it once the fixes are released upstream. The generic
script can stay for future patches.

<!-- NEXT_JS_LLM -->
