### PR TITLE
[backport] [PPF] Do not mark complete shell requests as partial

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -3165,6 +3165,13 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     // staleAt that corresponds to whatever payload the spawned entries get
     // filled with below.
     let staleAtForSpawnedEntries = staleAt
+    // Whether the payload that fulfills the spawned entries is an App Shell
+    // extracted from a larger response. Such a payload is a strict subset of
+    // the response, so it does not represent the entire UI of the target page
+    // — it's partial by construction, regardless of the server's marker. When
+    // the spawned entries are instead filled with the full response, its
+    // partialness comes from the marker (see `isResponsePartial` below).
+    let spawnedEntriesGetExtractedShell = false
     if (cacheData === null) {
       // No shell can be extracted without cache metadata (only present when
       // Cached Navigations is enabled). For routes without a distinct App Shell
@@ -3209,6 +3216,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
           // with the shell.
           serverDataThatSatisfiesSpawnedEntries = shellStageData
           staleAtForSpawnedEntries = shellStaleAt
+          spawnedEntriesGetExtractedShell = true
 
           // Separately, we'll also cache the entire response, by upserting it
           // into the cache.
@@ -3268,13 +3276,13 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     )
 
     // PPRRuntime and RuntimeShell prefetches are partial when the server
-    // marks the response as '~' (Partial). RuntimeShell additionally omits
-    // every dynamic suspense boundary below the App Shell, so its segments
-    // are always partial regardless of what the server marker says.
-    // Full/LoadingBoundary prefetches are always complete.
+    // marks the response as '~' (Partial). Full/LoadingBoundary prefetches
+    // are always complete. An App Shell extracted from a larger response is
+    // partial by construction; see `spawnedEntriesGetExtractedShell`.
     const isResponsePartial =
-      fetchStrategy === FetchStrategy.RuntimeShell ||
-      (fetchStrategy === FetchStrategy.PPRRuntime &&
+      spawnedEntriesGetExtractedShell ||
+      ((fetchStrategy === FetchStrategy.PPRRuntime ||
+        fetchStrategy === FetchStrategy.RuntimeShell) &&
         (cacheData?.isResponsePartial ?? false))
 
     const flightDatas = normalizeFlightData(

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/page.tsx
@@ -127,6 +127,15 @@ export default function Page() {
           </LinkAccordion>
         </li>
       </ul>
+
+      <h2>Complete shell</h2>
+      <ul>
+        <li>
+          <LinkAccordion href="/runtime-shell-complete">
+            Complete runtime shell
+          </LinkAccordion>
+        </li>
+      </ul>
     </main>
   )
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/runtime-shell-complete/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/app/(default)/runtime-shell-complete/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+export const prefetch = 'partial'
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<p id="cookie-loading">Loading cookie...</p>}>
+        <CookieDependent />
+      </Suspense>
+    </main>
+  )
+}
+
+async function CookieDependent() {
+  const cookieStore = await cookies()
+  const value = cookieStore.get('testCookie')?.value ?? 'none'
+  return <p id="cookie-value">{`Cookie: ${value}`}</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell/prefetch-app-shell.test.ts
@@ -70,6 +70,33 @@ describe('App Shell prefetching', () => {
     )
   })
 
