### PR TITLE
fix(next-env): add ESM package exports

### DIFF
--- a/packages/next-env/package.json
+++ b/packages/next-env/package.json
@@ -16,21 +16,41 @@
   "author": "Next.js Team <support@vercel.com>",
   "license": "MIT",
   "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "dev": "ncc build ./index.ts -w -o dist/",
+    "dev": "run-p dev:cjs dev:esm",
+    "dev:cjs": "ncc build ./index.ts -w -o dist/",
+    "dev:esm": "swc ./index.ts -w -o ./dist/index.mjs -C module.type=es6 -C jsc.target=es2015",
     "prebuild:source": "node ../../scripts/rm.mjs dist",
     "types": "tsc --declaration --emitDeclarationOnly --declarationDir dist",
-    "build:source": "ncc build ./index.ts -o ./dist/ --minify --no-cache --no-source-map-register",
+    "build:source": "pnpm build:source:cjs && pnpm build:source:esm",
+    "build:source:cjs": "ncc build ./index.ts -o ./dist/ --minify --no-cache --no-source-map-register",
+    "build:source:esm": "swc ./index.ts -o ./dist/index.mjs -C module.type=es6 -C jsc.target=es2015",
     "build": "pnpm build:source && pnpm types",
     "pack-for-isolated-tests": "pnpm pack --out ./packed.tgz"
   },
-  "devDependencies": {
-    "@vercel/ncc": "0.38.4",
+  "dependencies": {
     "dotenv": "16.3.1",
     "dotenv-expand": "10.0.0"
+  },
+  "devDependencies": {
+    "@swc/cli": "0.1.55",
+    "@swc/core": "1.11.24",
+    "@vercel/ncc": "0.38.4",
+    "npm-run-all": "4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1876,16 +1876,26 @@ importers:
         version: 6.0.2
 
   packages/next-env:
-    devDependencies:
-      '@vercel/ncc':
-        specifier: 0.38.4
-        version: 0.38.4
+    dependencies:
       dotenv:
         specifier: 16.3.1
         version: 16.3.1
       dotenv-expand:
         specifier: 10.0.0
         version: 10.0.0
+    devDependencies:
+      '@swc/cli':
+        specifier: 0.1.55
+        version: 0.1.55(@swc/core@1.11.24(@swc/helpers@0.5.23))(chokidar@3.6.0)
+      '@swc/core':
+        specifier: 1.11.24
+        version: 1.11.24(@swc/helpers@0.5.23)
+      '@vercel/ncc':
+        specifier: 0.38.4
+        version: 0.38.4
+      npm-run-all:
+        specifier: 4.1.5
+        version: 4.1.5
 
   packages/next-mdx:
     dependencies:

--- a/test/unit/preserve-process-env.test.ts
+++ b/test/unit/preserve-process-env.test.ts
@@ -1,8 +1,13 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
 import {
   loadEnvConfig,
   resetEnv,
   updateInitialEnv,
 } from '../../packages/next-env/'
+
+const execFileAsync = promisify(execFile)
 
 describe('preserve process env', () => {
   it('should not reassign `process.env`', () => {
@@ -25,5 +30,30 @@ describe('preserve process env', () => {
     } finally {
       delete process.env[key]
     }
+  })
+})
+
+describe('@next/env package exports', () => {
+  it('supports CommonJS and ESM imports', async () => {
+    const cjs = await execFileAsync(
+      process.execPath,
+      [
+        '-e',
+        `const env = require('@next/env'); console.log(typeof env.loadEnvConfig)`,
+      ],
+      { encoding: 'utf8' }
+    )
+    const esm = await execFileAsync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '-e',
+        `import { initialEnv, loadEnvConfig, processEnv, resetEnv, updateInitialEnv } from '@next/env'; console.log([loadEnvConfig, processEnv, resetEnv, updateInitialEnv].every((value) => typeof value === 'function')); loadEnvConfig(process.cwd()); console.log(typeof initialEnv)`,
+      ],
+      { encoding: 'utf8' }
+    )
+
+    expect(cjs.stdout.trim()).toBe('function')
+    expect(esm.stdout.trim()).toBe('true\nobject')
   })
 })


### PR DESCRIPTION
## Summary

`@next/env` currently publishes only a CommonJS build. Because of this, using a named ESM import fails with a `Named export 'loadEnvConfig' not found` error.

This PR adds a proper ESM build and conditional package exports while preserving the existing CommonJS behavior.

## What changed

- Added a separate ESM build for `@next/env`.
- Added conditional package exports for ESM and CommonJS consumers.
- Kept the existing CommonJS entry point working.
- Moved `dotenv` and `dotenv-expand` to runtime dependencies because they are imported by the ESM output.
- Added a regression test covering both CommonJS and ESM imports.
- Verified that mutable exports such as `initialEnv` preserve their live-binding behavior.

## Before

The CommonJS import worked:

```js
const { loadEnvConfig } = require('@next/env')
```

However, the equivalent ESM named import failed:

```js
import { loadEnvConfig } from '@next/env'
```

Error:

```text
SyntaxError: Named export 'loadEnvConfig' not found.
The requested module '@next/env' is a CommonJS module.
```

<img width="1280" height="746" alt="@next/env ESM named import error before the fix" src="https://github.com/user-attachments/assets/778ba5fa-175f-414a-b1d2-33dc7f153871" />

## After

The same ESM named import now works:

```js
import { loadEnvConfig } from '@next/env'
```

CommonJS consumers continue to work without any changes. I also verified the other named exports and confirmed that `initialEnv` updates correctly after calling `loadEnvConfig`.

<img width="1280" height="444" alt="@next/env CommonJS and ESM verification after the fix" src="https://github.com/user-attachments/assets/6c83d130-b162-474f-950a-1caf89357903" />

## Verification

- Built `@next/env` successfully.
- Packed and installed the local package in a clean test project.
- Verified the existing CommonJS import.
- Verified ESM named imports.
- Verified the live binding of `initialEnv`.
- Added a regression test covering both import modes.
- Completed the full repository build successfully.

Fixes #68091