### PR TITLE
Add agent feedback CLI

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -34,6 +34,7 @@ import type { NextTypegenOptions } from '../cli/next-typegen.js'
 import type { NextPostBuildOptions } from '../cli/next-post-build.js'
 import { ensureProfilesDir } from '../lib/profiles-dir'
 import type { NextRequestInsightsOptions } from '../cli/next-request-insights.js'
+import type { NextAgentFeedbackOptions } from '../cli/next-agent-feedback.js'
 
 /**
  * Create `.next-profiles` (with its `.gitignore`) when profiling/tracing is
@@ -637,6 +638,16 @@ program
     )
   })
   .usage('[directory] [options]')
+
+program
+  .command('agent-feedback', { hidden: true })
+  .description('Open a prepared Next.js agent feedback report for review.')
+  .requiredOption('--feedback <text>', 'The de-identified feedback to review.')
+  .action((options: NextAgentFeedbackOptions) => {
+    return import('../cli/next-agent-feedback.js').then((mod) =>
+      mod.nextAgentFeedback(options)
+    )
+  })
 
 const internal = program
   .command('internal')

--- a/packages/next/src/cli/next-agent-feedback.ts
+++ b/packages/next/src/cli/next-agent-feedback.ts
@@ -1,0 +1,46 @@
+import { spawn } from 'node:child_process'
+
+import { getAgentName } from '../telemetry/agent-name'
+
+export type NextAgentFeedbackOptions = {
+  feedback: string
+}
+
+export function createAgentFeedbackUrl(
+  feedback: string,
+  { nextVersion, agent }: { nextVersion?: string; agent?: string } = {}
+): string | undefined {
+  feedback = feedback.trim()
+  if (!feedback || feedback.length > 2000) {
+    return
+  }
+
+  return `https://nextjs.org/agent-feedback#report=${Buffer.from(
+    JSON.stringify({ feedback, nextVersion, agent })
+  ).toString('base64url')}`
+}
+
+export async function nextAgentFeedback(
+  options: NextAgentFeedbackOptions
+): Promise<void> {
+  const url = createAgentFeedbackUrl(options.feedback, {
+    nextVersion: process.env.__NEXT_VERSION,
+    agent: (await getAgentName()) ?? undefined,
+  })
+  if (!url) {
+    console.error('Feedback must be between 1 and 2000 characters.')
+    process.exitCode = 1
+    return
+  }
+
+  console.log(`Review and submit the report at:\n${url}`)
+
+  const isWindows = process.platform === 'win32'
+  const child = spawn(
+    isWindows ? 'cmd.exe' : process.platform === 'darwin' ? 'open' : 'xdg-open',
+    isWindows ? ['/c', 'start', '', url] : [url],
+    { detached: true, stdio: 'ignore', windowsHide: true }
+  )
+  child.on('error', () => {})
+  child.unref()
+}

--- a/test/unit/agent-feedback-cli.test.ts
+++ b/test/unit/agent-feedback-cli.test.ts
@@ -1,0 +1,27 @@
+import { createAgentFeedbackUrl } from '../../packages/next/src/cli/next-agent-feedback'
+
+describe('createAgentFeedbackUrl', () => {
+  it('encodes the report for the feedback page', () => {
+    const url = new URL(
+      createAgentFeedbackUrl('  Unicode works: café ☕  ', {
+        nextVersion: '16.3.1-canary.19',
+        agent: 'Codex',
+      })!
+    )
+    const report = new URLSearchParams(url.hash.slice(1)).get('report')
+
+    expect(url.origin + url.pathname).toBe('https://nextjs.org/agent-feedback')
+    expect(
+      JSON.parse(Buffer.from(report!, 'base64url').toString('utf8'))
+    ).toEqual({
+      feedback: 'Unicode works: café ☕',
+      nextVersion: '16.3.1-canary.19',
+      agent: 'Codex',
+    })
+  })
+
+  it('rejects invalid feedback', () => {
+    expect(createAgentFeedbackUrl(' ')).toBeUndefined()
+    expect(createAgentFeedbackUrl('a'.repeat(2001))).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- Add a hidden `next agent-feedback` command that prepares agent-authored feedback for review on nextjs.org.
- Include the installed Next.js version and detected coding agent, then encode the report as a URL fragment.
- Print the review URL and open it in the default browser without submitting anything.

## Verification

- `pnpm jest test/unit/agent-feedback-cli.test.ts --runInBand`
- `pnpm --filter=next types`
- Manually verified the compiled CLI preserves Unicode and emits the expected feedback, version, and agent metadata.

<!-- NEXT_JS_LLM -->