### PR TITLE
Treat a zero-length manifest as missing when the caller handles a missing one

### DIFF
--- a/packages/next/src/server/load-manifest.external.ts
+++ b/packages/next/src/server/load-manifest.external.ts
@@ -115,6 +115,19 @@ export function evalManifest<T extends object>(
   }
 
   if (content.length === 0) {
+    // A zero-length manifest is not a manifest that says nothing, it is a file
+    // whose contents have not landed yet. These files are emitted by the
+    // bundler, which truncates and rewrites them on every rebuild, so a reader
+    // in dev — where `shouldCache` is false and every request re-reads from
+    // disk — can observe the window between truncate and write. That is the
+    // same transient state `handleMissing` already tolerates for a file that is
+    // absent altogether, so give it the same answer rather than failing the
+    // request. Returning before the cache write keeps the empty read from being
+    // remembered, so the next read picks the contents up.
+    if (handleMissing) {
+      return undefined
+    }
+
     throw new Error('Manifest file is empty')
   }
 

--- a/packages/next/src/server/load-manifest.test.ts
+++ b/packages/next/src/server/load-manifest.test.ts
@@ -1,4 +1,4 @@
-import { loadManifest } from './load-manifest.external'
+import { evalManifest, loadManifest } from './load-manifest.external'
 import { readFileSync } from 'fs'
 
 jest.mock('fs')
@@ -78,5 +78,60 @@ describe('loadManifest', () => {
     expect(Object.isFrozen(result2)).toBe(true)
 
     expect(result).toBe(result2)
+  })
+})
+
+describe('evalManifest', () => {
+  const cache = new Map<string, unknown>()
+  const manifest =
+    'globalThis.__RSC_MANIFEST=(globalThis.__RSC_MANIFEST||{});' +
+    'globalThis.__RSC_MANIFEST["/page"]={"ssrModuleMapping":{}};'
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    cache.clear()
+  })
+
+  it('should evaluate the manifest from the file system', () => {
+    ;(readFileSync as jest.Mock).mockReturnValue(manifest)
+
+    const result = evalManifest('path/to/manifest', false) as any
+
+    expect(result.__RSC_MANIFEST['/page']).toEqual({ ssrModuleMapping: {} })
+  })
+
+  // A zero-length manifest is not a manifest that says nothing, it is a file
+  // whose contents have not landed yet: webpack's `emitAsset` truncates and
+  // rewrites these on every dev rebuild, and a reader can observe the window in
+  // between. That is the same transient state `handleMissing` already tolerates
+  // for a file that is absent altogether, so it gets the same answer instead of
+  // taking the request down with it.
+  it('should treat an empty manifest as missing when handling a missing manifest', () => {
+    ;(readFileSync as jest.Mock).mockReturnValue('')
+
+    expect(evalManifest('path/to/manifest', false, cache, true)).toBeUndefined()
+  })
+
+  // The tolerance is opt-in. A caller that did not ask for a missing manifest to
+  // be handled still requires the manifest, and still hears about it.
+  it('should throw for an empty manifest when not handling a missing manifest', () => {
+    ;(readFileSync as jest.Mock).mockReturnValue('')
+
+    expect(() => evalManifest('path/to/manifest', false, cache)).toThrow(
+      'Manifest file is empty'
+    )
+  })
+
+  // The empty read must not be remembered, or one unlucky read during a rebuild
+  // would serve an empty manifest for the life of the process.
+  it('should not cache an empty manifest, so a later read picks up the contents', () => {
+    ;(readFileSync as jest.Mock).mockReturnValue('')
+
+    expect(evalManifest('path/to/manifest', true, cache, true)).toBeUndefined()
+    expect(cache.has('path/to/manifest')).toBe(false)
+    ;(readFileSync as jest.Mock).mockReturnValue(manifest)
+
+    const result = evalManifest('path/to/manifest', true, cache, true) as any
+    expect(result.__RSC_MANIFEST['/page']).toEqual({ ssrModuleMapping: {} })
   })
 })


### PR DESCRIPTION
### What

In dev, a request that overlaps a rebuild can read one of the bundler's emitted
manifests while the file is zero bytes. When that manifest is the client
reference manifest, `evalManifest` throws `Manifest file is empty` (E328) and the
request can return a 500:

```
⨯ Error: Manifest file is empty
    at ignore-listed frames { page: '/pricing' }
 GET /pricing 500 in 1036ms
```

Repro: https://github.com/Faolain/nextjs-dev-manifest-empty-race (`npm run repro`)

### Why it happens

`RouteModule` loads its manifests with `shouldCache: !this.isDev`, so in dev
**every request re-reads them from disk**, while the bundler rewrites those same
files on every rebuild. `handleMissing` does not cover it: it catches the
`readFileSync` throw for a file that is *absent*, but a file that exists and is
empty does not throw, so it falls through to the `throw` below.

### The change

Treat a zero-length read the same way an absent file is already treated, but only
when the caller opted into that with `handleMissing`. The one call site that
passes it for this manifest already optional-chains the result
(`(clientReferenceManifest as any)?.__RSC_MANIFEST?.[...]`), so `undefined` is a
value it is already built to receive — a cold dev start, where the file does not
exist yet, takes exactly that path today.

Returning before the cache write matters: without it, one unlucky read during a
rebuild would be remembered for the life of the process.

A caller that did **not** pass `handleMissing` still gets the error, so nothing
that requires the manifest starts silently succeeding.

### Why not retry inside the read

That was my first instinct, and the measurement ruled it out. I instrumented both
loaders to re-read up to 5 times over ~10ms before giving up; every retry
exhausted all 5 attempts with the file still at `len=0`. The manifest is empty
for a sustained window, not a sub-millisecond torn write, so waiting for the next
request's read is the cheaper and more honest answer.

### Scope — this is a partial fix

The same race hits two more manifests through the JSON path, with a different
symptom:

| manifest | loader | symptom |
| --- | --- | --- |
| `.next/dev/server/app/<page>_client-reference-manifest.js` | `evalManifest` | `Manifest file is empty` (E328) |
| `.next/dev/server/next-font-manifest.json` | `loadManifest` | `Unexpected end of JSON input` |
| `.next/dev/build-manifest.json` | `loadManifest` | `Unexpected end of JSON input` |

In the repro this PR removes the E328 failures completely, and the JSON ones
remain. I did not extend it to those because their call sites do not pass
`handleMissing` and their consumers are not typed for `undefined`, so widening
the contract there felt like a maintainer's call rather than mine. The root fix
is presumably that these assets should reach their final path atomically, the way
#96384 / #96695 do for `prerender-manifest.json` — though those are Next's own
writes and these are bundler asset emissions, so the write path is different.

### Tests

`packages/next/src/server/load-manifest.test.ts` gains an `evalManifest` block,
written before the change:

- an empty manifest is treated as missing when `handleMissing` is set — **failed** before, passes after
- an empty read is not cached, so a later read picks the contents up — **failed** before, passes after
- an empty manifest still throws when `handleMissing` is not set — guards the existing contract
- a non-empty manifest still evaluates — guards the existing behaviour

```
Tests: 2 failed, 7 passed, 9 total   # before
Tests: 9 passed, 9 total             # after
```
