### PR TITLE
Migrate some async blocks to async closures

### DIFF
--- a/crates/next-api/src/aggregate_hmr.rs
+++ b/crates/next-api/src/aggregate_hmr.rs
@@ -58,7 +58,7 @@ impl Version for AggregateHmrVersion {
                 let version = TraitRef::cell(version.clone());
                 async move {
                     let id = version.id().owned().await?;
-                    Ok::<_, anyhow::Error>((path, id))
+                    anyhow::Ok((path, id))
                 }
             })
             .try_join()
@@ -93,7 +93,7 @@ impl AggregateHmrVersion {
                 let content = *content;
                 async move {
                     let version = content.version().into_trait_ref().await?;
-                    Ok::<_, anyhow::Error>((path, version))
+                    anyhow::Ok((path, version))
                 }
             })
             .try_join()
@@ -194,9 +194,9 @@ pub async fn diff_chunks_against(
             };
             Some((path.clone(), *content, TraitRef::cell(prev)))
         })
-        .map(|(path, content, prev)| async move {
+        .map(async |(path, content, prev)| {
             let update = content.update(prev).await?;
-            Ok::<_, anyhow::Error>((path, update))
+            anyhow::Ok((path, update))
         })
         .try_join()
         .await?;

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -827,7 +827,7 @@ impl AppProject {
                             .any(|route| route.as_str() == pathname.to_string())
                     })
                 })
