### PR TITLE
Add a Turbopack error for missing root layouts

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -899,6 +899,43 @@ impl Issue for DuplicateParallelRouteIssue {
 }
 
 #[turbo_tasks::value]
+struct MissingRootLayoutIssue {
+    app_dir: FileSystemPath,
+    page_path: FileSystemPath,
+}
+
+#[async_trait]
+#[turbo_tasks::value_impl]
+impl Issue for MissingRootLayoutIssue {
+    async fn file_path(&self) -> Result<FileSystemPath> {
+        Ok(self.page_path.clone())
+    }
+
+    fn stage(&self) -> IssueStage {
+        IssueStage::AppStructure
+    }
+
+    fn severity(&self) -> IssueSeverity {
+        IssueSeverity::Error
+    }
+
+    async fn title(&self) -> Result<StyledString> {
+        let page_path = self
+            .app_dir
+            .get_path_to(&self.page_path)
+            .context("page should be within the app directory")?;
+
+        Ok(StyledString::Text(
+            format!(
+                "{page_path} doesn't have a root layout. To fix this error, make sure every page \
+                 has a root layout."
+            )
+            .into(),
+        ))
+    }
+}
+
+#[turbo_tasks::value]
 struct MissingDefaultParallelRouteIssue {
     app_dir: FileSystemPath,
     app_page: AppPage,
@@ -1591,7 +1628,16 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         root_params
     };
 
-    if modules.page.is_some() {
+    if let Some(page_path) = &modules.page {
+        if root_layouts.await?.is_empty() {
+            MissingRootLayoutIssue {
+                app_dir: app_dir.clone(),
+                page_path: page_path.clone(),
+            }
+            .resolved_cell()
+            .emit();
+        }
+
         let app_path = AppPath::from(app_page.clone());
 
         let loader_tree = *directory_tree_to_loader_tree(

--- a/test/e2e/app-dir/app-edge/app-edge-invalid-reexport.test.ts
+++ b/test/e2e/app-dir/app-edge/app-edge-invalid-reexport.test.ts
@@ -4,6 +4,7 @@ import path from 'path'
 describe('app-dir edge SSR invalid reexport', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: {
+      'app/layout.tsx': new FileRef(path.join(__dirname, 'app', 'layout.tsx')),
       'app/export': new FileRef(path.join(__dirname, 'app', 'export')),
       'app/export/inherit/page.tsx':
         "export { default, runtime, preferredRegion } from '../basic/page'",

--- a/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { check, retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 // Skip on Turbopack because the user should create the layout manually
@@ -222,5 +222,42 @@ import stripAnsi from 'strip-ansi'
         })
       })
     }
+  }
+)
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'app-dir missing root layout',
+  () => {
+    const { next, isNextDev, skipped } = nextTestSetup({
+      files: {
+        app: new FileRef(path.join(__dirname, 'app')),
+        'next.config.js': new FileRef(path.join(__dirname, 'next.config.js')),
+      },
+      skipDeployment: true,
+      skipStart: true,
+    })
+
+    if (skipped) return
+
+    it('reports a compiler error without modifying the app', async () => {
+      if (isNextDev) {
+        await next.start()
+
+        const response = await next.fetch('/route')
+        expect(response.status).toBe(500)
+
+        await retry(async () => {
+          expect(stripAnsi(next.cliOutput)).toContain(
+            "route/page.js doesn't have a root layout. To fix this error, make sure every page has a root layout."
+          )
+        })
+      } else {
+        await expect(next.start()).rejects.toThrow('next build failed')
+        expect(stripAnsi(next.cliOutput)).toContain(
+          "route/page.js doesn't have a root layout. To fix this error, make sure every page has a root layout."
+        )
+      }
+
+      expect(await next.hasFile('app/layout.js')).toBe(false)
+    })
   }
 )

--- a/test/e2e/config-turbopack/index.test.ts
+++ b/test/e2e/config-turbopack/index.test.ts
@@ -6,6 +6,11 @@ const WARNING_MESSAGE = `ERROR: This build is using Turbopack, with a \`webpack\
 const itif = (condition: boolean) => (condition ? it : it.skip)
 
 const page = {
+  'app/layout.js': `
+export default function RootLayout({ children }) {
+  return <html><body>{children}</body></html>
+}
+`,
   'app/page.js': `
 export default function Page() {
   return <p>hello world</p>


### PR DESCRIPTION
## Summary

Turbopack currently builds an App Router page without a root layout, leaving the problem to surface later at runtime. Report it while building the app structure instead:

`route/page.js doesn't have a root layout. To fix this error, make sure every page has a root layout.`

The check uses the layouts already inherited during directory-tree traversal, so route groups and apps with multiple root layouts keep working. Route handlers are unaffected.

Webpack behavior is intentionally unchanged in this PR.

## Verification

- `HEADLESS=true pnpm test-dev-turbo test/e2e/app-dir/create-root-layout/create-root-layout.test.ts`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir/create-root-layout/create-root-layout.test.ts`
- `HEADLESS=true pnpm test-dev-webpack test/e2e/app-dir/create-root-layout/create-root-layout.test.ts`
- `HEADLESS=true pnpm test-start-webpack test/e2e/app-dir/create-root-layout/create-root-layout.test.ts`
- `HEADLESS=true pnpm test-dev-turbo test/e2e/app-dir/root-layout/root-layout.test.ts`
