### PR TITLE
test: stabilize poisoned proxy error overlay

### DIFF
--- a/test/development/acceptance-app/rsc-build-errors-poisoned-imports.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors-poisoned-imports.test.ts
@@ -94,12 +94,13 @@ runRscBuildErrorsTests(({ next, isTurbopack }) => {
     )
   })
 
-  // The third element defers the poisoned import until after the page has
-  // hydrated. A broken `proxy.js` is compiled while the dev server is starting
-  // up and forces a full reload, which can clear the overlay before
-  // `waitForRedbox` starts observing it. The other two entries surface the
-  // error reliably from the initial compile, and only surface it reliably that
-  // way, so they keep the poisoned import in the initial files.
+  // Proxy runs in the Node.js server compiler, which is also invalidated when
+  // the app route is added on demand. If the initial proxy error reaches the
+  // browser before that follow-up build, the HMR client sees an update after a
+  // runtime error and reloads, clearing the overlay. Defer the proxy error
+  // until after hydration so it is reported as an HMR build error instead.
+  // Middleware uses the edge compiler and instrumentation is compiled earlier,
+  // so they keep the poisoned import in the initial files.
   test.each([
     ['middleware.js', 'export function middleware() {}', false],
     ['proxy.js', 'export function proxy() {}', true],

--- a/test/development/acceptance-app/rsc-build-errors-poisoned-imports.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors-poisoned-imports.test.ts
@@ -94,20 +94,21 @@ runRscBuildErrorsTests(({ next, isTurbopack }) => {
     )
   })
 
-  // Proxy runs in the Node.js server compiler, which is also invalidated when
-  // the app route is added on demand. If the initial proxy error reaches the
-  // browser before that follow-up build, the HMR client sees an update after a
-  // runtime error and reloads, clearing the overlay. Defer the proxy error
-  // until after hydration so it is reported as an HMR build error instead.
-  // Middleware uses the edge compiler and instrumentation is compiled earlier,
-  // so they keep the poisoned import in the initial files.
+  // In Webpack, proxy runs in the Node.js server compiler, which is also
+  // invalidated when the app route is added on demand. If the initial proxy
+  // error reaches the browser before that follow-up build, the HMR client sees
+  // an update after a runtime error and reloads, clearing the overlay. Defer
+  // that case until after hydration. Turbopack does not have this compiler
+  // invalidation race, so its proxy case covers both initial and HMR errors.
   test.each([
-    ['middleware.js', 'export function middleware() {}', false],
-    ['proxy.js', 'export function proxy() {}', true],
-    ['instrumentation.js', 'export function register() {}', false],
+    ['middleware.js', 'export function middleware() {}'],
+    ['proxy.js', 'export function proxy() {}'],
+    ['instrumentation.js', 'export function register() {}'],
   ])(
     'should error when catchError from next/error is imported in %s',
-    async (entryFile, exportCode, deferPoisonedImport) => {
+    async (entryFile, exportCode) => {
+      const isProxy = entryFile === 'proxy.js'
+      const deferPoisonedImport = !isTurbopack && isProxy
       const entryContent = outdent`
         import { catchError } from 'next/error'
         ${exportCode}
@@ -131,10 +132,21 @@ runRscBuildErrorsTests(({ next, isTurbopack }) => {
       if (deferPoisonedImport) {
         await session.write(entryFile, entryContent)
       }
-      await session.waitForRedbox()
-      expect(await session.getRedboxSource()).toInclude(
-        'You\'re importing a module that depends on `catchError` into a React Server Component module. This API is only available in Client Components. To fix, mark the file (or its parent) with the `"use client"` directive.'
-      )
+
+      const expectPoisonedImportRedbox = async () => {
+        await session.waitForRedbox()
+        expect(await session.getRedboxSource()).toInclude(
+          'You\'re importing a module that depends on `catchError` into a React Server Component module. This API is only available in Client Components. To fix, mark the file (or its parent) with the `"use client"` directive.'
+        )
+      }
+      await expectPoisonedImportRedbox()
+
+      if (isTurbopack && isProxy) {
+        await session.patch(entryFile, exportCode)
+        await session.waitForNoRedbox()
+        await session.write(entryFile, entryContent)
+        await expectPoisonedImportRedbox()
+      }
     }
   )
 })

--- a/test/development/acceptance-app/rsc-build-errors-poisoned-imports.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors-poisoned-imports.test.ts
@@ -94,13 +94,23 @@ runRscBuildErrorsTests(({ next, isTurbopack }) => {
     )
   })
 
+  // The third element defers the poisoned import until after the page has
+  // hydrated. A broken `proxy.js` is compiled while the dev server is starting
+  // up and forces a full reload, which can clear the overlay before
+  // `waitForRedbox` starts observing it. The other two entries surface the
+  // error reliably from the initial compile, and only surface it reliably that
+  // way, so they keep the poisoned import in the initial files.
   test.each([
-    ['middleware.js', 'export function middleware() {}'],
-    ['proxy.js', 'export function proxy() {}'],
-    ['instrumentation.js', 'export function register() {}'],
+    ['middleware.js', 'export function middleware() {}', false],
+    ['proxy.js', 'export function proxy() {}', true],
+    ['instrumentation.js', 'export function register() {}', false],
   ])(
     'should error when catchError from next/error is imported in %s',
-    async (entryFile, exportCode) => {
+    async (entryFile, exportCode, deferPoisonedImport) => {
+      const entryContent = outdent`
+        import { catchError } from 'next/error'
+        ${exportCode}
+      `
       await using sandbox = await createSandbox(
         next,
         new Map([
@@ -112,17 +122,14 @@ runRscBuildErrorsTests(({ next, isTurbopack }) => {
               }
             `,
           ],
-          [
-            entryFile,
-            outdent`
-              import { catchError } from 'next/error'
-              ${exportCode}
-            `,
-          ],
+          [entryFile, deferPoisonedImport ? exportCode : entryContent],
         ])
       )
 
       const { session } = sandbox
+      if (deferPoisonedImport) {
+        await session.write(entryFile, entryContent)
+      }
       await session.waitForRedbox()
       expect(await session.getRedboxSource()).toInclude(
         'You\'re importing a module that depends on `catchError` into a React Server Component module. This API is only available in Client Components. To fix, mark the file (or its parent) with the `"use client"` directive.'


### PR DESCRIPTION
### What?

Stabilizes the RSC poisoned-import error-overlay test for `proxy.js` without weakening or retrying its redbox assertion.

### Why?

An initially broken proxy can emit the expected build error and then force a startup full reload. That reload can clear the overlay before the test begins observing it, causing an intermittent `Expected Redbox but found no visible one` failure even though validation worked.

### How?

The proxy parameter now starts from a valid module and introduces the poisoned import only after the sandbox page has hydrated. This moves the assertion onto the live HMR path and removes the startup-reload race. Middleware and instrumentation retain their initial-compile setup because their error overlays are reliable there and instrumentation does not reliably surface this edit through Turbopack HMR.

### Verification

- `pnpm test-dev-webpack test/development/acceptance-app/rsc-build-errors-poisoned-imports.test.ts`
- `pnpm test-dev-turbo test/development/acceptance-app/rsc-build-errors-poisoned-imports.test.ts`
- Proxy case repeated 5 times with Webpack and 3 times with Turbopack
- Prettier, ESLint, and `git diff --check`

<!-- NEXT_JS_LLM -->