### PR TITLE
Optimize fallible iterator joins

### DIFF
--- a/turbopack/crates/turbo-tasks/benches/join_iter_ext.rs
+++ b/turbopack/crates/turbo-tasks/benches/join_iter_ext.rs
@@ -1,0 +1,290 @@
+use std::{
+    cell::{Cell, RefCell},
+    future::Future,
+    pin::Pin,
+    rc::Rc,
+    task::{Context, Poll, Waker},
+};
+
+use anyhow::Result;
+use criterion::{BenchmarkId, Criterion, black_box};
+use futures::task::noop_waker;
+use turbo_tasks::{TryFlatJoinIterExt, TryJoinIterExt};
+
+const INPUT_SIZES: [usize; 7] = [1, 10, 100, 300, 1_000, 3_000, 10_000];
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Completion {
+    Immediate,
+    SecondPoll,
+    Sequential,
+}
+
+impl Completion {
+    fn name(self) -> &'static str {
+        match self {
+            Completion::Immediate => "immediate",
+            Completion::SecondPoll => "second_poll",
+            Completion::Sequential => "sequential",
+        }
+    }
+
+    fn expected_polls(self, input_size: usize) -> usize {
+        match self {
+            Completion::Immediate => 1,
+            Completion::SecondPoll => 2,
+            Completion::Sequential => input_size,
+        }
+    }
+}
+
+#[derive(Default)]
+struct SecondPollState {
+    wakers: RefCell<Vec<Waker>>,
+}
+
+impl SecondPollState {
+    fn wake_pending(&self) {
+        for waker in self.wakers.borrow_mut().drain(..) {
+            waker.wake();
+        }
+    }
+}
+
+struct SequentialState {
+    next: Cell<usize>,
+    wakers: RefCell<Vec<Option<Waker>>>,
+}
+
+impl SequentialState {
+    fn new(input_size: usize) -> Self {
+        Self {
+            next: Cell::new(0),
+            wakers: RefCell::new(vec![None; input_size]),
+        }
+    }
+
+    fn wake_pending(&self) {
+        if let Some(waker) = self
+            .wakers
+            .borrow_mut()
+            .get_mut(self.next.get())
+            .and_then(Option::take)
+        {
+            waker.wake();
+        }
+    }
+}
+
+enum Schedule {
+    Immediate,
+    SecondPoll {
+        polled: bool,
+        state: Rc<SecondPollState>,
+    },
+    Sequential {
+        target: usize,
+        state: Rc<SequentialState>,
+    },
+}
+
+impl Schedule {
+    fn new(
+        completion: Completion,
+        index: usize,
+        input_size: usize,
+        second_poll_state: &Option<Rc<SecondPollState>>,
+        sequential_state: &Option<Rc<SequentialState>>,
+    ) -> Self {
+        match completion {
+            Completion::Immediate => Schedule::Immediate,
+            Completion::SecondPoll => Schedule::SecondPoll {
+                polled: false,
+                state: second_poll_state.as_ref().unwrap().clone(),
+            },
+            Completion::Sequential => Schedule::Sequential {
+                // `join_all` initially polls in iterator order. The last future resolves, then
+                // the synchronous driver wakes one previously-pending future between outer polls.
+                target: input_size - index - 1,
+                state: sequential_state.as_ref().unwrap().clone(),
+            },
+        }
+    }
+
+    fn poll(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        match self {
+            Schedule::Immediate => Poll::Ready(()),
+            Schedule::SecondPoll { polled, .. } if *polled => Poll::Ready(()),
+            Schedule::SecondPoll { polled, state } => {
+                *polled = true;
+                // The synchronous driver wakes these after `join_all` has finished registering
+                // each pending child with its large-input `FuturesOrdered` representation.
+                state.wakers.borrow_mut().push(cx.waker().clone());
+                Poll::Pending
+            }
+            Schedule::Sequential { target, state } if state.next.get() == *target => {
+                state.next.set(*target + 1);
+                Poll::Ready(())
+            }
+            Schedule::Sequential { target, state } => {
+                state.wakers.borrow_mut()[*target] = Some(cx.waker().clone());
+                Poll::Pending
+            }
+        }
+    }
+}
+
+struct ValueFuture {
+    input: u32,
+    schedule: Schedule,
+}
+
+impl Future for ValueFuture {
+    type Output = Result<u32>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.schedule.poll(cx).map(|()| Ok(sync_value(self.input)))
+    }
+}
+
+struct FlatValueFuture {
+    input: u32,
+    schedule: Schedule,
+}
+
+impl Future for FlatValueFuture {
+    type Output = Result<[u32; 1]>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.schedule
+            .poll(cx)
+            .map(|()| Ok([sync_value(self.input)]))
+    }
+}
+
+#[inline(never)]
+fn sync_value(input: u32) -> u32 {
+    input.wrapping_mul(31).wrapping_add(7)
+}
+
+fn poll_to_ready<F, W>(future: F, expected_polls: usize, mut wake_pending: W) -> F::Output
+where
+    F: Future,
+    W: FnMut(),
+{
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut future = std::pin::pin!(future);
+
+    for poll_count in 1..=expected_polls {
+        if let Poll::Ready(output) = future.as_mut().poll(&mut cx) {
+            assert_eq!(poll_count, expected_polls);
+            return output;
+        }
+        wake_pending();
+    }
+
+    panic!("join future did not resolve after {expected_polls} polls");
+}
+
+struct CompletionStates {
+    second_poll: Option<Rc<SecondPollState>>,
+    sequential: Option<Rc<SequentialState>>,
+}
+
+impl CompletionStates {
+    fn new(completion: Completion, input_size: usize) -> Self {
+        Self {
+            second_poll: (completion == Completion::SecondPoll)
+                .then(|| Rc::new(SecondPollState::default())),
+            sequential: (completion == Completion::Sequential)
+                .then(|| Rc::new(SequentialState::new(input_size))),
+        }
+    }
+
+    fn wake_pending(&self) {
+        if let Some(state) = &self.second_poll {
+            state.wake_pending();
+        }
+        if let Some(state) = &self.sequential {
+            state.wake_pending();
+        }
+    }
+}
+
+fn bench_join<F, M>(c: &mut Criterion, name: &str, completion: Completion, make_future: M)
+where
+    F: Future<Output = Result<Vec<u32>>>,
+    M: Fn(usize, &CompletionStates) -> F,
+{
+    let mut group = c.benchmark_group(format!("{name}/{}", completion.name()));
+
+    for input_size in INPUT_SIZES {
+        group.bench_with_input(
+            BenchmarkId::new(name, input_size),
+            &input_size,
+            |b, &input_size| {
+                b.iter(|| {
+                    let states = CompletionStates::new(completion, input_size);
+                    let future = make_future(input_size, &states);
+                    black_box(
+                        poll_to_ready(future, completion.expected_polls(input_size), || {
+                            states.wake_pending()
+                        })
+                        .unwrap(),
+                    )
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("map_collect", input_size),
+            &input_size,
+            |b, &input_size| {
+                b.iter(|| {
+                    black_box(
+                        (0..input_size)
+                            .map(|index| sync_value(black_box(index as u32)))
+                            .collect::<Vec<_>>(),
+                    )
+                });
+            },
+        );
+    }
+}
+
+pub fn benchmark(c: &mut Criterion) {
+    for completion in [
+        Completion::Immediate,
+        Completion::SecondPoll,
+        Completion::Sequential,
+    ] {
+        bench_join(c, "try_join", completion, |input_size, states| {
+            (0..input_size)
+                .map(|index| ValueFuture {
+                    input: black_box(index as u32),
+                    schedule: Schedule::new(
+                        completion,
+                        index,
+                        input_size,
+                        &states.second_poll,
+                        &states.sequential,
+                    ),
+                })
+                .try_join()
+        });
+        bench_join(c, "try_flat_join", completion, |input_size, states| {
+            (0..input_size)
+                .map(|index| FlatValueFuture {
+                    input: black_box(index as u32),
+                    schedule: Schedule::new(
+                        completion,
+                        index,
+                        input_size,
+                        &states.second_poll,
+                        &states.sequential,
+                    ),
+                })
+                .try_flat_join()
+        });
+    }
+}

--- a/turbopack/crates/turbo-tasks/benches/mod.rs
+++ b/turbopack/crates/turbo-tasks/benches/mod.rs
@@ -2,11 +2,12 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
+pub(crate) mod join_iter_ext;
 pub(crate) mod scope;
 
 criterion_group!(
     name = turbo_tasks;
     config = Criterion::default();
-    targets = scope::overhead
+    targets = join_iter_ext::benchmark, scope::overhead
 );
 criterion_main!(turbo_tasks);

--- a/turbopack/crates/turbo-tasks/src/join_iter_ext.rs
+++ b/turbopack/crates/turbo-tasks/src/join_iter_ext.rs
@@ -1,13 +1,18 @@
 use std::{
     future::{Future, IntoFuture},
+    mem,
     pin::Pin,
-    task::Poll,
+    sync::{
+        Arc, Mutex, Weak,
+        atomic::{AtomicBool, Ordering},
+    },
+    task::{Context, Poll},
 };
 
 use anyhow::Result;
 use futures::{
-    FutureExt,
     future::{JoinAll, join_all},
+    task::{ArcWake, AtomicWaker, waker_ref},
 };
 use pin_project_lite::pin_project;
 
@@ -46,6 +51,220 @@ where
 }
 
 pin_project! {
+    struct MaybeDone<F>
+    where
+        F: Future,
+    {
+        #[pin]
+        future: F,
+        output: Option<F::Output>,
+    }
+}
+
+struct WakeTask {
+    index: usize,
+    queued: AtomicBool,
+    shared: Weak<WakeShared>,
+}
+
+impl ArcWake for WakeTask {
+    fn wake_by_ref(task: &Arc<Self>) {
+        if task.queued.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let Some(shared) = task.shared.upgrade() else {
+            return;
+        };
+        shared.queue.lock().unwrap().push(Arc::downgrade(task));
+        shared.parent.wake();
+    }
+}
+
+#[derive(Default)]
+struct WakeShared {
+    queue: Mutex<Vec<Weak<WakeTask>>>,
+    parent: AtomicWaker,
+}
+
+const WAKE_DRIVEN_THRESHOLD: usize = 30;
+
+enum PollState {
+    First,
+    Scanning,
+    Registering,
+    WakeDriven(Arc<WakeShared>),
+    Done,
+}
+
+/// Joins futures with an allocation-free scheduling fast path when they all resolve on the first
+/// poll. Small pending joins continue scanning directly; large pending joins install per-future
+/// wakers on the second poll and later poll only the futures those wakers enqueue.
+struct IterJoin<F>
+where
+    F: Future,
+{
+    elems: Pin<Box<[MaybeDone<F>]>>,
+    pending: usize,
+    state: PollState,
+    wake_tasks: Option<Box<[Option<Arc<WakeTask>>]>>,
+}
+
+impl<F> IterJoin<F>
+where
+    F: Future,
+{
+    fn new(iter: impl Iterator<Item = F>) -> Self {
+        let elems = iter
+            .map(|future| MaybeDone {
+                future,
+                output: None,
+            })
+            .collect::<Box<[_]>>();
+        Self {
+            pending: elems.len(),
+            elems: Box::into_pin(elems),
+            state: PollState::First,
+            wake_tasks: None,
+        }
+    }
+
+    fn take_outputs(&mut self) -> impl Iterator<Item = F::Output> + '_ {
+        iter_pin_mut(self.elems.as_mut()).map(|elem| elem.project().output.take().unwrap())
+    }
+}
+
+// SAFETY: The elements are pinned as part of the boxed slice and are never moved before the slice
+// is dropped. Projecting a pinned slice to its individual pinned elements preserves that pinning.
+fn iter_pin_mut<T>(slice: Pin<&mut [T]>) -> impl Iterator<Item = Pin<&mut T>> {
+    unsafe { slice.get_unchecked_mut() }
+        .iter_mut()
+        .map(|elem| unsafe { Pin::new_unchecked(elem) })
+}
+
+// SAFETY: Like `iter_pin_mut`, this projects one element without moving it from the pinned slice.
+fn get_pin_mut<T>(slice: Pin<&mut [T]>, index: usize) -> Pin<&mut T> {
+    unsafe { slice.map_unchecked_mut(|slice| &mut slice[index]) }
+}
+
+impl<F> IterJoin<F>
+where
+    F: Future,
+{
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        let this = self.get_mut();
+
+        match &this.state {
+            PollState::First => {
+                for elem in iter_pin_mut(this.elems.as_mut()) {
+                    let elem = elem.project();
+                    if let Poll::Ready(output) = elem.future.poll(cx) {
+                        *elem.output = Some(output);
+                        this.pending -= 1;
+                    }
+                }
+                if this.pending == 0 {
+                    this.state = PollState::Done;
+                    return Poll::Ready(());
+                }
+                this.state = if this.elems.len() <= WAKE_DRIVEN_THRESHOLD {
+                    PollState::Scanning
+                } else {
+                    PollState::Registering
+                };
+            }
+            PollState::Scanning => {
+                for elem in iter_pin_mut(this.elems.as_mut()) {
+                    let elem = elem.project();
+                    if elem.output.is_some() {
+                        continue;
+                    }
+                    if let Poll::Ready(output) = elem.future.poll(cx) {
+                        *elem.output = Some(output);
+                        this.pending -= 1;
+                    }
+                }
+                if this.pending == 0 {
+                    this.state = PollState::Done;
+                    return Poll::Ready(());
+                }
+            }
+            PollState::Registering => {
+                // Futures were initially polled with the parent waker so the all-ready case avoids
+                // scheduler setup. Poll each unfinished future once more with an indexed waker;
+                // after this pass, wake-driven polling can identify exactly which futures to poll.
+                let shared = Arc::new(WakeShared::default());
+                shared.parent.register(cx.waker());
+                let mut wake_tasks = vec![None; this.elems.len()].into_boxed_slice();
+                for (index, elem) in iter_pin_mut(this.elems.as_mut()).enumerate() {
+                    let elem = elem.project();
+                    if elem.output.is_some() {
+                        continue;
+                    }
+                    let task = Arc::new(WakeTask {
+                        index,
+                        queued: AtomicBool::new(false),
+                        shared: Arc::downgrade(&shared),
+                    });
+                    let waker = waker_ref(&task);
+                    let mut child_cx = Context::from_waker(&waker);
+                    if let Poll::Ready(output) = elem.future.poll(&mut child_cx) {
+                        *elem.output = Some(output);
+                        this.pending -= 1;
+                    } else {
+                        wake_tasks[index] = Some(task);
+                    }
+                }
+                if this.pending == 0 {
+                    this.state = PollState::Done;
+                    return Poll::Ready(());
+                }
+                this.wake_tasks = Some(wake_tasks);
+                this.state = PollState::WakeDriven(shared);
+            }
+            PollState::WakeDriven(shared) => {
+                let shared = Arc::clone(shared);
+                shared.parent.register(cx.waker());
+
+                let ready = {
+                    let mut queue = shared.queue.lock().unwrap();
+                    // Reset `queued` while holding the queue lock. A concurrent wake then either
+                    // observes the old queued item (which this poll handles) or waits for the lock
+                    // and appends a new item; it cannot be lost between those operations.
+                    let queued = mem::take(&mut *queue);
+                    queued
+                        .into_iter()
+                        .filter_map(|task| task.upgrade())
+                        .inspect(|task| task.queued.store(false, Ordering::Release))
+                        .collect::<Vec<_>>()
+                };
+
+                for task in ready {
+                    let mut elem = get_pin_mut(this.elems.as_mut(), task.index);
+                    let elem = elem.as_mut().project();
+                    if elem.output.is_some() {
+                        continue;
+                    }
+                    let waker = waker_ref(&task);
+                    let mut child_cx = Context::from_waker(&waker);
+                    if let Poll::Ready(output) = elem.future.poll(&mut child_cx) {
+                        *elem.output = Some(output);
+                        this.wake_tasks.as_mut().unwrap()[task.index] = None;
+                        this.pending -= 1;
+                    }
+                }
+                if this.pending == 0 {
+                    this.state = PollState::Done;
+                    return Poll::Ready(());
+                }
+            }
+            PollState::Done => panic!("IterJoin polled after completion"),
+        }
+
+        Poll::Pending
+    }
+}
+
+pin_project! {
     /// Future for the [TryJoinIterExt::try_join] method.
     #[must_use]
     pub struct TryJoin<F>
@@ -53,7 +272,7 @@ pin_project! {
         F: Future,
     {
         #[pin]
-        inner: JoinAll<F>,
+        inner: IterJoin<F>,
     }
 }
 
@@ -67,11 +286,10 @@ where
         self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        match self.project().inner.poll_unpin(cx) {
-            std::task::Poll::Ready(res) => {
-                std::task::Poll::Ready(res.into_iter().collect::<Result<Vec<_>>>())
-            }
-            std::task::Poll::Pending => std::task::Poll::Pending,
+        let mut this = self.project();
+        match this.inner.as_mut().poll(cx) {
+            Poll::Ready(()) => Poll::Ready(this.inner.get_mut().take_outputs().collect()),
+            Poll::Pending => Poll::Pending,
         }
     }
 }
