### PR TITLE
Turbopack: Avoid cloning paths in fs watcher if the path is already in a map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,7 +2630,7 @@ dependencies = [
  "forked_react_compiler_typeinference",
  "forked_react_compiler_utils",
  "forked_react_compiler_validation",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -2644,7 +2644,7 @@ checksum = "daccd93f89b1bc808a485767928b80456711e2141e54722e478795c84e0d5c7b"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_utils",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.1",
  "serde",
  "serde-transcode",
@@ -2670,7 +2670,7 @@ dependencies = [
  "forked_react_compiler_ast",
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_utils",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -2688,7 +2688,7 @@ dependencies = [
  "forked_react_compiler_optimization",
  "forked_react_compiler_ssa",
  "forked_react_compiler_utils",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.1",
 ]
 
@@ -2702,7 +2702,7 @@ dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
  "forked_react_compiler_utils",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.1",
  "serde_json",
 ]
@@ -2718,7 +2718,7 @@ dependencies = [
  "forked_react_compiler_lowering",
  "forked_react_compiler_ssa",
  "forked_react_compiler_utils",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.1",
 ]
 
@@ -2733,7 +2733,7 @@ dependencies = [
  "forked_react_compiler_hir",
  "forked_react_compiler_utils",
  "hmac-sha256",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.1",
  "serde_json",
 ]
@@ -2747,7 +2747,7 @@ dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
  "forked_react_compiler_utils",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.1",
 ]
 
@@ -2769,7 +2769,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5390b90b48cf2aaab7e511009e10e6b8c2c5b750a8c873881b4014e4295cb128"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.1",
 ]
 
@@ -2782,7 +2782,7 @@ dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
  "forked_react_compiler_utils",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.1",
 ]
 
