### PR TITLE
test: make app-document-import-order more robust

### DIFF
--- a/test/e2e/app-document-import-order/app-document-import-order.test.ts
+++ b/test/e2e/app-document-import-order/app-document-import-order.test.ts
@@ -16,32 +16,37 @@ describe('Root components import order', () => {
       expect($(sideEffectCall).text()).toEqual(expectSideEffectsOrder[index])
     })
   })
+
   // Only asserted for production builds: in development each entry is chunked from its own
   // per-page module graph, which can still merge a shared module into per-entry units.
   ;(isNextDev ? it.skip : it)(
     'loads modules shared by _app and the page only once',
     async () => {
-      const browser = await next.browser('/', { waitHydration: false })
-      const markerCount = await browser.eval(async () => {
-        const chunkUrls = [
-          ...new Set(
-            performance
-              .getEntriesByType('resource')
-              .map((entry) => entry.name)
-              .filter(
-                (url) => url.includes('/_next/static/') && url.endsWith('.js')
-              )
-          ),
-        ]
-        const chunks = await Promise.all(
-          chunkUrls.map((url) => fetch(url).then((response) => response.text()))
-        )
-        return chunks.filter((chunk) =>
-          chunk.includes('APP_PAGE_SHARED_MODULE_MARKER')
-        ).length
+      const requests: Set<string> = new Set()
+      await next.browser('/', {
+        beforePageLoad(page) {
+          page.on('request', (request) => {
+            const url = new URL(request.url(), next.url)
+            if (
+              url.pathname.startsWith('/_next/static/') &&
+              url.pathname.endsWith('.js')
+            ) {
+              requests.add(url.href)
+            }
+          })
+        },
       })
 
-      expect(markerCount).toBe(1)
+      const chunks = await Promise.all(
+        [...requests].map((url) =>
+          fetch(url).then((response) => response.text())
+        )
+      )
+      const matchingChunks = chunks.filter((chunk) =>
+        chunk.includes('APP_PAGE_SHARED_MODULE_MARKER')
+      )
+
+      expect(matchingChunks.length).toBe(1)
     }
   )
 


### PR DESCRIPTION
- The `brower.eval(callback)` version was a bit weird, use beforePageLoad as we do everywhere else
- Properly parse the URL and match against the pathname, to not break with `?dpl`