### PR TITLE
fix(turbopack): don't wait forever on a runtime-dependency chunk that is never injected

### DIFF
--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/runtime-backend-dom.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/dom/runtime-backend-dom.ts
@@ -181,21 +181,35 @@ const chunkResolvers: Map<ChunkUrl, ChunkResolver> = new Map()
     }
 
     if (sourceType === SourceType.Runtime) {
-      // We don't need to load chunks references from runtime code, as they're already
-      // present in the DOM.
       resolver.loadingStarted = true
 
       if (isCss(chunkUrl)) {
         // CSS chunks do not register themselves, and as such must be marked as
         // loaded instantly.
         resolver.resolve()
+        return resolver.promise
       }
 
-      // We need to wait for JS chunks to register themselves within `registerChunk`
-      // before we can start instantiating runtime modules, hence the absence of
-      // `resolver.resolve()` in this branch.
+      // In a worker the runtime's chunks are imported eagerly, so there is nothing
+      // left to do here.
+      if (typeof importScripts === 'function') {
+        return resolver.promise
+      }
 
-      return resolver.promise
+      // In a document, a chunk referenced from runtime code is *usually* already
+      // present as a `<script>` tag and resolves itself through `registerChunk`, so
+      // there is deliberately no `resolver.resolve()` for JS here.
+      //
+      // That is not guaranteed, though: a chunk can be listed as a runtime dependency
+      // without ever being injected into the document -- for example when its modules
+      // were also emitted into another chunk that *is* injected, leaving this one
+      // redundant and unreferenced. Nothing then loads it, nothing resolves it, and
+      // `registerChunk` waits on it forever, so runtime modules are never instantiated
+      // and the page never hydrates -- with no error, because a pending promise is not
+      // a failure.
+      //
+      // Fall through to the DOM loader below instead: it reuses the existing `<script>`
+      // when there is one (unchanged behaviour) and injects one otherwise.
     }
 
     if (typeof importScripts === 'function') {


### PR DESCRIPTION
### What

`doLoadChunk` returns early for `SourceType.Runtime` JS chunks, on the assumption —
stated in the comment it replaces — that such chunks are "already present in the DOM"
and will resolve their own resolver through `registerChunk`.

When a chunk is listed as a runtime dependency but never injected into the document,
nothing loads it, nothing resolves it, and the
`await Promise.all(params.otherChunks.map(loadInitialChunk))` in `registerChunk` never
settles. Entry modules are instantiated only after that await, so they never run.

For a Pages Router page that means its `__NEXT_P` registration module never executes, the
entrypoint never reaches `routeLoader`, and **the page never hydrates — with no error of
any kind**, because a pending promise is not a failure.

### Why it happens

Observed with `experimental.turbopackChunking.generateComponentChunks: true`. In the
reproduction, the page's entry chunk lists a chunk in `otherChunks` that

- exists in the build output and serves 200,
- is not referenced anywhere in the HTML,
- is never requested (0 network requests, no `<script>` element),
- has a resolver stuck at `{ loadingStarted: true, resolved: false }`,
- and would provide a module that is **already registered**, because component-level
  chunking duplicated that module into another chunk that *is* injected.

So the chunk is redundant and unreferenced, and waiting for it can never end.

### How

Keep the fast path for CSS (unchanged) and the early return for workers (unchanged, so
worker chunks are not re-`importScripts`ed). Let JS in a document fall through to the DOM
loader below, which already reuses an existing `<script src=…>` when there is one — the
normal case, behaviour unchanged — and injects one otherwise.

### Verification

Reproduction: https://github.com/yunsii/turbopack-generate-component-chunks-repro

The runtime JS is embedded in the `next-swc` native binary, so this was verified by
applying the equivalent change to a **built** output (`.next/static/chunks/turbopack-*.js`)
of that reproduction — same artifacts, only this logic differs. The repo contains the
patch script used (`debug/patch-runtime-fix.mjs`) so the check can be repeated.

| page | unpatched | patched |
|---|---|---|
| `/p0` | not hydrated | hydrated |
| `/p1` | not hydrated | hydrated |
| `/p4` (already fine) | hydrated | hydrated (unchanged) |

Verified on both `next@16.3.0` and `next@16.3.1-canary.25`. Cost: exactly **one**
additional chunk request on `/p0` (52 vs 51) — the previously orphaned chunk — with **zero
duplicate requests** and **zero JS exceptions**.

I have not built `next-swc` locally, so I have not run the Rust-side test suites against
this change; happy to follow up if a maintainer points me at the right ones.

### Note on the deeper fix

This makes the runtime resilient, but the chunk graph itself looks inconsistent: a chunk
that is never injected arguably should not appear in another chunk's `otherChunks` at all,
particularly when its modules are already provided by a duplicate chunk that is injected.
That would be a build-side change and I have not attempted it — this PR is the defensive
half, and it removes a failure mode that is completely silent today.


Fixes #97605
