### PR TITLE
Pages Router: Deprecate React 18 support

### DIFF
--- a/errors/react-version.mdx
+++ b/errors/react-version.mdx
@@ -1,53 +1,61 @@
 ---
-title: Minimum React Version
+title: React Version Support
+description: Learn which React versions are supported by Next.js and how to upgrade.
 ---
 
 ## Why This Error Occurred
 
-Your project is using an old version of `react` or `react-dom` that does not
-meet the suggested minimum version requirement.
+Your project is using a version of `react` or `react-dom` that is unsupported or
+deprecated in your version of Next.js.
 
-Next.js suggests using, at a minimum, `react@18.2.0` and `react-dom@18.2.0`.
-Older versions of `react` and `react-dom` do work with Next.js, however, they do
-not enable all of Next.js' features.
+- React versions earlier than `18.2.0` are unsupported.
+- React 18.2 and later remain supported in Next.js 16, but React 18 support is
+  deprecated.
+- React 19 is recommended for Next.js 16 and will be required in Next.js 17.
 
-For example, the following features are not enabled with old React versions:
+React 19 includes features used by Next.js, such as Actions and improved
+hydration errors. Upgrade `react` and `react-dom` together to keep their versions
+in sync.
 
-- [Fast Refresh](/docs/architecture/fast-refresh): instantly
-  view edits to your app without losing component state
-- Component stack trace in development: see the component tree that lead up to
-  an error
-- Hydration mismatch warnings: trace down discrepancies in your React tree that
-  cause performance problems
-
-This list is not exhaustive, but illustrative in the value of upgrading React!
+If you use TypeScript, upgrade `@types/react` and `@types/react-dom` at the same
+time.
 
 ## Possible Ways to Fix It
 
-**Via npm**
+Upgrade React and its TypeScript types with your package manager:
 
-```bash filename="Terminal"
-npm upgrade react@latest react-dom@latest
+```bash package="npm"
+npm install react@latest react-dom@latest @types/react@latest @types/react-dom@latest
 ```
 
-**Via Yarn**
-
-```bash filename="Terminal"
-yarn add react@latest react-dom@latest
+```bash package="yarn"
+yarn add react@latest react-dom@latest @types/react@latest @types/react-dom@latest
 ```
 
-**Manually** Open your `package.json` and upgrade `react` and `react-dom`:
+```bash package="pnpm"
+pnpm add react@latest react-dom@latest @types/react@latest @types/react-dom@latest
+```
+
+```bash package="bun"
+bun add react@latest react-dom@latest @types/react@latest @types/react-dom@latest
+```
+
+Alternatively, update your `package.json` manually:
 
 ```json filename="package.json"
 {
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
   }
 }
 ```
 
 ## Useful Links
 