@@ -109,7 +327,7 @@ where
 {
     fn try_join(self) -> TryJoin<F> {
         TryJoin {
-            inner: join_all(self.map(|f| f.into_future())),
+            inner: IterJoin::new(self.map(|f| f.into_future())),
         }
     }
 }
@@ -121,7 +339,7 @@ pin_project! {
         F: Future,
     {
         #[pin]
-        inner: JoinAll<F>,
+        inner: IterJoin<F>,
     }
 }
 
@@ -134,14 +352,14 @@ where
     type Output = Result<Vec<U::Item>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        match self.project().inner.poll_unpin(cx) {
-            Poll::Ready(res) => {
-                let mut v = Vec::new();
-                for r in res {
-                    v.extend(r?);
+        let mut this = self.project();
+        match this.inner.as_mut().poll(cx) {
+            Poll::Ready(()) => {
+                let mut output = Vec::new();
+                for result in this.inner.get_mut().take_outputs() {
+                    output.extend(result?);
                 }
-
-                Poll::Ready(Ok(v))
+                Poll::Ready(Ok(output))
             }
             Poll::Pending => Poll::Pending,
         }
@@ -174,7 +392,217 @@ where
 {
     fn try_flat_join(self) -> TryFlatJoin<F> {
         TryFlatJoin {
-            inner: join_all(self.map(|f| f.into_future())),
+            inner: IterJoin::new(self.map(|f| f.into_future())),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::{Future, ready},
+        marker::PhantomPinned,
+        pin::Pin,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        task::{Context, Poll},
+    };
+
+    use anyhow::{Result, anyhow};
+    use futures::{executor::block_on, task::AtomicWaker};
+
+    use crate::{TryFlatJoinIterExt, TryJoinIterExt};
+
+    struct PollTwice {
+        value: usize,
+        polled: bool,
+        result: Result<usize>,
+        _pinned: PhantomPinned,
+    }
+
+    impl Future for PollTwice {
+        type Output = Result<usize>;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            // SAFETY: Mutating these fields does not move the pinned future.
+            let this = unsafe { self.get_unchecked_mut() };
+            if this.polled {
+                Poll::Ready(std::mem::replace(&mut this.result, Ok(this.value)))
+            } else {
+                this.polled = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+
+    struct StepFuture {
+        value: usize,
+        ready: Arc<AtomicBool>,
+        waker: Arc<AtomicWaker>,
+        polls: Arc<AtomicUsize>,
+        _pinned: PhantomPinned,
+    }
+
+    struct ThreadWake {
+        ready: Arc<AtomicBool>,
+        started: bool,
+    }
+
+    impl Future for ThreadWake {
+        type Output = Result<usize>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if self.ready.load(Ordering::Acquire) {
+                return Poll::Ready(Ok(42));
+            }
+            if !self.started {
+                self.started = true;
+                let ready = Arc::clone(&self.ready);
+                let waker = cx.waker().clone();
+                std::thread::spawn(move || {
+                    ready.store(true, Ordering::Release);
+                    waker.wake();
+                });
+            }
+            Poll::Pending
+        }
+    }
+
+    impl Future for StepFuture {
+        type Output = Result<usize>;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            self.polls.fetch_add(1, Ordering::Relaxed);
+            if self.ready.load(Ordering::Acquire) {
+                Poll::Ready(Ok(self.value))
+            } else {
+                self.waker.register(cx.waker());
+                Poll::Pending
+            }
+        }
+    }
+
+    fn poll_twice(value: usize, result: Result<usize>) -> PollTwice {
+        PollTwice {
+            value,
+            polled: false,
+            result,
+            _pinned: PhantomPinned,
+        }
+    }
+
+    #[test]
+    fn immediate_join_preserves_order_at_all_sizes() {
+        for size in [0, 10, 100] {
+            let actual = block_on(
+                (0..size)
+                    .map(|value| ready(Ok::<_, anyhow::Error>(value)))
+                    .try_join(),
+            )
+            .unwrap();
+            assert_eq!(actual, (0..size).collect::<Vec<_>>());
+        }
+    }
+
+    #[test]
+    fn immediate_flat_join_preserves_order() {
+        let actual = block_on(
+            (0..100)
+                .map(|value| ready(Ok::<_, anyhow::Error>([value, value + 100])))
+                .try_flat_join(),
+        )
+        .unwrap();
+        let expected = (0..100)
+            .flat_map(|value| [value, value + 100])
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn large_non_unpin_futures_resolve_on_second_poll() {
+        let actual = block_on(
+            (0..100)
+                .map(|value| poll_twice(value, Ok(value)))
+                .try_join(),
+        )
+        .unwrap();
+        assert_eq!(actual, (0..100).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn errors_are_returned_in_input_order() {
+        let error = block_on(
+            [
+                poll_twice(0, Err(anyhow!("first"))),
+                poll_twice(1, Err(anyhow!("second"))),
+            ]
+            .into_iter()
+            .try_join(),
+        )
+        .unwrap_err();
+        assert_eq!(error.to_string(), "first");
+    }
+
+    #[test]
+    fn wake_from_another_thread_is_supported() {
+        let values = block_on(
+            [ThreadWake {
+                ready: Arc::new(AtomicBool::new(false)),
+                started: false,
+            }]
+            .into_iter()
+            .try_join(),
+        )
+        .unwrap();
+        assert_eq!(values, [42]);
+    }
+
+    #[test]
+    fn sequential_wakes_only_poll_ready_futures() {
+        let size = 100;
+        let polls = Arc::new(AtomicUsize::new(0));
+        let controls = (0..size)
+            .map(|_| {
+                (
+                    Arc::new(AtomicBool::new(false)),
+                    Arc::new(AtomicWaker::new()),
+                )
+            })
+            .collect::<Vec<_>>();
+        let future = controls
+            .iter()
+            .enumerate()
+            .map(|(value, (ready, waker))| StepFuture {
+                value,
+                ready: Arc::clone(ready),
+                waker: Arc::clone(waker),
+                polls: Arc::clone(&polls),
+                _pinned: PhantomPinned,
+            })
+            .try_join();
+        let mut future = std::pin::pin!(future);
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(future.as_mut().poll(&mut cx).is_pending());
+        let mut completed = false;
+        for (ready, waker) in &controls {
+            ready.store(true, Ordering::Release);
+            waker.wake();
+            match future.as_mut().poll(&mut cx) {
+                Poll::Ready(result) => {
+                    assert_eq!(result.unwrap(), (0..size).collect::<Vec<_>>());
+                    completed = true;
+                    break;
+                }
+                Poll::Pending => {}
+            }
+        }
+
+        assert!(completed);
+        assert!(polls.load(Ordering::Relaxed) <= size * 3);
     }
 }

--- a/turbopack/crates/turbo-tasks/src/join_iter_ext.rs
+++ b/turbopack/crates/turbo-tasks/src/join_iter_ext.rs
@@ -75,14 +75,14 @@ impl ArcWake for WakeTask {
         let Some(shared) = task.shared.upgrade() else {
             return;
         };
-        shared.queue.lock().unwrap().push(Arc::downgrade(task));
+        shared.queue.lock().unwrap().push(Arc::clone(task));
         shared.parent.wake();
     }
 }
 
 #[derive(Default)]
 struct WakeShared {
-    queue: Mutex<Vec<Weak<WakeTask>>>,
+    queue: Mutex<Vec<Arc<WakeTask>>>,
     parent: AtomicWaker,
 }
 
@@ -231,24 +231,28 @@ where
                     // observes the old queued item (which this poll handles) or waits for the lock
                     // and appends a new item; it cannot be lost between those operations.
                     let queued = mem::take(&mut *queue);
+                    for task in &queued {
+                        task.queued.store(false, Ordering::Release);
+                    }
                     queued
-                        .into_iter()
-                        .filter_map(|task| task.upgrade())
-                        .inspect(|task| task.queued.store(false, Ordering::Release))
-                        .collect::<Vec<_>>()
                 };
 
                 for task in ready {
+                    let wake_tasks = this.wake_tasks.as_mut().unwrap();
+                    if wake_tasks[task.index].is_none() {
+                        continue;
+                    }
                     let mut elem = get_pin_mut(this.elems.as_mut(), task.index);
                     let elem = elem.as_mut().project();
                     if elem.output.is_some() {
+                        wake_tasks[task.index] = None;
                         continue;
                     }
                     let waker = waker_ref(&task);
                     let mut child_cx = Context::from_waker(&waker);
                     if let Poll::Ready(output) = elem.future.poll(&mut child_cx) {
                         *elem.output = Some(output);
-                        this.wake_tasks.as_mut().unwrap()[task.index] = None;
+                        wake_tasks[task.index] = None;
                         this.pending -= 1;
                     }
                 }
@@ -451,6 +455,29 @@ mod tests {
         started: bool,
     }
 
+    struct WakeWhenReady {
+        value: usize,
+        polls: usize,
+        ready_after: usize,
+        completed: bool,
+    }
+
+    impl Future for WakeWhenReady {
+        type Output = Result<usize>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            assert!(!self.completed, "future polled after completion");
+            self.polls += 1;
+            cx.waker().wake_by_ref();
+            if self.polls == self.ready_after {
+                self.completed = true;
+                Poll::Ready(Ok(self.value))
+            } else {
+                Poll::Pending
+            }
+        }
+    }
+
     impl Future for ThreadWake {
         type Output = Result<usize>;
 
@@ -544,6 +571,22 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(error.to_string(), "first");
+    }
+
+    #[test]
+    fn completed_futures_queued_by_a_racing_wake_are_not_polled_again() {
+        let values = block_on(
+            (0..31)
+                .map(|value| WakeWhenReady {
+                    value,
+                    polls: 0,
+                    ready_after: if value == 30 { 3 } else { 2 },
+                    completed: false,
+                })
+                .try_join(),
+        )
+        .unwrap();
+        assert_eq!(values, (0..31).collect::<Vec<_>>());
     }
 
     #[test]


### PR DESCRIPTION
### What?

Adds Criterion micro-benchmarks for `try_join()` and `try_flat_join()` and replaces their `futures::join_all` backend with a specialized iterator join implementation.

At 10,000 immediately-ready futures, median time improves from 1.228 ms to 81.5 µs for `try_join()` and from 1.241 ms to 85.0 µs for `try_flat_join()`.

### Why?

`join_all` switches to `FuturesOrdered` above 30 inputs. Its per-future scheduling machinery is useful for pending futures, but it creates a large performance cliff when every future resolves immediately. The previous implementation was roughly 138× slower than synchronous map-and-collect at 10,000 inputs.

### How?

The new join implementation first polls every future directly using the parent waker. Fully synchronous joins complete without allocating per-future scheduling state.

When futures remain pending, small joins continue direct scanning while large joins lazily install indexed child wakers and poll only futures placed in the wake queue. This retains wake-driven scaling for large pending joins without paying that cost on the immediate path. Completed outputs are collected directly into the final result while preserving input and error order.

The benchmark covers immediate completion, completion on the second poll, and sequential completion across 1–10,000 inputs. Focused tests cover ordering, flattening, error selection, `!Unpin` futures, stale/racing wakes, sequential wake behavior, and cross-thread wakeups.

### Performance

Micro-benchmark medians at 10,000 inputs:

| Case | Before | After |
| --- | ---: | ---: |
| immediate `try_join` | 1.228 ms | 81.5 µs |
| immediate `try_flat_join` | 1.241 ms | 85.0 µs |
| second-poll `try_join` | 1.975 ms | ~472 µs |
| sequential `try_join` | 2.649 ms | ~1.84 ms |

Large-input scalability was also measured against the old `join_all` backend:

| Pattern | Size | Current PR | Old code | Current speedup |
| --- | ---: | ---: | ---: | ---: |
| immediate | 100k | 0.906 ms | 10.372 ms | 11.45× |
| immediate | 1M | 29.117 ms | 168.565 ms | 5.79× |
| second poll | 100k | 4.920 ms | 20.858 ms | 4.24× |
| second poll | 1M | 71.984 ms | 247.227 ms | 3.43× |
| sequential | 100k | 20.290 ms | 28.158 ms | 1.39× |
| sequential | 1M | 217.231 ms | 311.477 ms | 1.43× |

Both implementations completed all 1M-item cases without an OOM, hang, or poll-count failure. The current immediate path has a confirmed working-set cliff: 10× more inputs took 32× longer (independent rerun ~34×), versus 16× on old code. It remains 5.8× faster at 1M and uses less peak RSS, so this appears to be increased cache/allocation cost rather than O(N²) behavior. Sequential N-poll scaling remained close to linear (10.7× for 10× inputs).

Peak RSS at 1M was 55 / 74 / 120 MiB for current immediate / second-poll / sequential, versus 112 / 128 / 127 MiB on old code. These process-level numbers include synthetic benchmark control state.

Two larger clean-build A/B workloads were also measured with release `next-swc` binaries differing only in `join_iter_ext.rs`. Neither produced a reproducible top-level difference:

| Workload | Pairs | Candidate effect | Paired t 95% CI | Signs |
| --- | ---: | ---: | --- | --- |
| `heavy-npm-deps` | 8 | +0.66% slower | [-1.30%, +2.63%] | 5 faster / 3 slower |
| `nested-deps-app-router-many-pages` | 16 | -0.75% faster | [-2.11%, +0.61%] | 9 faster / 7 slower |

The first 8-pair many-pages run suggested -1.92%, but an independent 8-pair confirmation reversed direction (+0.44% slower), so the combined result is reported as **no detected difference**. The observed noise floors were approximately 2.0% and 1.36%, respectively; any complete-build effect is smaller than those runs could resolve.

### Verification

- `cargo test -p turbo-tasks join_iter_ext`
- `cargo clippy -p turbo-tasks --all-targets -- -D warnings`
- `cargo bench -p turbo-tasks --bench mod --no-run`
- `cargo bench -p turbo-tasks --bench mod -- 'try_join|try_flat_join' --test`
- `cargo fmt --all -- --check`
- 48 successful clean production Turbopack builds across the two A/B workloads

<!-- NEXT_JS_LLM -->
