### PR TITLE
fix(dynamic): respect parent Suspense when no loading is provided

### DIFF
--- a/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
@@ -48,8 +48,9 @@ function Loadable(options: LoadableOptions) {
       <Loading isLoading={true} pastDelay={true} error={null} />
     ) : null
 
-    // If it's non-SSR or provided a loading component, wrap it in a suspense boundary
-    const hasSuspenseBoundary = !opts.ssr || !!opts.loading
+    // If provided a loading component, wrap it in a suspense boundary.
+    // Otherwise let a parent suspense boundary handle the fallback.
+    const hasSuspenseBoundary = !!opts.loading
     const Wrap = hasSuspenseBoundary ? Suspense : Fragment
     const wrapProps = hasSuspenseBoundary ? { fallback: fallbackElement } : {}
     const children = opts.ssr ? (

--- a/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/loadable.tsx
@@ -48,9 +48,12 @@ function Loadable(options: LoadableOptions) {
       <Loading isLoading={true} pastDelay={true} error={null} />
     ) : null
 
-    // If provided a loading component, wrap it in a suspense boundary.
-    // Otherwise let a parent suspense boundary handle the fallback.
-    const hasSuspenseBoundary = !!opts.loading
+    // Custom loading always needs a local Suspense boundary.
+    // For `ssr: false` without loading, keep a local boundary only during SSR
+    // so BailoutToCSRError is caught for prerender; on the client skip the empty
+    // boundary so a parent Suspense can own the pending UI (avoids layout flicker).
+    const hasSuspenseBoundary =
+      !!opts.loading || (!opts.ssr && typeof window === 'undefined')
     const Wrap = hasSuspenseBoundary ? Suspense : Fragment
     const wrapProps = hasSuspenseBoundary ? { fallback: fallbackElement } : {}
     const children = opts.ssr ? (

--- a/packages/next/src/shared/lib/loadable.shared-runtime.tsx
+++ b/packages/next/src/shared/lib/loadable.shared-runtime.tsx
@@ -138,13 +138,21 @@ function createLoadableComponent(loadFn: any, options: any) {
 
     return React.useMemo(() => {
       if (state.loading || state.error) {
-        return React.createElement(opts.loading, {
-          isLoading: state.loading,
-          pastDelay: state.pastDelay,
-          timedOut: state.timedOut,
-          error: state.error,
-          retry: subscription.retry,
-        })
+        if (opts.loading) {
+          return React.createElement(opts.loading, {
+            isLoading: state.loading,
+            pastDelay: state.pastDelay,
+            timedOut: state.timedOut,
+            error: state.error,
+            retry: subscription.retry,
+          })
+        }
+
+        if (state.error) {
+          throw state.error
+        }
+
+        return null
       } else if (state.loaded) {
         return React.createElement(resolve(state.loaded), props)
       } else {

--- a/test/unit/next-dynamic.test.tsx
+++ b/test/unit/next-dynamic.test.tsx
@@ -4,6 +4,8 @@
 import { act, render } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import dynamic from 'next/dynamic'
+import { Suspense } from 'react'
+import appDynamic from '../../packages/next/src/shared/lib/app-dynamic'
 
 describe('next/dynamic', () => {
   it('test dynamic with jest', () => {
@@ -13,5 +15,66 @@ describe('next/dynamic', () => {
       const { unmount } = render(<App />)
       unmount()
     })
+  })
+
+  it('uses a parent Suspense fallback when no loading component is provided', () => {
+    const Dynamic = appDynamic(() => new Promise(() => {}))
+
+    const { queryByText, getByText } = render(
+      <Suspense fallback={<p>Parent fallback</p>}>
+        <main>
+          <Dynamic />
+          <footer>Page footer</footer>
+        </main>
+      </Suspense>
+    )
+
+    expect(getByText('Parent fallback')).toBeInTheDocument()
+    expect(queryByText('Page footer')).not.toBeInTheDocument()
+  })
+
+  it('uses a custom loading component when one is provided', () => {
+    const Dynamic = appDynamic(() => new Promise(() => {}), {
+      loading: () => <p>Custom loading</p>,
+    })
+
+    const { queryByText, getByText } = render(
+      <Suspense fallback={<p>Parent fallback</p>}>
+        <main>
+          <Dynamic />
+          <footer>Page footer</footer>
+        </main>
+      </Suspense>
+    )
+
+    expect(getByText('Custom loading')).toBeInTheDocument()
+    expect(getByText('Page footer')).toBeInTheDocument()
+    expect(queryByText('Parent fallback')).not.toBeInTheDocument()
+  })
+
+  it('uses a parent Suspense fallback for ssr:false without custom loading', () => {
+    const Dynamic = appDynamic(() => new Promise(() => {}), { ssr: false })
+
+    const { queryByText, getByText } = render(
+      <Suspense fallback={<p>Parent fallback</p>}>
+        <main>
+          <Dynamic />
+          <footer>Page footer</footer>
+        </main>
+      </Suspense>
+    )
+
+    expect(getByText('Parent fallback')).toBeInTheDocument()
+    expect(queryByText('Page footer')).not.toBeInTheDocument()
+  })
+
+  it('allows pages dynamic to render without a loading component', () => {
+    const App = dynamic(() => new Promise(() => {}), {
+      loading: undefined,
+    })
+
+    const { container } = render(<App />)
+
+    expect(container).toBeEmptyDOMElement()
   })
 })


### PR DESCRIPTION
## Summary
Fixes #73830

Implemented with Midfleet infrastructure.

## Details
- lazy-dynamic/loadable.tsx: only wrap with inner Suspense when loading is provided
- loadable.shared-runtime.tsx: null-guard when loading is absent
- unit coverage for parent fallback, custom loading, and ssr:false without loading

## Test plan
- [ ] pnpm test test/unit/next-dynamic.test.tsx
- [ ] pnpm test test/e2e/next-dynamic/next-dynamic.test.ts