### PR TITLE
Turbopack: enable export mangling by default in production builds

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -376,7 +376,7 @@ pub async fn get_client_module_options_context(
             source_maps,
             infer_module_side_effects: *next_config.turbopack_infer_module_side_effects().await?,
             cjs_tree_shaking: *next_config.turbopack_cjs_tree_shaking().await?,
-            mangle_export_names: *next_config.turbopack_mangle_export_names().await?,
+            mangle_export_names: *next_config.turbopack_mangle_export_names(mode).await?,
             cjs_scope_hoisting: *next_config.turbopack_cjs_scope_hoisting().await?,
             cross_module_constants: *next_config.turbopack_cross_module_constants().await?,
             preset_env_config,

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2570,13 +2570,20 @@ impl NextConfig {
         )
     }
 
+    /// Whether Turbopack should shorten ("mangle") the export names modules expose to each other.
+    ///
+    /// An explicit value always wins, in either direction — setting this to `true` in development
+    /// is honoured. `mode` only supplies the default when the option is unset: on in production
+    /// builds, off in development, where the extra module splitting costs rebuild time and the
+    /// short names make debugging harder for no benefit.
     #[turbo_tasks::function]
-    pub fn turbopack_mangle_export_names(&self) -> Vc<bool> {
-        Vc::cell(
-            self.experimental
-                .turbopack_mangle_export_names
-                .unwrap_or(false),
-        )
+    pub async fn turbopack_mangle_export_names(&self, mode: Vc<NextMode>) -> Result<Vc<bool>> {
+        Ok(Vc::cell(
+            match self.experimental.turbopack_mangle_export_names {
+                Some(explicit) => explicit,
+                None => !mode.await?.is_development(),
+            },
+        ))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -551,7 +551,7 @@ pub async fn get_server_module_options_context(
             source_maps,
             infer_module_side_effects: *next_config.turbopack_infer_module_side_effects().await?,
             cjs_tree_shaking: *next_config.turbopack_cjs_tree_shaking().await?,
-            mangle_export_names: *next_config.turbopack_mangle_export_names().await?,
+            mangle_export_names: *next_config.turbopack_mangle_export_names(mode).await?,
             cjs_scope_hoisting: *next_config.turbopack_cjs_scope_hoisting().await?,
             cross_module_constants: *next_config.turbopack_cross_module_constants().await?,
             ..Default::default()

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -2364,6 +2364,10 @@ export const defaultConfig = Object.freeze({
     turbopackInferModuleSideEffects: true,
     turbopackPluginRuntimeStrategy: 'childProcesses',
     turbopackSharedRuntime: !isStableBuild(),
+    // Pinned off for stable releases. Left unset on canary so the Turbopack side picks the
+    // default from the build mode (on for production builds, off in development) — see
+    // `NextConfig::turbopack_mangle_export_names`. An explicit value always wins either way.
+    turbopackMangleExportNames: isStableBuild() ? false : undefined,
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -280,7 +280,7 @@ struct TestOptions {
     infer_module_side_effects: bool,
     #[serde(default)]
     cjs_tree_shaking: bool,
-    #[serde(default)]
+    #[serde(default = "default_true")]
     mangle_export_names: bool,
     #[serde(default = "default_true")]
     cross_module_constants: bool,
@@ -314,7 +314,7 @@ impl Default for TestOptions {
             remove_unused_imports: default_true(),
             scope_hoisting: default_true(),
             cjs_tree_shaking: false,
-            mangle_export_names: false,
+            mangle_export_names: default_true(),
             cjs_scope_hoisting: false,
             cross_module_constants: true,
             infer_module_side_effects: default_true(),


### PR DESCRIPTION
Stacked on #97672 — enable export mangling by default on canary releases.

### What?

Two defaults change:

- **Next.js builds.** `experimental.turbopackMangleExportNames` is pinned to `false` for stable
  releases and left *unset* on canary, where Turbopack then defaults it from the build mode: on for
  production builds, off in development. Explicitly setting the option wins in either direction, so
  setting it to `true` in development is honoured.
- **Turbopack's own execution test suite.** `TestOptions::mangle_export_names` defaults to `true`,
  so all 279 fixtures exercise mangling instead of only the handful that opt in.

### Why?

The feature is verified by turbopack's own fixtures, targeted e2e suites, and a couple of
bundle-size measurements — a narrow slice of what Next.js's test suites actually cover. Defaulting
it on for canary puts every production-mode e2e and integration test through the mangled code path
for real users of the canary channel, without committing stable users to it yet. Turning it on for
stable is a separate, later decision that can stack on top of this once canary has soaked it.

Broad exposure has already earned its keep several times over. Turning mangling on in CI and in the
fixture suite surfaced bugs that no hand-picked suite had found, including a module-fragments helper
handing out another module's exports value (#97672's `EcmascriptExports::borrowed()`), a
client-reference proxy memoized per wrapper instance rather than per content, and a
code-elimination bug for export-less modules (fixed in the follow-up PR).

### How?

`defaultConfig` cannot see the build mode, so it only expresses the stable/canary split
(`isStableBuild() ? false : undefined`) and `NextConfig::turbopack_mangle_export_names(mode)`
supplies the mode-dependent default on the Turbopack side. This is deliberately *not* the shape of
the neighbouring `turbopackSharedRuntime: !isStableBuild()`: mangling should not apply in
development, and hard-forcing `false` there in Rust — as an earlier revision of this PR did — would
silently ignore a user who asked for it explicitly.

Mangling does **not** depend on minification. An earlier version of this PR gated it on
`minify(mode)`, which was wrong and has been removed; `--no-mangling` is a minifier flag and does
not affect export mangling.

Verified with a real `next build` A/B on a small app: the option left unset mangles (959,174 B total
emitted JS, 293,407 B gzipped) while explicitly setting it to `false` does not (966,519 B / 294,963
B gzipped), confirming both the default and the override. All 279 execution fixtures pass with the
suite default flipped, with no fixture needing an opt-out.

Note this layer does not change the `turbopack-emit-collect` snapshots on its own: making a module
without re-exports split additionally requires the split trigger added in the follow-up PR, so those
snapshots move there.

This is the layer to revert if canary turns up problems specific to running with the option on by
default; #97672 remains useful as an opt-in feature either way.

<!-- NEXT_JS_LLM -->


Co-authored-by: Luke Sandberg <210140+lukesandberg@users.noreply.github.com>


<!-- fleet ecdfa248-cd54-41ac-b4a2-c9d49e2a67ee -->
