### PR TITLE
Add prelude metadata header to cached prerenders

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -62,6 +62,8 @@ import { Bundler } from '../../lib/bundler'
 import { resolveCacheHandlerPathToFilesystem } from '../../lib/format-dynamic-import-path'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import type { __ApiPreviewProps } from '../../server/api-utils'
+import { HTML_LIMITED_BOT_UA_RE_STRING } from '../../shared/lib/router/utils/is-bot'
+import { NEXT_PRELUDE_METADATA_HEADER } from '../../client/components/app-router-headers'
 
 interface SharedRouteFields {
   /**
@@ -648,6 +650,21 @@ export async function handleBuildComplete({
   appPageKeys?: readonly string[] | undefined
   functionsConfigManifest: FunctionsConfigManifest
 }) {
+  const useHtmlLimitedBotsAfterCacheBypass =
+    process.env.NEXT_PRIVATE_HTML_LIMITED_BOTS_AFTER_CACHE_BYPASS === '1'
+
+  const filterHtmlLimitedBotsBypass = (
+    bypassFor: RouteHas[] | undefined
+  ): RouteHas[] | undefined => {
+    if (!useHtmlLimitedBotsAfterCacheBypass) {
+      return bypassFor
+    }
+
+    return bypassFor?.filter(
+      (bypass) => bypass.type !== 'header' || bypass.key !== 'user-agent'
+    )
+  }
+
   const adapterMod = interopDefault(
     await import(pathToFileURL(require.resolve(adapterPath)).href)
   ) as NextAdapter
@@ -1593,7 +1610,7 @@ export async function handleBuildComplete({
             renderingMode,
             bypassFor:
               isAppPage && srcRoute !== '/_not-found'
-                ? experimentalBypassFor
+                ? filterHtmlLimitedBotsBypass(experimentalBypassFor)
                 : undefined,
             bypassToken: previewProps.previewModeId,
           },
@@ -1866,7 +1883,9 @@ export async function handleBuildComplete({
             allowHeader,
             renderingMode,
             partialFallback: canEmitPartialFallback || undefined,
-            bypassFor: isAppPage ? experimentalBypassFor : undefined,
+            bypassFor: isAppPage
+              ? filterHtmlLimitedBotsBypass(experimentalBypassFor)
+              : undefined,
             bypassToken: previewProps.previewModeId,
           },
         }
@@ -2446,6 +2465,39 @@ export async function handleBuildComplete({
         projectDir: dir,
         repoRoot: repoRoot,
       })
+
+      if (useHtmlLimitedBotsAfterCacheBypass) {
+        // This is a temporary bridge for testing the Vercel proxy's after-cache
+        // bypass support before the deployment config has a first-class adapter
+        // interface. adapter-vercel creates this Build Output API directory.
+        const outputDir = path.join(distDir, 'output')
+        await fs.mkdir(outputDir, { recursive: true })
+        await fs.writeFile(
+          path.join(outputDir, 'deployment_config_v3.json'),
+          JSON.stringify({
+            after_cache_bypass: [
+              {
+                hasAll: [
+                  {
+                    type: 'request.header',
+                    key: 'user-agent',
+                    value: {
+                      re: `.*(?:${
+                        config.htmlLimitedBots || HTML_LIMITED_BOT_UA_RE_STRING
+                      }).*`,
+                    },
+                  },
+                  {
+                    type: 'cache.response.header',
+                    key: NEXT_PRELUDE_METADATA_HEADER,
+                    value: { eq: '0' },
+                  },
+                ],
+              },
+            ],
+          })
+        )
+      }
     } catch (err) {
       Log.error(`Failed to run onBuildComplete from ${adapterMod.name}`)
       throw err

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -33,6 +33,7 @@ export const NEXT_RSC_UNION_QUERY = '_rsc' as const
 
 export const NEXT_ROUTER_STALE_TIME_HEADER = 'x-nextjs-stale-time' as const
 export const NEXT_DID_POSTPONE_HEADER = 'x-nextjs-postponed' as const
+export const NEXT_MISSING_METADATA_HEADER = 'x-next-missing-metadata' as const
 export const NEXT_REWRITTEN_PATH_HEADER = 'x-nextjs-rewritten-path' as const
 export const NEXT_REWRITTEN_QUERY_HEADER = 'x-nextjs-rewritten-query' as const
 export const NEXT_IS_PRERENDER_HEADER = 'x-nextjs-prerender' as const

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -33,7 +33,7 @@ export const NEXT_RSC_UNION_QUERY = '_rsc' as const
 
 export const NEXT_ROUTER_STALE_TIME_HEADER = 'x-nextjs-stale-time' as const
 export const NEXT_DID_POSTPONE_HEADER = 'x-nextjs-postponed' as const
-export const NEXT_MISSING_METADATA_HEADER = 'x-next-missing-metadata' as const
+export const NEXT_PRELUDE_METADATA_HEADER = 'x-next-prelude-metadata' as const
 export const NEXT_REWRITTEN_PATH_HEADER = 'x-nextjs-rewritten-path' as const
 export const NEXT_REWRITTEN_QUERY_HEADER = 'x-nextjs-rewritten-query' as const
 export const NEXT_IS_PRERENDER_HEADER = 'x-nextjs-prerender' as const

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -33,6 +33,11 @@ export const NEXT_RSC_UNION_QUERY = '_rsc' as const
 
 export const NEXT_ROUTER_STALE_TIME_HEADER = 'x-nextjs-stale-time' as const
 export const NEXT_DID_POSTPONE_HEADER = 'x-nextjs-postponed' as const
+/**
+ * This is a response-only header intended for downstream infrastructure, not
+ * for the client. It contains no sensitive information and is safe to expose
+ * if a fronting CDN does not strip it.
+ */
 export const NEXT_PRELUDE_METADATA_HEADER = 'x-next-prelude-metadata' as const
 export const NEXT_REWRITTEN_PATH_HEADER = 'x-nextjs-rewritten-path' as const
 export const NEXT_REWRITTEN_QUERY_HEADER = 'x-nextjs-rewritten-query' as const

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -76,6 +76,7 @@ import {
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_ROUTER_STALE_TIME_HEADER,
+  NEXT_MISSING_METADATA_HEADER,
   NEXT_URL,
   RSC_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
@@ -9562,6 +9563,11 @@ async function prerenderToStream(
         serverDynamicTracking,
         allowEmptyStaticShell
       )
+
+      if (dynamicValidation.hasDynamicMetadata) {
+        metadata.headers ??= {}
+        metadata.headers[NEXT_MISSING_METADATA_HEADER] = '1'
+      }
 
       const getServerInsertedHTML = makeGetServerInsertedHTML({
         polyfills,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -76,7 +76,7 @@ import {
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
   NEXT_ROUTER_STALE_TIME_HEADER,
-  NEXT_MISSING_METADATA_HEADER,
+  NEXT_PRELUDE_METADATA_HEADER,
   NEXT_URL,
   RSC_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
@@ -9566,7 +9566,7 @@ async function prerenderToStream(
 
       if (dynamicValidation.hasDynamicMetadata) {
         metadata.headers ??= {}
-        metadata.headers[NEXT_MISSING_METADATA_HEADER] = '1'
+        metadata.headers[NEXT_PRELUDE_METADATA_HEADER] = '0'
       }
 
       const getServerInsertedHTML = makeGetServerInsertedHTML({

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -9564,7 +9564,7 @@ async function prerenderToStream(
         allowEmptyStaticShell
       )
 
-      if (dynamicValidation.hasDynamicMetadata) {
+      if (dynamicValidation.hasDynamicMetadata && !preludeIsEmpty) {
         metadata.headers ??= {}
         metadata.headers[NEXT_PRELUDE_METADATA_HEADER] = '0'
       }

--- a/test/e2e/app-dir/metadata-streaming-cache-components/app/dynamic-metadata/empty/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming-cache-components/app/dynamic-metadata/empty/page.tsx
@@ -1,0 +1,15 @@
+import { connection } from 'next/server'
+
+export const instant = false
+
+export default async function Page() {
+  await connection()
+  return <div id="empty-shell-content">empty shell content</div>
+}
+
+export async function generateMetadata() {
+  await connection()
+  return {
+    title: 'dynamic-metadata - empty',
+  }
+}

--- a/test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-default-bots.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-default-bots.test.ts
@@ -180,6 +180,15 @@ function countSubstring(str: string, substr: string): number {
         await assertNoConsoleErrors(browser)
       })
 
+      it('should omit the header when dynamic metadata has an empty static shell', async () => {
+        const response = await next.fetch('/dynamic-metadata/empty')
+        expect(response.headers.get('x-next-prelude-metadata')).toBeNull()
+
+        const $ = cheerio.load(await response.text())
+        expect($('title').text()).toBe('dynamic-metadata - empty')
+        expect($('#empty-shell-content').text()).toBe('empty shell content')
+      })
+
       it('should insert static metadata in head when dynamic page content is under a layout Suspense boundary', async () => {
         const response = await next.fetch('/dynamic-page/partial')
         expect(response.headers.get('x-next-prelude-metadata')).toBeNull()

--- a/test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-default-bots.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-default-bots.test.ts
@@ -111,7 +111,10 @@ function countSubstring(str: string, substr: string): number {
 
     describe('Cache Components metadata streaming', () => {
       it('should generate metadata in head when page is fully static', async () => {
-        const $ = await next.render$('/fully-static')
+        const response = await next.fetch('/fully-static')
+        expect(response.headers.get('x-next-missing-metadata')).toBeNull()
+
+        const $ = cheerio.load(await response.text())
         expect($('head title').text()).toBe('fully static')
         expect(countSubstring($.html(), '<title>')).toBe(1)
 
@@ -159,7 +162,10 @@ function countSubstring(str: string, substr: string): number {
       })
 
       it('should insert dynamic metadata in body under a layout Suspense boundary', async () => {
-        const $ = await next.render$('/dynamic-metadata/partial')
+        const response = await next.fetch('/dynamic-metadata/partial')
+        expect(response.headers.get('x-next-missing-metadata')).toBe('1')
+
+        const $ = cheerio.load(await response.text())
         expect($('body title').text()).toBe('dynamic-metadata - partial')
         expect(countSubstring($.html(), '<title>')).toBe(1)
 
@@ -175,7 +181,10 @@ function countSubstring(str: string, substr: string): number {
       })
 
       it('should insert static metadata in head when dynamic page content is under a layout Suspense boundary', async () => {
-        const $ = await next.render$('/dynamic-page/partial')
+        const response = await next.fetch('/dynamic-page/partial')
+        expect(response.headers.get('x-next-missing-metadata')).toBeNull()
+
+        const $ = cheerio.load(await response.text())
         expect($('head title').text()).toBe('dynamic-page - partial')
         expect(countSubstring($.html(), '<title>')).toBe(1)
 

--- a/test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-default-bots.test.ts
+++ b/test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-default-bots.test.ts
@@ -112,7 +112,7 @@ function countSubstring(str: string, substr: string): number {
     describe('Cache Components metadata streaming', () => {
       it('should generate metadata in head when page is fully static', async () => {
         const response = await next.fetch('/fully-static')
-        expect(response.headers.get('x-next-missing-metadata')).toBeNull()
+        expect(response.headers.get('x-next-prelude-metadata')).toBeNull()
 
         const $ = cheerio.load(await response.text())
         expect($('head title').text()).toBe('fully static')
@@ -163,7 +163,7 @@ function countSubstring(str: string, substr: string): number {
 
       it('should insert dynamic metadata in body under a layout Suspense boundary', async () => {
         const response = await next.fetch('/dynamic-metadata/partial')
-        expect(response.headers.get('x-next-missing-metadata')).toBe('1')
+        expect(response.headers.get('x-next-prelude-metadata')).toBe('0')
 
         const $ = cheerio.load(await response.text())
         expect($('body title').text()).toBe('dynamic-metadata - partial')
@@ -182,7 +182,7 @@ function countSubstring(str: string, substr: string): number {
 
       it('should insert static metadata in head when dynamic page content is under a layout Suspense boundary', async () => {
         const response = await next.fetch('/dynamic-page/partial')
-        expect(response.headers.get('x-next-missing-metadata')).toBeNull()
+        expect(response.headers.get('x-next-prelude-metadata')).toBeNull()
 
         const $ = cheerio.load(await response.text())
         expect($('head title').text()).toBe('dynamic-page - partial')

--- a/test/production/app-dir/adapter-prerender-metadata/adapter-prerender-metadata.test.ts
+++ b/test/production/app-dir/adapter-prerender-metadata/adapter-prerender-metadata.test.ts
@@ -30,6 +30,9 @@ const classificationKey = ({ routeType, response, compute }: Classification) =>
 describe('adapter-prerender-metadata', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    env: {
+      NEXT_PRIVATE_HTML_LIMITED_BOTS_AFTER_CACHE_BYPASS: '1',
+    },
   })
 
   async function getPrerenders() {
@@ -42,6 +45,67 @@ describe('adapter-prerender-metadata', () => {
   async function getPrerenderManifest() {
     return next.readJSON('.next/prerender-manifest.json')
   }
+
+  it('moves the HTML-limited bot bypass after the cache', async () => {
+    const { outputs }: AdapterBuildContext = await next.readJSON(
+      'build-complete.json'
+    )
+    const page = outputs.prerenders.find(
+      (output) => output.pathname === '/ppr-shell'
+    )
+
+    expect(
+      outputs.prerenders
+        .flatMap((output) => output.config.bypassFor ?? [])
+        .filter(
+          (bypass) => bypass.type === 'header' && bypass.key === 'user-agent'
+        )
+    ).toEqual([])
+
+    expect(page.config.bypassFor).toEqual([
+      {
+        type: 'header',
+        key: 'next-action',
+      },
+      {
+        type: 'header',
+        key: 'content-type',
+        value: 'multipart/form-data;.*',
+      },
+    ])
+
+    const prerenderManifest = await getPrerenderManifest()
+    expect(
+      prerenderManifest.routes['/ppr-shell'].experimentalBypassFor
+    ).toContainEqual({
+      type: 'header',
+      key: 'user-agent',
+      value: '.*(?:MyHTMLLimitedBot).*',
+    })
+
+    expect(
+      await next.readJSON('.next/output/deployment_config_v3.json')
+    ).toEqual({
+      after_cache_bypass: [
+        {
+          hasAll: [
+            {
+              type: 'request.header',
+              key: 'user-agent',
+              value: {
+                re: '.*(?:MyHTMLLimitedBot).*',
+              },
+            },
+            {
+              type: 'cache.response.header',
+              key: 'x-next-prelude-metadata',
+              value: { eq: '0' },
+            },
+          ],
+        },
+      ],
+    })
+  })
 
   it('exercises every valid classification combination', async () => {
     const cases: Array<

--- a/test/production/app-dir/adapter-prerender-metadata/next.config.js
+++ b/test/production/app-dir/adapter-prerender-metadata/next.config.js
@@ -3,6 +3,7 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  htmlLimitedBots: /MyHTMLLimitedBot/i,
   adapterPath: require.resolve('./my-adapter.mjs'),
 }
 


### PR DESCRIPTION
## Summary

- Add `x-next-prelude-metadata: 0` to non-empty cached Cache Components prerenders whose metadata remains unresolved.
- Keep the header absent when metadata is already resolved or the static shell is empty. Empty shells require a blocking full render regardless, so the marker would not improve the later bot-routing decision.
- Behind `NEXT_PRIVATE_HTML_LIMITED_BOTS_AFTER_CACHE_BYPASS=1`, remove the HTML-limited bot matcher from adapter-bound `experimentalBypassFor` rules while retaining the server-action and multipart bypasses.
- Under the same flag, write `deployment_config_v3.json` after the adapter finishes. Its `after_cache_bypass` rule requires both an HTML-limited bot user agent and a cached `x-next-prelude-metadata: 0` response.
- Keep this as a private Build Output API bridge for deployment testing while the first-class Next.js, adapter, and BOA interface is designed.

## Verification

- `pnpm test-start-turbo test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-default-bots.test.ts`
- `pnpm test-start-webpack test/e2e/app-dir/metadata-streaming-cache-components/metadata-streaming-cache-components-default-bots.test.ts`
- `pnpm test-start-turbo test/production/app-dir/adapter-prerender-metadata/adapter-prerender-metadata.test.ts`
- `pnpm --filter=next build`
- Changed-file Prettier and ESLint checks

<!-- NEXT_JS_LLM -->
