### PR TITLE
test: stabilize read-only page recreation

### DIFF
--- a/test/development/read-only-source-hmr/test/index.test.ts
+++ b/test/development/read-only-source-hmr/test/index.test.ts
@@ -121,7 +121,11 @@ describe('Read-only source HMR', () => {
       await retry(async () => {
         if (!process.env.IS_TURBOPACK_TEST) {
           // webpack doesn't automatically refresh the page when a page is added?
-          await browser.refresh()
+          // Don't wait for subresources while webpack recompiles the restored route,
+          // and let retry handle reloads aborted by a concurrent Fast Refresh.
+          await browser
+            .refresh({ waitUntil: 'domcontentloaded' })
+            .catch(() => {})
         }
         expect(await getBrowserBodyText(browser)).toContain('Hello World')
       })


### PR DESCRIPTION
### What?

Stabilizes the read-only source HMR page deletion and recreation test in webpack development mode.

### Why?

The test reloads after restoring a deleted page because webpack does not automatically refresh when the route reappears. In polling watch mode, that reload could wait for the full page load or be aborted by a concurrent Fast Refresh navigation. Either error escaped the retry callback, allowing one transient navigation race to fail the test before it could retry.

### How?

The webpack-only reload now waits only until the document is available instead of waiting on potentially slow subresources. Transient reload failures are handled inside the retry callback, while the existing page-content assertion remains the success condition. This preserves the test's intent and ensures a route that does not recover still fails.

### Verification

- Fresh `pnpm build` followed by a cold headless webpack run: 3 passed
- Three additional headless webpack runs: 3 passed each
- Headless Turbopack run: 2 passed, 1 expected skip
- Focused Prettier and ESLint checks

<!-- NEXT_JS_LLM -->
