### PR TITLE
docs: document React browser API

### DIFF
--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -218,6 +218,37 @@ This can be useful for third-party libraries that rely on browser APIs like `win
 
 See the [live demo](https://next-spa-patterns.labs.vercel.dev/browser-only) and its [source code](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/browser-only).
 
+The App Router uses React Canary releases, which include the new [`browser`](https://react.dev/reference/react-dom/browser) API. Call `browser` inside `use` in a Client Component that needs browser APIs:
+
+```tsx filename="app/browser-only-editor.tsx"
+'use client'
+
+import { use } from 'react'
+import { browser } from 'react-dom'
+
+export default function BrowserOnlyEditor() {
+  use(browser('The editor requires browser APIs.'))
+  return <Editor />
+}
+```
+
+Then wrap it in a Suspense boundary:
+
+```tsx filename="app/page.tsx"
+import { Suspense } from 'react'
+import BrowserOnlyEditor from './browser-only-editor'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading editor...</p>}>
+      <BrowserOnlyEditor />
+    </Suspense>
+  )
+}
+```
+
+During prerendering, `use(browser())` suspends to the closest `<Suspense>` boundary. The component then renders normally in the browser.
+
 ### Shallow routing on the client
 
 If you are migrating from a strict SPA like [Create React App](/docs/app/guides/migrating/from-create-react-app) or [Vite](/docs/app/guides/migrating/from-vite), you might have existing code which shallow routes to update the URL state. This can be useful for manual transitions between views in your application _without_ using the default Next.js file-system routing.

--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -216,11 +216,9 @@ const ClientOnlyComponent = dynamic(() => import('./component'), {
 
 This can be useful for third-party libraries that rely on browser APIs like `window` or `document`. You can also add a `useEffect` that checks for the existence of these APIs, and if they do not exist, return `null` or a loading state which would be prerendered.
 
-See the [live demo](https://next-spa-patterns.labs.vercel.dev/browser-only) and its [source code](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/browser-only).
-
 The App Router uses React Canary releases, which include the new [`browser`](https://react.dev/reference/react-dom/browser) API. Call `browser` inside `use` in a Client Component that needs browser APIs:
 
-```tsx filename="app/browser-only-editor.tsx"
+```jsx filename="app/browser-only-editor.jsx"
 'use client'
 
 import { use } from 'react'
@@ -234,7 +232,7 @@ export default function BrowserOnlyEditor() {
 
 Then wrap it in a Suspense boundary:
 
-```tsx filename="app/page.tsx"
+```jsx filename="app/page.jsx"
 import { Suspense } from 'react'
 import BrowserOnlyEditor from './browser-only-editor'
 
@@ -248,6 +246,8 @@ export default function Page() {
 ```
 
 During prerendering, `use(browser())` suspends to the closest `<Suspense>` boundary. The component then renders normally in the browser.
