### PR TITLE
Turbopack: Show last modified file when waiting for the filesystem to settle

### DIFF
--- a/test/development/fs-settling-event/fs-settling-event.test.ts
+++ b/test/development/fs-settling-event/fs-settling-event.test.ts
@@ -33,6 +33,7 @@ import path from 'path'
           () => {
             const output = stripAnsi(next.cliOutput.slice(outputIndex))
             expect(output).toContain('waiting for the filesystem to settle')
+            expect(output).toContain(pkgFile)
           },
           // The event fires after ~5s; allow a generous window to avoid flakes.
           15000,

--- a/turbopack/crates/turbo-tasks-fs/src/watcher/batch_schedule.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher/batch_schedule.rs
@@ -1,5 +1,4 @@
 use std::{
-    path::PathBuf,
     sync::{
         Arc,
         mpsc::{Receiver, RecvTimeoutError},
@@ -11,7 +10,10 @@ use serde::Serialize;
 use turbo_rcstr::RcStr;
 use turbo_tasks::message_queue::{CompilationEvent, Severity};
 
-use crate::{DiskWatcherConfig, watcher::fs_api::DiskFileSystemWatcherApi};
+use crate::{
+    DiskWatcherConfig,
+    watcher::{BatchedInvalidations, fs_api::DiskFileSystemWatcherApi},
+};
 
 /// Decides how long a batch of watcher events stays open, and emits a repeated
 /// [`FilesystemSettlingEvent`] for as long as it does.
@@ -26,8 +28,6 @@ struct PendingBatch {
     started: Instant,
     /// The batch is flushed once this passes without any further events.
     deadline: Instant,
-    /// The most recently changed path in the batch, for diagnostics.
-    last_modified_path: Option<PathBuf>,
     /// When to emit the next [`FilesystemSettlingEvent`].
     settling_event_next_at: Instant,
     /// Grows exponentially (up to [`BatchSchedule::settling_event_max_delay`]) so that a writer
@@ -45,19 +45,17 @@ impl BatchSchedule {
     }
 
     /// Keeps the batch open for at least `delay` from now, opening a new batch if there isn't one.
-    pub fn extend(&mut self, delay: Duration, last_modified_path: Option<PathBuf>) {
+    pub fn extend(&mut self, delay: Duration) {
         let now = Instant::now();
         let deadline = now.checked_add(delay).unwrap_or_else(far_future);
         match &mut self.pending {
             Some(pending) => {
                 pending.deadline = pending.deadline.max(deadline);
-                pending.last_modified_path = last_modified_path;
             }
             None => {
                 self.pending = Some(PendingBatch {
                     started: now,
                     deadline,
-                    last_modified_path,
                     settling_event_next_at: now
                         .checked_add(self.settling_event_initial_delay)
                         .unwrap_or_else(far_future),
@@ -76,6 +74,7 @@ impl BatchSchedule {
         &mut self,
         rx: &Receiver<notify::Result<notify::Event>>,
         fs: &FsApi,
+        batch: &BatchedInvalidations,
     ) -> Result<notify::Result<notify::Event>, RecvTimeoutError> {
         let max_event_delay = self.settling_event_max_delay;
         loop {
@@ -86,7 +85,7 @@ impl BatchSchedule {
 
             let now = Instant::now();
             if now >= pending.settling_event_next_at {
-                pending.emit_settling_event(fs, now, max_event_delay);
+                pending.emit_settling_event(fs, batch, now, max_event_delay);
             }
 
             let timeout = pending
@@ -120,6 +119,7 @@ impl PendingBatch {
     fn emit_settling_event<FsApi: DiskFileSystemWatcherApi>(
         &mut self,
         fs: &FsApi,
+        batch: &BatchedInvalidations,
         now: Instant,
         max_event_delay: Duration,
     ) {
@@ -127,9 +127,8 @@ impl PendingBatch {
         if let Some(turbo_tasks) = fs.turbo_tasks() {
             turbo_tasks.send_compilation_event(Arc::new(FilesystemSettlingEvent {
                 elapsed_secs: (now - self.started).as_secs_f64(),
-                last_modified_path: self
-                    .last_modified_path
-                    .as_ref()
+                last_modified_path: batch
+                    .last_updated_path()
                     .map(|path| RcStr::from(format!("{path:?}"))),
             }));
         }

--- a/turbopack/crates/turbo-tasks-fs/src/watcher/batch_schedule.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher/batch_schedule.rs
@@ -1,4 +1,5 @@
 use std::{
+    path::PathBuf,
     sync::{
         Arc,
         mpsc::{Receiver, RecvTimeoutError},
@@ -7,6 +8,7 @@ use std::{
 };
 
 use serde::Serialize;
+use turbo_rcstr::RcStr;
 use turbo_tasks::message_queue::{CompilationEvent, Severity};
 
 use crate::{DiskWatcherConfig, watcher::fs_api::DiskFileSystemWatcherApi};
@@ -24,6 +26,8 @@ struct PendingBatch {
     started: Instant,
     /// The batch is flushed once this passes without any further events.
     deadline: Instant,
+    /// The most recently changed path in the batch, for diagnostics.
+    last_modified_path: Option<PathBuf>,
     /// When to emit the next [`FilesystemSettlingEvent`].
     settling_event_next_at: Instant,
     /// Grows exponentially (up to [`BatchSchedule::settling_event_max_delay`]) so that a writer
@@ -41,15 +45,19 @@ impl BatchSchedule {
     }
 
     /// Keeps the batch open for at least `delay` from now, opening a new batch if there isn't one.
-    pub fn extend(&mut self, delay: Duration) {
+    pub fn extend(&mut self, delay: Duration, last_modified_path: Option<PathBuf>) {
         let now = Instant::now();
         let deadline = now.checked_add(delay).unwrap_or_else(far_future);
         match &mut self.pending {
-            Some(pending) => pending.deadline = pending.deadline.max(deadline),
+            Some(pending) => {
+                pending.deadline = pending.deadline.max(deadline);
+                pending.last_modified_path = last_modified_path;
+            }
             None => {
                 self.pending = Some(PendingBatch {
                     started: now,
                     deadline,
+                    last_modified_path,
                     settling_event_next_at: now
                         .checked_add(self.settling_event_initial_delay)
                         .unwrap_or_else(far_future),
@@ -119,6 +127,10 @@ impl PendingBatch {
         if let Some(turbo_tasks) = fs.turbo_tasks() {
             turbo_tasks.send_compilation_event(Arc::new(FilesystemSettlingEvent {
                 elapsed_secs: (now - self.started).as_secs_f64(),
+                last_modified_path: self
+                    .last_modified_path
+                    .as_ref()
+                    .map(|path| RcStr::from(format!("{path:?}"))),
             }));
         }
         self.event_interval = self.event_interval.saturating_mul(2).min(max_event_delay);
@@ -137,6 +149,8 @@ impl PendingBatch {
 pub struct FilesystemSettlingEvent {
     /// How long the current batch has been held open, in seconds.
     pub elapsed_secs: f64,
+    /// The most recently changed path in the current batch.
+    pub last_modified_path: Option<RcStr>,
 }
 
 impl CompilationEvent for FilesystemSettlingEvent {
@@ -149,9 +163,14 @@ impl CompilationEvent for FilesystemSettlingEvent {
     }
 
     fn message(&self) -> String {
+        let last_modified = self
+            .last_modified_path
+            .as_deref()
+            .map(|path| format!("; last modified: {path}"))
+            .unwrap_or_default();
         format!(
             "Turbopack has seen frequent file updates and is waiting for the filesystem to settle \
-             ({:.1}s elapsed so far).",
+             ({:.1}s elapsed so far{last_modified}).",
             self.elapsed_secs
         )
     }

--- a/turbopack/crates/turbo-tasks-fs/src/watcher/mod.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher/mod.rs
@@ -667,8 +667,8 @@ impl DiskWatcher {
                             delay = delay.max(config.extended_batch_delay_duration);
                         }
 
-                        if batch.add_event(event) {
-                            schedule.extend(delay);
+                        if let Some(last_modified_path) = batch.add_event(event) {
+                            schedule.extend(delay, Some(last_modified_path.into()));
                         }
                     }
                     // Error raised by notify watcher itself
@@ -677,6 +677,7 @@ impl DiskWatcher {
 
                         let flags = InvalidationFlags::PATH_AND_CHILDREN
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR;
+                        let last_modified_path = paths.last().cloned();
                         if paths.is_empty() {
                             batch.mark(Box::from(fs.root_path()), flags);
                         } else {
@@ -684,7 +685,7 @@ impl DiskWatcher {
                                 batch.mark(path.into_boxed_path(), flags);
                             }
                         }
-                        schedule.extend(config.batch_delay);
+                        schedule.extend(config.batch_delay, last_modified_path);
                     }
                     Err(RecvTimeoutError::Timeout) => {
                         // the batch is complete: break out to invalidate the collected paths.
@@ -863,28 +864,30 @@ impl BatchedInvalidations {
     /// Updates the batch to contain updated paths from the given event. Does not perform any
     /// invalidations.
     ///
-    /// Returns `true` if the event contained relevant events, or `false` if it was filtered out.
+    /// Returns the event's final path if it contained relevant events, or [`None`] if it was
+    /// filtered out.
     #[must_use]
-    fn add_event(&mut self, event: notify::Event) -> bool {
+    fn add_event(&mut self, event: notify::Event) -> Option<Box<Path>> {
         let paths: Vec<PathBuf> = event.paths;
-        if paths.is_empty() {
-            return false;
-        }
+        let last_path = |paths: &[PathBuf]| paths.last().map(|path| Box::from(path.as_path()));
         match event.kind {
             EventKind::Modify(ModifyKind::Data(_)) => {
+                let last_modified_path = last_path(&paths);
                 for path in paths {
                     self.mark(path.into_boxed_path(), InvalidationFlags::PATH);
                 }
-                true
+                last_modified_path
             }
             // Some backends (fsevents, polling) can report metadata events for file content changes
             EventKind::Modify(ModifyKind::Metadata(kind)) if self.is_content_change(kind) => {
+                let last_modified_path = last_path(&paths);
                 for path in paths {
                     self.mark(path.into_boxed_path(), InvalidationFlags::PATH);
                 }
-                true
+                last_modified_path
             }
             EventKind::Create(_) => {
+                let last_modified_path = last_path(&paths);
                 for path in paths {
                     self.mark_parent_dir(&path);
                     self.mark_new_path(&path);
@@ -894,9 +897,10 @@ impl BatchedInvalidations {
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR,
                     );
                 }
-                true
+                last_modified_path
             }
             EventKind::Remove(_) => {
+                let last_modified_path = last_path(&paths);
                 for path in paths {
                     self.mark_parent_dir(&path);
                     self.mark(
@@ -905,10 +909,11 @@ impl BatchedInvalidations {
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR,
                     );
                 }
-                true
+                last_modified_path
             }
             // A single event emitted with both the `From` and `To` paths.
             EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => {
+                let last_modified_path = last_path(&paths);
                 let [source, destination] = <[PathBuf; 2]>::try_from(paths)
                     .expect("RenameMode::Both event must contain exactly two paths");
                 self.mark_parent_dir(&source);
@@ -922,12 +927,13 @@ impl BatchedInvalidations {
                     destination.into_boxed_path(),
                     InvalidationFlags::PATH_AND_CHILDREN,
                 );
-                true
+                last_modified_path
             }
             // We expect `RenameMode::Both` to cover most of the cases we need to invalidate,
             // but we also check other RenameModes to cover cases where notify couldn't match the
             // two rename events.
             EventKind::Any | EventKind::Modify(ModifyKind::Any | ModifyKind::Name(..)) => {
+                let last_modified_path = last_path(&paths);
                 for path in paths {
                     self.mark_parent_dir(&path);
                     self.mark(
@@ -936,13 +942,13 @@ impl BatchedInvalidations {
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR,
                     );
                 }
-                true
+                last_modified_path
             }
             EventKind::Modify(ModifyKind::Metadata(..) | ModifyKind::Other)
             | EventKind::Access(_)
             | EventKind::Other => {
                 // ignored
-                false
+                None
             }
         }
     }

--- a/turbopack/crates/turbo-tasks-fs/src/watcher/mod.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher/mod.rs
@@ -676,15 +676,7 @@ impl DiskWatcher {
                     Ok(Err(notify::Error { kind, paths })) => {
                         println!("watch error ({paths:?}): {kind:?} ");
 
-                        let flags = InvalidationFlags::PATH_AND_CHILDREN
-                            | InvalidationFlags::PATH_AND_CHILDREN_DIR;
-                        if paths.is_empty() {
-                            batch.mark(Box::from(fs.root_path()), flags);
-                        } else {
-                            for path in paths {
-                                batch.mark(path.into_boxed_path(), flags);
-                            }
-                        }
+                        batch.add_error(paths, fs.root_path());
                         schedule.extend(config.batch_delay);
                     }
                     Err(RecvTimeoutError::Timeout) => {
@@ -963,6 +955,18 @@ impl BatchedInvalidations {
             true
         } else {
             false
+        }
+    }
+
+    /// Updates the batch to invalidate paths associated with a watcher error.
+    fn add_error(&mut self, paths: Vec<PathBuf>, root_path: &Path) {
+        let flags = InvalidationFlags::PATH_AND_CHILDREN | InvalidationFlags::PATH_AND_CHILDREN_DIR;
+        if paths.is_empty() {
+            self.last_updated_index = Some(self.mark(Box::from(root_path), flags));
+        } else {
+            for path in paths {
+                self.last_updated_index = Some(self.mark(path.into_boxed_path(), flags));
+            }
         }
     }
 

--- a/turbopack/crates/turbo-tasks-fs/src/watcher/mod.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher/mod.rs
@@ -23,17 +23,18 @@ use bincode::{
     error::{DecodeError, EncodeError},
 };
 use bitflags::bitflags;
+use indexmap::map::Entry;
 use notify::{
     Config, EventKind, PollWatcher, RecommendedWatcher, Watcher,
     event::{MetadataKind, ModifyKind, RenameMode},
 };
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use tokio::sync::{RwLock, RwLockWriteGuard};
 use tracing::instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    FxIndexSet, InvalidationReason, InvalidationReasonKind, Invalidator, ResolvedVc, TraitRef,
-    TurboTasksApi, spawn_thread, trace::TraceRawVcs, util::StaticOrArc,
+    FxIndexMap, FxIndexSet, InvalidationReason, InvalidationReasonKind, Invalidator, ResolvedVc,
+    TraitRef, TurboTasksApi, spawn_thread, trace::TraceRawVcs, util::StaticOrArc,
 };
 
 use crate::{
@@ -607,7 +608,7 @@ impl DiskWatcher {
 
         'outer: loop {
             loop {
-                match schedule.recv_event(&rx, &*fs) {
+                match schedule.recv_event(&rx, &*fs, &batch) {
                     Ok(Ok(event)) => {
                         // TODO: We might benefit from some user-facing diagnostics if it rescans
                         // occur frequently (i.e. more than X times in Y minutes)
@@ -667,8 +668,8 @@ impl DiskWatcher {
                             delay = delay.max(config.extended_batch_delay_duration);
                         }
 
-                        if let Some(last_modified_path) = batch.add_event(event) {
-                            schedule.extend(delay, Some(last_modified_path.into()));
+                        if batch.add_event(event) {
+                            schedule.extend(delay);
                         }
                     }
                     // Error raised by notify watcher itself
@@ -677,7 +678,6 @@ impl DiskWatcher {
 
                         let flags = InvalidationFlags::PATH_AND_CHILDREN
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR;
-                        let last_modified_path = paths.last().cloned();
                         if paths.is_empty() {
                             batch.mark(Box::from(fs.root_path()), flags);
                         } else {
@@ -685,7 +685,7 @@ impl DiskWatcher {
                                 batch.mark(path.into_boxed_path(), flags);
                             }
                         }
-                        schedule.extend(config.batch_delay, last_modified_path);
+                        schedule.extend(config.batch_delay);
                     }
                     Err(RecvTimeoutError::Timeout) => {
                         // the batch is complete: break out to invalidate the collected paths.
@@ -782,7 +782,9 @@ bitflags! {
 /// needs to happen for each, rather than in several separate sets. This avoids cloning each
 /// `PathBuf` into multiple collections.
 struct BatchedInvalidations {
-    paths: FxHashMap<Box<Path>, InvalidationFlags>,
+    paths: FxIndexMap<Box<Path>, InvalidationFlags>,
+    /// The most recently updated entry in [`Self::paths`].
+    last_updated_index: Option<usize>,
     /// See [`Self::new_paths`]). Stored as [`None`] in non-recursive mode.
     new_paths: Option<FxHashSet<Box<Path>>>,
     /// Whether events are coming from [`PollWatcher`] instead of [`RecommendedWatcher`], which
@@ -793,7 +795,8 @@ struct BatchedInvalidations {
 impl BatchedInvalidations {
     fn new(recursive_mode: DiskWatcherRecursiveMode, polling: bool) -> Self {
         Self {
-            paths: FxHashMap::default(),
+            paths: FxIndexMap::default(),
+            last_updated_index: None,
             new_paths: match recursive_mode {
                 DiskWatcherRecursiveMode::NonRecursive => Some(FxHashSet::default()),
                 DiskWatcherRecursiveMode::Recursive => None,
@@ -831,6 +834,7 @@ impl BatchedInvalidations {
 
     fn clear(&mut self) {
         self.paths.clear();
+        self.last_updated_index = None;
         if let Some(new_paths) = &mut self.new_paths {
             new_paths.clear();
         }
@@ -844,8 +848,25 @@ impl BatchedInvalidations {
         }
     }
 
-    fn mark(&mut self, path: Box<Path>, flags: InvalidationFlags) {
-        *self.paths.entry(path).or_insert(InvalidationFlags::empty()) |= flags;
+    /// Sets the `flags` for `path`. Returns the index that was modified.
+    fn mark(&mut self, path: Box<Path>, flags: InvalidationFlags) -> usize {
+        match self.paths.entry(path) {
+            Entry::Occupied(mut entry) => {
+                *entry.get_mut() |= flags;
+                entry.index()
+            }
+            Entry::Vacant(entry) => {
+                let index = entry.index();
+                entry.insert(flags);
+                index
+            }
+        }
+    }
+
+    fn last_updated_path(&self) -> Option<&Path> {
+        self.last_updated_index
+            .and_then(|index| self.paths.get_index(index))
+            .map(|(path, _)| &**path)
     }
 
     fn mark_parent_dir(&mut self, path: &Path) {
@@ -864,56 +885,48 @@ impl BatchedInvalidations {
     /// Updates the batch to contain updated paths from the given event. Does not perform any
     /// invalidations.
     ///
-    /// Returns the event's final path if it contained relevant events, or [`None`] if it was
-    /// filtered out.
+    /// Returns whether the event contained relevant events.
     #[must_use]
-    fn add_event(&mut self, event: notify::Event) -> Option<Box<Path>> {
+    fn add_event(&mut self, event: notify::Event) -> bool {
         let paths: Vec<PathBuf> = event.paths;
-        let last_path = |paths: &[PathBuf]| paths.last().map(|path| Box::from(path.as_path()));
+        let mut last_updated_index = None;
         match event.kind {
             EventKind::Modify(ModifyKind::Data(_)) => {
-                let last_modified_path = last_path(&paths);
                 for path in paths {
-                    self.mark(path.into_boxed_path(), InvalidationFlags::PATH);
+                    last_updated_index =
+                        Some(self.mark(path.into_boxed_path(), InvalidationFlags::PATH));
                 }
-                last_modified_path
             }
             // Some backends (fsevents, polling) can report metadata events for file content changes
             EventKind::Modify(ModifyKind::Metadata(kind)) if self.is_content_change(kind) => {
-                let last_modified_path = last_path(&paths);
                 for path in paths {
-                    self.mark(path.into_boxed_path(), InvalidationFlags::PATH);
+                    last_updated_index =
+                        Some(self.mark(path.into_boxed_path(), InvalidationFlags::PATH));
                 }
-                last_modified_path
             }
             EventKind::Create(_) => {
-                let last_modified_path = last_path(&paths);
                 for path in paths {
                     self.mark_parent_dir(&path);
                     self.mark_new_path(&path);
-                    self.mark(
+                    last_updated_index = Some(self.mark(
                         path.into_boxed_path(),
                         InvalidationFlags::PATH_AND_CHILDREN
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR,
-                    );
+                    ));
                 }
-                last_modified_path
             }
             EventKind::Remove(_) => {
-                let last_modified_path = last_path(&paths);
                 for path in paths {
                     self.mark_parent_dir(&path);
-                    self.mark(
+                    last_updated_index = Some(self.mark(
                         path.into_boxed_path(),
                         InvalidationFlags::PATH_AND_CHILDREN
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR,
-                    );
+                    ));
                 }
-                last_modified_path
             }
             // A single event emitted with both the `From` and `To` paths.
             EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => {
-                let last_modified_path = last_path(&paths);
                 let [source, destination] = <[PathBuf; 2]>::try_from(paths)
                     .expect("RenameMode::Both event must contain exactly two paths");
                 self.mark_parent_dir(&source);
@@ -923,33 +936,33 @@ impl BatchedInvalidations {
                 );
                 self.mark_parent_dir(&destination);
                 self.mark_new_path(&destination);
-                self.mark(
+                last_updated_index = Some(self.mark(
                     destination.into_boxed_path(),
                     InvalidationFlags::PATH_AND_CHILDREN,
-                );
-                last_modified_path
+                ));
             }
             // We expect `RenameMode::Both` to cover most of the cases we need to invalidate,
             // but we also check other RenameModes to cover cases where notify couldn't match the
             // two rename events.
             EventKind::Any | EventKind::Modify(ModifyKind::Any | ModifyKind::Name(..)) => {
-                let last_modified_path = last_path(&paths);
                 for path in paths {
                     self.mark_parent_dir(&path);
-                    self.mark(
+                    last_updated_index = Some(self.mark(
                         path.into_boxed_path(),
                         InvalidationFlags::PATH_AND_CHILDREN
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR,
-                    );
+                    ));
                 }
-                last_modified_path
             }
             EventKind::Modify(ModifyKind::Metadata(..) | ModifyKind::Other)
             | EventKind::Access(_)
-            | EventKind::Other => {
-                // ignored
-                None
-            }
+            | EventKind::Other => {}
+        }
+        if let Some(index) = last_updated_index {
+            self.last_updated_index = Some(index);
+            true
+        } else {
+            false
         }
     }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/vercel/next.js/pull/96116

If we're waiting a long time for your filesystem to settle, we should show you the last modified path, so at least you can have an idea of why this is happening.