### PR TITLE
fix: reuse a single drain listener when piping Node streams through gzip

### DIFF
--- a/packages/next/src/server/lib/release-compression-stream.test.ts
+++ b/packages/next/src/server/lib/release-compression-stream.test.ts
@@ -12,9 +12,11 @@ type StreamRecord = { closed: boolean }
 /** Records every zlib stream the middleware creates, and whether it closed. */
 function trackCompressionStreams(): {
   records: StreamRecord[]
+  streams: Array<zlib.Gzip | zlib.Deflate>
   restore: () => void
 } {
   const records: StreamRecord[] = []
+  const streams: Array<zlib.Gzip | zlib.Deflate> = []
   const originals: Array<[string, unknown]> = []
 
   for (const name of ['createGzip', 'createDeflate'] as const) {
@@ -31,6 +33,7 @@ function trackCompressionStreams(): {
           record.closed = true
         })
         records.push(record)
+        streams.push(stream)
         return stream
       },
     })
@@ -38,6 +41,7 @@ function trackCompressionStreams(): {
 
   return {
     records,
+    streams,
     restore: () => {
       for (const [name, original] of originals) {
         Object.defineProperty(zlib, name, {
@@ -194,5 +198,92 @@ describe('releaseCompressionStream', () => {
     expect(outcome.threw).toBeNull()
     // Cleanup must not leave a stray listener behind on the response.
     expect(outcome.drainListeners).toBe(0)
+  })
+})
+
+describe('compression middleware drain forwarding', () => {
+  let tracker: ReturnType<typeof trackCompressionStreams>
+  let server: http.Server | undefined
+
+  beforeEach(() => {
+    tracker = trackCompressionStreams()
+  })
+
+  afterEach(async () => {
+    tracker.restore()
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()))
+      server = undefined
+    }
+  })
+
+  it('does not forward removeListener, so res.once(drain) leaks on Gzip', async () => {
+    // If this starts failing, the vendored `compression` forwards
+    // `removeListener` / `off` and `pipeNodeReadableToNodeResponse` can go
+    // back to `res.once('drain')` per write.
+    const compress = setupCompression()
+    const seen = { drainListeners: -1 }
+
+    server = http.createServer((req, res) => {
+      // @ts-expect-error not express req/res
+      compress(req, res, () => {})
+      res.setHeader('content-type', 'text/html')
+      res.write(`<html><body>${'x'.repeat(4096)}`)
+      // Flush so the zlib stream exists before we attach drain listeners.
+      ;(res as any).flush()
+
+      for (let i = 0; i < 12; i++) {
+        res.once('drain', () => {})
+      }
+
+      seen.drainListeners = tracker.streams[0]?.listenerCount('drain') ?? -1
+      res.end('</body></html>')
+    })
+    const url = await listen(server)
+
+    const res = await fetch(url, {
+      headers: { 'accept-encoding': 'gzip' },
+      signal: AbortSignal.timeout(10_000),
+    })
+    await res.arrayBuffer()
+
+    expect(tracker.streams).toHaveLength(1)
+    expect(seen.drainListeners).toBeGreaterThanOrEqual(12)
+  })
+
+  it('does not accumulate Gzip drain listeners for a single res.on(drain)', async () => {
+    const compress = setupCompression()
+    const seen = { drainListeners: -1 }
+
+    server = http.createServer((req, res) => {
+      // @ts-expect-error not express req/res
+      compress(req, res, () => {})
+      res.setHeader('content-type', 'text/html')
+      res.write(`<html><body>${'x'.repeat(4096)}`)
+      ;(res as any).flush()
+
+      const onDrain = () => {}
+      res.on('drain', onDrain)
+      // Simulate many backpressure cycles without adding more listeners.
+      for (let i = 0; i < 12; i++) {
+        tracker.streams[0]?.emit('drain')
+      }
+
+      seen.drainListeners = tracker.streams[0]?.listenerCount('drain') ?? -1
+      res.off('drain', onDrain)
+      res.end('</body></html>')
+    })
+    const url = await listen(server)
+
+    const res = await fetch(url, {
+      headers: { 'accept-encoding': 'gzip' },
+      signal: AbortSignal.timeout(10_000),
+    })
+    await res.arrayBuffer()
+
+    expect(tracker.streams).toHaveLength(1)
+    // One listener for the reused handler. `off` is also not forwarded, so
+    // it may still be present — the point is it does not grow past 1.
+    expect(seen.drainListeners).toBe(1)
   })
 })

--- a/packages/next/src/server/lib/release-compression-stream.test.ts
+++ b/packages/next/src/server/lib/release-compression-stream.test.ts
@@ -12,11 +12,9 @@ type StreamRecord = { closed: boolean }
 /** Records every zlib stream the middleware creates, and whether it closed. */
 function trackCompressionStreams(): {
   records: StreamRecord[]
-  streams: Array<zlib.Gzip | zlib.Deflate>
   restore: () => void
 } {
   const records: StreamRecord[] = []
-  const streams: Array<zlib.Gzip | zlib.Deflate> = []
   const originals: Array<[string, unknown]> = []
 
   for (const name of ['createGzip', 'createDeflate'] as const) {
@@ -33,7 +31,6 @@ function trackCompressionStreams(): {
           record.closed = true
         })
         records.push(record)
-        streams.push(stream)
         return stream
       },
     })