+
+See both approaches in the [live demo](https://next-spa-patterns.labs.vercel.dev/browser-only) and its [source code](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/browser-only).
 
 ### Shallow routing on the client
 

--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -216,7 +216,7 @@ const ClientOnlyComponent = dynamic(() => import('./component'), {
 
 This can be useful for third-party libraries that rely on browser APIs like `window` or `document`. You can also add a `useEffect` that checks for the existence of these APIs, and if they do not exist, return `null` or a loading state which would be prerendered.
 
-The App Router uses React Canary releases, which include the new [`browser`](https://react.dev/reference/react-dom/browser) API. Call `browser` inside `use` in a Client Component that needs browser APIs:
+React 19.3 includes the [`browser`](https://react.dev/reference/react-dom/browser) API. Call `browser` inside `use` in a Client Component that needs browser APIs:
 
 ```jsx filename="app/browser-only-editor.jsx"
 'use client'

--- a/docs/01-app/02-guides/single-page-applications.mdx
+++ b/docs/01-app/02-guides/single-page-applications.mdx
@@ -216,17 +216,30 @@ const ClientOnlyComponent = dynamic(() => import('./component'), {
 
 This can be useful for third-party libraries that rely on browser APIs like `window` or `document`. You can also add a `useEffect` that checks for the existence of these APIs, and if they do not exist, return `null` or a loading state which would be prerendered.
 
-React 19.3 includes the [`browser`](https://react.dev/reference/react-dom/browser) API. Call `browser` inside `use` in a Client Component that needs browser APIs:
+React 19.3 includes the [`browser`](https://react.dev/reference/react-dom/browser) API. Use `use(browser())` only when a Client Component's first browser render cannot match server-rendered HTML.
+
+During prerendering, `use(browser())` suspends to the closest `<Suspense>` boundary. The fallback becomes the component's initial HTML, so crawlers that don't execute JavaScript see the fallback instead of the component. Keep content that should be indexed outside the browser-only boundary.
+
+For example, this editor reads a saved draft from `localStorage`:
 
 ```jsx filename="app/browser-only-editor.jsx"
 'use client'
 
-import { use } from 'react'
+import { use, useState } from 'react'
 import { browser } from 'react-dom'
 
 export default function BrowserOnlyEditor() {
-  use(browser('The editor requires browser APIs.'))
-  return <Editor />
+  use(browser('The saved draft is stored in localStorage.'))
+
+  const [draft, setDraft] = useState(() => localStorage.getItem('draft') ?? '')
+
+  function handleChange(event) {
+    const nextDraft = event.target.value
+    setDraft(nextDraft)
+    localStorage.setItem('draft', nextDraft)
+  }
+
+  return <textarea value={draft} onChange={handleChange} />
 }
 ```
 
@@ -238,16 +251,16 @@ import BrowserOnlyEditor from './browser-only-editor'
 
 export default function Page() {
   return (
-    <Suspense fallback={<p>Loading editor...</p>}>
+    <Suspense fallback={<p>Loading editor…</p>}>
       <BrowserOnlyEditor />
     </Suspense>
   )
 }
 ```
 
-During prerendering, `use(browser())` suspends to the closest `<Suspense>` boundary. The component then renders normally in the browser.
+In the browser, `browser()` returns `undefined`, and the editor renders with the saved draft.
 
-See both approaches in the [live demo](https://next-spa-patterns.labs.vercel.dev/browser-only) and its [source code](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/browser-only).
+See both approaches in the [live demo](https://next-spa-patterns.labs.vercel.dev/browser-only). The [demo source](https://github.com/vercel-labs/next-spa-patterns/tree/main/app/browser-only) contains the complete examples.
 
 ### Shallow routing on the client
 

--- a/docs/01-app/02-guides/view-transitions.mdx
+++ b/docs/01-app/02-guides/view-transitions.mdx
@@ -47,7 +47,7 @@ You can find the resources used in this example here:
 - [Demo](https://react-view-transitions-demo.labs.vercel.dev)
 - [Code](https://github.com/vercel-labs/react-view-transitions-demo)
 
-View transitions work in the App Router with no configuration. The App Router uses [React canary releases](https://react.dev/blog/2023/05/03/react-canaries), which contain all stable React 19 changes as well as newer features like `ViewTransition`. You do not need to install `react@canary` yourself.
+View transitions work in the App Router with no configuration. React 19.3 includes the `<ViewTransition>` component and `addTransitionType` API used in this guide.
 
 > [!NOTE]
 > React's integration uses newer View Transitions API features (transition types and `view-transition-class`), available in Chromium 125+ and recent Safari and Firefox versions. Some animations may behave differently in Safari. Without browser support, your application works normally; the transitions do not animate.


### PR DESCRIPTION
### What?

- Documents React Canary's new `browser` API in the SPA guide
- Adds examples for marking a Client Component as browser-only and wrapping it in Suspense

### Why?

The App Router includes React Canary releases, and the `browser` API now provides a Suspense-based option for components that depend on browser APIs such as `window` or `document`.

### How?

The guide calls `browser()` inside `use()` in a Client Component. It then wraps that component in Suspense so prerendering can show the closest fallback before the component renders in the browser.

### Testing

- `prettier --check docs/01-app/02-guides/single-page-applications.mdx`
- `alex docs/01-app/02-guides/single-page-applications.mdx --quiet` (only existing SPA dictionary warnings)