-- [Fast Refresh blog post](/blog/next-9-4#fast-refresh)
-- [Fast Refresh docs](/docs/architecture/fast-refresh)
+- [React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide)
+- [Upgrading Next.js](/docs/app/getting-started/upgrading)

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'fs'
+import { existsSync } from 'fs'
 import { createRequire } from 'module'
 import { basename, extname, join, relative, isAbsolute, resolve } from 'path'
 import { pathToFileURL } from 'url'
@@ -68,12 +68,7 @@ const REACT_18_DEPRECATION_WARNING =
 function getInstalledPackageVersion(dir: string, name: 'react' | 'react-dom') {
   try {
     const projectRequire = createRequire(join(dir, 'package.json'))
-    const packageJsonPath = projectRequire.resolve(`${name}/package.json`)
-    return (
-      JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
-        version?: string
-      }
-    ).version
+    return (projectRequire(name) as { version?: string }).version
   } catch {
     return undefined
   }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -61,6 +61,36 @@ import { hrtimeBigIntDurationToString } from '../build/duration-to-string'
 export { normalizeConfig } from './config-shared'
 export type { DomainLocale, NextConfig } from './config-shared'
 
+const REACT_18_DEPRECATION_WARNING =
+  'React 18 support is deprecated in Next.js 16 and will be removed in Next.js 17. Please upgrade to React 19. Learn more: https://nextjs.org/docs/messages/react-version'
+
+function getInstalledPackageVersion(name: 'react' | 'react-dom') {
+  try {
+    return (require(name) as { version?: string }).version
+  } catch {
+    return undefined
+  }
+}
+
+function warnIfReact18IsInstalled(
+  phase: PHASE_TYPE,
+  silent: boolean | undefined
+) {
+  if (
+    silent !== false ||
+    (phase !== PHASE_DEVELOPMENT_SERVER && phase !== PHASE_PRODUCTION_BUILD)
+  ) {
+    return
+  }
+
+  const reactVersion = getInstalledPackageVersion('react')
+  const reactDomVersion = getInstalledPackageVersion('react-dom')
+
+  if (reactVersion?.startsWith('18.') || reactDomVersion?.startsWith('18.')) {
+    Log.warnOnce(REACT_18_DEPRECATION_WARNING)
+  }
+}
+
 function normalizeNextConfigZodErrors(
   error: ZodError<NextConfig>
 ): [warnings: string[], fatalErrors: string[]] {
@@ -1817,6 +1847,8 @@ export default async function loadConfig(
   const logTiming = opts.silent === false
   const startTimeNanos = logTiming ? process.hrtime.bigint() : undefined
   const [config, meta] = await loadConfigImpl(phase, dir, opts)
+
+  warnIfReact18IsInstalled(phase, opts.silent)
 
   if (!meta.cacheHit && logTiming) {
     const durationNanos = process.hrtime.bigint() - startTimeNanos!

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'fs'
+import { createRequire } from 'module'
 import { basename, extname, join, relative, isAbsolute, resolve } from 'path'
 import { pathToFileURL } from 'url'
 import findUp from 'next/dist/compiled/find-up'
@@ -64,9 +65,10 @@ export type { DomainLocale, NextConfig } from './config-shared'
 const REACT_18_DEPRECATION_WARNING =
   'React 18 support is deprecated in Next.js 16 and will be removed in Next.js 17. Please upgrade to React 19. Learn more: https://nextjs.org/docs/messages/react-version'
 
-function getInstalledPackageVersion(name: 'react' | 'react-dom') {
+function getInstalledPackageVersion(dir: string, name: 'react' | 'react-dom') {
   try {
-    return (require(name) as { version?: string }).version
+    const projectRequire = createRequire(join(dir, 'package.json'))
+    return (projectRequire(name) as { version?: string }).version
   } catch {
     return undefined
   }
@@ -74,6 +76,7 @@ function getInstalledPackageVersion(name: 'react' | 'react-dom') {
 
 function warnIfReact18IsInstalled(
   phase: PHASE_TYPE,
+  dir: string,
   silent: boolean | undefined
 ) {
   if (
@@ -83,8 +86,8 @@ function warnIfReact18IsInstalled(
     return
   }
 
-  const reactVersion = getInstalledPackageVersion('react')
-  const reactDomVersion = getInstalledPackageVersion('react-dom')
+  const reactVersion = getInstalledPackageVersion(dir, 'react')
+  const reactDomVersion = getInstalledPackageVersion(dir, 'react-dom')
 
   if (reactVersion?.startsWith('18.') || reactDomVersion?.startsWith('18.')) {
     Log.warnOnce(REACT_18_DEPRECATION_WARNING)
@@ -1848,7 +1851,7 @@ export default async function loadConfig(
   const startTimeNanos = logTiming ? process.hrtime.bigint() : undefined
   const [config, meta] = await loadConfigImpl(phase, dir, opts)
 
-  warnIfReact18IsInstalled(phase, opts.silent)
+  warnIfReact18IsInstalled(phase, dir, opts.silent)
 
   if (!meta.cacheHit && logTiming) {
     const durationNanos = process.hrtime.bigint() - startTimeNanos!

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import { createRequire } from 'module'
 import { basename, extname, join, relative, isAbsolute, resolve } from 'path'
 import { pathToFileURL } from 'url'
@@ -68,7 +68,12 @@ const REACT_18_DEPRECATION_WARNING =
 function getInstalledPackageVersion(dir: string, name: 'react' | 'react-dom') {
   try {
     const projectRequire = createRequire(join(dir, 'package.json'))
-    return (projectRequire(name) as { version?: string }).version
+    const packageJsonPath = projectRequire.resolve(`${name}/package.json`)
+    return (
+      JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+        version?: string
+      }
+    ).version
   } catch {
     return undefined
   }

--- a/test/e2e/deprecation-warnings/deprecation-warnings.test.ts
+++ b/test/e2e/deprecation-warnings/deprecation-warnings.test.ts
@@ -12,10 +12,14 @@ describe('deprecation-warnings', () => {
     it('should not emit any deprecation warnings when no config file exists', async () => {
       await next.start()
 
-      const logs = next.cliOutput
-      expect(logs).not.toContain('deprecated')
-      expect(logs).not.toContain('has been renamed')
-      expect(logs).not.toContain('no longer needed')
+      // React version warnings are covered by the dedicated React version test.
+      const configLogs = next.cliOutput
+        .split('\n')
+        .filter((line) => !line.includes('React 18 support is deprecated'))
+        .join('\n')
+      expect(configLogs).not.toContain('deprecated')
+      expect(configLogs).not.toContain('has been renamed')
+      expect(configLogs).not.toContain('no longer needed')
     })
   })
 

--- a/test/e2e/react-current-version/react-current-version.test.ts
+++ b/test/e2e/react-current-version/react-current-version.test.ts
@@ -2,6 +2,9 @@ import { isReact18, nextTestSetup, isNextDev } from 'e2e-utils'
 import { join } from 'path'
 import { retry } from 'next-test-utils'
 
+const react18DeprecationWarning =
+  'React 18 support is deprecated in Next.js 16 and will be removed in Next.js 17. Please upgrade to React 19. Learn more: https://nextjs.org/docs/messages/react-version'
+
 function makeIndexPage(runtime: string) {
   return `import ReactDOM from 'react-dom'
 import Image from 'next/image'
@@ -32,6 +35,48 @@ export const config = {
 }
 
 describe('react-current-version', () => {
+  describe('React 18 deprecation warning', () => {
+    const { next, isNextDeploy, skipped } = nextTestSetup({
+      files: join(__dirname, 'app'),
+      skipStart: true,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDeploy) {
+      it('should skip in deploy mode', () => {})
+      return
+    }
+
+    if (isNextDev) {
+      it('warns during next dev only when using React 18', async () => {
+        await next.start()
+        await retry(() => {
+          expect(next.cliOutput).toContain('Running next.config')
+        })
+
+        const warningCount =
+          next.cliOutput.split(react18DeprecationWarning).length - 1
+        expect(warningCount).toBe(isReact18 ? 1 : 0)
+      })
+    } else {
+      it('warns during next build only when using React 18 but not during next start', async () => {
+        const buildResult = await next.build()
+        const warningCount =
+          buildResult.cliOutput.split(react18DeprecationWarning).length - 1
+        expect(warningCount).toBe(isReact18 ? 1 : 0)
+
+        const outputIndex = next.cliOutput.length
+        await next.start()
+        expect(next.cliOutput.slice(outputIndex)).not.toContain(
+          react18DeprecationWarning
+        )
+      })
+    }
+  })
+
   describe('Basics', () => {
     const { next, isTurbopack } = nextTestSetup({
       files: join(__dirname, 'app'),

--- a/test/e2e/react-current-version/react-current-version.test.ts
+++ b/test/e2e/react-current-version/react-current-version.test.ts
@@ -39,20 +39,6 @@ describe('react-current-version', () => {
     const { next, isNextDeploy, skipped } = nextTestSetup({
       files: join(__dirname, 'app'),
       skipStart: true,
-      overrideFiles: {
-        'next.config.js': `
-// The installed version must come from package metadata rather than the
-// mutable runtime export loaded by next.config.js.
-for (const name of ['react', 'react-dom']) {
-  const dependency = require(name)
-  dependency.version = dependency.version.startsWith('18.')
-    ? '19.0.0'
-    : '18.0.0'
-}
-
-module.exports = {}
-`,
-      },
     })
 
     if (skipped) {

--- a/test/e2e/react-current-version/react-current-version.test.ts
+++ b/test/e2e/react-current-version/react-current-version.test.ts
@@ -39,6 +39,20 @@ describe('react-current-version', () => {
     const { next, isNextDeploy, skipped } = nextTestSetup({
       files: join(__dirname, 'app'),
       skipStart: true,
+      overrideFiles: {
+        'next.config.js': `
+// The installed version must come from package metadata rather than the
+// mutable runtime export loaded by next.config.js.
+for (const name of ['react', 'react-dom']) {
+  const dependency = require(name)
+  dependency.version = dependency.version.startsWith('18.')
+    ? '19.0.0'
+    : '18.0.0'
+}
+
+module.exports = {}
+`,
+      },
     })
 
     if (skipped) {

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -489,6 +489,11 @@ function getPreambleOutput(cliOutput: string): string {
   const lines: string[] = []
 
   for (const line of cliOutput.split('\n')) {
+    // React version warnings are covered by the dedicated React version test.
+    if (line.includes('React 18 support is deprecated')) {
+      continue
+    }
+
     if (line.includes('Creating an optimized production build')) {
       break
     }


### PR DESCRIPTION
## Summary

- warn during `next dev` and `next build` when React 18 is installed, while keeping `next start` quiet
- explain that React 18 remains supported in Next.js 16 but will be removed in Next.js 17
- update the React version guidance with React 19 and TypeScript type upgrade commands

## Verification

- `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-dev-turbo test/e2e/react-current-version/react-current-version.test.ts`
- `NEXT_TEST_REACT_VERSION=18.3.1 NEXT_TEST_PREFER_OFFLINE=1 pnpm test-dev-turbo test/e2e/react-current-version/react-current-version.test.ts`
- targeted production build/start coverage passed with React 18 and React 19
- Not passing: `pnpm --filter=next types` (existing unrelated errors in `httpget.ts`, `image-optimizer.ts`, `proxy-request.ts`, telemetry typings, and compiled declarations)
- Not passing: `pnpm lint` (existing unused Turbo Tasks check)

<!-- NEXT_JS_LLM -->