-                .map(|(pathname, app_entrypoint)| async {
+                .map(async |(pathname, app_entrypoint)| {
                     Ok((
                         pathname.to_string().into(),
                         app_entry_point_to_route(self, app_entrypoint.clone())

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -34,7 +34,7 @@ pub async fn map_client_references(
     let manifest = graph
         .await?
         .iter_reachable_modules()?
-        .map(|module| async move {
+        .map(async |module| {
             if let Some(client_reference_module) =
                 ResolvedVc::try_downcast_type::<EcmascriptClientReferenceModule>(module)
             {

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -54,7 +54,7 @@ pub(crate) async fn collect_next_dynamic_chunks(
     let chunking_availability = &chunking_availability;
     let dynamic_import_chunks = dynamic_import_entries
         .iter()
-        .map(|(dynamic_entry, parent_client_reference)| async move {
+        .map(async |(dynamic_entry, parent_client_reference)| {
             let module = ResolvedVc::upcast::<Box<dyn ChunkableModule>>(*dynamic_entry);
 
             // This is the availability info for the parent chunk group, i.e. the client reference
@@ -124,7 +124,7 @@ pub async fn map_next_dynamic(
         graph
             .await?
             .iter_reachable_modules()?
-            .map(|module| async move {
+            .map(async |module| {
                 if let Some(dynamic_entry_module) =
                     ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(module)
                     && module.ident().await?.layer.as_ref().is_some_and(|layer| {

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -103,7 +103,7 @@ impl NextDynamicGraphs {
                 let result = self
                     .0
                     .iter()
-                    .map(|graph| async move {
+                    .map(async |graph| {
                         Ok(graph
                             .get_next_dynamic_imports_for_endpoint(entry)
                             .await?
@@ -300,7 +300,7 @@ impl ServerActionsGraphs {
                 let result = self
                     .0
                     .iter()
-                    .map(|graph| async move {
+                    .map(async |graph| {
                         graph
                             .get_server_actions_for_endpoint(entry, rsc_asset_context)
                             .owned()
@@ -372,7 +372,7 @@ impl ServerActionsGraph {
 
             let actions = data
                 .iter()
-                .map(|(module, (layer, actions))| async move {
+                .map(async |(module, (layer, actions))| {
                     let actions = actions.await?;
                     actions
                         .actions

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -124,7 +124,7 @@ impl VersionedContentMap {
                 let rel = root.get_path_to(&path)?;
                 Some((RcStr::from(rel), path))
             })
-            .map(|(name, path)| async move {
+            .map(async |(name, path)| {
                 // Skip Redirect assets: they're symlinks with no file content,
                 // so versioning them would bail with "not a file".
                 let Some(asset) = *self.get_asset(path).await? else {
@@ -337,7 +337,7 @@ async fn get_entries(assets: OperationVc<ExpandedOutputAssets>) -> Result<Vc<Get
     let assets_ref = assets.connect().await?;
     let entries = assets_ref
         .iter()
-        .map(|&asset| async move {
+        .map(async |&asset| {
             let path = asset.path().owned().await?;
             Ok((path, asset))
         })

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -192,7 +192,7 @@ pub async fn get_app_client_references_chunks(
 
                 let ssr_modules = client_reference_types
                     .iter()
-                    .map(|client_reference_ty| async move {
+                    .map(async |client_reference_ty| {
                         Ok(match client_reference_ty {
                             ClientReferenceType::EcmascriptClientReference(
                                 ecmascript_client_reference,
@@ -241,7 +241,7 @@ pub async fn get_app_client_references_chunks(
 
                 let client_modules = client_reference_types
                     .iter()
-                    .map(|client_reference_ty| async move {
+                    .map(async |client_reference_ty| {
                         Ok(match client_reference_ty {
                             ClientReferenceType::EcmascriptClientReference(
                                 ecmascript_client_reference,
@@ -351,7 +351,7 @@ pub async fn get_client_references_chunks_for_hmr(
     let mut extras: FxIndexSet<ResolvedVc<Box<dyn OutputAsset>>> = client_references_chunks_ref
         .layout_segment_client_chunks
         .values()
-        .map(|&assets| async move {
+        .map(async |&assets| {
             let primary = assets.primary_assets().await?;
             Ok(primary.iter().copied().collect::<Vec<_>>())
         })

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -241,12 +241,12 @@ async fn get_pages_structure_for_root_directory(
                 next_router_path: next_router_path.clone(),
                 items: items
                     .into_iter()
-                    .map(|(_, v)| async move { v.to_resolved().await })
+                    .map(|(_, v)| v.to_resolved())
                     .try_join()
                     .await?,
                 children: children
                     .into_iter()
-                    .map(|(_, v)| async move { v.to_resolved().await })
+                    .map(|(_, v)| v.to_resolved())
                     .try_join()
                     .await?,
             }
@@ -386,13 +386,13 @@ async fn get_pages_structure_for_directory(
             items: items
                 .into_iter()
                 .map(|(_, v)| v)
-                .map(|v| async move { v.to_resolved().await })
+                .map(|v| v.to_resolved())
                 .try_join()
                 .await?,
             children: children
                 .into_iter()
                 .map(|(_, v)| v)
-                .map(|v| async move { v.to_resolved().await })
+                .map(|v| v.to_resolved())
                 .try_join()
                 .await?,
         }

--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -1361,9 +1361,7 @@ async fn parse_segment_config_from_loader_tree_internal(
     let parallel_configs = loader_tree
         .parallel_routes
         .values()
-        .map(|loader_tree| async move {
-            Box::pin(parse_segment_config_from_loader_tree_internal(loader_tree)).await
-        })
+        .map(|loader_tree| Box::pin(parse_segment_config_from_loader_tree_internal(loader_tree)))
         .try_join()
         .await?;
 

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -1684,7 +1684,7 @@ async fn output_assets_operation(
 
     let endpoint_assets = endpoints
         .iter()
-        .map(|endpoint| endpoint.output().await?.output_assets)
+        .map(async |endpoint| endpoint.output().await?.output_assets.await)
         .try_join()
         .await?;
 

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -1684,7 +1684,7 @@ async fn output_assets_operation(
 
     let endpoint_assets = endpoints
         .iter()
-        .map(|endpoint| async move { endpoint.output().await?.output_assets.await })
+        .map(|endpoint| endpoint.output().await?.output_assets)
         .try_join()
         .await?;
 

--- a/turbopack/crates/turbopack-analyze/tests/split_chunk.rs
+++ b/turbopack/crates/turbopack-analyze/tests/split_chunk.rs
@@ -22,7 +22,7 @@ static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn split_chunk() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let mut code = CodeBuilder::new(true, false);
         code += "Hello world!\n";
         code += "This is a test file.\n";

--- a/turbopack/crates/turbopack-bench/src/lib.rs
+++ b/turbopack/crates/turbopack-bench/src/lib.rs
@@ -88,7 +88,7 @@ fn bench_startup_internal(
                     |b, &(bundler, test_app)| {
                         let test_app = &**test_app;
                         let browser = &*browser;
-                        b.to_async(&runtime).try_iter_custom(|iters, m| async move {
+                        b.to_async(&runtime).try_iter_custom(async |iters, m| {
                             let mut value = m.zero();
 
                             for _ in 0..iters {
@@ -183,7 +183,7 @@ fn bench_hmr_internal(
 
                         b.to_async(&runtime).try_iter_async(
                             &runtime,
-                            || async {
+                            async || {
                                 let mut app = PreparedApp::new_without_copy(
                                     bundler,
                                     test_app.path().to_path_buf(),
@@ -318,7 +318,7 @@ fn bench_hmr_internal(
                                     Ok((guard, value))
                                 }
                             },
-                            |guard| async move {
+                            async |guard| {
                                 let hmr_is_happening = guard
                                     .page()
                                     .evaluate_expression("globalThis.HMR_IS_HAPPENING")
@@ -484,7 +484,7 @@ fn bench_startup_cached_internal(
                     |b, &(bundler, test_app)| {
                         let test_app = &**test_app;
                         let browser = &*browser;
-                        b.to_async(&runtime).try_iter_custom(|iters, m| async move {
+                        b.to_async(&runtime).try_iter_custom(async |iters, m| {
                             // Run a complete build, shut down, and test running it again
                             let mut app =
                                 PreparedApp::new(bundler, test_app.path().to_path_buf()).await?;

--- a/turbopack/crates/turbopack-bench/src/util/mod.rs
+++ b/turbopack/crates/turbopack-bench/src/util/mod.rs
@@ -164,7 +164,7 @@ impl<A: AsyncExecutor> AsyncBencherExtension<A> for AsyncBencher<'_, '_, A> {
         let log_progress = read_env_bool("TURBOPACK_BENCH_PROGRESS");
 
         let routine = &routine;
-        self.iter_custom(|iters| async move {
+        self.iter_custom(async |iters| {
             let measurement = WallTime;
             let value = routine(iters, measurement).await.expect("routine failed");
             if log_progress {
@@ -208,7 +208,7 @@ impl<A: AsyncExecutor> AsyncBencherExtension<A> for AsyncBencher<'_, '_, A> {
             input
         }))));
 
-        self.iter_custom(|iters| async move {
+        self.iter_custom(async |iters| {
             let measurement = WallTime;
 
             let input = input_mutex

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -262,27 +262,20 @@ async fn build_internal(
         source_maps_type,
     );
 
-    let entry_requests = (*entry_requests
-        .into_iter()
-        .map(|r| async move {
-            Ok(match r {
-                EntryRequest::Relative(p) => Request::relative(
-                    p.clone().into(),
-                    Default::default(),
-                    Default::default(),
-                    false,
-                ),
-                EntryRequest::Module(m, p) => Request::module(
-                    m.clone().into(),
-                    p.clone().into(),
-                    Default::default(),
-                    Default::default(),
-                ),
-            })
-        })
-        .try_join()
-        .await?)
-        .to_vec();
+    let entry_requests = entry_requests.into_iter().map(|r| match r {
+        EntryRequest::Relative(p) => Request::relative(
+            p.clone().into(),
+            Default::default(),
+            Default::default(),
+            false,
+        ),
+        EntryRequest::Module(m, p) => Request::module(
+            m.clone().into(),
+            p.clone().into(),
+            Default::default(),
+            Default::default(),
+        ),
+    });
 
     let origin =
         PlainResolveOrigin::new(asset_context, project_fs.root().await?.join("_")?).await?;
@@ -292,7 +285,6 @@ async fn build_internal(
     let project_dir = &project_dir;
     let entries = async move {
         entry_requests
-            .into_iter()
             .map(|request_vc| {
                 let origin_path = origin_path.clone();
                 async move {
@@ -524,7 +516,7 @@ async fn build_internal(
 
     all_assets
         .iter()
-        .map(|c| async move { c.content().write(c.path().owned().await?).await })
+        .map(async |c| c.content().write(c.path().owned().await?).await)
         .try_join()
         .await?;
 

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -183,7 +183,7 @@ pub async fn create_web_entry_source(
 
     let entries: Vec<_> = entries
         .into_iter()
-        .map(|module| async move {
+        .map(async |module| {
             if let (Some(chunkable_module), Some(entry)) = (
                 ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(module),
                 ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(module),

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -768,7 +768,7 @@ pub type PlainTrace = Vec<PlainTraceItem>;
 async fn into_plain_trace(traces: Vec<Vec<ReadRef<AssetIdent>>>) -> Result<Vec<PlainTrace>> {
     let mut plain_traces = traces
         .into_iter()
-        .map(|trace| async move {
+        .map(async |trace| {
             let mut plain_trace = trace
                 .into_iter()
                 .filter(|asset| {

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -683,7 +683,7 @@ impl ModuleGraphImportTracer {
             .await?
             .modules
             .iter()
-            .map(|(&module, _)| async move { Ok((module.ident().await?.path.clone(), module)) })
+            .map(async |(&module, _)| Ok((module.ident().await?.path.clone(), module)))
             .try_join()
             .await?;
         let mut map: FxHashMap<FileSystemPath, Vec<ResolvedVc<Box<dyn Module>>>> =
@@ -711,7 +711,7 @@ impl ImportTracer for ModuleGraphImportTracer {
         return Ok(ImportTraces::cell(ImportTraces(
             modules
                 .iter()
-                .map(|m| async move {
+                .map(async |m| {
                     let Some(&module_idx) = graph.modules.get(m) else {
                         // The only way this could really happen is if `path_to_modules` is computed
                         // from a different graph than graph`.  Just error out.
@@ -2344,7 +2344,7 @@ pub mod tests {
                 // test traversing backwards from 'd' which is only in the child graph
                 let d_module = child_graph
                     .enumerate_nodes()
-                    .map(|(_index, module)| async move {
+                    .map(async |(_index, module)| {
                         Ok(match module {
                             crate::module_graph::SingleModuleGraphNode::Module(module) => {
                                 if module.ident().to_string().owned().await? == "[test]/d.js" {
@@ -2854,7 +2854,7 @@ pub mod tests {
                 .await?
                 .modules
                 .keys()
-                .map(|m| async move { Ok((*m, m.ident().await?.path.path.clone())) })
+                .map(async |m| Ok((*m, m.ident().await?.path.path.clone())))
                 .try_join()
                 .await?
                 .into_iter()

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -141,7 +141,7 @@ pub async fn referenced_modules_and_affecting_sources(
                 modules.extend(
                     resolve_result
                         .affecting_sources_iter()
-                        .map(|source| async move {
+                        .map(async |source| {
                             Ok(ResolvedVc::upcast(
                                 RawModule::new(*source).to_resolved().await?,
                             ))

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -131,7 +131,7 @@ pub async fn referenced_modules_and_affecting_sources(
         .references()
         .await?
         .iter()
-        .map(|reference| async {
+        .map(async |reference| {
             let trait_ref = reference.into_trait_ref().await?;
             let resolve_result = reference.resolve_reference().await?;
             if let Some(chunking_type) = &trait_ref.chunking_type() {
@@ -211,7 +211,7 @@ pub async fn primary_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<V
         .references()
         .await?
         .iter()
-        .map(|reference| async { reference.resolve_reference().await?.primary_modules().await })
+        .map(async |reference| reference.resolve_reference().await?.primary_modules().await)
         .try_join()
         .await?
         .into_iter()
@@ -246,7 +246,7 @@ pub async fn primary_chunkable_referenced_modules(
         .references()
         .await?
         .iter()
-        .map(|reference| async {
+        .map(async |reference| {
             let trait_ref = reference.into_trait_ref().await?;
             if let Some(chunking_type) = &trait_ref.chunking_type() {
                 if !include_traced && chunking_type.is_traced() {

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -890,7 +890,7 @@ impl ResolveResult {
     #[turbo_tasks::function]
     pub async fn as_raw_module_result(&self) -> Result<Vc<ModuleResolveResult>> {
         Ok(self
-            .map_module(|asset| async move {
+            .map_module(async |asset| {
                 Ok(ModuleResolveResultItem::Module(ResolvedVc::upcast(
                     RawModule::new(*asset).to_resolved().await?,
                 )))
@@ -1138,7 +1138,7 @@ async fn realpath(
             result
                 .symlinks
                 .iter()
-                .map(|path| async move {
+                .map(async |path| {
                     Ok(ResolvedVc::upcast(
                         FileSource::new(path.clone()).to_resolved().await?,
                     ))
@@ -1540,7 +1540,7 @@ pub async fn resolve_raw(
     ) -> Result<Vec<Vc<ResolveResult>>> {
         Ok(matches
             .iter()
-            .map(|m| async move {
+            .map(async |m| {
                 Ok(if let PatternMatch::File(request, path) = m {
                     Some(to_result(request.clone(), path, collect_affecting_sources).await?)
                 } else {
@@ -1930,9 +1930,7 @@ async fn resolve_internal_inline(
             Request::Alternatives { requests } => {
                 let results = requests
                     .iter()
-                    .map(|req| async {
-                        resolve_internal_inline(lookup_path.clone(), **req, options).await
-                    })
+                    .map(|req| resolve_internal_inline(lookup_path.clone(), **req, options))
                     .try_join()
                     .await?;
 
@@ -3169,7 +3167,7 @@ async fn resolved(
                 result
                     .symlinks
                     .iter()
-                    .map(|symlink| async move {
+                    .map(async |symlink| {
                         anyhow::Ok(ResolvedVc::upcast(
                             FileSource::new(symlink.clone()).to_resolved().await?,
                         ))

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -440,7 +440,7 @@ impl Request {
                     .copied()
                     .map(|v| *v)
                     .map(Request::as_relative)
-                    .map(|v| async move { v.to_resolved().await })
+                    .map(|v| v.to_resolved())
                     .try_join()
                     .await?;
                 Request::Alternatives { requests }.cell()
@@ -500,7 +500,7 @@ impl Request {
                     .iter()
                     .copied()
                     .map(|req| req.with_query(query.clone()))
-                    .map(|v| async move { v.to_resolved().await })
+                    .map(|v| v.to_resolved())
                     .try_join()
                     .await?;
                 Request::Alternatives { requests }.cell()
@@ -578,7 +578,7 @@ impl Request {
                     .iter()
                     .copied()
                     .map(|req| req.with_fragment(fragment.clone()))
-                    .map(|v| async move { v.to_resolved().await })
+                    .map(|v| v.to_resolved())
                     .try_join()
                     .await?;
                 Request::Alternatives { requests }.cell()
@@ -690,7 +690,7 @@ impl Request {
             Request::Alternatives { requests } => {
                 let requests = requests
                     .iter()
-                    .map(|req| async { req.append_path(suffix.clone()).to_resolved().await })
+                    .map(|req| req.append_path(suffix.clone()).to_resolved())
                     .try_join()
                     .await?;
                 Request::Alternatives { requests }.cell()

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -190,7 +190,7 @@ impl CssChunk {
         }
         let assets = chunk_items
             .iter()
-            .map(|chunk_item| async move {
+            .map(async |chunk_item| {
                 Ok((
                     rcstr!("chunk item"),
                     chunk_item.content_ident().to_resolved().await?,
@@ -257,7 +257,7 @@ impl OutputAssetsReference for CssChunk {
         let references = content
             .chunk_items
             .iter()
-            .map(|item| async {
+            .map(async |item| {
                 let refs = item.references().await?;
                 let single_css_chunk = if should_generate_single_item_chunks {
                     Some(ResolvedVc::upcast(
@@ -353,7 +353,7 @@ impl OutputChunk for CssChunk {
             .await?;
         let imports_chunk_items: Vec<_> = entries_chunk_items
             .iter()
-            .map(|&css_item| async move {
+            .map(async |&css_item| {
                 Ok(css_item
                     .content()
                     .await?
@@ -498,7 +498,7 @@ impl Introspectable for CssChunk {
                 .await?
                 .chunk_items
                 .iter()
-                .map(|chunk_item| async move {
+                .map(async |chunk_item| {
                     Ok((
                         rcstr!("entry module"),
                         IntrospectableModule::new(chunk_item.module())

--- a/turbopack/crates/turbopack-dev-server/src/html.rs
+++ b/turbopack/crates/turbopack-dev-server/src/html.rs
@@ -131,7 +131,7 @@ impl DevHtmlAsset {
         let all_chunk_groups = self
             .entries
             .iter()
-            .map(|entry| async move {
+            .map(async |entry| {
                 let &DevHtmlEntry {
                     chunkable_module,
                     chunking_context,

--- a/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
+++ b/turbopack/crates/turbopack-dev-server/src/introspect/mod.rs
@@ -135,7 +135,7 @@ impl GetContentSourceContent for IntrospectionSource {
         let has_children = !children.is_empty();
         let children = children
             .iter()
-            .map(|(name, child)| async move {
+            .map(async |(name, child)| {
                 let ty = child.ty().await;
                 let ty = str_or_err(&ty);
                 let title = child.title().await;

--- a/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/asset_graph.rs
@@ -89,7 +89,7 @@ async fn expand(
     let mut assets_set = FxHashSet::default();
     let root_assets_with_path = root_assets
         .iter()
-        .map(|&asset| async move {
+        .map(async |&asset| {
             let path = asset.path().await?;
             Ok((path, asset))
         })
@@ -220,7 +220,7 @@ impl ContentSource for AssetGraphContentSource {
                     )),
                 )
             })
-            .map(|v| async move { v.to_resolved().await })
+            .map(|v| v.to_resolved())
             .try_join()
             .await?;
         Ok(Vc::<RouteTrees>::cell(routes).merge())
@@ -307,7 +307,7 @@ impl Introspectable for AssetGraphContentSource {
         let root_assets = this.root_assets.await?;
         let root_asset_children = root_assets
             .iter()
-            .map(|&asset| async move {
+            .map(async |&asset| {
                 Ok((
                     rcstr!("root"),
                     IntrospectableOutputAsset::new(*asset).to_resolved().await?,
@@ -320,7 +320,7 @@ impl Introspectable for AssetGraphContentSource {
         let expanded_asset_children = expanded_assets
             .values()
             .filter(|&a| !root_assets.contains(a))
-            .map(|&asset| async move {
+            .map(async |&asset| {
                 Ok((
                     rcstr!("inner"),
                     IntrospectableOutputAsset::new(*asset).to_resolved().await?,
@@ -364,7 +364,7 @@ impl Introspectable for FullyExpanded {
         let expanded_assets = expand(&*source.root_assets.await?, &source.root_path, None).await?;
         let children = expanded_assets
             .iter()
-            .map(|(_k, &v)| async move {
+            .map(async |(_k, &v)| {
                 Ok((
                     rcstr!("asset"),
                     IntrospectableOutputAsset::new(*v).to_resolved().await?,

--- a/turbopack/crates/turbopack-dev-server/src/source/combined.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/combined.rs
@@ -27,7 +27,7 @@ impl ContentSource for CombinedContentSource {
         let all_routes = self
             .sources
             .iter()
-            .map(|s| async move { s.get_routes().to_resolved().await })
+            .map(|s| s.get_routes().to_resolved())
             .try_join()
             .await?;
         Ok(Vc::<RouteTrees>::cell(all_routes).merge())
@@ -51,7 +51,7 @@ impl Introspectable for CombinedContentSource {
         let titles = self
             .sources
             .iter()
-            .map(|&source| async move {
+            .map(async |&source| {
                 Ok(
                     if let Some(source) =
                         ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(source)
@@ -85,11 +85,7 @@ impl Introspectable for CombinedContentSource {
             self.sources
                 .iter()
                 .copied()
-                .map(|s| async move { Ok(ResolvedVc::try_sidecast::<Box<dyn Introspectable>>(s)) })
-                .try_join()
-                .await?
-                .into_iter()
-                .flatten()
+                .flat_map(ResolvedVc::try_sidecast::<Box<dyn Introspectable>>)
                 .map(|i| (rcstr!("source"), i))
                 .collect(),
         ))

--- a/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/route_tree.rs
@@ -168,7 +168,7 @@ impl RouteTree {
         self.static_segments.extend(
             static_segments
                 .into_iter()
-                .map(|(key, value)| async {
+                .map(async |(key, value)| {
                     Ok((
                         key,
                         if value.len() == 1 {

--- a/turbopack/crates/turbopack-dev-server/src/source/router.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/router.rs
@@ -105,7 +105,7 @@ impl ContentSource for PrefixedRouterContentSource {
         Ok(Vc::<RouteTrees>::cell(
             inner_trees
                 .chain(once(self.fallback.get_routes()))
-                .map(|v| async move { v.to_resolved().await })
+                .map(|v| v.to_resolved())
                 .try_join()
                 .await?,
         )

--- a/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/static_assets.rs
@@ -66,7 +66,7 @@ async fn get_routes_from_directory(dir: FileSystemPath) -> Result<Vc<RouteTree>>
             ),
             _ => None,
         })
-        .map(|v| async move { v.to_resolved().await })
+        .map(|v| v.to_resolved())
         .try_join()
         .await?;
     Ok(Vc::<RouteTrees>::cell(routes).merge())

--- a/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
+++ b/turbopack/crates/turbopack-dev-server/src/source/wrapping_source.rs
@@ -54,7 +54,7 @@ async fn wrap_sources_operation(
                     **s, *processor,
                 ))
             })
-            .map(|v| async move { v.to_resolved().await })
+            .map(|v| v.to_resolved())
             .try_join()
             .await?,
     ))

--- a/turbopack/crates/turbopack-ecmascript/benches/references.rs
+++ b/turbopack/crates/turbopack-ecmascript/benches/references.rs
@@ -145,7 +145,7 @@ fn bench_full(b: &mut Bencher, input: &BenchInput) {
             });
             (tt, module)
         },
-        |(tt, module)| async move {
+        async |(tt, module)| {
             tt.run_once(async move {
                 // `analyze_ecmascript_module` performs eventually-consistent Vc reads. Reading
                 // not-yet-settled state at the top level is fine for a throughput benchmark, but

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/code_module_ids_and_paths.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/code_module_ids_and_paths.rs
@@ -62,7 +62,7 @@ pub async fn item_code_module_ids_and_paths(
             .await?
             .chunk_items
             .iter()
-            .map(|item| async {
+            .map(async |item| {
                 Ok((
                     item.chunk_item.id().await?,
                     item.chunk_item

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/content_entry.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/content_entry.rs
@@ -71,7 +71,7 @@ impl EcmascriptChunkContentEntries {
                             batch
                                 .chunk_items
                                 .iter()
-                                .map(|item| async move {
+                                .map(async |item| {
                                     Ok((
                                         item.chunk_item.id().await?,
                                         EcmascriptChunkContentEntry::new(

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -150,7 +150,7 @@ impl Chunk for EcmascriptChunk {
 
         let assets = chunk_items
             .iter()
-            .map(|&chunk_item| async move {
+            .map(async |&chunk_item| {
                 Ok((
                     rcstr!("chunk item"),
                     chunk_item.content_ident().to_resolved().await?,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/placeable.rs
@@ -124,7 +124,7 @@ async fn side_effects_from_package_json(
                         })
                     }
                 })
-                .map(|glob| async move {
+                .map(async |glob| {
                     Ok(match glob {
                         Either::Left(glob) => {
                             match glob.to_resolved().await {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk_list/version.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk_list/version.rs
@@ -38,7 +38,7 @@ impl Version for ChunkListVersion {
                 .by_path
                 .iter()
                 .map(|(path, version)| (path, TraitRef::cell(version.clone())))
-                .map(|(path, version)| async move {
+                .map(async |(path, version)| {
                     let id = version.id().owned().await?;
                     Ok((path, id))
                 })

--- a/turbopack/crates/turbopack-ecmascript/src/hmr/content.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/hmr/content.rs
@@ -31,7 +31,7 @@ impl EcmascriptMergedChunkContent {
             versions: self
                 .contents
                 .iter()
-                .map(|content| async move { content.ecmascript_chunk_version().await })
+                .map(|content| content.ecmascript_chunk_version())
                 .try_join()
                 .await?,
         }

--- a/turbopack/crates/turbopack-ecmascript/src/hmr/merger.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/hmr/merger.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::version::{VersionedContent, VersionedContentMerger, VersionedContents};
 
 use crate::hmr::{EcmascriptHmrChunkContent, content::EcmascriptMergedChunkContent};

--- a/turbopack/crates/turbopack-ecmascript/src/hmr/merger.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/hmr/merger.rs
@@ -28,7 +28,7 @@ impl VersionedContentMerger for EcmascriptChunkContentMerger {
         let contents = contents
             .await?
             .iter()
-            .map(|content| async move {
+            .map(|content| {
                 if let Some(content) =
                     ResolvedVc::try_sidecast::<Box<dyn EcmascriptHmrChunkContent>>(*content)
                 {
@@ -37,8 +37,7 @@ impl VersionedContentMerger for EcmascriptChunkContentMerger {
                     bail!("expected Vc<Box<dyn EcmascriptHmrChunkContent>>")
                 }
             })
-            .try_join()
-            .await?;
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(Vc::upcast(EcmascriptMergedChunkContent { contents }.cell()))
     }

--- a/turbopack/crates/turbopack-ecmascript/src/hmr/update.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/hmr/update.rs
@@ -237,7 +237,7 @@ pub async fn update_ecmascript_merged_chunk(
     let to_contents = content
         .contents
         .iter()
-        .map(|content| async move {
+        .map(async |content| {
             let entries = content.entries().await?;
             let version = content.ecmascript_chunk_version().await?;
             Ok((*content, entries, version))

--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/side_effects/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/side_effects/module.rs
@@ -93,7 +93,7 @@ impl Module for SideEffectsModule {
         references.extend(
             self.side_effects
                 .iter()
-                .map(|side_effect| async move {
+                .map(async |side_effect| {
                     Ok(ResolvedVc::upcast(
                         SingleChunkableModuleReference::new(
                             *ResolvedVc::upcast(*side_effect),

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -158,7 +158,7 @@ impl AmdDefineWithDependenciesCodeGen {
         let resolved_elements = self
             .dependencies_requests
             .iter()
-            .map(|element| async move {
+            .map(async |element| {
                 Ok(match element {
                     AmdDefineDependencyElement::Request {
                         request,

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -120,7 +120,7 @@ impl AsyncModule {
         let reference_idents = references
             .await?
             .iter()
-            .map(|r| async {
+            .map(async |r| {
                 let Some(referenced_asset) = get_inherit_async_referenced_asset(*r).await? else {
                     return Ok(None);
                 };
@@ -173,7 +173,7 @@ impl AsyncModule {
                 && references
                     .await?
                     .iter()
-                    .map(|r| async {
+                    .map(async |r| {
                         let Some(referenced_asset) = get_inherit_async_referenced_asset(*r).await?
                         else {
                             return Ok(false);

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -375,7 +375,7 @@ async fn get_all_export_names(
     let star_export_names = exports
         .star_exports
         .iter()
-        .map(|esm_ref| async {
+        .map(async |esm_ref| {
             Ok(
                 if let ReferencedAsset::Some(m) =
                     ReferencedAsset::from_resolve_result(esm_ref.resolve_reference()).await?

--- a/turbopack/crates/turbopack-ecmascript/src/references/hot_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/hot_module.rs
@@ -135,7 +135,7 @@ impl ModuleHotReferenceCodeGen {
         let resolved_ids: Vec<ReadRef<PatternMapping>> = self
             .references
             .iter()
-            .map(|reference| async move {
+            .map(async |reference| {
                 let r = reference.await?;
                 let resolve_result = reference.resolve_reference();
                 PatternMapping::resolve_request(
@@ -156,7 +156,7 @@ impl ModuleHotReferenceCodeGen {
         let esm_reimports: Vec<Option<(String, SyntaxContext, Expr)>> = self
             .esm_references
             .iter()
-            .map(|esm_ref| async move {
+            .map(async |esm_ref| {
                 let Some(esm_ref) = esm_ref else {
                     return Ok(None);
                 };

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1640,7 +1640,7 @@ async fn handle_call<'a, G: Fn(BumpVec<'a, Effect<'a>>) + Send + Sync>(
     let linked_args_cache = OnceCell::new();
 
     // Create the lazy linking closure that will be passed to handle_well_known_function_call
-    let linked_args = || async {
+    let linked_args = async || {
         linked_args_cache
             .get_or_try_init(|| async {
                 unlinked_args
@@ -4014,15 +4014,12 @@ async fn require_resolve_visitor<'a>(
         )
         .to_resolved()
         .await?;
-        let mut values =
-            resolved
-                .await?
-                .primary_sources()
-                .map(|source| async move {
-                    Ok(require_resolve(source.ident().await?.path.clone()).into())
-                })
-                .try_join()
-                .await?;
+        let mut values = resolved
+            .await?
+            .primary_sources()
+            .map(async |source| Ok(require_resolve(source.ident().await?.path.clone()).into()))
+            .try_join()
+            .await?;
 
         match values.len() {
             0 => JsValue::unknown(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1640,17 +1640,14 @@ async fn handle_call<'a, G: Fn(BumpVec<'a, Effect<'a>>) + Send + Sync>(
     let linked_args_cache = OnceCell::new();
 
     // Create the lazy linking closure that will be passed to handle_well_known_function_call
-    let linked_args = async || {
-        linked_args_cache
-            .get_or_try_init(|| async {
-                unlinked_args
-                    .iter()
-                    .map(|arg| arg.clone_in(state.arena.get_or_default()))
-                    .map(|arg| state.link_value(arg, ImportAttributes::empty_ref()))
-                    .try_join()
-                    .await
-            })
-            .await
+    let linked_args = || {
+        linked_args_cache.get_or_try_init(|| {
+            unlinked_args
+                .iter()
+                .map(|arg| arg.clone_in(state.arena.get_or_default()))
+                .map(|arg| state.link_value(arg, ImportAttributes::empty_ref()))
+                .try_join()
+        })
     };
 
     match func {

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -465,7 +465,7 @@ impl PatternMapping {
                     .collect();
                 let map = items
                     .into_iter()
-                    .map(|(k, v)| async move {
+                    .map(async |(k, v)| {
                         let single_pattern_mapping = to_single_pattern_mapping(
                             origin,
                             chunking_context,

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -62,7 +62,7 @@ impl Module for TsConfigModuleAsset {
         references.extend(
             configs[1..]
                 .iter()
-                .map(|(_, config_asset)| async move {
+                .map(async |(_, config_asset)| {
                     Ok(ResolvedVc::upcast(
                         TsExtendsReference::new(**config_asset)
                             .to_resolved()

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -207,7 +207,7 @@ impl ModuleReference for WebpackRuntimeAssetReference {
 
         Ok(resolved
             .await?
-            .map_module(|source| async move {
+            .map_module(async |source| {
                 Ok(ModuleResolveResultItem::Module(ResolvedVc::upcast(
                     WebpackModuleAsset::new(
                         *source,

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -382,7 +382,7 @@ pub async fn custom_evaluate(evaluate_context: impl EvaluateContext) -> Result<V
     // sending the job.
 
     let (mut operation, _) = FutureRetry::new(
-        || async {
+        async || {
             let mut operation = pool.operation().await?;
             operation
                 .send(Bytes::from(serde_json::to_vec(

--- a/turbopack/crates/turbopack-node/src/process_pool/mod.rs
+++ b/turbopack/crates/turbopack-node/src/process_pool/mod.rs
@@ -886,15 +886,13 @@ pub struct ChildProcessOperation {
 impl Operation for ChildProcessOperation {
     async fn recv(&mut self) -> Result<Bytes> {
         let bytes = self
-            .with_process(|process| async move {
-                process.recv().await.context("failed to receive message")
-            })
+            .with_process(async |process| process.recv().await.context("failed to receive message"))
             .await?;
         Ok(bytes)
     }
 
     async fn send(&mut self, message: Bytes) -> Result<()> {
-        self.with_process(|process| async move {
+        self.with_process(async |process| {
             timeout(Duration::from_secs(30), process.send(message))
                 .await
                 .context("timeout while sending message")?

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -233,7 +233,7 @@ async fn extra_configs_changed(
 
     let configs = config_paths
         .into_iter()
-        .map(|path| async move {
+        .map(async |path| {
             Ok(
                 if matches!(&*path.get_type().await?, FileSystemEntryType::File) {
                     match *asset_context

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -622,11 +622,11 @@ impl EvaluateContext for WebpackLoaderContext {
                         .try_join();
                     let file_subscriptions = file_paths
                         .iter()
-                        .map(|p| async move { self.cwd.join(p)?.read().await })
+                        .map(async |p| self.cwd.join(p)?.read().await)
                         .try_join();
                     let directory_subscriptions = directories
                         .iter()
-                        .map(|(dir, glob)| async move {
+                        .map(async |(dir, glob)| {
                             self.cwd
                                 .join(dir)?
                                 .track_glob(Glob::new(glob.clone(), GlobOptions::default()), false)

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -204,7 +204,7 @@ async fn resolve_node_pre_gyp_files(
         return Ok(*ModuleResolveResult::modules_with_affecting_sources(
             sources
                 .into_iter()
-                .map(|(key, source)| async move {
+                .map(async |(key, source)| {
                     Ok((
                         RequestKey::new(key),
                         ResolvedVc::upcast(RawModule::new(source).to_resolved().await?),
@@ -214,9 +214,7 @@ async fn resolve_node_pre_gyp_files(
                 .await?,
             affecting_paths
                 .into_iter()
-                .map(|p| async move {
-                    anyhow::Ok(ResolvedVc::upcast(FileSource::new(p).to_resolved().await?))
-                })
+                .map(async |p| Ok(ResolvedVc::upcast(FileSource::new(p).to_resolved().await?)))
                 .try_join()
                 .await?,
         ));
@@ -323,7 +321,7 @@ async fn resolve_node_gyp_build_files(
                 return Ok(*ModuleResolveResult::modules_with_affecting_sources(
                     resolved
                         .into_iter()
-                        .map(|(key, source)| async move {
+                        .map(async |(key, source)| {
                             Ok((
                                 RequestKey::new(key),
                                 ResolvedVc::upcast(RawModule::new(*source).to_resolved().await?),
@@ -434,7 +432,7 @@ async fn resolve_node_bindings_files(
         root_context_dir = parent;
     }
 
-    let try_path = |sub_path: RcStr| async move {
+    let try_path = async |sub_path: RcStr| {
         let path = root_context_dir.join(&sub_path)?;
         Ok(
             if matches!(*path.get_type().await?, FileSystemEntryType::File) {
@@ -454,7 +452,7 @@ async fn resolve_node_bindings_files(
 
     let modules = BINDINGS_TRY
         .iter()
-        .map(|try_dir| try_path.clone()(format!("{}/{}", try_dir, file_name).into()))
+        .map(|try_dir| try_path(format!("{}/{}", try_dir, file_name).into()))
         .try_flat_join()
         .await?;
     Ok(*ModuleResolveResult::modules(modules))

--- a/turbopack/crates/turbopack-test-utils/src/snapshot.rs
+++ b/turbopack/crates/turbopack-test-utils/src/snapshot.rs
@@ -187,7 +187,7 @@ async fn diff_paths(
 ) -> Result<FxHashSet<FileSystemPath>> {
     let mut map = left
         .iter()
-        .map(|p| async move { Ok((p.path.clone(), p.clone())) })
+        .map(async |p| Ok((p.path.clone(), p.clone())))
         .try_join()
         .await?
         .iter()

--- a/turbopack/crates/turbopack/src/global_module_ids.rs
+++ b/turbopack/crates/turbopack/src/global_module_ids.rs
@@ -49,7 +49,7 @@ pub async fn get_global_module_id_strategy(
             .into_iter()
             .map(|m| m.ident())
             .chain(async_idents.into_iter())
-            .map(|ident| async move {
+            .map(async |ident| {
                 let ident = ident.to_resolved().await?;
                 let ident_str = ident.to_string().await?;
                 let hash = hash_xxh3_hash64(&ident_str);


### PR DESCRIPTION
This is everything except `turbo-tasks-[backend]`

Using ast-grep replacement:

- search: `|$$$ARGS| async move {$$$BODY}`
- replace: `async |$$$ARGS| {$$$BODY}`

This also made it obvious in some places that we don't actually need async-await,
e.g. `.map(async |v| v.to_resolved.await)`