### PR TITLE
Sweep stale Turbopack output from distDir on dev startup

### DIFF
--- a/packages/next/src/lib/recursive-delete.ts
+++ b/packages/next/src/lib/recursive-delete.ts
@@ -59,16 +59,22 @@ function unlinkPath(
   }
 }
 
-/** Returns whether `p`'s own mtime is at least `maxAgeMs` in the past. */
-function isStale(p: string, maxAgeMs: number): boolean {
+const FUTURE_MTIME_TOLERANCE_MS = 60 * 60 * 1000
+
+/** Returns whether `p`'s own mtime falls outside the retained time range. */
+function isStale(
+  p: string,
+  staleBefore: number,
+  futureMtimeThreshold: number
+): boolean {
   try {
     // lstat, not stat: a symlink is deleted based on its own age, not its
     // target's.
-    return Date.now() - fs.lstatSync(p).mtimeMs >= maxAgeMs
+    const mtimeMs = fs.lstatSync(p).mtimeMs
+    return mtimeMs <= staleBefore || mtimeMs > futureMtimeThreshold
   } catch (e) {
     if (isError(e) && e.code === 'ENOENT') {
-      // Already gone; let the delete run and no-op on ENOENT.
-      return true
+      return false
     }
     throw e
   }
@@ -95,19 +101,29 @@ export async function recursiveDeleteSyncWithAsyncRetries(
    */
   maxAgeMs?: number
 ): Promise<void> {
-  await deleteContents(dir, exclude, maxAgeMs, '')
+  const now = Date.now()
+  await deleteContents(dir, {
+    exclude,
+    staleBefore: maxAgeMs === undefined ? undefined : now - maxAgeMs,
+    futureMtimeThreshold: now + FUTURE_MTIME_TOLERANCE_MS,
+  })
 }
 
-/**
- * @returns whether anything was kept, so a parent directory knows not to
- * remove itself.
- */
+/** @returns whether anything was kept. */
 async function deleteContents(
   dir: string,
-  exclude: RegExp | undefined,
-  maxAgeMs: number | undefined,
-  /** Relative path to the directory being deleted, used for exclude */
-  previousPath: string
+  {
+    exclude,
+    staleBefore,
+    futureMtimeThreshold,
+    previousPath,
+  }: {
+    exclude: RegExp | undefined
+    staleBefore: number | undefined
+    futureMtimeThreshold: number
+    /** Relative path to the directory being deleted, used for exclude */
+    previousPath?: string
+  }
 ): Promise<boolean> {
   let result
   try {
@@ -124,7 +140,7 @@ async function deleteContents(
   await Promise.all(
     result.map(async (part: Dirent) => {
       const absolutePath = join(dir, part.name)
-      const pp = join(previousPath, part.name)
+      const pp = join(previousPath ?? '', part.name)
 
       if (exclude?.test(pp)) {
         keptAnything = true
@@ -135,11 +151,21 @@ async function deleteContents(
       // delete the links and not the destination.
       const isDirectory = part.isDirectory()
       if (isDirectory) {
-        if (await deleteContents(absolutePath, exclude, maxAgeMs, pp)) {
+        if (
+          await deleteContents(absolutePath, {
+            exclude,
+            staleBefore,
+            futureMtimeThreshold,
+            previousPath: pp,
+          })
+        ) {
           keptAnything = true
           return
         }
-      } else if (maxAgeMs !== undefined && !isStale(absolutePath, maxAgeMs)) {
+      } else if (
+        staleBefore !== undefined &&
+        !isStale(absolutePath, staleBefore, futureMtimeThreshold)
+      ) {
         keptAnything = true
         return
       }
@@ -147,6 +173,5 @@ async function deleteContents(
       return unlinkPath(absolutePath, isDirectory)
     })
   )
-
   return keptAnything
 }

--- a/packages/next/src/lib/recursive-delete.ts
+++ b/packages/next/src/lib/recursive-delete.ts
@@ -59,6 +59,21 @@ function unlinkPath(
   }
 }
 
+/** Returns whether `p`'s own mtime is at least `maxAgeMs` in the past. */
+function isStale(p: string, maxAgeMs: number): boolean {
+  try {
+    // lstat, not stat: a symlink is deleted based on its own age, not its
+    // target's.
+    return Date.now() - fs.lstatSync(p).mtimeMs >= maxAgeMs
+  } catch (e) {
+    if (isError(e) && e.code === 'ENOENT') {
+      // Already gone; let the delete run and no-op on ENOENT.
+      return true
+    }
+    throw e
+  }
+}
+
 /**
  * Recursively delete directory contents.
  *
@@ -74,34 +89,64 @@ export async function recursiveDeleteSyncWithAsyncRetries(
   dir: string,
   /** Exclude based on relative file path */
   exclude?: RegExp,
-  /** Relative path to the directory being deleted, used for exclude */
-  previousPath: string = ''
+  /**
+   * Only delete files whose mtime is at least this old. Directories are
+   * removed once empty.
+   */
+  maxAgeMs?: number
 ): Promise<void> {
+  await deleteContents(dir, exclude, maxAgeMs, '')
+}
+
+/**
+ * @returns whether anything was kept, so a parent directory knows not to
+ * remove itself.
+ */
+async function deleteContents(
+  dir: string,
+  exclude: RegExp | undefined,
+  maxAgeMs: number | undefined,
+  /** Relative path to the directory being deleted, used for exclude */
+  previousPath: string
+): Promise<boolean> {
   let result
   try {
     result = fs.readdirSync(dir, { withFileTypes: true })
   } catch (e) {
     if (isError(e) && e.code === 'ENOENT') {
-      return
+      return false
     }
     throw e
   }
+
+  let keptAnything = false
 
   await Promise.all(
     result.map(async (part: Dirent) => {
       const absolutePath = join(dir, part.name)
       const pp = join(previousPath, part.name)
-      const isNotExcluded = !exclude || !exclude.test(pp)
 
-      if (isNotExcluded) {
-        // Note: readdir does not follow symbolic links, that's good: we want to
-        // delete the links and not the destination.
-        let isDirectory = part.isDirectory()
-        if (isDirectory) {
-          await recursiveDeleteSyncWithAsyncRetries(absolutePath, exclude, pp)
-        }
-        return unlinkPath(absolutePath, isDirectory)
+      if (exclude?.test(pp)) {
+        keptAnything = true
+        return
       }
+
+      // Note: readdir does not follow symbolic links, that's good: we want to
+      // delete the links and not the destination.
+      const isDirectory = part.isDirectory()
+      if (isDirectory) {
+        if (await deleteContents(absolutePath, exclude, maxAgeMs, pp)) {
+          keptAnything = true
+          return
+        }
+      } else if (maxAgeMs !== undefined && !isStale(absolutePath, maxAgeMs)) {
+        keptAnything = true
+        return
+      }
+
+      return unlinkPath(absolutePath, isDirectory)
     })
   )
+
+  return keptAnything
 }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -390,6 +390,7 @@ export const experimentalSchema = {
   turbopackFileSystemCacheForDev: z.boolean().optional(),
   turbopackFileSystemCacheForBuild: z.boolean().optional(),
   turbopackSeedCacheFromWorktree: z.boolean().optional(),
+  turbopackStaleOutputMaxAge: z.number().min(0).finite().optional(),
   turbopackSourceMaps: z.boolean().optional(),
   turbopackInputSourceMaps: z.boolean().optional(),
   turbopackModuleFragments: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -959,6 +959,12 @@ export interface ExperimentalConfig {
   turbopackSeedCacheFromWorktree?: boolean
 
   /**
+   * The maximum age, in milliseconds, of Turbopack development output kept
+   * between dev server sessions. Defaults to one week.
+   */
+  turbopackStaleOutputMaxAge?: number
+
+  /**
    * Enable source maps. Defaults to true.
    */
   turbopackSourceMaps?: boolean
@@ -2338,6 +2344,7 @@ export const defaultConfig = Object.freeze({
     mcpServer: true,
     turbopackFileSystemCacheForDev: true,
     turbopackFileSystemCacheForBuild: true,
+    turbopackStaleOutputMaxAge: 7 * 24 * 60 * 60 * 1000, // One week
     turbopackInferModuleSideEffects: true,
     turbopackPluginRuntimeStrategy: 'childProcesses',
     turbopackSharedRuntime: !isStableBuild(),

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -159,21 +159,14 @@ const isTestMode = !!(
 
 const sessionId = Math.floor(Number.MAX_SAFE_INTEGER * Math.random())
 
-/** How long an emitted asset may go unwritten before startup sweeps it. */
-const STALE_OUTPUT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000 // One week
-
 /** Output directory (relative to `distDir`) of server-HMR-managed chunks. */
 const SERVER_HMR_CHUNKS_DIR = join('server', 'chunks')
 
-/**
- * Directories (relative to `distDir`) holding content-hashed turbopack output,
- * per the chunking contexts in `next-core`. Entry chunks are deliberately left
- * out: their paths derive from the route rather than a content hash, so they
- * are overwritten in place instead of accumulating.
- */
 const STALE_SWEPT_OUTPUT_DIRS = [
   join('static', 'chunks'),
   join('static', 'media'),
+  join('server', 'app'),
+  join('server', 'pages'),
   SERVER_HMR_CHUNKS_DIR,
   join('server', 'edge', 'chunks'),
   join('server', 'edge', 'assets'),
@@ -476,7 +469,7 @@ export async function createHotReloaderTurbopack(
       recursiveDeleteSyncWithAsyncRetries(
         join(distDir, subDir),
         undefined,
-        STALE_OUTPUT_MAX_AGE_MS
+        nextConfig.experimental.turbopackStaleOutputMaxAge!
       )
     )
   )

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -18,6 +18,7 @@ import type {
   TurbopackConnectedMessage,
 } from './hot-reloader-types'
 import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
+import { recursiveDeleteSyncWithAsyncRetries } from '../../lib/recursive-delete'
 import type {
   Update as TurbopackUpdate,
   Endpoint,
@@ -158,8 +159,25 @@ const isTestMode = !!(
 
 const sessionId = Math.floor(Number.MAX_SAFE_INTEGER * Math.random())
 
+/** How long an emitted asset may go unwritten before startup sweeps it. */
+const STALE_OUTPUT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000 // One week
+
 /** Output directory (relative to `distDir`) of server-HMR-managed chunks. */
 const SERVER_HMR_CHUNKS_DIR = join('server', 'chunks')
+
+/**
+ * Directories (relative to `distDir`) holding content-hashed turbopack output,
+ * per the chunking contexts in `next-core`. Entry chunks are deliberately left
+ * out: their paths derive from the route rather than a content hash, so they
+ * are overwritten in place instead of accumulating.
+ */
+const STALE_SWEPT_OUTPUT_DIRS = [
+  join('static', 'chunks'),
+  join('static', 'media'),
+  SERVER_HMR_CHUNKS_DIR,
+  join('server', 'edge', 'chunks'),
+  join('server', 'edge', 'assets'),
+]
 
 declare const __next__clear_chunk_cache__: (() => void) | null | undefined
 
@@ -445,6 +463,23 @@ export async function createHotReloaderTurbopack(
       distDir,
     })
   }
+
+  // Clean up any old output files from previous runs. This is safe as Turbopack
+  // will restore any missing chunks from persistent cache or recompute them.
+  //
+  // That only holds here, before the project exists: once turbo-tasks has
+  // recorded a write effect for a path, the write dedups on the recorded hash
+  // without checking the file, so a deleted output stays missing for the rest
+  // of the session.
+  await Promise.all(
+    STALE_SWEPT_OUTPUT_DIRS.map((subDir) =>
+      recursiveDeleteSyncWithAsyncRetries(
+        join(distDir, subDir),
+        undefined,
+        STALE_OUTPUT_MAX_AGE_MS
+      )
+    )
+  )
 
   const project = await bindings.turbo.createProject(
     {

--- a/test/unit/recursive-delete.test.ts
+++ b/test/unit/recursive-delete.test.ts
@@ -50,6 +50,32 @@ describe('recursiveDeleteSyncWithAsyncRetries', () => {
       expect(cleanupResult.length).toBe(0)
     }
   })
+
+  it('should only delete files older than maxAgeMs, and empty out dirs', async () => {
+    const dir = join(__dirname, 'isolated', 'ttl')
+    try {
+      await fs.outputFile(join(dir, 'stale', 'old.js'), 'old')
+      await fs.outputFile(join(dir, 'fresh', 'new.js'), 'new')
+      await fs.outputFile(join(dir, 'mixed', 'old.js'), 'old')
+      await fs.outputFile(join(dir, 'mixed', 'new.js'), 'new')
+
+      const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+      for (const p of ['stale/old.js', 'mixed/old.js']) {
+        await fs.utimes(join(dir, p), weekAgo, weekAgo)
+      }
+
+      await recursiveDeleteSyncWithAsyncRetries(dir, undefined, 60 * 60 * 1000)
+
+      expect((await recursiveReadDir(dir)).sort()).toEqual([
+        '/fresh/new.js',
+        '/mixed/new.js',
+      ])
+      // `stale` held nothing but stale files, so the directory goes too
+      expect(await fs.pathExists(join(dir, 'stale'))).toBe(false)
+    } finally {
+      await recursiveDeleteSyncWithAsyncRetries(dir)
+    }
+  })
 })
 
 describe('calcBackoffMs', () => {

--- a/test/unit/recursive-delete.test.ts
+++ b/test/unit/recursive-delete.test.ts
@@ -58,11 +58,14 @@ describe('recursiveDeleteSyncWithAsyncRetries', () => {
       await fs.outputFile(join(dir, 'fresh', 'new.js'), 'new')
       await fs.outputFile(join(dir, 'mixed', 'old.js'), 'old')
       await fs.outputFile(join(dir, 'mixed', 'new.js'), 'new')
+      await fs.outputFile(join(dir, 'future.js'), 'future')
 
       const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
       for (const p of ['stale/old.js', 'mixed/old.js']) {
         await fs.utimes(join(dir, p), weekAgo, weekAgo)
       }
+      const twoHoursFromNow = new Date(Date.now() + 2 * 60 * 60 * 1000)
+      await fs.utimes(join(dir, 'future.js'), twoHoursFromNow, twoHoursFromNow)
 
       await recursiveDeleteSyncWithAsyncRetries(dir, undefined, 60 * 60 * 1000)
 


### PR DESCRIPTION
## Summary

Turbopack dev never removes the content-hashed chunks it supersedes, so `.next/dev` grows without bound. Webpack dev avoids this by wiping `distDir` on every start.

Adds a `maxAgeMs` argument to `recursiveDeleteSyncWithAsyncRetries`: delete files whose mtime is at least that old, remove directories once empty. Turbopack dev passes one week.

## Verification

- `pnpm test-unit test/unit/recursive-delete.test.ts`
- ~Not run:~ dev-server behavior against a real `.next/dev`

<!-- NEXT_JS_LLM -->
