### PR TITLE
Don't serve a dev route whose file has been deleted

### DIFF
--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -940,6 +940,15 @@ export async function setupFsCheck(opts: {
               continue
             }
 
+            // The route table is rebuilt by the file watcher some time after
+            // the filesystem changes, so it can still list a route whose file
+            // has just been deleted. That route no longer exists.
+            try {
+              await fs.access(route.filename)
+            } catch {
+              continue
+            }
+
             const isAppFile = type === 'appFile'
 
             // Attempt to ensure the page/app file is compiled and ready.

--- a/test/development/app-dir/dev-route-freshness/app/layout.tsx
+++ b/test/development/app-dir/dev-route-freshness/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/dev-route-freshness/app/page.tsx
+++ b/test/development/app-dir/dev-route-freshness/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/dev-route-freshness/dev-route-freshness.test.ts
+++ b/test/development/app-dir/dev-route-freshness/dev-route-freshness.test.ts
@@ -1,0 +1,47 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+
+// The file watcher takes a moment to notice a change, and the dev server
+// serves from what the watcher last told it. These tests make the first
+// request for a route at varying delays after the filesystem changed, so that
+// some of them arrive before the watcher has caught up. Files are written
+// directly: next.patchFile waits after writing into app/, which would hide
+// exactly that window.
+const DELAYS_MS = [0, 15, 30, 60]
+const ITERATIONS = 20
+
+describe('dev-route-freshness', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('responds 404 to a request made right after a page is deleted', async () => {
+    const failures: string[] = []
+    for (let i = 0; i < ITERATIONS; i++) {
+      const pathname = `/deleted-${i}`
+      const dir = path.join(next.testDir, `app/deleted-${i}`)
+      await fs.mkdir(dir, { recursive: true })
+      await fs.writeFile(
+        path.join(dir, 'page.tsx'),
+        `export default function Page() { return <p>${pathname}</p> }`
+      )
+      await retry(async () => {
+        expect((await next.fetch(pathname)).status).toBe(200)
+      }, 15_000)
+
+      const delay = DELAYS_MS[i % DELAYS_MS.length]
+      await fs.rm(dir, { recursive: true, force: true })
+      await waitFor(delay)
+      const res = await next.fetch(pathname)
+      if (res.status !== 404) {
+        failures.push(`${pathname} after ${delay}ms: ${res.status}`)
+      }
+      await retry(async () => {
+        expect((await next.fetch(pathname)).status).toBe(404)
+      }, 15_000)
+    }
+    expect(failures).toEqual([])
+  })
+})

--- a/test/development/app-dir/dev-route-freshness/next.config.js
+++ b/test/development/app-dir/dev-route-freshness/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
Since the router tables are rebuilt some time after the filesystem changes, a request that arrives right after a page is deleted may still match the route and render the deleted page. Check that the matched route's file exists before ensuring it; if it is gone, the route is not a match and the request should fall through to the 404.

The new test deletes pages and requests them at varying delays after the deletion. Before this change, requests made immediately after a deletion returned 200 on both bundlers. Local run results:

<img width="1265" height="235" alt="Screenshot 2026-08-21 at 02 19 54" src="https://github.com/user-attachments/assets/b0950d31-d4f8-4f97-9b1b-fead11a28e4d" />
