### PR TITLE
Turbopack: deduplicate Pages Router app chunks

### DIFF
--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -233,11 +233,11 @@ impl PagesProject {
     }
 
     #[turbo_tasks::function]
-    async fn to_endpoint(
+    async fn to_page_endpoint(
         self: Vc<Self>,
         item: Vc<PagesStructureItem>,
         ty: PageEndpointType,
-    ) -> Result<Vc<Box<dyn Endpoint>>> {
+    ) -> Result<Vc<PageEndpoint>> {
         let PagesStructureItem {
             next_router_path,
             original_path,
@@ -245,15 +245,23 @@ impl PagesProject {
         } = &*item.await?;
         let pathname: RcStr = format!("/{}", next_router_path.path).into();
         let original_name = format!("/{}", original_path.path).into();
-        let endpoint = Vc::upcast(PageEndpoint::new(
+        Ok(PageEndpoint::new(
             ty,
             self,
             pathname,
             original_name,
             item,
             self.pages_structure(),
-        ));
-        Ok(endpoint)
+        ))
+    }
+
+    #[turbo_tasks::function]
+    async fn to_endpoint(
+        self: Vc<Self>,
+        item: Vc<PagesStructureItem>,
+        ty: PageEndpointType,
+    ) -> Result<Vc<Box<dyn Endpoint>>> {
+        Ok(Vc::upcast(self.to_page_endpoint(item, ty)))
     }
 
     #[turbo_tasks::function]
@@ -264,9 +272,16 @@ impl PagesProject {
         ))
     }
 
+    /// The `/_app` endpoint. Its client chunk group is generated first and seeds the availability
+    /// information of every other page, so it must never depend on an individual page.
+    #[turbo_tasks::function]
+    async fn app_page_endpoint(self: Vc<Self>) -> Result<Vc<PageEndpoint>> {
+        Ok(self.to_page_endpoint(*self.pages_structure().await?.app, PageEndpointType::Html))
+    }
+
     #[turbo_tasks::function]
     pub async fn app_endpoint(self: Vc<Self>) -> Result<Vc<Box<dyn Endpoint>>> {
-        Ok(self.to_endpoint(*self.pages_structure().await?.app, PageEndpointType::Html))
+        Ok(Vc::upcast(self.app_page_endpoint()))
     }
 
     #[turbo_tasks::function]
@@ -797,12 +812,24 @@ impl PageEndpoint {
                 .iter()
                 .map(|m| ResolvedVc::upcast(*m))
                 .collect();
+            // Like App Router layouts, `/_app` is always loaded before the page. Chunk it first so
+            // the page's chunks don't include modules that the browser already downloaded with
+            // `/_app`.
+            let availability_info = if this.pathname == "/_app" {
+                AvailabilityInfo::root()
+            } else {
+                this.pages_project
+                    .app_page_endpoint()
+                    .client_chunk_group()
+                    .await?
+                    .availability_info
+            };
             let client_chunk_group = client_chunking_context.evaluated_chunk_group(
                 AssetIdent::from_path(this.page.await?.base_path.clone()).into_vc(),
                 ChunkGroup::Entry(evaluatable_assets),
                 module_graph,
                 OutputAssets::empty(),
-                AvailabilityInfo::root(),
+                availability_info,
             );
 
             Ok(client_chunk_group)

--- a/test/e2e/app-document-import-order/app-document-import-order.test.ts
+++ b/test/e2e/app-document-import-order/app-document-import-order.test.ts
@@ -2,7 +2,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Root components import order', () => {
-  const { next, isTurbopack } = nextTestSetup({
+  const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: __dirname,
   })
 
@@ -16,6 +16,34 @@ describe('Root components import order', () => {
       expect($(sideEffectCall).text()).toEqual(expectSideEffectsOrder[index])
     })
   })
+  // Only asserted for production builds: in development each entry is chunked from its own
+  // per-page module graph, which can still merge a shared module into per-entry units.
+  ;(isNextDev ? it.skip : it)(
+    'loads modules shared by _app and the page only once',
+    async () => {
+      const browser = await next.browser('/', { waitHydration: false })
+      const markerCount = await browser.eval(async () => {
+        const chunkUrls = [
+          ...new Set(
+            performance
+              .getEntriesByType('resource')
+              .map((entry) => entry.name)
+              .filter(
+                (url) => url.includes('/_next/static/') && url.endsWith('.js')
+              )
+          ),
+        ]
+        const chunks = await Promise.all(
+          chunkUrls.map((url) => fetch(url).then((response) => response.text()))
+        )
+        return chunks.filter((chunk) =>
+          chunk.includes('APP_PAGE_SHARED_MODULE_MARKER')
+        ).length
+      })
+
+      expect(markerCount).toBe(1)
+    }
+  )
 
   // Test relies on webpack splitChunks overrides.
   ;(isTurbopack ? it.skip : it)(

--- a/test/e2e/app-document-import-order/sideEffectModule.js
+++ b/test/e2e/app-document-import-order/sideEffectModule.js
@@ -7,4 +7,6 @@ const sideEffect = (arg) => {
   return sideEffect.callArguments
 }
 
+globalThis.__appPageSharedModuleMarker = 'APP_PAGE_SHARED_MODULE_MARKER'
+
 export default sideEffect


### PR DESCRIPTION
Previously, Turbopack treated `_app` and Pages router pages as completely separate.

So using code both in `_app` and `pages/foo.tsx` would lead to a lot of duplicated code to be loaded at runtime.
But in reality, `_app` is always loaded for Pages, so we can thread the availability info and skip chunking modules that were already loaded by `_app`.

Recreation of https://github.com/vercel/next.js/pull/97549