@@ -41,7 +38,6 @@ function trackCompressionStreams(): {
 
   return {
     records,
-    streams,
     restore: () => {
       for (const [name, original] of originals) {
         Object.defineProperty(zlib, name, {
@@ -198,92 +194,5 @@ describe('releaseCompressionStream', () => {
     expect(outcome.threw).toBeNull()
     // Cleanup must not leave a stray listener behind on the response.
     expect(outcome.drainListeners).toBe(0)
-  })
-})
-
-describe('compression middleware drain forwarding', () => {
-  let tracker: ReturnType<typeof trackCompressionStreams>
-  let server: http.Server | undefined
-
-  beforeEach(() => {
-    tracker = trackCompressionStreams()
-  })
-
-  afterEach(async () => {
-    tracker.restore()
-    if (server) {
-      await new Promise<void>((resolve) => server!.close(() => resolve()))
-      server = undefined
-    }
-  })
-
-  it('does not forward removeListener, so res.once(drain) leaks on Gzip', async () => {
-    // If this starts failing, the vendored `compression` forwards
-    // `removeListener` / `off` and `pipeNodeReadableToNodeResponse` can go
-    // back to `res.once('drain')` per write.
-    const compress = setupCompression()
-    const seen = { drainListeners: -1 }
-
-    server = http.createServer((req, res) => {
-      // @ts-expect-error not express req/res
-      compress(req, res, () => {})
-      res.setHeader('content-type', 'text/html')
-      res.write(`<html><body>${'x'.repeat(4096)}`)
-      // Flush so the zlib stream exists before we attach drain listeners.
-      ;(res as any).flush()
-
-      for (let i = 0; i < 12; i++) {
-        res.once('drain', () => {})
-      }
-
-      seen.drainListeners = tracker.streams[0]?.listenerCount('drain') ?? -1
-      res.end('</body></html>')
-    })
-    const url = await listen(server)
-
-    const res = await fetch(url, {
-      headers: { 'accept-encoding': 'gzip' },
-      signal: AbortSignal.timeout(10_000),
-    })
-    await res.arrayBuffer()
-
-    expect(tracker.streams).toHaveLength(1)
-    expect(seen.drainListeners).toBeGreaterThanOrEqual(12)
-  })
-
-  it('does not accumulate Gzip drain listeners for a single res.on(drain)', async () => {
-    const compress = setupCompression()
-    const seen = { drainListeners: -1 }
-
-    server = http.createServer((req, res) => {
-      // @ts-expect-error not express req/res
-      compress(req, res, () => {})
-      res.setHeader('content-type', 'text/html')
-      res.write(`<html><body>${'x'.repeat(4096)}`)
-      ;(res as any).flush()
-
-      const onDrain = () => {}
-      res.on('drain', onDrain)
-      // Simulate many backpressure cycles without adding more listeners.
-      for (let i = 0; i < 12; i++) {
-        tracker.streams[0]?.emit('drain')
-      }
-
-      seen.drainListeners = tracker.streams[0]?.listenerCount('drain') ?? -1
-      res.off('drain', onDrain)
-      res.end('</body></html>')
-    })
-    const url = await listen(server)
-
-    const res = await fetch(url, {
-      headers: { 'accept-encoding': 'gzip' },
-      signal: AbortSignal.timeout(10_000),
-    })
-    await res.arrayBuffer()
-
-    expect(tracker.streams).toHaveLength(1)
-    // One listener for the reused handler. `off` is also not forwarded, so
-    // it may still be present — the point is it does not grow past 1.
-    expect(seen.drainListeners).toBe(1)
   })
 })

--- a/packages/next/src/server/pipe-readable.test.ts
+++ b/packages/next/src/server/pipe-readable.test.ts
@@ -1,0 +1,175 @@
+/* eslint-env jest */
+/**
+ * @jest-environment node
+ */
+import type { AddressInfo } from 'node:net'
+
+import { EventEmitter } from 'node:events'
+import http from 'node:http'
+import zlib from 'node:zlib'
+import { Readable } from 'node:stream'
+import { promisify } from 'node:util'
+import setupCompression from 'next/dist/compiled/compression'
+
+import { pipeNodeReadableToNodeResponse } from './pipe-readable'
+
+const gunzip = promisify(zlib.gunzip)
+
+// Large enough that the socket keeps applying backpressure to a slow reader,
+// so `res.write()` returns `false` many more times than Node's listener limit.
+const CHUNK_SIZE = 64 * 1024
+const CHUNK_COUNT = 48
+const FILL = 'x'.charCodeAt(0)
+
+/**
+ * Counts how many `drain` listeners get added to each zlib stream the
+ * `compression` middleware creates. Counting registrations rather than sampling
+ * `listenerCount` keeps the assertion deterministic: the middleware forwards
+ * `res.on` to the stream but not `removeListener`, so anything added is there
+ * to stay.
+ */
+function trackGzipDrainRegistrations(): {
+  streams: number
+  drainRegistrations: number
+  restore: () => void
+} {
+  const state = { streams: 0, drainRegistrations: 0, restore: () => {} }
+  const originals: Array<[string, unknown]> = []
+
+  for (const name of ['createGzip', 'createDeflate'] as const) {
+    const original = zlib[name]
+    originals.push([name, original])
+    // zlib's exports are non-writable, so they have to be redefined.
+    Object.defineProperty(zlib, name, {
+      configurable: true,
+      writable: true,
+      value: (...args: Parameters<typeof original>) => {
+        const stream = original(...args)
+        state.streams++
+        stream.on('newListener', (event) => {
+          if (event === 'drain') state.drainRegistrations++
+        })
+        return stream
+      },
+    })
+  }
+
+  state.restore = () => {
+    for (const [name, original] of originals) {
+      Object.defineProperty(zlib, name, {
+        configurable: true,
+        writable: true,
+        value: original,
+      })
+    }
+  }
+
+  return state
+}
+
+function createServer() {
+  const compress = setupCompression()
+
+  return http.createServer((req, res) => {
+    // @ts-expect-error not express req/res
+    compress(req, res, () => {})
+    res.setHeader('content-type', 'text/html')
+
+    let sent = 0
+    const readable = Readable.from(
+      (function* () {
+        while (sent++ < CHUNK_COUNT) {
+          yield Buffer.alloc(CHUNK_SIZE, FILL)
+        }
+      })()
+    )
+
+    void pipeNodeReadableToNodeResponse(readable, res)
+  })
+}
+
+async function listen(server: http.Server): Promise<string> {
+  await new Promise<void>((resolve) => server.listen(0, resolve))
+  const { port } = server.address() as AddressInfo
+  return `http://127.0.0.1:${port}`
+}
+
+/**
+ * Reads the response a chunk at a time, pausing in between, so the server sees
+ * sustained backpressure instead of draining immediately.
+ */
+async function readSlowly(url: string) {
+  return new Promise<{ encoding?: string; body: Buffer }>((resolve, reject) => {
+    const req = http.get(
+      url,
+      { headers: { 'accept-encoding': 'gzip' } },
+      (res) => {
+        const parts: Buffer[] = []
+        res.on('data', (chunk: Buffer) => {
+          parts.push(chunk)
+          res.pause()
+          setTimeout(() => res.resume(), 2)
+        })
+        res.on('end', () =>
+          resolve({
+            encoding: res.headers['content-encoding'],
+            body: Buffer.concat(parts),
+          })
+        )
+        res.on('error', reject)
+      }
+    )
+    req.on('error', reject)
+  })
+}
+
+describe('pipeNodeReadableToNodeResponse', () => {
+  let tracker: ReturnType<typeof trackGzipDrainRegistrations>
+  let server: http.Server | undefined
+  let warnings: string[]
+  let onWarning: (warning: Error) => void
+
+  beforeEach(() => {
+    tracker = trackGzipDrainRegistrations()
+    warnings = []
+    onWarning = (warning) => {
+      if (warning.name === 'MaxListenersExceededWarning') {
+        warnings.push(warning.message)
+      }
+    }
+    process.on('warning', onWarning)
+  })
+
+  afterEach(async () => {
+    process.off('warning', onWarning)
+    tracker.restore()
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()))
+      server = undefined
+    }
+  })
+
+  it('reuses one gzip drain listener across many backpressured writes', async () => {
+    server = createServer()
+    const url = await listen(server)
+
+    const { encoding, body } = await readSlowly(url)
+
+    expect(encoding).toBe('gzip')
+    expect(tracker.streams).toBe(1)
+
+    // Without reuse this is one registration per backpressured write, which
+    // Node reports as a probable leak once it passes `defaultMaxListeners`.
+    expect(tracker.drainRegistrations).toBe(1)
+    expect(tracker.drainRegistrations).toBeLessThan(
+      EventEmitter.defaultMaxListeners
+    )
+    expect(warnings).toEqual([])
+
+    // The reused listener must still resume the readable, or the response
+    // stalls partway through.
+    const decompressed = await gunzip(body)
+    expect(decompressed).toHaveLength(CHUNK_SIZE * CHUNK_COUNT)
+    expect(decompressed.every((byte) => byte === FILL)).toBe(true)
+  })
+})

--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -166,6 +166,13 @@ export async function pipeNodeReadableToNodeResponse(
     // a `once` listener is never removed from the stream it was added to. Each
     // backpressured write would leak one, and past ten Node reports the stream
     // as a probable leak via `MaxListenersExceededWarning`.
+    //
+    // TODO: the upstream fix for that asymmetry is
+    // https://github.com/expressjs/compression/pull/153, which intercepts
+    // `removeListener` so it reaches the zlib stream. It has been open since
+    // 2019 and is not in upstream 1.8.1; we vendor 1.7.4. If it ever lands and
+    // we upgrade, `res.off('drain', onDrain)` below would start working with
+    // compression active and the caveat on the `close` handler could go away.
     let paused = false
     const onDrain = () => {
       // The listener outlives the readable: `off` below cannot reach the zlib

--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -159,7 +159,19 @@ export async function pipeNodeReadableToNodeResponse(
 
     const finished = createPromiseWithResolvers<void>()
 
+    // Reuse one `drain` listener for the response. Do not use
+    // `res.once('drain')` per backpressured write: the vendored `compression`
+    // middleware forwards `res.on('drain')` to the Gzip stream but does not
+    // forward `removeListener`, so each `once()` permanently adds a listener
+    // and eventually emits `MaxListenersExceededWarning`. This is the same
+    // handle `releaseCompressionStream` uses. Match `createWriterFromResponse`.
+    const onDrain = () => {
+      readable.resume()
+    }
+    res.on('drain', onDrain)
+
     res.once('close', () => {
+      res.off('drain', onDrain)
       readable.destroy()
       finished.resolve()
     })
@@ -204,9 +216,6 @@ export async function pipeNodeReadableToNodeResponse(
 
       if (!ok) {
         readable.pause()
-        res.once('drain', () => {
-          readable.resume()
-        })
       }
     })
 

--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -159,18 +159,28 @@ export async function pipeNodeReadableToNodeResponse(
 
     const finished = createPromiseWithResolvers<void>()
 
-    // Reuse one `drain` listener for the response. Do not use
-    // `res.once('drain')` per backpressured write: the vendored `compression`
-    // middleware forwards `res.on('drain')` to the Gzip stream but does not
-    // forward `removeListener`, so each `once()` permanently adds a listener
-    // and eventually emits `MaxListenersExceededWarning`. This is the same
-    // handle `releaseCompressionStream` uses. Match `createWriterFromResponse`.
+    // One `drain` listener for the whole response, as in
+    // `createWriterFromResponse` above. It must not be `res.once('drain')` per
+    // backpressured write: the `compression` middleware forwards `res.on` to
+    // its zlib stream but leaves `removeListener` pointing at the response, so
+    // a `once` listener is never removed from the stream it was added to. Each
+    // backpressured write would leak one, and past ten Node reports the stream
+    // as a probable leak via `MaxListenersExceededWarning`.
+    let paused = false
     const onDrain = () => {
+      // The listener outlives the readable: `off` below cannot reach the zlib
+      // stream either, so a late drain can arrive after teardown.
+      if (!paused || readable.destroyed) return
+
+      paused = false
       readable.resume()
     }
     res.on('drain', onDrain)
 
     res.once('close', () => {
+      // Only removes the listener when compression is inactive, which is the
+      // case where it was added to the response itself. Otherwise it lives on
+      // the zlib stream, which is released with the response.
       res.off('drain', onDrain)
       readable.destroy()
       finished.resolve()
@@ -215,6 +225,7 @@ export async function pipeNodeReadableToNodeResponse(
       }
 
       if (!ok) {
+        paused = true
         readable.pause()
       }
     })


### PR DESCRIPTION
## Summary

On Next 16.3+, App Router HTML and RSC responses are piped with `pipeNodeReadableToNodeResponse`. Under gzip backpressure it called `res.once('drain')` on every write that returned `false`, which leaks one listener per backpressured write onto the zlib stream:

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 drain listeners added to [Gzip]. MaxListeners is 10.
```

The `compression` middleware overrides only `res.on`, forwarding it to the zlib stream once that stream exists (or buffering it until then). It leaves `removeListener` pointing at the response, so a `once` listener is added to the stream but never removed from it. `off` cannot reach it either.

`createWriterFromResponse`, directly above in the same file, already uses a single `res.on('drain')` for the response lifetime. This makes the Node-readable path match: pause on `write() === false`, resume from one listener, `off` on `close`.

Resuming on that event is correct for both cases. With compression active the wrapped `res.write` writes into the zlib stream, so `false` means the zlib stream's buffer is full and its `drain` is the right signal — the middleware separately wires the socket's `drain` to `stream.resume()`. With compression inactive the listener stays on the response, where `off` does remove it.

The pause is latched so a `drain` only resumes a readable that this function paused, and a `drain` arriving after teardown is ignored.

### Scope

- Distinct from #96173 / `releaseCompressionStream`, which destroys the zlib stream on **abort**. This warning fires on a **live** stream that is still flowing: slow clients, large streamed HTML/RSC.
- Deliberately leaves the bare `readable.destroy()` in the `close` handler alone. That is the separate abort-reason bug in #96704, with fixes already open in #96715 and #96717.
- Not fixable by bumping the vendored `compression`: as #96173 established, upstream `compression@1.8.1` still has no premature-close handling, and it is a prebuilt bundle here. `setMaxListeners` or `compress: false` would only hide this.
- Mentioned as a `compress: false` workaround in #95130.

## Verification

`packages/next/src/server/pipe-readable.test.ts` drives real backpressure (48 × 64 KiB through a throttled reader) and asserts exactly one `drain` registration on the zlib stream, no `MaxListenersExceededWarning`, and a complete, byte-correct payload after `gunzip`. The payload assertion is what catches a latch that stalls the stream.

Confirmed it fails without the fix. Measured against the real compiled function on Next 16.3, patching only the drain handling:

| | before | after |
| --- | --- | --- |
| `drain` registrations on `[Gzip]` | 48 (one per backpressured write) | **1** |
| `MaxListenersExceededWarning` | 1 | **0** |
| decompressed payload | complete | complete |

At 120 × 64 KiB the before-count scales with writes (120 registrations); the after-count stays at 1. Separately reproduced end to end on a Next 16.3 standalone production build with `compress: true`: slow-consuming a large gzipped page emitted the warning, and after this change it did not, with `Content-Encoding: gzip` still set and valid gzip on the wire.

I could not run `pnpm test` in this checkout, so please treat CI as the source of truth for harness integration. The assertions themselves were validated against the real function as described above.