### PR TITLE
Handle history entries created before hydration

### DIFF
--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -20,6 +20,7 @@ import {
   createMutableActionQueue,
 } from './components/app-router-instance'
 import AppRouter from './components/app-router'
+import { initializeEarlyHistory } from './components/history-handlers'
 import type { InitialRSCPayload } from '../shared/lib/app-router-types'
 import { createInitialRouterState } from './components/router-reducer/create-initial-router-state'
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
@@ -376,14 +377,18 @@ export async function hydrate(
   initializeRouterTransitionModules(instrumentationModules)
 
   const initialTimestamp = Date.now()
-  const actionQueue: AppRouterActionQueue = createMutableActionQueue(
-    createInitialRouterState({
-      navigatedAt: initialTimestamp,
-      initialRSCPayload,
-      initialFlightStreamForCache,
-      location: window.location,
-    })
-  )
+  const initialRouterState = createInitialRouterState({
+    navigatedAt: initialTimestamp,
+    initialRSCPayload,
+    initialFlightStreamForCache,
+    location: window.location,
+  })
+  initializeEarlyHistory({
+    tree: initialRouterState.tree,
+    renderedSearch: initialRouterState.renderedSearch,
+  })
+  const actionQueue: AppRouterActionQueue =
+    createMutableActionQueue(initialRouterState)
 
   const reactEl = (
     <StrictModeIfEnabled>

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -20,7 +20,10 @@ import {
   createMutableActionQueue,
 } from './components/app-router-instance'
 import AppRouter from './components/app-router'
-import { initializeEarlyHistory } from './components/history-handlers'
+import {
+  getHistoryActivationUrl,
+  initializeEarlyHistory,
+} from './components/history-handlers'
 import type { InitialRSCPayload } from '../shared/lib/app-router-types'
 import { createInitialRouterState } from './components/router-reducer/create-initial-router-state'
 import { MissingSlotContext } from '../shared/lib/app-router-context.shared-runtime'
@@ -381,7 +384,7 @@ export async function hydrate(
     navigatedAt: initialTimestamp,
     initialRSCPayload,
     initialFlightStreamForCache,
-    location: window.location,
+    location: getHistoryActivationUrl(),
   })
   initializeEarlyHistory({
     tree: initialRouterState.tree,

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -52,6 +52,7 @@ import { getAssetTokenQuery } from '../../shared/lib/deployment-id'
 import {
   installHistoryHandlers,
   shouldSkipFirstHistoryWrite,
+  writeHistory,
 } from './history-handlers'
 
 const globalMutable: {
@@ -101,9 +102,9 @@ function HistoryUpdater({
     ) {
       // This intentionally mutates React state, pushRef is overwritten to ensure additional push/replace calls do not trigger an additional history entry.
       pushRef.pendingPush = false
-      window.history.pushState(historyState, '', canonicalUrl)
+      writeHistory('pushState', historyState, canonicalUrl)
     } else {
-      window.history.replaceState(historyState, '', canonicalUrl)
+      writeHistory('replaceState', historyState, canonicalUrl)
     }
 
     setLastCommittedTree(tree)

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -49,11 +49,7 @@ import DefaultGlobalError from './builtin/global-error'
 import { RootLayoutBoundary } from '../../lib/framework/boundary-components'
 import type { StaticIndicatorState } from '../dev/hot-reloader/app/hot-reloader-app'
 import { getAssetTokenQuery } from '../../shared/lib/deployment-id'
-import {
-  installHistoryHandlers,
-  shouldSkipFirstHistoryWrite,
-  writeHistory,
-} from './history-handlers'
+import { installHistoryHandlers, writeHistory } from './history-handlers'
 
 const globalMutable: {
   pendingMpaPath?: string
@@ -72,13 +68,6 @@ function HistoryUpdater({
     }
 
     const { tree, pushRef, canonicalUrl, renderedSearch } = appRouterState
-
-    if (shouldSkipFirstHistoryWrite()) {
-      // Skip the write: it would overwrite the traversed-to entry's state.
-      // The tree was rendered even though the history write is skipped.
-      setLastCommittedTree(tree)
-      return
-    }
 
     const appHistoryState: AppHistoryState = {
       tree,

--- a/packages/next/src/client/components/history-handlers.ts
+++ b/packages/next/src/client/components/history-handlers.ts
@@ -12,6 +12,9 @@ type EarlyHistory = {
   href: string
   // Whether any pushState, replaceState or popstate happened since.
   changed: boolean
+  // Scopes the activation marker to this document. An entry marked by an
+  // earlier document is not one this document can render.
+  token: number
 }
 
 // The script's pushState/replaceState wrappers keep the method they replaced.
@@ -32,6 +35,7 @@ type HistoryEntry =
   | { kind: 'unknown' }
 
 let activationHistoryState: AppHistoryState | undefined
+let activationToken: number | undefined
 
 function readHistoryEntry(state: unknown): HistoryEntry {
   if (state === null || typeof state !== 'object') {
@@ -46,7 +50,10 @@ function readHistoryEntry(state: unknown): HistoryEntry {
         | undefined,
     }
   }
-  if (historyState[ACTIVATION_MARKER] === true) {
+  if (
+    activationToken !== undefined &&
+    historyState[ACTIVATION_MARKER] === activationToken
+  ) {
     return { kind: 'activation' }
   }
   return { kind: 'unknown' }
@@ -54,6 +61,7 @@ function readHistoryEntry(state: unknown): HistoryEntry {
 
 export function initializeEarlyHistory(historyState: AppHistoryState): void {
   activationHistoryState = historyState
+  activationToken = window.__next_h?.token
 }
 
 // A Back/Forward press before the router's popstate listener exists moves the

--- a/packages/next/src/client/components/history-handlers.ts
+++ b/packages/next/src/client/components/history-handlers.ts
@@ -234,13 +234,9 @@ export function installHistoryHandlers(): () => void {
   window.addEventListener('popstate', onPopState)
 
   if (handoff !== null) {
-    // History changed before the router was listening. Render the current
-    // entry the way a popstate onto it would, except that an entry the router
-    // knows nothing about is adopted rather than reloaded, as the first
-    // history write would have done before the script existed.
-    renderHistoryEntry(
-      handoff.kind === 'unknown' ? { kind: 'activation' } : handoff
-    )
+    // History changed before the router was listening. Treat the current
+    // entry the same way a popstate onto it would be treated.
+    renderHistoryEntry(handoff)
   }
 
   return () => {

--- a/packages/next/src/client/components/history-handlers.ts
+++ b/packages/next/src/client/components/history-handlers.ts
@@ -59,6 +59,12 @@ function readHistoryEntry(state: unknown): HistoryEntry {
   return { kind: 'unknown' }
 }
 
+// The URL the server rendered the initial payload for. It may differ from the
+// current URL if history changed before hydration.
+export function getHistoryActivationUrl(): URL {
+  return new URL(window.__next_h?.href ?? window.location.href)
+}
+
 export function initializeEarlyHistory(historyState: AppHistoryState): void {
   activationHistoryState = historyState
   activationToken = window.__next_h?.token

--- a/packages/next/src/client/components/history-handlers.ts
+++ b/packages/next/src/client/components/history-handlers.ts
@@ -3,7 +3,10 @@ import { restore, traverse } from './navigator'
 
 // The inline script in server/app-render/history-bootstrap.ts runs with the
 // shell, long before the Router effect below installs the history handlers.
-// It records whether history changed in between.
+// It marks the entry the document was activated on and records whether
+// history changed in between.
+const ACTIVATION_MARKER = '__PRIVATE_NEXTJS_INTERNALS_HISTORY_ACTIVATION'
+
 type EarlyHistory = {
   // The URL the document was activated on.
   href: string
@@ -20,17 +23,49 @@ declare global {
   }
 }
 
+type HistoryEntry =
+  // Written by the App Router, possibly in an earlier document.
+  | { kind: 'app'; historyState: AppHistoryState | undefined }
+  // The activation entry, or an entry written from it before the router took
+  // over. Both render with the initial payload.
+  | { kind: 'activation' }
+  | { kind: 'unknown' }
+
+let activationHistoryState: AppHistoryState | undefined
+
+function readHistoryEntry(state: unknown): HistoryEntry {
+  if (state === null || typeof state !== 'object') {
+    return { kind: 'unknown' }
+  }
+  const historyState = state as Record<string, unknown>
+  if (historyState.__NA === true) {
+    return {
+      kind: 'app',
+      historyState: historyState.__PRIVATE_NEXTJS_INTERNALS_TREE as
+        | AppHistoryState
+        | undefined,
+    }
+  }
+  if (historyState[ACTIVATION_MARKER] === true) {
+    return { kind: 'activation' }
+  }
+  return { kind: 'unknown' }
+}
+
+export function initializeEarlyHistory(historyState: AppHistoryState): void {
+  activationHistoryState = historyState
+}
+
 // A Back/Forward press before the router's popstate listener exists moves the
 // browser to a different history entry than the one the document was activated
 // on, and the resulting popstate fires with nobody listening. The bootstrap
 // script recorded it, so until the listener is installed a recorded change
-// onto a router-written entry means a traversal went unobserved.
+// onto an entry the router can render means a traversal went unobserved.
 function hasMissedTraversal(): boolean {
   return (
     window.__next_h?.changed === true &&
-    // Only entries written by the app router can be restored; on any other
-    // entry the traversal is left unhandled, as before.
-    window.history.state?.__NA === true
+    // On any other entry the traversal is left unhandled, as before.
+    readHistoryEntry(window.history.state).kind !== 'unknown'
   )
 }
 
@@ -42,6 +77,17 @@ export function shouldSkipFirstHistoryWrite(): boolean {
   }
   checkedMissedTraversalBeforeHistoryWrite = true
   return hasMissedTraversal()
+}
+
+export function writeHistory(
+  method: 'pushState' | 'replaceState',
+  historyState: Record<string, unknown>,
+  url: string
+): void {
+  // The first write on the activation entry inherits its marker through
+  // preserveCustomHistoryState. The entry is the router's from here on.
+  delete historyState[ACTIVATION_MARKER]
+  window.history[method](historyState, '', url)
 }
 
 /**
@@ -56,13 +102,19 @@ function handlePopState(state: PopStateEvent['state']): void {
     return
   }
 
+  const historyEntry = readHistoryEntry(state)
   // This case happens when the history entry was pushed by the `pages` router.
-  if (!state.__NA) {
+  if (historyEntry.kind === 'unknown') {
     window.location.reload()
     return
   }
 
-  traverse(window.location.href, state.__PRIVATE_NEXTJS_INTERNALS_TREE)
+  traverse(
+    window.location.href,
+    historyEntry.kind === 'app'
+      ? historyEntry.historyState
+      : activationHistoryState
+  )
 }
 
 function copyNextJsInternalHistoryState(data: any) {

--- a/packages/next/src/client/components/history-handlers.ts
+++ b/packages/next/src/client/components/history-handlers.ts
@@ -64,27 +64,13 @@ export function initializeEarlyHistory(historyState: AppHistoryState): void {
   activationToken = window.__next_h?.token
 }
 
-// A Back/Forward press before the router's popstate listener exists moves the
-// browser to a different history entry than the one the document was activated
-// on, and the resulting popstate fires with nobody listening. The bootstrap
-// script recorded it, so until the listener is installed a recorded change
-// onto an entry the router can render means a traversal went unobserved.
-function hasMissedTraversal(): boolean {
+function isSameRoute(
+  a: Pick<URL, 'origin' | 'pathname' | 'search'>,
+  b: Pick<URL, 'origin' | 'pathname' | 'search'>
+): boolean {
   return (
-    window.__next_h?.changed === true &&
-    // On any other entry the traversal is left unhandled, as before.
-    readHistoryEntry(window.history.state).kind !== 'unknown'
+    a.origin === b.origin && a.pathname === b.pathname && a.search === b.search
   )
-}
-
-let checkedMissedTraversalBeforeHistoryWrite = false
-
-export function shouldSkipFirstHistoryWrite(): boolean {
-  if (checkedMissedTraversalBeforeHistoryWrite) {
-    return false
-  }
-  checkedMissedTraversalBeforeHistoryWrite = true
-  return hasMissedTraversal()
 }
 
 export function writeHistory(
@@ -92,6 +78,12 @@ export function writeHistory(
   historyState: Record<string, unknown>,
   url: string
 ): void {
+  // History changed before the router took over. The current entry is handed
+  // off in installHistoryHandlers; writing the payload's state onto it here
+  // would mislabel it.
+  if (window.__next_h?.changed) {
+    return
+  }
   // The first write on the activation entry inherits its marker through
   // preserveCustomHistoryState. The entry is the router's from here on.
   delete historyState[ACTIVATION_MARKER]
@@ -110,7 +102,10 @@ function handlePopState(state: PopStateEvent['state']): void {
     return
   }
 
-  const historyEntry = readHistoryEntry(state)
+  renderHistoryEntry(readHistoryEntry(state))
+}
+
+function renderHistoryEntry(historyEntry: HistoryEntry): void {
   // This case happens when the history entry was pushed by the `pages` router.
   if (historyEntry.kind === 'unknown') {
     window.location.reload()
@@ -142,7 +137,15 @@ function copyNextJsInternalHistoryState(data: any) {
 }
 
 export function installHistoryHandlers(): () => void {
-  const missedTraversal = hasMissedTraversal()
+  const earlyHistory = window.__next_h
+  let handoff: HistoryEntry | null = null
+  if (earlyHistory?.changed) {
+    // Whatever the current entry holds, the initial payload is what the
+    // server would render for the activation route.
+    handoff = isSameRoute(new URL(earlyHistory.href), window.location)
+      ? { kind: 'activation' }
+      : readHistoryEntry(window.history.state)
+  }
 
   // Remove the bootstrap script's wrappers, unless application code wrapped
   // them in turn.
@@ -224,8 +227,14 @@ export function installHistoryHandlers(): () => void {
 
   window.addEventListener('popstate', onPopState)
 
-  if (missedTraversal) {
-    handlePopState(window.history.state)
+  if (handoff !== null) {
+    // History changed before the router was listening. Render the current
+    // entry the way a popstate onto it would, except that an entry the router
+    // knows nothing about is adopted rather than reloaded, as the first
+    // history write would have done before the script existed.
+    renderHistoryEntry(
+      handoff.kind === 'unknown' ? { kind: 'activation' } : handoff
+    )
   }
 
   return () => {

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -24,7 +24,7 @@ export interface InitialRouterStateParameters {
   navigatedAt: number
   initialRSCPayload: InitialRSCPayload
   initialFlightStreamForCache?: ReadableStream<Uint8Array> | null
-  location: Location | null
+  location: Pick<Location, 'href' | 'pathname' | 'search' | 'hash'> | null
 }
 
 export function createInitialRouterState({

--- a/packages/next/src/server/app-render/history-bootstrap.ts
+++ b/packages/next/src/server/app-render/history-bootstrap.ts
@@ -1,10 +1,11 @@
 // React emits this inline script with the shell, before the external bootstrap
 // scripts that eventually install the App Router's history handlers (see
-// client/components/history-handlers.ts). Until then it records whether
-// history changed. It runs in every App Router document, so it has no
-// dependencies and stays small.
+// client/components/history-handlers.ts). Until then it marks the entry the
+// document was activated on and records whether history changed. It runs in
+// every App Router document, so it has no dependencies and stays small.
 const historyBootstrapScript = String.raw`
 ;(function () {
+  const marker = '__PRIVATE_NEXTJS_INTERNALS_HISTORY_ACTIVATION'
   const earlyHistory = {
     href: location.href,
     changed: false,
@@ -15,9 +16,29 @@ const historyBootstrapScript = String.raw`
     earlyHistory.changed = true
   }
 
+  // An entry written from the activation entry renders the same page, so it
+  // inherits the mark. Like copyNextJsInternalHistoryState in
+  // history-handlers.ts, absent state becomes an object to carry it. The
+  // router's own writes carry their state already; the first one happens
+  // before the wrappers are removed.
+  function inheritActivation(data) {
+    if (data && data.__NA === true) {
+      return data
+    }
+    if (data == null) {
+      data = {}
+    }
+    const current = history.state
+    if (current && current[marker] === true) {
+      data[marker] = true
+    }
+    return data
+  }
+
   const originalPushState = history.pushState
   function pushState(data, unused, url) {
     recordChange()
+    data = inheritActivation(data)
     return originalPushState.call(history, data, unused, url)
   }
   pushState.__original = originalPushState
@@ -25,9 +46,19 @@ const historyBootstrapScript = String.raw`
   const originalReplaceState = history.replaceState
   function replaceState(data, unused, url) {
     recordChange()
+    data = inheritActivation(data)
     return originalReplaceState.call(history, data, unused, url)
   }
   replaceState.__original = originalReplaceState
+
+  // The entry may still carry the router state of the document that created
+  // it. The new document's payload supersedes that, so the entry is marked as
+  // this document's activation entry instead.
+  const activationState = Object.assign({}, history.state)
+  delete activationState.__NA
+  delete activationState.__PRIVATE_NEXTJS_INTERNALS_TREE
+  activationState[marker] = true
+  originalReplaceState.call(history, activationState, '', location.href)
 
   history.pushState = pushState
   history.replaceState = replaceState

--- a/packages/next/src/server/app-render/history-bootstrap.ts
+++ b/packages/next/src/server/app-render/history-bootstrap.ts
@@ -6,9 +6,11 @@
 const historyBootstrapScript = String.raw`
 ;(function () {
   const marker = '__PRIVATE_NEXTJS_INTERNALS_HISTORY_ACTIVATION'
+  const token = Math.random()
   const earlyHistory = {
     href: location.href,
     changed: false,
+    token,
   }
   self.__next_h = earlyHistory
 
@@ -29,8 +31,8 @@ const historyBootstrapScript = String.raw`
       data = {}
     }
     const current = history.state
-    if (current && current[marker] === true) {
-      data[marker] = true
+    if (current && current[marker] === token) {
+      data[marker] = token
     }
     return data
   }
@@ -57,7 +59,7 @@ const historyBootstrapScript = String.raw`
   const activationState = Object.assign({}, history.state)
   delete activationState.__NA
   delete activationState.__PRIVATE_NEXTJS_INTERNALS_TREE
-  activationState[marker] = true
+  activationState[marker] = token
   originalReplaceState.call(history, activationState, '', location.href)
 
   history.pushState = pushState

--- a/packages/next/src/server/app-render/history-bootstrap.ts
+++ b/packages/next/src/server/app-render/history-bootstrap.ts
@@ -18,12 +18,12 @@ const historyBootstrapScript = String.raw`
     earlyHistory.changed = true
   }
 
-  // An entry written from the activation entry renders the same page, so it
-  // inherits the mark. Like copyNextJsInternalHistoryState in
-  // history-handlers.ts, absent state becomes an object to carry it. The
-  // router's own writes carry their state already; the first one happens
-  // before the wrappers are removed.
-  function inheritActivation(data) {
+  // An entry written from an entry the router can render renders the same
+  // page, so it inherits that entry's router state or activation mark. Like
+  // copyNextJsInternalHistoryState in history-handlers.ts, absent state
+  // becomes an object to carry it. The router's own writes carry their state
+  // already; the first one happens before the wrappers are removed.
+  function inheritRouterState(data) {
     if (data && data.__NA === true) {
       return data
     }
@@ -31,7 +31,11 @@ const historyBootstrapScript = String.raw`
       data = {}
     }
     const current = history.state
-    if (current && current[marker] === token) {
+    if (current && current.__NA === true) {
+      data.__NA = true
+      data.__PRIVATE_NEXTJS_INTERNALS_TREE =
+        current.__PRIVATE_NEXTJS_INTERNALS_TREE
+    } else if (current && current[marker] === token) {
       data[marker] = token
     }
     return data
@@ -40,7 +44,7 @@ const historyBootstrapScript = String.raw`
   const originalPushState = history.pushState
   function pushState(data, unused, url) {
     recordChange()
-    data = inheritActivation(data)
+    data = inheritRouterState(data)
     return originalPushState.call(history, data, unused, url)
   }
   pushState.__original = originalPushState
@@ -48,7 +52,7 @@ const historyBootstrapScript = String.raw`
   const originalReplaceState = history.replaceState
   function replaceState(data, unused, url) {
     recordChange()
-    data = inheritActivation(data)
+    data = inheritRouterState(data)
     return originalReplaceState.call(history, data, unused, url)
   }
   replaceState.__original = originalReplaceState

--- a/test/e2e/app-dir/back-before-hydration/app/layout.tsx
+++ b/test/e2e/app-dir/back-before-hydration/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react'
 import { RouterUrl } from './router-url'
+import { ServerPathname } from './server-pathname'
 import { ThirdPartyPush } from './third-party-push'
 
 export default function RootLayout({
@@ -14,6 +15,7 @@ export default function RootLayout({
         <Suspense>
           <RouterUrl />
         </Suspense>
+        <ServerPathname />
         {children}
       </body>
     </html>

--- a/test/e2e/app-dir/back-before-hydration/app/server-pathname.tsx
+++ b/test/e2e/app-dir/back-before-hydration/app/server-pathname.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+
+// Renders the router's pathname on the server and during hydration, so a
+// mismatch between the two shows up as a hydration error.
+export function ServerPathname() {
+  return <output id="server-pathname">{usePathname()}</output>
+}

--- a/test/e2e/app-dir/back-before-hydration/app/third-party-push.tsx
+++ b/test/e2e/app-dir/back-before-hydration/app/third-party-push.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect } from 'react'
 
-// Simulates a third-party script writing to history between the router's
-// traversal detection and its popstate replay: this component's effect runs
-// after all insertion effects but before the parent router's effects.
+// Simulates a third-party script writing to history after hydration has
+// committed but before the router has taken over: this component's effect
+// runs after all insertion effects but before the parent router's effects.
 export function ThirdPartyPush() {
   useEffect(() => {
     if ((window as any).__injectThirdPartyPush) {

--- a/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
+++ b/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
@@ -308,6 +308,19 @@ describe('back navigation before hydration after reload', () => {
         expect(await readRouterUrl(browser)).toBe(postPath)
       })
 
+      // The entry pushed before hydration is still traversable.
+      await browser.forward()
+      await retry(async () => {
+        expect(await readRouterUrl(browser)).toBe(`${postPath}?tp=1`)
+      })
+      expect(await browser.eval('window.history.state.thirdParty')).toBe(true)
+      expect(await browser.eval('window.__stayed')).toBe(true)
+      await browser.back()
+      await retry(async () => {
+        expect(await readRouterUrl(browser)).toBe(postPath)
+      })
+      expect(await browser.eval('window.__stayed')).toBe(true)
+
       await browser.elementById('to-home').click()
       await waitForPage(browser, '#home')
     })
@@ -394,6 +407,19 @@ describe('back navigation before hydration after reload', () => {
         expect(await browser.elementByCss('h1').text()).toBe('Post')
         expect(await readRouterUrl(browser)).toBe(`${postPath}?tp=1`)
       })
+      expect(await browser.eval('window.history.state.a')).toBe(1)
+
+      // Both early entries remain traversable.
+      await browser.forward()
+      await retry(async () => {
+        expect(await readRouterUrl(browser)).toBe(`${postPath}?tp=2`)
+      })
+      expect(await browser.eval('window.history.state.b')).toBe(2)
+      await browser.back()
+      await retry(async () => {
+        expect(await readRouterUrl(browser)).toBe(`${postPath}?tp=1`)
+      })
+      expect(await browser.eval('window.__stayed')).toBe(true)
     })
   })
 })

--- a/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
+++ b/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
@@ -355,6 +355,27 @@ describe('back navigation before hydration after reload', () => {
       await waitForPage(browser, '#home')
     })
 
+    it('does not render onto an entry marked by a previous document', async () => {
+      const { browser, page, releaseScripts } = await loadStalled(postPath)
+
+      await page.evaluate(`window.history.pushState(null, '', '${homePath}')`)
+      releaseScripts()
+      await retry(async () => {
+        expect(await readRouterUrl(browser)).toBe(homePath)
+      })
+
+      // The reloaded document renders the home page. The entry left behind at
+      // /post was marked by the previous document, whose payload is gone, so
+      // going back to it must not render the home page there.
+      await browser.refresh()
+      await waitForPage(browser, '#home')
+      await browser.eval('window.__reloaded = true')
+      await browser.back()
+      await waitForPage(browser, '#post')
+      expect(new URL(await browser.url()).pathname).toBe(postPath)
+      expect(await browser.eval('window.__reloaded')).not.toBe(true)
+    })
+
     it('keeps a history wrapper installed before hydration', async () => {
       const { browser, page, releaseScripts } = await loadStalled(postPath)
 

--- a/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
+++ b/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
@@ -325,7 +325,7 @@ describe('back navigation before hydration after reload', () => {
       await waitForPage(browser, '#home')
     })
 
-    it('leaves the traversal unhandled when a third-party write lands before the replay', async () => {
+    it('handles a third-party write that lands during hydration', async () => {
       const { browser, page, releaseScripts } = await clickThenReloadStalled(
         homePath,
         'to-post',
@@ -336,23 +336,54 @@ describe('back navigation before hydration after reload', () => {
       expect(new URL(await browser.url()).pathname).toBe(homePath)
 
       // Arms an effect in the fixture that pushes a third-party history
-      // entry between the router's traversal detection and its replay.
+      // entry after hydration has committed but before the router's own
+      // effect has run.
       await page.evaluate('window.__injectThirdPartyPush = true')
       releaseScripts()
 
       await retry(async () => {
-        // The traversal cannot be replayed onto the third-party entry. The
-        // content stays on the reloaded page, like before the fix — and in
-        // particular the router must not reload a page that just loaded.
+        // The entry was pushed from the traversed-to home entry, so it
+        // renders the home page at the pushed URL.
         expect(await browser.eval('window.__stayed')).toBe(true)
         expect(new URL(await browser.url()).search).toBe('?tp=1')
-        expect(await browser.elementByCss('h1').text()).toBe('Post')
-        // TODO: The router never learns about the third-party entry.
-        expect(await readRouterUrl(browser)).toBe(homePath)
+        expect(await browser.elementByCss('h1').text()).toBe('Home')
+        expect(await readRouterUrl(browser)).toBe(`${homePath}?tp=1`)
       })
 
-      await browser.elementById('to-home').click()
-      await waitForPage(browser, '#home')
+      await browser.elementById('to-post').click()
+      await waitForPage(browser, '#post')
+    })
+
+    describe.each([
+      { method: 'pushState' as const, search: '?after=back-push' },
+      { method: 'replaceState' as const, search: '?after=back-replace' },
+    ])('$method after an early traversal', ({ method, search }) => {
+      it('renders the traversed-to page at the written URL', async () => {
+        const { browser, page, releaseScripts } = await clickThenReloadStalled(
+          homePath,
+          'to-post',
+          '#post'
+        )
+
+        await browser.back({ waitUntil: 'commit' })
+        await page.evaluate(
+          `window.history.${method}({ thirdParty: true }, '', '${homePath}${search}')`
+        )
+        releaseScripts()
+
+        await waitForPage(browser, '#home')
+        await retry(async () => {
+          expect(await readRouterUrl(browser)).toBe(`${homePath}${search}`)
+        })
+        expect(await browser.eval('window.__stayed')).toBe(true)
+
+        await browser.elementById('to-post').click()
+        await waitForPage(browser, '#post')
+        await browser.back()
+        await waitForPage(browser, '#home')
+        expect(new URL(await browser.url()).search).toBe(search)
+        expect(await browser.eval('window.__stayed')).toBe(true)
+      })
     })
 
     it('does not render onto an entry marked by a previous document', async () => {

--- a/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
+++ b/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
@@ -407,6 +407,30 @@ describe('back navigation before hydration after reload', () => {
       expect(await browser.eval('window.__reloaded')).not.toBe(true)
     })
 
+    // Writes that bypass history.pushState/replaceState (or come from another
+    // framework) leave entries the router knows nothing about.
+    it('adopts an unknown entry on the same route', async () => {
+      const { browser, page, releaseScripts } = await loadStalled(postPath)
+
+      await page.evaluate(
+        `History.prototype.pushState.call(window.history, { foreign: true }, '', '${postPath}')`
+      )
+      releaseScripts()
+
+      await retry(async () => {
+        expect(await readRouterUrl(browser)).toBe(postPath)
+      })
+      expect(await browser.eval('window.__stayed')).toBe(true)
+      expect(await browser.eval('window.history.state.foreign')).toBe(true)
+
+      await browser.elementById('to-home').click()
+      await waitForPage(browser, '#home')
+      await browser.back()
+      await waitForPage(browser, '#post')
+      expect(await browser.eval('window.history.state.foreign')).toBe(true)
+      expect(await browser.eval('window.__stayed')).toBe(true)
+    })
+
     it('keeps a history wrapper installed before hydration', async () => {
       const { browser, page, releaseScripts } = await loadStalled(postPath)
 

--- a/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
+++ b/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
@@ -128,7 +128,7 @@ describe('back navigation before hydration after reload', () => {
   const searchPath = '/search'
 
   it('reconciles the URL with the rendered content once hydration completes', async () => {
-    const { browser, releaseScripts } = await clickThenReloadStalled(
+    const { browser, page, releaseScripts } = await clickThenReloadStalled(
       homePath,
       'to-post',
       '#post'
@@ -139,6 +139,11 @@ describe('back navigation before hydration after reload', () => {
     await browser.back({ waitUntil: 'commit' })
     expect(new URL(await browser.url()).pathname).toBe(homePath)
 
+    // The server rendered the post page. Hydration must match it even though
+    // the URL now says otherwise.
+    await page.evaluate(
+      'document.getElementById("server-pathname").__server = true'
+    )
     releaseScripts()
 
     // We traversed back, so once the router is up it must render the home
@@ -148,6 +153,9 @@ describe('back navigation before hydration after reload', () => {
     await retry(async () => {
       expect(await readRouterUrl(browser)).toBe(homePath)
     })
+    expect(
+      await browser.eval('document.getElementById("server-pathname").__server')
+    ).toBe(true)
 
     // History traversal must still work after recovery.
     await browser.forward()

--- a/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
+++ b/test/e2e/app-dir/back-before-hydration/back-before-hydration.test.ts
@@ -415,6 +415,26 @@ describe('back navigation before hydration after reload', () => {
       expect(await browser.eval('window.__reloaded')).not.toBe(true)
     })
 
+    it('adopts a null-state pushState to another pathname', async () => {
+      const { browser, page, releaseScripts } = await loadStalled(postPath)
+
+      await page.evaluate(`window.history.pushState(null, '', '/shallow-path')`)
+      releaseScripts()
+
+      await retry(async () => {
+        expect(await readRouterUrl(browser)).toBe('/shallow-path')
+      })
+      expect(await browser.elementByCss('h1').text()).toBe('Post')
+      expect(await browser.eval('window.__stayed')).toBe(true)
+
+      await browser.elementById('to-home').click()
+      await waitForPage(browser, '#home')
+      await browser.back()
+      await waitForPage(browser, '#post')
+      expect(new URL(await browser.url()).pathname).toBe('/shallow-path')
+      expect(await browser.eval('window.__stayed')).toBe(true)
+    })
+
     // Writes that bypass history.pushState/replaceState (or come from another
     // framework) leave entries the router knows nothing about.
     it('adopts an unknown entry on the same route', async () => {
@@ -437,6 +457,25 @@ describe('back navigation before hydration after reload', () => {
       await waitForPage(browser, '#post')
       expect(await browser.eval('window.history.state.foreign')).toBe(true)
       expect(await browser.eval('window.__stayed')).toBe(true)
+    })
+
+    it('reloads when traversed onto an unknown entry for another route', async () => {
+      const { browser, page, releaseScripts } = await loadStalled(postPath)
+
+      await page.evaluate(`
+        History.prototype.pushState.call(window.history, { foreign: true }, '', '${postPath}?foreign=1')
+        History.prototype.pushState.call(window.history, { foreign: true }, '', '${postPath}?foreign=2')
+        window.history.back()
+      `)
+      await retry(async () => {
+        expect(new URL(page.url()).search).toBe('?foreign=1')
+      })
+      releaseScripts()
+
+      await retry(async () => {
+        expect(await browser.eval('window.__stayed')).not.toBe(true)
+        expect(await readRouterUrl(browser)).toBe(`${postPath}?foreign=1`)
+      })
     })
 
     it('keeps a history wrapper installed before hydration', async () => {


### PR DESCRIPTION
Stacked on #97526.

The App Router's first history write after hydration assumes nothing happened to history since the document was created, and stamps the initial payload's state onto whatever entry is current. #97526 recovers one case, a Back press onto a router-written entry. This handles the rest: the entry the document started on after an early push and Back, entries created by pushState/replaceState before hydration, writes made after an early Back or during hydration, entries left by another document or another router, and the hydration mismatch that a Back press before hydration causes today.

Each commit fixes one of those and adds the scenario for it to the back-before-hydration suite. One commit restructures the handoff without changing behavior so the ones after it can share a path.
