### PR TITLE
Add Cache Components option to create-next-app

### DIFF
--- a/packages/create-next-app/create-app.ts
+++ b/packages/create-next-app/create-app.ts
@@ -43,6 +43,7 @@ export async function createApp({
   bundler,
   disableGit,
   reactCompiler,
+  cacheComponents,
   agentsMd,
 }: {
   appPath: string
@@ -62,6 +63,7 @@ export async function createApp({
   bundler: Bundler
   disableGit?: boolean
   reactCompiler: boolean
+  cacheComponents: boolean
   agentsMd: boolean
 }): Promise<void> {
   let repoInfo: RepoInfo | undefined
@@ -255,6 +257,7 @@ export async function createApp({
       skipInstall,
       bundler,
       reactCompiler,
+      cacheComponents,
     })
   }
 

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -51,6 +51,10 @@ const program = new Command(packageJson.name)
   .option('--js, --javascript', 'Initialize as a JavaScript project.')
   .option('--tailwind', 'Initialize with Tailwind CSS config. (default)')
   .option('--react-compiler', 'Initialize with React Compiler enabled.')
+  .option(
+    '--cache-components',
+    'Initialize with Cache Components enabled. (default)'
+  )
   .option('--eslint', 'Initialize with ESLint config.')
   .option('--biome', 'Initialize with Biome config.')
   .option('--app', 'Initialize as an App Router project.')
@@ -245,6 +249,7 @@ async function run(): Promise<void> {
       empty: false,
       disableGit: false,
       reactCompiler: false,
+      cacheComponents: true,
       agentsMd: true,
     }
 
@@ -284,6 +289,11 @@ async function run(): Promise<void> {
         key: 'app',
         values: { true: 'App Router', false: 'Pages Router' },
         flags: { true: '--app', false: '--no-app' },
+      },
+      {
+        key: 'cacheComponents',
+        values: { true: 'Cache Components', false: 'No Cache Components' },
+        flags: { true: '--cache-components', false: '--no-cache-components' },
       },
       {
         key: 'agentsMd',
@@ -582,6 +592,32 @@ async function run(): Promise<void> {
       }
     }
 
+    // Cache Components is an App Router feature, so only offer it when the App
+    // Router is in use.
+    if (
+      opts.app &&
+      !opts.api &&
+      !opts.cacheComponents &&
+      !args.includes('--no-cache-components')
+    ) {
+      if (skipPrompt) {
+        opts.cacheComponents = getPrefOrDefault('cacheComponents')
+      } else {
+        const styledCacheComponents = blue('Cache Components')
+        const { cacheComponents } = await prompts({
+          onState: onPromptState,
+          type: 'toggle',
+          name: 'cacheComponents',
+          message: `Would you like to use ${styledCacheComponents}? (recommended)`,
+          initial: getPrefOrDefault('cacheComponents'),
+          active: 'Yes',
+          inactive: 'No',
+        })
+        opts.cacheComponents = Boolean(cacheComponents)
+        preferences.cacheComponents = Boolean(cacheComponents)
+      }
+    }
+
     const importAliasPattern = /^[^*"]+\/\*\s*$/
     if (
       typeof opts.importAlias !== 'string' ||
@@ -725,6 +761,7 @@ async function run(): Promise<void> {
       bundler,
       disableGit: opts.disableGit,
       reactCompiler: opts.reactCompiler,
+      cacheComponents: opts.cacheComponents,
       agentsMd: opts.agentsMd,
     })
   } catch (reason) {
@@ -760,6 +797,7 @@ async function run(): Promise<void> {
       bundler,
       disableGit: opts.disableGit,
       reactCompiler: opts.reactCompiler,
+      cacheComponents: opts.cacheComponents,
       agentsMd: opts.agentsMd,
     })
   }

--- a/packages/create-next-app/index.ts
+++ b/packages/create-next-app/index.ts
@@ -51,10 +51,7 @@ const program = new Command(packageJson.name)
   .option('--js, --javascript', 'Initialize as a JavaScript project.')
   .option('--tailwind', 'Initialize with Tailwind CSS config. (default)')
   .option('--react-compiler', 'Initialize with React Compiler enabled.')
-  .option(
-    '--cache-components',
-    'Initialize with Cache Components enabled. (default)'
-  )
+  .option('--cache-components', 'Initialize with Cache Components enabled.')
   .option('--eslint', 'Initialize with ESLint config.')
   .option('--biome', 'Initialize with Biome config.')
   .option('--app', 'Initialize as an App Router project.')
@@ -249,7 +246,7 @@ async function run(): Promise<void> {
       empty: false,
       disableGit: false,
       reactCompiler: false,
-      cacheComponents: true,
+      cacheComponents: false,
       agentsMd: true,
     }
 
@@ -608,7 +605,7 @@ async function run(): Promise<void> {
           onState: onPromptState,
           type: 'toggle',
           name: 'cacheComponents',
-          message: `Would you like to use ${styledCacheComponents}? (recommended)`,
+          message: `Would you like to use ${styledCacheComponents}?`,
           initial: getPrefOrDefault('cacheComponents'),
           active: 'Yes',
           inactive: 'No',

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -60,6 +60,7 @@ export const installTemplate = async ({
   skipInstall,
   bundler,
   reactCompiler,
+  cacheComponents,
 }: InstallTemplateArgs) => {
   console.log(bold(`Using ${packageManager}.`));
 
@@ -145,6 +146,24 @@ export const installTemplate = async ({
     configContent = configContent.replace(
       "/* config options here */\n",
       "/* config options here */\n  reactCompiler: true,\n",
+    );
+
+    await fs.writeFile(nextConfigFile, configContent);
+  }
+
+  if (cacheComponents) {
+    const nextConfigFile = path.join(
+      root,
+      mode === "js" ? "next.config.mjs" : "next.config.ts",
+    );
+    let configContent = await fs.readFile(nextConfigFile, "utf8");
+
+    // `partialPrefetching` is enabled alongside `cacheComponents` because the
+    // only reason to disable it is when adopting `cacheComponents` from before
+    // the option existed.
+    configContent = configContent.replace(
+      "/* config options here */\n",
+      "/* config options here */\n  cacheComponents: true,\n  partialPrefetching: true,\n",
     );
 
     await fs.writeFile(nextConfigFile, configContent);

--- a/packages/create-next-app/templates/types.ts
+++ b/packages/create-next-app/templates/types.ts
@@ -33,6 +33,7 @@ export interface InstallTemplateArgs {
   skipInstall: boolean;
   bundler: Bundler;
   reactCompiler: boolean;
+  cacheComponents: boolean;
 }
 
 export enum Bundler {

--- a/test/production/create-next-app/index.test.ts
+++ b/test/production/create-next-app/index.test.ts
@@ -187,6 +187,7 @@ describe('create-next-app', () => {
         "  --eslint                ESLint (use --biome for Biome, --no-eslint for None)
           --no-react-compiler     No React Compiler (use --react-compiler for React Compiler)
           --no-src-dir            No src/ directory (use --src-dir for src/ directory)
+          --cache-components      Cache Components (use --no-cache-components for No Cache Components)
           --agents-md             AGENTS.md (use --no-agents-md for No AGENTS.md)
           --import-alias          "@/*""
       `)
@@ -207,6 +208,7 @@ describe('create-next-app', () => {
           '--no-src-dir',
           '--no-import-alias',
           '--no-react-compiler',
+          '--no-cache-components',
           '--no-agents-md',
           '--skip-install',
           ...(process.env.NEXT_RSPACK ? ['--rspack'] : []),

--- a/test/production/create-next-app/index.test.ts
+++ b/test/production/create-next-app/index.test.ts
@@ -187,7 +187,7 @@ describe('create-next-app', () => {
         "  --eslint                ESLint (use --biome for Biome, --no-eslint for None)
           --no-react-compiler     No React Compiler (use --react-compiler for React Compiler)
           --no-src-dir            No src/ directory (use --src-dir for src/ directory)
-          --cache-components      Cache Components (use --no-cache-components for No Cache Components)
+          --no-cache-components   No Cache Components (use --cache-components for Cache Components)
           --agents-md             AGENTS.md (use --no-agents-md for No AGENTS.md)
           --import-alias          "@/*""
       `)


### PR DESCRIPTION
When initializing a new project with create-next-app, the interactive prompt will now ask the user if they want to enable Cache Components.

For now the option defaults to off. We'll flip the default back on once there's a flow that guides users to the right recommendation based on the kind of site they're building. The option can still be enabled interactively, or with the `--cache-components` flag.

If the user chooses to enable Cache Components, the project will also be initialized with Partial Prefetching enabled. There's no separate prompt for Partial Prefetching; the only reason they are separate configs is because Cache Components shipped in 16.0 before Partial Prefetching existed.

This is not a breaking change because it does not change any behavior in Next.js itself, only the create-next-app CLI. It has no impact on any existing Next.js projects.