+  it('can navigate without extra requests if a runtime app shell is complete', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal the link and fetch the shell. The route uses cookies, so this will be
+    // a runtime shell.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/runtime-shell-complete"]')
+        .click()
+    }, [{ includes: 'Cookie: none', kind: 'runtime' }])
+
+    // Navigate. The shell is complete, so this shouldn't require fetching anything else.
+    await act(async () => {
+      await browser.elementByCss('a[href="/runtime-shell-complete"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementById('cookie-value').text()).toEqual(
+      'Cookie: none'
+    )
+  })
+
   it('runtime-prefetches per-link content of a dynamic route whose static-attempt hint is unset', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
@@ -61,12 +61,12 @@ export default function Page() {
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/test-independent-head/a">
+          <LinkAccordion href="/test-independent-head/a" prefetch={true}>
             Independent head A
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/test-independent-head/b">
+          <LinkAccordion href="/test-independent-head/b" prefetch={true}>
             Independent head B
           </LinkAccordion>
         </li>

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
@@ -555,13 +555,13 @@ describe('prefetch inlining', () => {
         page = p
       },
     })
-    const act = createRouterAct(page!)
+    const act = createRouterAct(page!, { includeAppShellRequests: true })
 
     // Reveal a default (auto) link to the route. The route is a Partial
     // Prefetching route (the page is partial), so every segment the
     // prefetch walks is held to the runtime-completeness contract — and the
     // route's static-attempt hint is unset because the page reads cookies,
-    // so the walked layout deopts directly to the batched runtime prefetch,
+    // so the walked layout deopts directly to the batched runtime shell,
     // which serves its whole subtree. The inlined layout content arrives in
     // that runtime response. (No static bundle request fires: the Shell
     // phase already runtime-cached every entry in the bundle chain, and a
@@ -578,9 +578,8 @@ describe('prefetch inlining', () => {
       { includes: 'Static layout content', kind: 'runtime' }
     )
 
-    // Reveal a prefetch={true} link to the same route. Everything is
-    // already runtime-cached at the per-link tier by the prefetch above, so
-    // opting in has nothing left to fetch.
+    // Reveal a prefetch={true} link to the same route. The shell is complete,
+    // so a runtime prefetch will not give us any more data and should be skipped.
     await act(async () => {
       await browser
         .elementByCss(
@@ -628,7 +627,7 @@ describe('prefetch inlining', () => {
         page = p
       },
     })
-    const act = createRouterAct(page!)
+    const act = createRouterAct(page!, { includeAppShellRequests: true })
 
     await act(
       async () => {
@@ -729,7 +728,7 @@ describe('prefetch inlining', () => {
         page = p
       },
     })
-    const act = createRouterAct(page!)
+    const act = createRouterAct(page!, { includeAppShellRequests: true })
 
     await act(
       async () => {

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts
@@ -510,18 +510,20 @@ describe('runtime prefetching', () => {
       // Clear cookies after the test. This currently doesn't happen automatically.
       await using _ = defer(() => browser.deleteCookies())
 
-      const act = createRouterAct(page)
+      const act = createRouterAct(page, { includeAppShellRequests: true })
 
       await browser.addCookie({ name: 'testCookie', value: 'initialValue' })
 
-      // Reveal the link to trigger a runtime prefetch for the initial cookie value
+      // Reveal the link.
+      // We won't actually perform a runtime prefetch, because the request is
+      // satisfied by the app shell.
       await act(async () => {
         const linkToggle = await browser.elementByCss(
           `input[data-link-accordion="/${prefix}/cookies-only"]`
         )
         await linkToggle.click()
       }, [
-        // Should allow reading cookies
+        // Should allow reading cookies in the app shell
         {
           includes: 'Cookie: initialValue',
         },
@@ -561,11 +563,14 @@ describe('runtime prefetching', () => {
         // Clear cookies after the test. This currently doesn't happen automatically.
         await using _ = defer(() => browser.deleteCookies())
 
-        const act = createRouterAct(page)
+        const act = createRouterAct(page, { includeAppShellRequests: true })
 
         await browser.addCookie({ name: 'testCookie', value: 'initialValue' })
 
-        // Reveal the link to trigger a runtime prefetch for the initial cookie value
+        // Reveal the link.
+        // We won't actually perform a runtime prefetch, because the request is
+        // satisfied by the app shell.
+
         await act(async () => {
           const linkToggle = await browser.elementByCss(
             `input[data-link-accordion="/${prefix}/cookies-only"]`
@@ -1056,11 +1061,13 @@ describe('runtime prefetching', () => {
           page = p
         },
       })
-      const act = createRouterAct(page)
+      const act = createRouterAct(page, { includeAppShellRequests: true })
 
       const STATIC_CONTENT = 'This page errors after a cookies call'
 
-      // Reveal the link to trigger a runtime prefetch
+      // Reveal the link.
+      // We won't actually perform a runtime prefetch, because the request is
+      // satisfied by the app shell.
       await act(async () => {
         const linkToggle = await browser.elementByCss(
           `input[data-link-accordion="/errors/error-after-cookies"]`
@@ -1077,7 +1084,7 @@ describe('runtime prefetching', () => {
         expect(getCliOutput()).toContain('Error: Kaboom')
       }
 
-      // Navigate to the page. We already have the paged cached.
+      // Navigate to the page. We already have the page cached.
       // Even though the render errored, we shouldn't fetch it again.
       await act(async () => {
         await browser

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/speculative-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/app/speculative-cookies/page.tsx
@@ -7,20 +7,16 @@ import { cookies } from 'next/headers'
 // Prefetching segment, the page requires runtime-completeness during the
 // Speculative phase (which the consuming test enters via a `prefetch={true}`
 // link), and with the hint unset the scheduler skips the static attempt
-// entirely and issues the runtime prefetch directly. Unlike the uses-cookies
-// fixture, the Speculative runtime prefetch RESOLVES the cookies() read, so
-// the cookie-derived content itself arrives in the runtime response.
+// entirely and issues the runtime prefetch directly.
+// It also awaits searchParams so that a speculative prefetch has non-shell
+// contents to resolve.
 export const prefetch = 'partial'
 
-async function CookieContent() {
-  const cookieStore = await cookies()
-  const value = cookieStore.get('testCookie')?.value ?? 'none'
-  return (
-    <div id="speculative-cookie-content">{`Speculative-cookies cookie: ${value}`}</div>
-  )
+type PageProps = {
+  searchParams: Promise<SearchParams>
 }
 
-export default function Page() {
+export default function Page(props: PageProps) {
   return (
     <main>
       <p id="page-content">Speculative-cookies page shell text</p>
@@ -29,8 +25,34 @@ export default function Page() {
           <p id="speculative-cookie-loading">Loading speculative cookie...</p>
         }
       >
-        <CookieContent />
+        <CookieContent {...props} />
       </Suspense>
     </main>
+  )
+}
+
+async function CookieContent(props: PageProps) {
+  const cookieStore = await cookies()
+  const value = cookieStore.get('testCookie')?.value ?? 'none'
+  return (
+    <>
+      <div id="speculative-cookie-content">{`Speculative-cookies cookie: ${value}`}</div>
+      <Suspense
+        fallback={
+          <p id="speculative-search-params-loading">Loading search params...</p>
+        }
+      >
+        <SearchParamsContent {...props} />
+      </Suspense>
+    </>
+  )
+}
+
+type SearchParams = Record<string, string | string[]>
+
+async function SearchParamsContent(props: PageProps) {
+  const searchCount = Object.keys(await props.searchParams).length
+  return (
+    <div id="search-params-content">{`Search params count: ${searchCount}`}</div>
   )
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-static-shell/prefetch-static-shell.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-static-shell/prefetch-static-shell.test.ts
@@ -123,11 +123,8 @@ describe('static App Shell prefetch attempt', () => {
         .elementByCss('input[data-link-accordion="/uses-cookies"]')
         .click()
     }, [
-      // The page (the new part) arrives in the runtime shell response.
-      // (The bare cookies() read itself isn't resolved by the runtime
-      // prerender — it stays a hole for the navigation-time dynamic
-      // request — so we only assert on the shell text.)
-      { includes: 'Cookies page shell text', kind: 'runtime' },
+      // Cookies are included in the runtime shell.
+      { includes: 'cookie-content', kind: 'runtime' },
       // No static attempt for the new part: the page content must not
       // arrive in a static per-segment response. (The route tree prefetch
       // is also `kind: 'static'`, but its response doesn't contain rendered
@@ -382,29 +379,15 @@ describe('static App Shell prefetch attempt', () => {
         .elementByCss('input[data-link-accordion="/speculative-cookies"]')
         .click()
     }, [
-      // Two runtime responses arrive, in order, and each resolves the
-      // cookies() read (a runtime prefetch renders with the request's
-      // cookies):
-      //
-      // 1. The Shell phase's runtime shell request — the same direct
-      //    runtime shell behavior the hint-unset tests above exercise,
-      //    except that here the session content resolves instead of
-      //    remaining a hole.
-      { includes: 'Speculative-cookies page shell text', kind: 'runtime' },
+      // 1. Runtime shell (includes cookies)
       { includes: 'Speculative-cookies cookie: none', kind: 'runtime' },
-      // 2. The Speculative phase's runtime prefetch of the page segment,
-      //    which re-delivers the page content. (It fires on top of the
-      //    runtime shell entry because a per-URL runtime prefetch can
-      //    provide content a URL-independent shell response cannot.)
-      { includes: 'Speculative-cookies page shell text', kind: 'runtime' },
-      { includes: 'Speculative-cookies cookie: none', kind: 'runtime' },
+      // 2. Runtime prefetch (includes cookies and search params)
+      { includes: 'Search params count: 0', kind: 'runtime' },
+
       // No static attempt in either phase: the page content must not
       // arrive in ANY static per-segment response. (The server does emit
       // static data for the segment — the shell text is in it — but with
-      // the hint unset nothing fetches it: this blanket rejection
-      // was verified empirically against the full request log. The route
-      // tree prefetch is also kind: 'static', but its response doesn't
-      // contain rendered page content, so it can't match this.)
+      // the hint unset nothing fetches it.
       {
         includes: 'Speculative-cookies page shell text',
         kind: 'static',


### PR DESCRIPTION
Backports #97503 ("[PPF] Do not mark complete shell requests as partial") to `next-16-3`.

## Adaptation

The cherry-pick did not apply mechanically. `next-16-3` predates the refactor stack that landed on canary between #96406 and #96878, so none of the functions the original patch touches (`writeResponsePayloadsIntoCache`, `isFullResponsePartial`, `shellWasRequested`) exist on this branch. The behavior change is hand-ported instead; the test changes applied as-is.

On canary the shell-tier and full-payload writes are separate calls, so the fix was simply to stop overriding `isFullResponsePartial` at two write sites. On `next-16-3` both writes funnel through a single `isResponsePartial` in `fetchSegmentPrefetchesUsingDynamicRequest`, which unconditionally forces `true` for any `RuntimeShell` request. Copying the canary expression directly would also have un-marked the one case where forcing partial is correct: when the payload fulfilling the spawned entries is an App Shell extracted from a larger response, it is a strict subset and partial by construction regardless of the server marker.

So this adds a `spawnedEntriesGetExtractedShell` flag alongside the existing `staleAtForSpawnedEntries`, set only in that branch, reproducing canary's post-PR behavior exactly:

| case | full payload | shell payload |
| --- | --- | --- |
| no shell extractable | server marker | — |
| shell is the whole response | server marker | — |
| shell is a strict prefix | server marker | hardcoded `true` |

## Verification

- `pnpm test-start-turbo test/e2e/app-dir/segment-cache/` — 40 suites passed, 3 skipped, 202 tests passed, 16 snapshots. Run across the whole directory rather than just the four suites the patch touches, since the hand-port changes cache keying and could regress unrelated prefetch paths.
- Not run: `pnpm build-all` (`@next/swc#build-native-auto` fails locally — the installed `napi` CLI rejects the `--cargo-cwd` flag this branch passes. Unrelated to this change; the change is client-side TypeScript only and was verified against a JS-only `pnpm --filter=next build`.)

<!-- NEXT_JS_LLM -->