### PR TITLE
[ci] Derive the PR Stats baseline from the PR's base ref

### DIFF
--- a/.github/actions/next-stats-action/README.md
+++ b/.github/actions/next-stats-action/README.md
@@ -23,7 +23,9 @@ const StatsConfig = {
   // the command to build the app (app source should be in `.stats-app`)
   appBuildCommand: string,
   appStartCommand: string | undefined,
-  // the main branch to compare against (what PRs will be merging into)
+  // fallback branch to compare against, used when the run has no base ref of
+  // its own (pushes, releases, local runs). For a pull request the branch it
+  // targets wins, so PRs into a release branch are diffed against that branch.
   mainBranch: 'canary',
   // the main repository path (relative to https://github.com/)
   mainRepo: 'vercel/next.js',

--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -54,9 +54,16 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
     // load stats config from allowed locations
     const { statsConfig, relativeStatsAppDir } = loadStatsConfig()
 
-    if (actionInfo.isLocal && actionInfo.prRef === statsConfig.mainBranch) {
+    // Compare against whatever the PR actually targets, so that PRs into a
+    // release branch are diffed against that branch instead of canary. Only
+    // pull_request events carry a base ref; the fallback covers `LOCAL_STATS`
+    // runs, which have no event payload. Releases ignore this entirely and
+    // pick the last stable tag below.
+    const baselineRef = actionInfo.baseRef ?? statsConfig.mainBranch
+
+    if (actionInfo.isLocal && actionInfo.prRef === baselineRef) {
       throw new Error(
-        `'GITHUB_REF' can not be the same as mainBranch in 'stats-config.js'.\n` +
+        `'GITHUB_REF' can not be the same as the baseline branch "${baselineRef}".\n` +
           `This will result in comparing against the same branch`
       )
     }
@@ -71,7 +78,7 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
     actionInfo.commitId = await getCommitId(diffRepoDir)
 
     if (!actionInfo.skipClone) {
-      let mainRef = statsConfig.mainBranch
+      let mainRef = baselineRef
 
       if (actionInfo.isRelease) {
         logger(`Release detected, using last stable tag: "${actionInfo.prRef}"`)
@@ -91,11 +98,12 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
         }
       }
 
+      logger(`Using "${mainRef}" as the baseline`)
       await cloneRepo(statsConfig.mainRepo, mainRepoDir, mainRef)
 
       if (!actionInfo.isRelease && statsConfig.autoMergeMain) {
         logger('Attempting auto merge of main branch')
-        await mergeBranch(statsConfig.mainBranch, mainRepoDir, diffRepoDir)
+        await mergeBranch(baselineRef, mainRepoDir, diffRepoDir)
       }
     }
     let mainRepoPkgPaths

--- a/.github/actions/next-stats-action/src/prepare/action-info.js
+++ b/.github/actions/next-stats-action/src/prepare/action-info.js
@@ -54,6 +54,7 @@ module.exports = function actionInfo() {
     gitRoot: GIT_ROOT_DIR || 'https://github.com/',
     prRepo: GITHUB_REPOSITORY,
     prRef: GITHUB_REF,
+    baseRef: null,
     isLocal: LOCAL_STATS,
     commitId: null,
     issueId: ISSUE_ID,
@@ -83,6 +84,7 @@ module.exports = function actionInfo() {
       if (prData) {
         info.prRepo = prData.head.repo.full_name
         info.prRef = prData.head.ref
+        info.baseRef = prData.base.ref
         info.issueId = prData.number
 
         if (!info.commentEndpoint) {


### PR DESCRIPTION

`PR Stats` compared every pull request against a hardcoded base branch, which is `canary`. For a pull request into a release branch that is the wrong baseline for two reasons: the diff is against a different major, and the auto merge of the baseline into the pull request branch cannot succeed. This is especially noticeable on old branches where we fail to produce stats outright because the harness simply can't handle latest `canary`.

We now use the base ref from the PR event falling back to the hardcoded value for local runs.

For a canary pull request `base.ref` equals the old hardcoded value, so behaviour on canary is unchanged. However, stacked PRs now (correctly) diff against their parent frame instead of the trunk of the stack.