### PR TITLE
docs: document deploymentId build ID override and Pages Router skew in 16.2

### DIFF
--- a/docs/01-app/02-guides/self-hosting.mdx
+++ b/docs/01-app/02-guides/self-hosting.mdx
@@ -182,6 +182,8 @@ module.exports = {
 }
 ```
 
+> **Good to know:** When [`deploymentId`](/docs/app/api-reference/config/next-config-js/deploymentId) is set, Next.js uses a constant build ID and `generateBuildId` has no effect. [Version skew](#version-skew) is detected from the deployment ID instead.
+
 ## Multi-Server Deployments
 
 When running Next.js across multiple server instances (for example, containers behind a load balancer), there are additional considerations to ensure consistent behavior.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/deploymentId.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/deploymentId.mdx
@@ -68,12 +68,15 @@ module.exports = {
 }
 ```
 
+A per-deployment value only avoids skew if requests are also routed by deployment. Next.js does not route on `?dpl=`, so that routing comes from your host or CDN. Without it, clients that reach an instance from another deployment during a rollout will reload rather than navigate.
+
 ## Version History
 
-| Version    | Changes                                               |
-| ---------- | ----------------------------------------------------- |
-| `v14.1.4`  | `deploymentId` stabilized as top-level config option. |
-| `v13.4.10` | `experimental.deploymentId` introduced.               |
+| Version    | Changes                                                                                                                                       |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `v16.2.0`  | Pages Router detects version skew from the response header rather than the build ID, and the build ID is constant when `deploymentId` is set. |
+| `v14.1.4`  | `deploymentId` stabilized as top-level config option.                                                                                         |
+| `v13.4.10` | `experimental.deploymentId` introduced.                                                                                                       |
 
 ## Related
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/generateBuildId.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/generateBuildId.mdx
@@ -17,3 +17,5 @@ module.exports = {
   },
 }
 ```
+
+> **Good to know:** When [`deploymentId`](/docs/app/api-reference/config/next-config-js/deploymentId) is set, Next.js uses a constant build ID and `generateBuildId` has no effect. [Version skew](/docs/app/guides/self-hosting#version-skew) is detected from the deployment ID instead.


### PR DESCRIPTION
- Addressing: https://github.com/vercel/next.js/issues/97632