### PR TITLE
Fix duplicate RSC route handler outputs

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -48,6 +48,7 @@ import {
 } from '../../lib/constants'
 
 import { normalizeLocalePath } from '../../shared/lib/i18n/normalize-locale-path'
+import { isAppRouteRoute } from '../../lib/is-app-route-route'
 import { getStaticMetadataPrerenderPathname } from '../../lib/metadata/get-metadata-route'
 import { isStaticMetadataFile } from '../../lib/metadata/is-metadata-route'
 import { addPathPrefix } from '../../shared/lib/router/utils/add-path-prefix'
@@ -661,6 +662,11 @@ export async function handleBuildComplete({
       prerenders: [],
       staticFiles: [],
     }
+    const appPagePathnames = new Set(
+      (appPageKeys ?? [])
+        .filter((appPath) => !isAppRouteRoute(appPath))
+        .map((appPath) => normalizeAppPath(appPath))
+    )
 
     const clientHashes: Record<string, string> | undefined =
       bundler === Bundler.Turbopack && config.supportsImmutableAssets
@@ -1215,11 +1221,6 @@ export async function handleBuildComplete({
             outputs.appPages.push(output)
           } else {
             outputs.appRoutes.push(output)
-            outputs.appRoutes.push({
-              ...output,
-              pathname: normalizePagePath(output.pathname) + '.rsc',
-              id: normalizePagePath(output.pathname) + '.rsc',
-            })
           }
         }
       }
@@ -2164,7 +2165,7 @@ export async function handleBuildComplete({
           pagePath
         ) + getDestinationQuery(route.routeKeys)
 
-      const hasAppPages = Boolean(appPageKeys && appPageKeys.length > 0)
+      const hasAppPage = appPagePathnames.has(route.page)
 
       const suffixedHas =
         isFallbackFalse && !pageKeys.includes(route.page)
@@ -2179,7 +2180,7 @@ export async function handleBuildComplete({
       // conditions, so that case keeps a separate entry per form.
       const canMergeSuffixedAndPlain =
         config.experimental.collapseAdapterRoutes &&
-        hasAppPages &&
+        hasAppPage &&
         suffixedHas === plainHas
 
       if (canMergeSuffixedAndPlain) {
@@ -2213,7 +2214,7 @@ export async function handleBuildComplete({
         // the `.rsc` payload, and a per-segment prefetch request. The suffix
         // group accepts both forms, and the destination copies the matched
         // suffix, so each request resolves to the artifact that it asks for.
-        if (hasAppPages) {
+        if (hasAppPage) {
           dynamicRoutes.push({
             source: pagePath + '.rsc',
             sourceRegex: sourceRegex.replace(

--- a/test/production/adapter-config/adapter-config.test.ts
+++ b/test/production/adapter-config/adapter-config.test.ts
@@ -91,6 +91,20 @@ describe('adapter-config', () => {
     expect(staticOutputs.length).toBeGreaterThan(0)
     expect(prerenderOutputs.length).toBeGreaterThan(0)
 
+    const appRouteRscPathnames = outputs.appRoutes
+      .map((output) => output.pathname)
+      .filter((pathname) => pathname.endsWith('.rsc'))
+    expect(appRouteRscPathnames).toEqual([])
+
+    const dynamicRscRouteSources = routing.dynamicRoutes
+      .map((route) => route.source)
+      .filter((source) => source.endsWith('.rsc'))
+      .sort()
+    expect(dynamicRscRouteSources).toEqual([
+      '/isr-app/[slug].rsc',
+      '/node-app/[slug].rsc',
+    ])
+
     const expectedRouteConfigs = [
       {
         pathname: '/docs/node-app',


### PR DESCRIPTION
### What?

This fixes an issue where the build adapter generated unnecessary `.rsc` outputs and dynamic `.rsc` routes for App Router route handlers. Route handlers now produce only their handler output, while App Router pages continue to receive their required RSC outputs.

### Why?

I noticed that every route handler was getting an extra RSC output. In larger applications, this could double the number of generated routes and cause deployments to reach route limits. I investigated the behavior and fixed it without changing the existing behavior for App Router pages.

### How?

The build now distinguishes App Router pages from route handlers when generating adapter outputs and dynamic RSC routes. I added regression assertions to ensure route handlers do not emit `.rsc` outputs while dynamic App Router pages still do.

I also verified the change locally end-to-end in the official development container, including the relevant production tests with both Turbopack and webpack.

Fixes #97564