### PR TITLE
Avoid GitHub API rate limits for create-next-app examples

### DIFF
--- a/packages/create-next-app/helpers/examples.ts
+++ b/packages/create-next-app/helpers/examples.ts
@@ -67,10 +67,13 @@ export function hasRepo({
   branch,
   filePath,
 }: RepoInfo): Promise<boolean> {
-  const contentsUrl = `https://api.github.com/repos/${username}/${name}/contents`
-  const packagePath = `${filePath ? `/${filePath}` : ''}/package.json`
+  // Avoid GitHub's low unauthenticated API rate limit. create-next-app only
+  // needs to verify that the example's package.json can be downloaded.
+  const packagePath = `${filePath ? `${filePath}/` : ''}package.json`
 
-  return isUrlOk(contentsUrl + packagePath + `?ref=${branch}`)
+  return isUrlOk(
+    `https://raw.githubusercontent.com/${username}/${name}/${branch}/${packagePath}`
+  )
 }
 
 export function existsInRepo(nameOrUrl: string): Promise<boolean> {


### PR DESCRIPTION
### What?

Use GitHub's raw content endpoint to validate the `package.json` for create-next-app examples supplied as repository URLs.

### Why?

The previous validation used GitHub's unauthenticated Contents API. Parallel create-next-app tests can exhaust the shared runner IP's low API quota, after which valid examples are reported as missing before download or package-manager installation begins.

This surfaced as `EPERM` because execa labels a child exit code of `1` with Node's matching errno name; the underlying create-next-app output showed the repository lookup failure.

### How?

Probe the example's `package.json` directly on `raw.githubusercontent.com`. This preserves the existing existence check while removing the rate-limited API request from URL-based example creation. The actual archive download continues to use `codeload.github.com` as before.

### Verification

- `IS_WEBPACK_TEST=1 NEXT_TEST_MODE=start pnpm test-start test/production/create-next-app/package-manager/yarn.test.ts`
- `pnpm build-all`
- `pnpm --filter create-next-app build`
- `pnpm types`

<!-- NEXT_JS_LLM -->
