### PR TITLE
[ci] Authenticate Turborepo remote caching with OIDC instead of a static PAT

### DIFF
--- a/.github/actions/sccache/action.yml
+++ b/.github/actions/sccache/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: 'SCCACHE_BASE_DIR for path normalization (default: $GITHUB_WORKSPACE)'
     required: false
     default: ''
-  turbo-token:
-    description: 'Fallback TURBO_TOKEN if not set in environment (e.g. from secrets.TURBO_TOKEN)'
-    required: false
-    default: ''
 runs:
   using: 'node20'
   main: 'main.js'

--- a/.github/actions/sccache/start.sh
+++ b/.github/actions/sccache/start.sh
@@ -1,28 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Normalize TURBO_API and TURBO_TOKEN: prefer environment values and
-# fall back to Vercel's public API and the secret passed as an action input.
+# Default TURBO_API to Vercel's public API when the workflow does not set it.
 if [ -z "${TURBO_API:-}" ]; then
   export TURBO_API="https://api.vercel.com"
   echo "TURBO_API=${TURBO_API}" >> "$GITHUB_ENV"
 fi
 
-if [ -z "${TURBO_TOKEN:-}" ]; then
-  if [ -n "${INPUT_TURBO_TOKEN:-}" ]; then
-    export TURBO_TOKEN="${INPUT_TURBO_TOKEN}"
-    echo "TURBO_TOKEN=${TURBO_TOKEN}" >> "$GITHUB_ENV"
-  else
-    echo "WARNING: no TURBO_TOKEN available"
-  fi
+# Exported by `vercel/setup-turborepo-remote-cache-action`, and unset entirely
+# when that step was skipped. Bind them so the substring expansions below don't
+# trip `set -u`, which rejects an unset name even in `${var:0:3}`.
+TURBO_TOKEN="${TURBO_TOKEN:-}"
+TURBO_TEAM="${TURBO_TEAM:-}"
+
+if [ -z "$TURBO_TOKEN" ]; then
+  echo "WARNING: no TURBO_TOKEN available"
 fi
 
-if [ -z "${TURBO_TEAM:-}" ]; then
-  export TURBO_TEAM="vtest314-next-adapter-e2e-tests"
-  echo "TURBO_TEAM=${TURBO_TEAM}" >> "$GITHUB_ENV"
-fi
-
-echo "::add-mask::${TURBO_TOKEN:-}"
+echo "::add-mask::${TURBO_TOKEN}"
 echo "Cache endpoint: ${TURBO_API:0:9}..."
 echo "TURBO_TOKEN: ${TURBO_TOKEN:0:3}..."
 echo "TURBO_TEAM: ${TURBO_TEAM}"

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -30,11 +30,10 @@ env:
   # --env-mode loose is a breaking change required with turbo 2.x since Strict mode is now the default
   # TODO: we should add the relevant envs later to to switch to strict mode
   TURBO_ARGS: '-v --env-mode loose --remote-cache-timeout 90 --summarize --log-order stream'
-  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
   # Prefer shared remote cache across runs, but keep local cache enabled so jobs
   # degrade gracefully if the remote cache or token is unavailable.
   TURBO_CACHE: 'local:rw,remote:rw'
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   # Without this environment variable, rust-lld will fail because some dependencies defaults to newer version of macOS by default.
   #
   # See https://doc.rust-lang.org/rustc/platform-support/apple-darwin.html#os-version for more details
@@ -136,11 +135,21 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NEXT_TELEMETRY_DISABLED: 1
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 25
           persist-credentials: false
