### PR TITLE
[react-sync] Check assignability before assigning the actor

### DIFF
--- a/scripts/sync-react.js
+++ b/scripts/sync-react.js
@@ -301,6 +301,43 @@ async function findHighestNPMReactVersion(versionLike) {
       })[0]
 }
 
+/**
+ * Assigns `actor` to the given Pull Request if they can be assigned.
+ * On scheduled runs `github.actor` often resolves to a bot like
+ * `github-actions[bot]`, which cannot be assigned. User tokens silently
+ * ignore non-assignable assignees but GitHub App tokens fail the whole
+ * request with 403, so check assignability first and skip instead.
+ * @param {InstanceType<typeof Octokit>} octokit
+ * @param {string | undefined} actor
+ * @param {number} pullRequestNumber
+ */
+async function assignActorIfAssignable(octokit, actor, pullRequestNumber) {
+  if (actor === undefined) {
+    return null
+  }
+  try {
+    await octokit.rest.issues.checkUserCanBeAssigned({
+      owner: repoOwner,
+      repo: repoName,
+      assignee: actor,
+    })
+  } catch (error) {
+    if (error instanceof Error && 'status' in error && error.status === 404) {
+      console.warn(
+        `'${actor}' cannot be assigned in ${repoOwner}/${repoName}. Skipping assignment.`
+      )
+      return null
+    }
+    throw error
+  }
+  return octokit.rest.issues.addAssignees({
+    owner: repoOwner,
+    repo: repoName,
+    issue_number: pullRequestNumber,
+    assignees: [actor],
+  })
+}
+
 async function main() {
   const cwd = process.cwd()
   const errors = []
@@ -733,15 +770,8 @@ Or run this command again without the --no-install flag to do both automatically
       { pullRequestId: pullRequest.data.node_id }
     )
 
-    await Promise.all([
-      actor
-        ? octokit.rest.issues.addAssignees({
-            owner: repoOwner,
-            repo: repoName,
-            issue_number: pullRequest.data.number,
-            assignees: [actor],
-          })
-        : Promise.resolve(),
+    const finalizeResults = await Promise.allSettled([
+      assignActorIfAssignable(octokit, actor, pullRequest.data.number),
       octokit.rest.pulls.requestReviewers({
         owner: repoOwner,
         repo: repoName,
@@ -755,6 +785,16 @@ Or run this command again without the --no-install flag to do both automatically
         labels: pullRequestLabels,
       }),
     ])
+    const failures = finalizeResults.filter(
+      (result) => result.status === 'rejected'
+    )
+    if (failures.length > 0) {
+      // eslint-disable-next-line no-undef -- Defined in Node.js
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        `${failures.length} of ${finalizeResults.length} requests to finalize the Pull Request failed.`
+      )
+    }
   }
 
   console.log(prDescription)


### PR DESCRIPTION

On scheduled runs of the Update React workflow, `github.actor` often resolves to `github-actions[bot]`, which cannot be assigned to pull requests in `vercel/next.js`. Since the sync switched to the GitHub App token, adding a non-assignable assignee fails the request with 403 e.g. https://github.com/vercel/next.js/actions/runs/32392135342/job/96500520936#step:8:781 (user tokens silently ignored it instead), which failed the entire sync run and raced the in-flight reviewer request, leaving the created pull request without a reviewer. 

The script now checks assignability and skips assignment with a warning when the actor cannot be assigned, and the finalize requests (assign, request reviewers, add labels) run through `Promise.allSettled`, with any failures rethrown together as an `AggregateError` so the run still fails on real errors.