@@ -3026,7 +3026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -3037,7 +3037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -3078,7 +3078,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3097,7 +3097,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3838,12 +3838,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -4316,7 +4316,7 @@ dependencies = [
  "dashmap 5.5.3",
  "data-encoding",
  "getrandom 0.3.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.10.5",
  "lazy_static",
  "lightningcss-derive",
@@ -4883,7 +4883,7 @@ dependencies = [
  "byteorder",
  "either",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "next-core",
  "regex",
  "roaring",
@@ -4977,7 +4977,7 @@ dependencies = [
  "bincode 2.0.1",
  "either",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "indoc",
  "itertools 0.10.5",
  "lightningcss",
@@ -5039,7 +5039,7 @@ dependencies = [
  "easy-error",
  "either",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "indoc",
  "modularize_imports",
  "next-taskless",
@@ -5381,7 +5381,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.14.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
  "ruzstd",
 ]
@@ -5394,7 +5394,7 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -5693,7 +5693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -5704,7 +5704,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_derive",
 ]
@@ -6759,7 +6759,7 @@ dependencies = [
  "bytecheck 0.8.1",
  "bytes",
  "hashbrown 0.17.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "munge",
  "ptr_meta 0.3.0",
  "rancor",
@@ -7066,7 +7066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -7299,7 +7299,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -7370,7 +7370,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde_core",
@@ -7397,7 +7397,7 @@ version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "libyml",
  "memchr",
@@ -7460,7 +7460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "939a4c696178684fc5fc1426625b882805418bbb56e056d21f9d4946a9d6ff51"
 dependencies = [
  "hashbrown 0.15.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_json",
  "shrink-to-fit-macro",
  "smallvec",
@@ -7678,7 +7678,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6635404b73efc136af3a7956e53c53d4f34b2f16c95a15c438929add0f69412"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "smallvec",
  "static-self-derive",
 ]
@@ -7807,7 +7807,7 @@ dependencies = [
  "bytes-str",
  "dashmap 6.1.0",
  "either",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "jsonc-parser",
  "once_cell",
  "par-core",
@@ -7963,7 +7963,7 @@ dependencies = [
  "bytes-str",
  "dashmap 6.1.0",
  "globset",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "once_cell",
  "regex",
  "regress 0.11.1",
@@ -8240,7 +8240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3770a6524c4898f747dd8c880cc8fdc8457de8fdccbf160b4802034e40fed69f"
 dependencies = [
  "arrayvec 0.7.6",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "is-macro",
  "rustc-hash 2.1.1",
  "serde",
@@ -8452,7 +8452,7 @@ checksum = "310ab13e49dd014e2f050213d10ddfc34c5684e438bf81844a6e7ae7f7ba91d8"
 dependencies = [
  "arrayvec 0.7.6",
  "bitflags 2.9.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "num-bigint",
  "num_cpus",
  "once_cell",
@@ -8508,7 +8508,7 @@ checksum = "28d3bbd3fe0815a3642631b17848861d07d9b92b85b6341e02f4e8bd8d1c2491"
 dependencies = [
  "anyhow",
  "foldhash 0.1.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "once_cell",
  "precomputed-map",
  "preset_env_base",
@@ -8552,7 +8552,7 @@ dependencies = [
  "forked_react_compiler",
  "forked_react_compiler_ast",
  "forked_react_compiler_hir",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -8670,7 +8670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b847c1419056e271c11a2fe1d36f988c9f121d0239ec401cbb3e622480ee3e8"
 dependencies = [
  "better_scoped_tls",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "once_cell",
  "par-core",
  "phf 0.11.2",
@@ -8704,7 +8704,7 @@ version = "56.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0237fee1a78c87bfdb4c06723feedb99610b61703f13956d02594683c10540d"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "par-core",
  "serde",
  "swc_atoms",
@@ -8747,7 +8747,7 @@ dependencies = [
  "Inflector",
  "anyhow",
  "bitflags 2.9.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "is-macro",
  "path-clean",
  "pathdiff",
@@ -8774,7 +8774,7 @@ checksum = "5afbe52092d7b1b929156762f986294a559bba0221ef80a1017e806b1d8f9c34"
 dependencies = [
  "bytes-str",
  "dashmap 6.1.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "once_cell",
  "par-core",
  "petgraph 0.7.1",
@@ -8817,7 +8817,7 @@ checksum = "46fa764bc0ea6a9ca6683fe5c32faf50accc8a6b86b96d4b124429473307ef30"
 dependencies = [
  "base64 0.22.1",
  "bytes-str",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "once_cell",
  "rustc-hash 2.1.1",
  "serde",
@@ -8885,7 +8885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff0adbc5dd5676057ce6b0f63618838ba8691240972e3374189463f64214dd5e"
 dependencies = [
  "dragonbox_ecma",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "num_cpus",
  "once_cell",
  "par-core",
@@ -9600,7 +9600,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -9613,7 +9613,7 @@ version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe30f93627849fa362d4a602212d41bb237dc2bd0f8ba0b2ce785012e124220"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.0.4",
  "toml_datetime 1.0.0+spec-1.1.0",
@@ -9646,7 +9646,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -9659,7 +9659,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.11",
  "winnow 0.7.14",
 ]
@@ -9963,7 +9963,7 @@ version = "0.0.0"
 dependencies = [
  "bincode 2.0.1",
  "either",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "mime",
  "ringmap",
  "serde",
@@ -9992,7 +9992,7 @@ name = "turbo-frozenmap"
 version = "0.1.0"
 dependencies = [
  "bincode 2.0.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
 ]
@@ -10084,7 +10084,7 @@ dependencies = [
  "erased-serde",
  "event-listener",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "parking_lot",
  "pin-project-lite",
  "rayon",
@@ -10125,7 +10125,7 @@ dependencies = [
  "fs-err",
  "futures",
  "hashbrown 0.14.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "indoc",
  "jiff",
  "lzzzz",
@@ -10231,7 +10231,7 @@ dependencies = [
  "fs-err",
  "futures",
  "include_dir",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "jsonc-parser",
  "mime",
  "notify",
@@ -10295,7 +10295,7 @@ name = "turbo-tasks-macros"
 version = "0.1.0"
 dependencies = [
  "either",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -10530,7 +10530,7 @@ dependencies = [
  "data-encoding",
  "either",
  "erased-serde",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "num-bigint",
  "patricia_tree",
  "petgraph 0.8.3",
@@ -10657,7 +10657,7 @@ dependencies = [
  "data-encoding",
  "either",
  "forked_react_compiler",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "indoc",
  "itertools 0.10.5",
  "next-custom-transforms",
@@ -10718,7 +10718,7 @@ dependencies = [
  "async-trait",
  "bincode 2.0.1",
  "either",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -11012,7 +11012,7 @@ dependencies = [
  "either",
  "flate2",
  "hashbrown 0.14.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.10.5",
  "postcard",
  "rayon",
@@ -11364,7 +11364,7 @@ dependencies = [
  "dunce",
  "futures",
  "getrandom 0.2.15",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "replace_with",
  "shared-buffer",
@@ -11723,7 +11723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
 ]
@@ -11739,7 +11739,7 @@ dependencies = [
  "cfg-if",
  "cmake",
  "derive_more 2.0.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "js-sys",
  "more-asserts",
  "paste",
@@ -11821,7 +11821,7 @@ dependencies = [
  "ciborium",
  "derive_builder 0.12.0",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "saffron",
  "schemars 0.8.21",
  "semver",
@@ -11912,7 +11912,7 @@ dependencies = [
  "enumset",
  "getrandom 0.2.15",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "more-asserts",
  "rkyv 0.8.16",
  "serde",
@@ -11937,7 +11937,7 @@ dependencies = [
  "dashmap 6.1.0",
  "enum-iterator",
  "fnv",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "libc",
  "libunwind",
  "mach2",
@@ -12066,7 +12066,7 @@ checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags 2.9.1",
  "hashbrown 0.15.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
  "serde",
 ]
@@ -12079,7 +12079,7 @@ checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
 dependencies = [
  "bitflags 2.9.1",
  "hashbrown 0.15.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
  "serde",
 ]
@@ -12092,7 +12092,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.9.1",
  "hashbrown 0.15.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -12121,7 +12121,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "hashbrown 0.15.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "libc",
  "log",
  "mach2",
@@ -12159,7 +12159,7 @@ dependencies = [
  "cranelift-bitset 0.125.4",
  "cranelift-entity 0.125.4",
  "gimli 0.32.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "object 0.37.3",
  "postcard",
@@ -12374,7 +12374,7 @@ dependencies = [
  "ciborium",
  "document-features",
  "ignore",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "leb128",
  "lexical-sort",
  "libc",
@@ -12955,7 +12955,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.104",
  "wasm-metadata",
@@ -12986,7 +12986,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -13005,7 +13005,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -13085,7 +13085,7 @@ dependencies = [
  "cargo-lock",
  "chrono",
  "clap",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "num-format",
  "owo-colors",
  "plotters",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,7 @@ futures-retry = "0.6.0"
 futures-util = "0.3.31"
 hashbrown = "0.14.5"
 image = { version = "0.25.8", default-features = false }
-indexmap = "2.13.0"
+indexmap = "2.14.0"
 indoc = "2.0.0"
 itertools = "0.10.5"
 lightningcss = { version = "1.0.0-alpha.72", features = [

--- a/turbopack/crates/turbo-tasks-fs/src/watcher/mod.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher/mod.rs
@@ -5,6 +5,7 @@ mod mock_fs_api;
 
 use std::{
     any::Any,
+    borrow::Cow,
     collections::BTreeSet,
     env, fmt,
     path::{Path, PathBuf},
@@ -23,7 +24,7 @@ use bincode::{
     error::{DecodeError, EncodeError},
 };
 use bitflags::bitflags;
-use indexmap::map::Entry;
+use indexmap::map::{RawEntryApiV1, raw_entry_v1::RawEntryMut};
 use notify::{
     Config, EventKind, PollWatcher, RecommendedWatcher, Watcher,
     event::{MetadataKind, ModifyKind, RenameMode},
@@ -777,8 +778,8 @@ struct BatchedInvalidations {
     paths: FxIndexMap<Box<Path>, InvalidationFlags>,
     /// The most recently updated entry in [`Self::paths`].
     last_updated_index: Option<usize>,
-    /// See [`Self::new_paths`]). Stored as [`None`] in non-recursive mode.
-    new_paths: Option<FxHashSet<Box<Path>>>,
+    /// See [`Self::new_paths`]. Stored as [`None`] in recursive mode.
+    new_paths: Option<FxHashSet<usize>>,
     /// Whether events are coming from [`PollWatcher`] instead of [`RecommendedWatcher`], which
     /// changes how a file content change is reported. See [`Self::is_content_change`].
     polling: bool,
@@ -832,24 +833,24 @@ impl BatchedInvalidations {
         }
     }
 
-    /// Records `path` as newly-created so its watch can be (re-)established. No-op in recursive
+    /// Records `index` as newly-created so its watch can be (re-)established. No-op in recursive
     /// watching mode.
-    fn mark_new_path(&mut self, path: &Path) {
+    fn mark_new_path(&mut self, index: usize) {
         if let Some(new_paths) = &mut self.new_paths {
-            new_paths.insert(Box::from(path));
+            new_paths.insert(index);
         }
     }
 
     /// Sets the `flags` for `path`. Returns the index that was modified.
-    fn mark(&mut self, path: Box<Path>, flags: InvalidationFlags) -> usize {
-        match self.paths.entry(path) {
-            Entry::Occupied(mut entry) => {
+    fn mark(&mut self, path: Cow<'_, Path>, flags: InvalidationFlags) -> usize {
+        match self.paths.raw_entry_mut_v1().from_key(path.as_ref()) {
+            RawEntryMut::Occupied(mut entry) => {
                 *entry.get_mut() |= flags;
                 entry.index()
             }
-            Entry::Vacant(entry) => {
+            RawEntryMut::Vacant(entry) => {
                 let index = entry.index();
-                entry.insert(flags);
+                entry.insert(path.into_owned().into_boxed_path(), flags);
                 index
             }
         }
@@ -863,7 +864,7 @@ impl BatchedInvalidations {
 
     fn mark_parent_dir(&mut self, path: &Path) {
         if let Some(parent) = path.parent() {
-            self.mark(Box::from(parent), InvalidationFlags::PATH_DIR);
+            self.mark(Cow::Borrowed(parent), InvalidationFlags::PATH_DIR);
         }
     }
 
@@ -871,7 +872,10 @@ impl BatchedInvalidations {
     /// must have their watches (re-)established before [`Self::execute`] is called (see the note
     /// there). Always empty in recursive mode.
     fn new_paths(&self) -> impl Iterator<Item = &Path> {
-        self.new_paths.iter().flatten().map(|path| &**path)
+        self.new_paths
+            .iter()
+            .flatten()
+            .map(|&index| self.paths.get_index(index).unwrap().0.as_ref())
     }
 
     /// Updates the batch to contain updated paths from the given event. Does not perform any
@@ -885,33 +889,32 @@ impl BatchedInvalidations {
         match event.kind {
             EventKind::Modify(ModifyKind::Data(_)) => {
                 for path in paths {
-                    last_updated_index =
-                        Some(self.mark(path.into_boxed_path(), InvalidationFlags::PATH));
+                    last_updated_index = Some(self.mark(Cow::Owned(path), InvalidationFlags::PATH));
                 }
             }
             // Some backends (fsevents, polling) can report metadata events for file content changes
             EventKind::Modify(ModifyKind::Metadata(kind)) if self.is_content_change(kind) => {
                 for path in paths {
-                    last_updated_index =
-                        Some(self.mark(path.into_boxed_path(), InvalidationFlags::PATH));
+                    last_updated_index = Some(self.mark(Cow::Owned(path), InvalidationFlags::PATH));
                 }
             }
             EventKind::Create(_) => {
                 for path in paths {
                     self.mark_parent_dir(&path);
-                    self.mark_new_path(&path);
-                    last_updated_index = Some(self.mark(
-                        path.into_boxed_path(),
+                    let index = self.mark(
+                        Cow::Owned(path),
                         InvalidationFlags::PATH_AND_CHILDREN
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR,
-                    ));
+                    );
+                    self.mark_new_path(index);
+                    last_updated_index = Some(index);
                 }
             }
             EventKind::Remove(_) => {
                 for path in paths {
                     self.mark_parent_dir(&path);
                     last_updated_index = Some(self.mark(
-                        path.into_boxed_path(),
+                        Cow::Owned(path),
                         InvalidationFlags::PATH_AND_CHILDREN
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR,
                     ));
@@ -921,17 +924,17 @@ impl BatchedInvalidations {
             EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => {
                 let [source, destination] = <[PathBuf; 2]>::try_from(paths)
                     .expect("RenameMode::Both event must contain exactly two paths");
+
                 self.mark_parent_dir(&source);
-                self.mark(
-                    source.into_boxed_path(),
+                self.mark(Cow::Owned(source), InvalidationFlags::PATH_AND_CHILDREN);
+
+                self.mark_parent_dir(&destination);
+                let index = self.mark(
+                    Cow::Owned(destination),
                     InvalidationFlags::PATH_AND_CHILDREN,
                 );
-                self.mark_parent_dir(&destination);
-                self.mark_new_path(&destination);
-                last_updated_index = Some(self.mark(
-                    destination.into_boxed_path(),
-                    InvalidationFlags::PATH_AND_CHILDREN,
-                ));
+                self.mark_new_path(index);
+                last_updated_index = Some(index);
             }
             // We expect `RenameMode::Both` to cover most of the cases we need to invalidate,
             // but we also check other RenameModes to cover cases where notify couldn't match the
@@ -940,7 +943,7 @@ impl BatchedInvalidations {
                 for path in paths {
                     self.mark_parent_dir(&path);
                     last_updated_index = Some(self.mark(
-                        path.into_boxed_path(),
+                        Cow::Owned(path),
                         InvalidationFlags::PATH_AND_CHILDREN
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR,
                     ));
@@ -962,10 +965,10 @@ impl BatchedInvalidations {
     fn add_error(&mut self, paths: Vec<PathBuf>, root_path: &Path) {
         let flags = InvalidationFlags::PATH_AND_CHILDREN | InvalidationFlags::PATH_AND_CHILDREN_DIR;
         if paths.is_empty() {
-            self.last_updated_index = Some(self.mark(Box::from(root_path), flags));
+            self.last_updated_index = Some(self.mark(Cow::Borrowed(root_path), flags));
         } else {
             for path in paths {
-                self.last_updated_index = Some(self.mark(path.into_boxed_path(), flags));
+                self.last_updated_index = Some(self.mark(Cow::Owned(path), flags));
             }
         }
     }


### PR DESCRIPTION
This is a spiritual continuation of https://github.com/vercel/next.js/pull/96114 . See https://github.com/vercel/next.js/pull/94735 for motivation.

This codepath should already be pretty cheap, but in some cases (notably inotify on Linux where updates aren't debounced as aggressively by the OS) it could become somewhat hot and waste CPU while other somewhat-CPU-heavy work is happening in other software (e.g. `pnpm`).

This removes two more sources of clones:
- If we only have a `&Path`, but it's already in the `paths` map, we can use the raw entry API to avoid cloning it.
- `new_paths` can use `usize` indexes into the `FxIndexMap` instead of storing another clone of the path. We could also encode this information as flags on `path`, but the iteration over `new_paths` must happen as a separate loop before the normal batch execution loop (near the bottom of `DiskWatcher::watch_thread`), so I'd like to keep it as a separate data structure to avoid having to filter out a bunch of unrelated keys without the flag when finally processing the batch.