+
+      - name: Set up Turborepo remote cache
+        if: ${{ vars.TURBO_TEAM != '' }}
+        continue-on-error: true
+        uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -247,6 +256,9 @@ jobs:
     env:
       # Disable all build caches for production/staging/force-preview deploys
       NEXT_SKIP_BUILD_CACHE: ${{ contains(fromJSON('["production","staging","force-preview"]'), needs.deploy-target.outputs.value) && '1' || '' }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       # Enable long paths on Windows to avoid MAX_PATH (260 char) errors
       # with deeply nested node_modules/.pnpm paths
@@ -262,6 +274,13 @@ jobs:
           # this fails, but fetch with enough depth that we're likely to find a recent tag.
           fetch-depth: 100
           persist-credentials: false
+
+      - name: Set up Turborepo remote cache
+        if: ${{ vars.TURBO_TEAM != '' }}
+        continue-on-error: true
+        uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -480,10 +499,20 @@ jobs:
 
     runs-on: ubuntu-latest-16-core-oss
 
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Set up Turborepo remote cache
+        if: ${{ vars.TURBO_TEAM != '' }}
+        continue-on-error: true
+        uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -127,6 +127,9 @@ jobs:
 
   build-native:
     name: build-native
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     needs: ['changes']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
@@ -138,6 +141,9 @@ jobs:
 
   build-native-windows:
     name: build-native-windows
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     needs: ['changes']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
@@ -151,6 +157,9 @@ jobs:
 
   build-next:
     name: build-next
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       needsPlaywright: 'no'
@@ -226,6 +235,9 @@ jobs:
   lint:
     name: lint
     needs: ['build-next']
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       needsPlaywright: 'no'
@@ -266,6 +278,9 @@ jobs:
     name: types and precompiled
     needs: ['changes', 'build-native', 'build-next']
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       needsPlaywright: 'no'
@@ -278,6 +293,9 @@ jobs:
     needs: ['changes', 'build-next']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       needsRust: 'yes'
@@ -300,6 +318,9 @@ jobs:
     needs: ['optimize-ci', 'changes', 'build-next']
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/test-turbopack-rust-bench-test.yml
     secrets: inherit
 
@@ -308,6 +329,9 @@ jobs:
     needs: ['changes', 'build-next']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       needsRust: 'yes'
@@ -322,6 +346,9 @@ jobs:
     needs: ['changes', 'build-next']
     if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       needsRust: 'yes'
@@ -360,6 +387,9 @@ jobs:
           - '--scenario=heavy-npm-deps-dev --page=homepage'
           - '--scenario=heavy-npm-deps-build --page=homepage'
           - '--scenario=heavy-npm-deps-build-turbo-cache-enabled --page=homepage'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |
@@ -374,6 +404,9 @@ jobs:
     name: test devlow package
     needs: ['optimize-ci', 'changes']
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipNativeBuild: 'yes'
@@ -403,6 +436,9 @@ jobs:
         group: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
         # Empty value uses default
         react: ['', '18.3.1']
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |
@@ -444,6 +480,9 @@ jobs:
         group: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
         # Empty value uses default
         react: ['', '18.3.1']
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 20.9.0
@@ -481,6 +520,9 @@ jobs:
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
         # Empty value uses default
         react: ['', '18.3.1']
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 20.19.x
@@ -527,6 +569,9 @@ jobs:
         group: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
         # Empty value uses default
         react: ['', '18.3.1']
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 20.19.x
@@ -554,6 +599,9 @@ jobs:
     needs: ['optimize-ci', 'changes', 'build-next']
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipNativeBuild: 'yes'
@@ -583,6 +631,9 @@ jobs:
     if: false
     # if: ${{ needs.changes.outputs.docs-only == 'false' }}
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       skipNativeBuild: 'yes'
@@ -603,6 +654,9 @@ jobs:
       matrix:
         node: [20, 22] # TODO: use env var like [env.NODE_MAINTENANCE_VERSION, env.NODE_LTS_VERSION]
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       needsPlaywright: 'no'
@@ -626,6 +680,9 @@ jobs:
         # https://github.com/microsoft/playwright/issues/40724
         node: [22, '24.15.0']
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: ${{ matrix.node }}
@@ -650,6 +707,9 @@ jobs:
         # pin once we update to playwright 1.60.0 or newer.
         node: [22, '24.15.0']
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: ${{ matrix.node }}
@@ -671,6 +731,9 @@ jobs:
       matrix:
         node: [20, 22] # TODO: use env var like [env.NODE_MAINTENANCE_VERSION, env.NODE_LTS_VERSION]
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       needsPlaywright: 'no'
@@ -693,6 +756,9 @@ jobs:
       matrix:
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |
@@ -719,6 +785,9 @@ jobs:
       matrix:
         group: [1/5, 2/5, 3/5, 4/5, 5/5]
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |
@@ -866,6 +935,9 @@ jobs:
         group: [1/10, 2/10, 3/10, 4/10, 5/10, 6/10, 7/10, 8/10, 9/10, 10/10]
         # Empty value uses default
         react: ['', '18.3.1']
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |
@@ -889,6 +961,9 @@ jobs:
     needs: ['optimize-ci', 'changes', 'build-native-windows', 'build-next']
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |
@@ -911,6 +986,9 @@ jobs:
     needs: ['optimize-ci', 'changes', 'build-native-windows', 'build-next']
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: 20.9.0
@@ -936,6 +1014,9 @@ jobs:
     needs: ['optimize-ci', 'changes', 'build-native-windows', 'build-next']
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |
@@ -975,6 +1056,9 @@ jobs:
         group: [1/10, 2/10, 3/10, 4/10, 5/10, 6/10, 7/10, 8/10, 9/10, 10/10]
         # Empty value uses default
         react: ['', '18.3.1']
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |
@@ -994,6 +1078,9 @@ jobs:
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
 
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       browser: 'firefox webkit'
@@ -1040,6 +1127,9 @@ jobs:
       fail-fast: false
       matrix:
         group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |
@@ -1076,6 +1166,9 @@ jobs:
       fail-fast: false
       matrix:
         group: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       afterBuild: |

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -121,11 +121,10 @@ env:
   # disable backtrace for test snapshots
   RUST_BACKTRACE: 0
 
-  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
   # Prefer shared remote cache across runs, but keep local cache enabled so jobs
   # degrade gracefully if the remote cache or token is unavailable.
   TURBO_CACHE: 'local:rw,remote:rw'
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
   NEXT_TELEMETRY_DISABLED: 1
   # `skipNativeInstall: 'no'` must force the download even though CI otherwise
@@ -184,6 +183,13 @@ jobs:
         with:
           fetch-depth: 25
           persist-credentials: false
+
+      - name: Set up Turborepo remote cache
+        if: ${{ vars.TURBO_TEAM != '' }}
+        continue-on-error: true
+        uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       # Depends on rust-toolchain.toml in the checkout
       - name: Install Rust
@@ -288,8 +294,6 @@ jobs:
       - name: Start sccache
         uses: ./.github/actions/sccache
         if: ${{ runner.os != 'Windows' && (inputs.uploadNativeArtifact || inputs.needsNextest == 'yes' || inputs.needsRust == 'yes') }}
-        with:
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       # Infer the Rust target triple from the runner's OS/arch. napi would build
       # for the host target if `--target` were omitted, but Turborepo does not

--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -45,6 +45,9 @@ jobs:
   # First, build Next.js to execute across tests.
   build-next:
     name: build-next
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: ${{ inputs.nodeVersion }}
@@ -54,6 +57,9 @@ jobs:
 
   build-native:
     name: build-native
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: ${{ inputs.nodeVersion }}
@@ -92,6 +98,9 @@ jobs:
       fail-fast: false
       matrix:
         group: ${{ fromJSON(needs.generate-matrices.outputs.e2e) }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: ${{ inputs.nodeVersion }}
@@ -124,6 +133,9 @@ jobs:
       fail-fast: false
       matrix:
         group: ${{ fromJSON(needs.generate-matrices.outputs.integration) }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: ${{ inputs.nodeVersion }}

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -17,11 +17,10 @@ env:
   TURBO_VERSION: 2.9.4
   TEST_CONCURRENCY: 6
 
-  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
   # Prefer shared remote cache across runs, but keep local cache enabled so jobs
   # degrade gracefully if the remote cache or token is unavailable.
   TURBO_CACHE: 'local:rw,remote:rw'
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   NEXT_TELEMETRY_DISABLED: 1
   # Vercel KV Store for test timings
   KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
@@ -75,6 +74,9 @@ jobs:
           retention-days: 1
 
   build:
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     secrets: inherit
     with:
@@ -94,6 +96,9 @@ jobs:
         # Keep in sync with STATS_EXPECTED_BUNDLERS
         bundler: [webpack, turbopack]
     runs-on: ubuntu-latest-16-core-arm-oss
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -113,13 +118,20 @@ jobs:
       - run: cp -r packages/next-swc/native .github/actions/next-stats-action/native
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
 
+      - name: Set up Turborepo remote cache
+        if: ${{ vars.TURBO_TEAM != '' }}
+        continue-on-error: true
+        uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
+
+      # `TURBO_TOKEN` reaches this Docker action through the job environment.
       - uses: ./.github/actions/next-stats-action
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
         with:
           bundler: ${{ matrix.bundler }}
         env:
           TURBO_TEAM: ${{ env.TURBO_TEAM }}
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_CACHE: ${{ env.TURBO_CACHE }}
           PREVIEW_BUILDS_BASE_URL: ${{ vars.PREVIEW_BUILDS_BASE_URL }}
 

--- a/.github/workflows/rspack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-build-integration-tests.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   test-dev:
     name: Rspack integration tests
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/integration_tests_reusable.yml
     with:
       name: rspack-production

--- a/.github/workflows/rspack-nextjs-dev-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-dev-integration-tests.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   test-dev:
     name: Rspack integration tests
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/integration_tests_reusable.yml
     with:
       name: rspack-development

--- a/.github/workflows/test-turbopack-rust-bench-test.yml
+++ b/.github/workflows/test-turbopack-rust-bench-test.yml
@@ -15,8 +15,7 @@ on:
 env:
   TURBOPACK_BENCH_COUNTS: '100'
   TURBOPACK_BENCH_PROGRESS: '1'
-  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
 jobs:
   test:
@@ -49,10 +48,15 @@ jobs:
       - run: pnpm install
         working-directory: turbopack/benchmark-apps
 
+      - name: Set up Turborepo remote cache
+        if: ${{ vars.TURBO_TEAM != '' }}
+        continue-on-error: true
+        uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
+
       - name: Start sccache
         uses: ./.github/actions/sccache
-        with:
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       - name: Build benchmarks for tests
         timeout-minutes: 120

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -174,6 +174,9 @@ jobs:
     name: Run Deploy Tests (Webpack)
     needs: setup
     if: ${{ github.event.inputs.deployScriptPath == '' }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     secrets: inherit
     strategy:
@@ -208,6 +211,9 @@ jobs:
   test-deploy-turbopack:
     name: Run Deploy Tests (Turbopack)
     needs: [setup]
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     secrets: inherit
     strategy:
@@ -258,6 +264,9 @@ jobs:
     name: Run Deploy Adapter Tests (Turbopack)
     needs: setup
     if: ${{ github.event.inputs.deployScriptPath == '' }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_reusable.yml
     secrets: inherit
     strategy:

--- a/.github/workflows/test_e2e_project_reset_cron.yml
+++ b/.github/workflows/test_e2e_project_reset_cron.yml
@@ -14,12 +14,6 @@ env:
   VERCEL_ADAPTER_TEST_TOKEN: ${{ secrets.VERCEL_ADAPTER_TEST_TOKEN }}
   VERCEL_TURBOPACK_TEST_TEAM: vtest314-next-turbo-e2e-tests
   VERCEL_TURBOPACK_TEST_TOKEN: ${{ secrets.VERCEL_TURBOPACK_TEST_TOKEN }}
-  # Unrelated to the teams above: this is the Turborepo remote cache team.
-  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
-  # Prefer shared remote cache across runs, but keep local cache enabled so jobs
-  # degrade gracefully if the remote cache or token is unavailable.
-  TURBO_CACHE: 'local:rw,remote:rw'
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 run-name: test-e2e-project-reset (scheduled)
 

--- a/.github/workflows/turbopack-benchmark.yml
+++ b/.github/workflows/turbopack-benchmark.yml
@@ -20,11 +20,10 @@ concurrency:
 env:
   CI: 1
   RUST_LOG: 'off'
-  TURBO_TEAM: 'vtest314-next-adapter-e2e-tests'
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
   # Prefer shared remote cache across runs, but keep local cache enabled so jobs
   # degrade gracefully if the remote cache or token is unavailable.
   TURBO_CACHE: 'local:rw,remote:rw'
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 permissions:
   contents: read
@@ -45,10 +44,15 @@ jobs:
       - name: Install cargo-codspeed
         run: cargo binstall --locked --no-confirm cargo-codspeed@3.0.5
 
+      - name: Set up Turborepo remote cache
+        if: ${{ vars.TURBO_TEAM != '' }}
+        continue-on-error: true
+        uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
+
       - name: Start sccache
         uses: ./.github/actions/sccache
-        with:
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       - name: Install pnpm dependencies
         working-directory: turbopack/benchmark-apps
@@ -82,10 +86,15 @@ jobs:
       - name: Install cargo-codspeed
         run: cargo binstall --locked --no-confirm cargo-codspeed@3.0.5
 
+      - name: Set up Turborepo remote cache
+        if: ${{ vars.TURBO_TEAM != '' }}
+        continue-on-error: true
+        uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
+
       - name: Start sccache
         uses: ./.github/actions/sccache
-        with:
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       - name: Install pnpm dependencies
         working-directory: turbopack/benchmark-apps
@@ -120,10 +129,15 @@ jobs:
       - name: Install cargo-codspeed
         run: cargo binstall --locked --no-confirm cargo-codspeed@3.0.5
 
+      - name: Set up Turborepo remote cache
+        if: ${{ vars.TURBO_TEAM != '' }}
+        continue-on-error: true
+        uses: vercel/setup-turborepo-remote-cache-action@135046f5efcadb17337d9b29b8d5b4035ae64b10 # v1.0.0
+        with:
+          team: ${{ vars.TURBO_TEAM }}
+
       - name: Start sccache
         uses: ./.github/actions/sccache
-        with:
-          turbo-token: ${{ secrets.TURBO_TOKEN }}
 
       - name: Build the benchmark target(s)
         env:

--- a/.github/workflows/turbopack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/turbopack-nextjs-build-integration-tests.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   test-dev:
     name: Next.js integration tests
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/integration_tests_reusable.yml
     with:
       name: turbopack-production

--- a/.github/workflows/turbopack-nextjs-dev-integration-tests.yml
+++ b/.github/workflows/turbopack-nextjs-dev-integration-tests.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   test-dev:
     name: Next.js integration tests
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/integration_tests_reusable.yml
     with:
       name: turbopack-development


### PR DESCRIPTION
CI authenticated to Vercel Remote Cache with a long-lived Personal Access Token in the `TURBO_TOKEN` repository secret. That token never expired, is scoped to a team member rather than the team, and is readable by every job that inherits secrets.

Each job now mints its own short-lived, cache-only token instead, using `vercel/setup-turborepo-remote-cache-action` against a Turborepo CLI OIDC policy configured on the Vercel team following https://vercel.com/docs/monorepos/remote-caching/external-ci-cd#openid-connect-oidc

Forks skip the step entirely since they won't have access to repository variables. During outages or any other permission errors, the steps outcome will simply be ignore and we fall back to uncached behavior. 

This could lead to silent regressions or hiding new, incorrect callsites lacking necessary permissions. A Datadog monitor is not as simple as I'd like since DD does not track outcome but conclusion (which is always success for continue-on-error). Adding custom tags via DD CLI feels to heavy. We'll revisit if this becomes a recurring issue.

## Test plan

- Turborepo cache still functions in CI on this branch: https://github.com/vercel/next.js/actions/runs/32314345819/job/96263533767?pr=97590#step:31:60