### PR TITLE
Migrate remaining async blocks to async closures

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -300,11 +300,10 @@ impl ServerActionsGraphs {
                 let result = self
                     .0
                     .iter()
-                    .map(async |graph| {
+                    .map(|graph| {
                         graph
                             .get_server_actions_for_endpoint(entry, rsc_asset_context)
                             .owned()
-                            .await
                     })
                     .try_flat_join()
                     .await?;

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -295,12 +295,8 @@ impl VersionedContentMap {
         };
         let keys = keys
             .into_iter()
-            .map(|path| {
-                let root = root.clone();
-                async move { Ok(root.get_path_to(&path).map(RcStr::from)) }
-            })
-            .try_flat_join()
-            .await?;
+            .filter_map(|path| root.get_path_to(&path).map(RcStr::from))
+            .collect();
         Ok(Vc::cell(keys))
     }
 

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -105,11 +105,7 @@ pub async fn emit_assets(
         let first = iter.next().unwrap();
         let ext: RcStr = path.extension().unwrap_or_default().into();
         let conflicts = iter
-            .map(async |next| {
-                assets_diff(*next, *first, ext.clone(), node_root.clone())
-                    .owned()
-                    .await
-            })
+            .map(|next| assets_diff(*next, *first, ext.clone(), node_root.clone()).owned())
             .try_flat_join()
             .await?;
         if let Some(detail) = conflicts.into_iter().next() {

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1883,12 +1883,11 @@ impl OutputFileTracingIncludesExcludes {
                             .iter()
                             .flat_map(|pattern| pattern.iter())
                             .filter_map(|pattern| pattern.as_str())
-                            .map(async |pattern_str| {
+                            .map(|pattern_str| {
                                 let (glob, root) = relativize_glob(pattern_str, &project_path)?;
                                 Ok((RcStr::from(glob), root))
                             })
-                            .try_join()
-                            .await?;
+                            .collect::<Result<Vec<_>>>()?;
                         Ok((route_pattern, file_patterns))
                     })
                     .try_join()

--- a/turbopack/crates/turbo-tasks-backend/benches/overhead.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/overhead.rs
@@ -68,7 +68,7 @@ pub fn overhead(c: &mut Criterion) {
                     }
                     start.elapsed()
                 })
-                .then(|r| async { r.unwrap() })
+                .then(async |r| r.unwrap())
             });
         });
 
@@ -113,7 +113,7 @@ pub fn overhead(c: &mut Criterion) {
                         while futures.next().await.is_some() {}
                         start.elapsed()
                     })
-                    .then(|r| async { r.unwrap() })
+                    .then(async |r| r.unwrap())
                 });
             },
         );

--- a/turbopack/crates/turbo-tasks-backend/tests/call_types.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/call_types.rs
@@ -69,8 +69,9 @@ async fn async_fn_vc_arg(n: Vc<u32>) -> Result<Vc<u32>> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_methods() {
-    run_once(&REGISTRATION, || {
-        test_methods_operation().read_strongly_consistent()
+    run_once(&REGISTRATION, || async {
+        test_methods_operation().read_strongly_consistent().await?;
+        anyhow::Ok(())
     })
     .await
     .unwrap()
@@ -127,7 +128,7 @@ impl Value {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trait_methods() {
-    run_once(&REGISTRATION, async || {
+    run_once(&REGISTRATION, || async {
         test_trait_methods_operation()
             .read_strongly_consistent()
             .await?;

--- a/turbopack/crates/turbo-tasks-backend/tests/call_types.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/call_types.rs
@@ -69,9 +69,8 @@ async fn async_fn_vc_arg(n: Vc<u32>) -> Result<Vc<u32>> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_methods() {
-    run_once(&REGISTRATION, || async {
-        test_methods_operation().read_strongly_consistent().await?;
-        anyhow::Ok(())
+    run_once(&REGISTRATION, || {
+        test_methods_operation().read_strongly_consistent()
     })
     .await
     .unwrap()
@@ -128,7 +127,7 @@ impl Value {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trait_methods() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         test_trait_methods_operation()
             .read_strongly_consistent()
             .await?;

--- a/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
@@ -19,7 +19,7 @@ static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_transitive_emitting() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
         let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
         let result_val = result_op.connect().strongly_consistent().await?;
@@ -38,7 +38,7 @@ async fn test_transitive_emitting() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_transitive_emitting_indirect() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
         let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
         let collectibles_op = my_transitive_emitting_function_collectibles(rcstr!(""), rcstr!(""));
@@ -57,7 +57,7 @@ async fn test_transitive_emitting_indirect() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_multi_emitting() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
         let result_op = my_multi_emitting_function();
         let result_val = result_op.connect().strongly_consistent().await?;
@@ -76,7 +76,7 @@ async fn test_multi_emitting() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn taking_collectibles() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let result_op = my_collecting_function();
         let result_val = result_op.connect().strongly_consistent().await?;
         let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
@@ -92,7 +92,7 @@ async fn taking_collectibles() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn taking_collectibles_extra_layer() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let result_op = my_collecting_function_indirect();
         let result_val = result_op.connect().strongly_consistent().await?;
         let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
@@ -108,7 +108,7 @@ async fn taking_collectibles_extra_layer() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn taking_collectibles_parallel() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!("a"));
         let result_val = result_op.connect().strongly_consistent().await?;
         let list = result_op.take_collectibles::<Box<dyn ValueToString>>();
@@ -150,7 +150,7 @@ async fn taking_collectibles_parallel() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn taking_collectibles_with_resolve() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let result_op = my_transitive_emitting_function_with_resolve(rcstr!("resolve"));
         result_op.connect().strongly_consistent().await?;
         let list = result_op.take_collectibles::<Box<dyn ValueToString>>();

--- a/turbopack/crates/turbo-tasks-backend/tests/debug.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/debug.rs
@@ -155,7 +155,7 @@ async fn test_struct_transparent_debug() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_struct_option_debug() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let a = StructWithOption { option: None }.resolved_cell();
         assert_eq!(
             format!(
@@ -189,7 +189,7 @@ async fn test_struct_option_debug() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_struct_vec_debug() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let a = StructWithVec { vec: Vec::new() }.resolved_cell();
         assert_eq!(
             format!(
@@ -223,7 +223,7 @@ async fn test_struct_vec_debug() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_struct_ignore_debug() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let a = StructWithIgnore {
             dont_ignore: 42,
             ignore: Mutex::new(()),

--- a/turbopack/crates/turbo-tasks-backend/tests/derive_value_to_string.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/derive_value_to_string.rs
@@ -103,7 +103,7 @@ enum MixedEnum {
 /// No attribute: delegates to Display::to_string(self).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_display_delegation() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let v: ResolvedVc<Box<dyn ValueToString>> =
             ResolvedVc::upcast(SimpleDisplay(42).resolved_cell());
         assert_eq!(
@@ -119,7 +119,7 @@ async fn test_display_delegation() {
 /// FormatAutoFields on structs: named fields, positional fields, and constant strings.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_struct_format_strings() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let v1: ResolvedVc<Box<dyn ValueToString>> = ResolvedVc::upcast(
             NamedFields {
                 name: "foo".into(),
@@ -155,7 +155,7 @@ async fn test_struct_format_strings() {
 /// DirectExpr form: single expression delegation.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_struct_direct_expr() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let v: ResolvedVc<Box<dyn ValueToString>> = ResolvedVc::upcast(
             DirectExpr {
                 name: "hello".into(),
@@ -176,7 +176,7 @@ async fn test_struct_direct_expr() {
 /// FormatExprs on structs: format string with explicit expressions, including Vc delegation.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_struct_format_exprs() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let v1: ResolvedVc<Box<dyn ValueToString>> = ResolvedVc::upcast(
             FormatExprs {
                 name: "test".into(),
@@ -210,7 +210,7 @@ async fn test_struct_format_exprs() {
 /// Enum with per-variant auto-field format strings and default variant names.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_enum_variants() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         // Per-variant attributes
         assert_eq!(
             &*to_string_operation(ResolvedVc::upcast(Kind::Module.resolved_cell()))
@@ -261,7 +261,7 @@ async fn test_enum_variants() {
 /// Enum with mixed forms: constant literal, Vc delegation, and format exprs.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mixed_enum() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         assert_eq!(
             &*to_string_operation(ResolvedVc::upcast(MixedEnum::Literal.resolved_cell()))
                 .read_strongly_consistent()
@@ -330,7 +330,7 @@ enum TortureEnum {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_torture_enum() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let named_resolved = NamedFields {
             name: "x".into(),
             count: 1,

--- a/turbopack/crates/turbo-tasks-backend/tests/detached.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/detached.rs
@@ -17,7 +17,7 @@ static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_spawns_detached() -> anyhow::Result<()> {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         println!("test_spawns_detached");
         // HACK: The watch channel we use has an incorrect implementation of `TraceRawVcs`, just
         // disable GC for the test so this can't cause any problems.
@@ -86,7 +86,7 @@ async fn spawns_detached(
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_spawns_detached_changing() -> anyhow::Result<()> {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
         // HACK: The watch channel we use has an incorrect implementation of `TraceRawVcs`
         prevent_gc();

--- a/turbopack/crates/turbo-tasks-backend/tests/dirty_in_progress.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/dirty_in_progress.rs
@@ -13,7 +13,7 @@ static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_dirty_in_progress() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let cases = [
             (1, 3, 2, 2, ""),
             (11, 13, 12, 42, "12"),

--- a/turbopack/crates/turbo-tasks-backend/tests/effects.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/effects.rs
@@ -128,7 +128,7 @@ impl CapturedEffect for TestEffectCaptured {
 
     async fn apply(&self) -> Result<(), ApplyError> {
         let body = if self.content {
-            Some(|| async {
+            Some(async || {
                 self.shared.total_applies.fetch_add(1, Ordering::Relaxed);
                 *self
                     .shared

--- a/turbopack/crates/turbo-tasks-backend/tests/emptied_cells.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/emptied_cells.rs
@@ -10,7 +10,7 @@ static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_emptied_cells() {
-    run(&REGISTRATION, || async {
+    run(&REGISTRATION, async || {
         let input_op = get_state_operation();
         let input_vc = input_op.resolve().strongly_consistent().await?;
         let input = input_op.read_strongly_consistent().await?;

--- a/turbopack/crates/turbo-tasks-backend/tests/emptied_cells_session_dependent.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/emptied_cells_session_dependent.rs
@@ -10,7 +10,7 @@ static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_emptied_cells_session_dependent() {
-    run(&REGISTRATION, || async {
+    run(&REGISTRATION, async || {
         let input_op = get_state_operation();
         let input_vc = input_op.resolve().strongly_consistent().await?;
         let input = input_op.read_strongly_consistent().await?;

--- a/turbopack/crates/turbo-tasks-backend/tests/errors.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/errors.rs
@@ -99,7 +99,7 @@ async fn indirect_panic_with_context() -> Result<Vc<u32>> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_bail() {
-    test(async || {
+    test(|| {
         assert_error(
             direct_bail(),
             indoc! {"
@@ -109,14 +109,13 @@ async fn test_direct_bail() {
                 - Execution of direct_bail failed
                 - direct bail error"},
         )
-        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_bail_with_context() {
-    test(async || {
+    test(|| {
         assert_error(
             direct_bail_with_context(),
             indoc! {"
@@ -130,14 +129,13 @@ async fn test_direct_bail_with_context() {
                 - bail-context
                 - direct bail error"},
         )
-        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_panic() {
-    test(async || {
+    test(|| {
         assert_error(
             direct_panic(),
             indoc! {"
@@ -147,7 +145,6 @@ async fn test_direct_panic() {
                 - Execution of direct_panic failed
                 - direct panic error"},
         )
-        .await
     })
     .await;
 }
@@ -155,7 +152,7 @@ async fn test_direct_panic() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_panic_with_context() {
     // Note: panic! is synchronous, so .context() cannot wrap it
-    test(async || {
+    test(|| {
         assert_error(
             direct_panic_with_context(),
             indoc! {"
@@ -165,14 +162,13 @@ async fn test_direct_panic_with_context() {
                 - Execution of direct_panic_with_context failed
                 - direct panic error"},
         )
-        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_bail() {
-    test(async || {
+    test(|| {
         assert_error(
             indirect_bail(),
             indoc! {"
@@ -183,14 +179,13 @@ async fn test_indirect_bail() {
                 - Execution of direct_bail failed
                 - direct bail error"},
         )
-        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_bail_with_context() {
-    test(async || {
+    test(|| {
         assert_error(
             indirect_bail_with_context(),
             indoc! {"
@@ -205,14 +200,13 @@ async fn test_indirect_bail_with_context() {
                 - Execution of direct_bail failed
                 - direct bail error"},
         )
-        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_panic() {
-    test(async || {
+    test(|| {
         assert_error(
             indirect_panic(),
             indoc! {"
@@ -223,14 +217,13 @@ async fn test_indirect_panic() {
                 - Execution of direct_panic failed
                 - direct panic error"},
         )
-        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_panic_with_context() {
-    test(async || {
+    test(|| {
         assert_error(
             indirect_panic_with_context(),
             indoc! {"
@@ -245,7 +238,6 @@ async fn test_indirect_panic_with_context() {
                 - Execution of direct_panic failed
                 - direct panic error"},
         )
-        .await
     })
     .await;
 }
@@ -300,7 +292,7 @@ async fn indirect_panic_with_context_in_context() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_bail_in_context() {
-    test(async || {
+    test(|| {
         assert_error(
             direct_bail_in_context(),
             indoc! {"
@@ -314,14 +306,13 @@ async fn test_direct_bail_in_context() {
                 - Execution of direct_bail failed
                 - direct bail error"},
         )
-        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_bail_with_context_in_context() {
-    test(async || {
+    test(|| {
         assert_error(
             direct_bail_with_context_in_context(),
             indoc! {"
@@ -337,14 +328,13 @@ async fn test_direct_bail_with_context_in_context() {
                 - bail-context
                 - direct bail error"},
         )
-        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_panic_in_context() {
-    test(async || {
+    test(|| {
         assert_error(
             direct_panic_in_context(),
             indoc! {"
@@ -358,14 +348,13 @@ async fn test_direct_panic_in_context() {
                 - Execution of direct_panic failed
                 - direct panic error"},
         )
-        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_panic_with_context_in_context() {
-    test(async || {
+    test(|| {
         assert_error(
             direct_panic_with_context_in_context(),
             indoc! {"
@@ -379,14 +368,13 @@ async fn test_direct_panic_with_context_in_context() {
                 - Execution of direct_panic_with_context failed
                 - direct panic error"},
         )
-        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_bail_in_context() {
-    test(async || {
+    test(|| {
         assert_error(
             indirect_bail_in_context(),
             indoc! {"
@@ -401,14 +389,13 @@ async fn test_indirect_bail_in_context() {
                 - Execution of direct_bail failed
                 - direct bail error"},
         )
-        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_bail_with_context_in_context() {
-    test(async || {
+    test(|| {
         assert_error(
             indirect_bail_with_context_in_context(),
             indoc! {"
@@ -425,14 +412,13 @@ async fn test_indirect_bail_with_context_in_context() {
                 - Execution of direct_bail failed
                 - direct bail error"},
         )
-        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_panic_in_context() {
-    test(async || {
+    test(|| {
         assert_error(
             indirect_panic_in_context(),
             indoc! {"
@@ -447,14 +433,13 @@ async fn test_indirect_panic_in_context() {
                 - Execution of direct_panic failed
                 - direct panic error"},
         )
-        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_panic_with_context_in_context() {
-    test(async || {
+    test(|| {
         assert_error(
             indirect_panic_with_context_in_context(),
             indoc! {"
@@ -471,7 +456,6 @@ async fn test_indirect_panic_with_context_in_context() {
                 - Execution of direct_panic failed
                 - direct panic error"},
         )
-        .await
     })
     .await;
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/errors.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/errors.rs
@@ -99,7 +99,7 @@ async fn indirect_panic_with_context() -> Result<Vc<u32>> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_bail() {
-    test(|| {
+    test(async || {
         assert_error(
             direct_bail(),
             indoc! {"
@@ -109,13 +109,14 @@ async fn test_direct_bail() {
                 - Execution of direct_bail failed
                 - direct bail error"},
         )
+        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_bail_with_context() {
-    test(|| {
+    test(async || {
         assert_error(
             direct_bail_with_context(),
             indoc! {"
@@ -129,13 +130,14 @@ async fn test_direct_bail_with_context() {
                 - bail-context
                 - direct bail error"},
         )
+        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_panic() {
-    test(|| {
+    test(async || {
         assert_error(
             direct_panic(),
             indoc! {"
@@ -145,6 +147,7 @@ async fn test_direct_panic() {
                 - Execution of direct_panic failed
                 - direct panic error"},
         )
+        .await
     })
     .await;
 }
@@ -152,7 +155,7 @@ async fn test_direct_panic() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_panic_with_context() {
     // Note: panic! is synchronous, so .context() cannot wrap it
-    test(|| {
+    test(async || {
         assert_error(
             direct_panic_with_context(),
             indoc! {"
@@ -162,13 +165,14 @@ async fn test_direct_panic_with_context() {
                 - Execution of direct_panic_with_context failed
                 - direct panic error"},
         )
+        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_bail() {
-    test(|| {
+    test(async || {
         assert_error(
             indirect_bail(),
             indoc! {"
@@ -179,13 +183,14 @@ async fn test_indirect_bail() {
                 - Execution of direct_bail failed
                 - direct bail error"},
         )
+        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_bail_with_context() {
-    test(|| {
+    test(async || {
         assert_error(
             indirect_bail_with_context(),
             indoc! {"
@@ -200,13 +205,14 @@ async fn test_indirect_bail_with_context() {
                 - Execution of direct_bail failed
                 - direct bail error"},
         )
+        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_panic() {
-    test(|| {
+    test(async || {
         assert_error(
             indirect_panic(),
             indoc! {"
@@ -217,13 +223,14 @@ async fn test_indirect_panic() {
                 - Execution of direct_panic failed
                 - direct panic error"},
         )
+        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_panic_with_context() {
-    test(|| {
+    test(async || {
         assert_error(
             indirect_panic_with_context(),
             indoc! {"
@@ -238,6 +245,7 @@ async fn test_indirect_panic_with_context() {
                 - Execution of direct_panic failed
                 - direct panic error"},
         )
+        .await
     })
     .await;
 }
@@ -292,7 +300,7 @@ async fn indirect_panic_with_context_in_context() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_bail_in_context() {
-    test(|| {
+    test(async || {
         assert_error(
             direct_bail_in_context(),
             indoc! {"
@@ -306,13 +314,14 @@ async fn test_direct_bail_in_context() {
                 - Execution of direct_bail failed
                 - direct bail error"},
         )
+        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_bail_with_context_in_context() {
-    test(|| {
+    test(async || {
         assert_error(
             direct_bail_with_context_in_context(),
             indoc! {"
@@ -328,13 +337,14 @@ async fn test_direct_bail_with_context_in_context() {
                 - bail-context
                 - direct bail error"},
         )
+        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_panic_in_context() {
-    test(|| {
+    test(async || {
         assert_error(
             direct_panic_in_context(),
             indoc! {"
@@ -348,13 +358,14 @@ async fn test_direct_panic_in_context() {
                 - Execution of direct_panic failed
                 - direct panic error"},
         )
+        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_panic_with_context_in_context() {
-    test(|| {
+    test(async || {
         assert_error(
             direct_panic_with_context_in_context(),
             indoc! {"
@@ -368,13 +379,14 @@ async fn test_direct_panic_with_context_in_context() {
                 - Execution of direct_panic_with_context failed
                 - direct panic error"},
         )
+        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_bail_in_context() {
-    test(|| {
+    test(async || {
         assert_error(
             indirect_bail_in_context(),
             indoc! {"
@@ -389,13 +401,14 @@ async fn test_indirect_bail_in_context() {
                 - Execution of direct_bail failed
                 - direct bail error"},
         )
+        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_bail_with_context_in_context() {
-    test(|| {
+    test(async || {
         assert_error(
             indirect_bail_with_context_in_context(),
             indoc! {"
@@ -412,13 +425,14 @@ async fn test_indirect_bail_with_context_in_context() {
                 - Execution of direct_bail failed
                 - direct bail error"},
         )
+        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_panic_in_context() {
-    test(|| {
+    test(async || {
         assert_error(
             indirect_panic_in_context(),
             indoc! {"
@@ -433,13 +447,14 @@ async fn test_indirect_panic_in_context() {
                 - Execution of direct_panic failed
                 - direct panic error"},
         )
+        .await
     })
     .await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_panic_with_context_in_context() {
-    test(|| {
+    test(async || {
         assert_error(
             indirect_panic_with_context_in_context(),
             indoc! {"
@@ -456,6 +471,7 @@ async fn test_indirect_panic_with_context_in_context() {
                 - Execution of direct_panic failed
                 - direct panic error"},
         )
+        .await
     })
     .await;
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/filter_unused_args.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/filter_unused_args.rs
@@ -10,7 +10,7 @@ static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_filtered_impl_method_args() -> Result<()> {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
 
         let uses_arg = UsesArg(0).cell();
@@ -40,7 +40,7 @@ async fn test_filtered_impl_method_args() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_filtered_trait_method_args() -> Result<()> {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
 
         let uses_arg = UsesArg(0).cell();
@@ -70,7 +70,7 @@ async fn test_filtered_trait_method_args() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_filtered_impl_method_self() -> Result<()> {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
 
         let uses_arg = UsesArg(0).cell();
@@ -106,7 +106,7 @@ async fn test_filtered_impl_method_self() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_filtered_trait_method_self() -> Result<()> {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
 
         let uses_arg = UsesArg(0).cell();
@@ -142,7 +142,7 @@ async fn test_filtered_trait_method_self() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_filtered_plain_method_args() -> Result<()> {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
 
         assert_eq!(

--- a/turbopack/crates/turbo-tasks-backend/tests/hashed_cell_mode.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/hashed_cell_mode.rs
@@ -72,7 +72,7 @@ async fn consume_hashed(input: ResolvedVc<Step>) -> Result<Vc<ConsumeResult>> {
 /// Test 1: When the value changes, the consumer SHOULD be invalidated and re-execute.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_hashed_cell_mode_change_triggers_invalidation() {
-    run(&REGISTRATION, || async {
+    run(&REGISTRATION, async || {
         let state_op = create_state_operation();
         let state_vc = state_op.resolve().strongly_consistent().await?;
         let state = state_op.read_strongly_consistent().await?;
@@ -103,7 +103,7 @@ async fn test_hashed_cell_mode_change_triggers_invalidation() {
 /// With `serialization = "hash"`, the consumer should not be re-executed.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_hashed_cell_mode_equal_value_no_invalidation() {
-    run(&REGISTRATION, || async {
+    run(&REGISTRATION, async || {
         let state_op = create_state_operation();
         let state_vc = state_op.resolve().strongly_consistent().await?;
         let state = state_op.read_strongly_consistent().await?;

--- a/turbopack/crates/turbo-tasks-backend/tests/immutable.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/immutable.rs
@@ -10,7 +10,7 @@ static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_hidden_mutate() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
         let input = *create_input().to_resolved().await?;
         input.await?.state.set(1);

--- a/turbopack/crates/turbo-tasks-backend/tests/invalidation.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/invalidation.rs
@@ -19,7 +19,7 @@ fn create_state_operation() -> Vc<Step> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_invalidation_map() {
-    run(&REGISTRATION, || async {
+    run(&REGISTRATION, async || {
         let state_op = create_state_operation();
         let state_vc = state_op.resolve().strongly_consistent().await?;
         let state = state_op.read_strongly_consistent().await?;
@@ -99,7 +99,7 @@ async fn get_value(map: OperationVc<Map>, key: String) -> Result<Vc<GetValueResu
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_invalidation_set() {
-    run(&REGISTRATION, || async {
+    run(&REGISTRATION, async || {
         let state_op = create_state_operation();
         let state_vc = state_op.resolve().strongly_consistent().await?;
         let state = state_op.read_strongly_consistent().await?;

--- a/turbopack/crates/turbo-tasks-backend/tests/operation_vc.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/operation_vc.rs
@@ -27,7 +27,7 @@ fn use_operations() -> Vc<i32> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_use_operations() -> Result<()> {
-    run(&REGISTRATION, || async {
+    run(&REGISTRATION, async || {
         assert_eq!(*use_operations().read_strongly_consistent().await?, 42);
         Ok(())
     })

--- a/turbopack/crates/turbo-tasks-backend/tests/random_change.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/random_change.rs
@@ -11,7 +11,7 @@ static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_random_change() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let state_op = make_state_operation();
         let state_vc = state_op.resolve().strongly_consistent().await?;
         let state = state_op.read_strongly_consistent().await?;

--- a/turbopack/crates/turbo-tasks-backend/tests/read_ref_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/read_ref_cell.rs
@@ -15,7 +15,7 @@ static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_read_ref() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
         let counter = Counter::cell(Counter {
             value: Mutex::new((0, Default::default())),

--- a/turbopack/crates/turbo-tasks-backend/tests/recompute.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/recompute.rs
@@ -12,7 +12,7 @@ static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recompute() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
         let input = ChangingInput {
             state: State::new(1),
@@ -63,7 +63,7 @@ async fn recompute() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn immutable_analysis() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
         let input = ChangingInput {
             state: State::new(1),
@@ -149,7 +149,7 @@ async fn compute2(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
 /// This tests the basic dependency propagation through a simple two-task chain.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recompute_dependency() {
-    run(&REGISTRATION, || async {
+    run(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
         let input = *get_dependency_input().to_resolved().await?;
         // Reset state to 1 at the start of each iteration (important for multi-run tests)

--- a/turbopack/crates/turbo-tasks-backend/tests/recompute_collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/recompute_collectibles.rs
@@ -14,7 +14,7 @@ static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recompute() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
         let input = *ChangingInput::new(1).to_resolved().await?;
         let input2 = *ChangingInput::new(2).to_resolved().await?;

--- a/turbopack/crates/turbo-tasks-backend/tests/resolved_vc.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/resolved_vc.rs
@@ -118,7 +118,7 @@ async fn test_into_future() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_sidecast() -> Result<()> {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let concrete_value = ImplementsAAndB.resolved_cell();
         let as_a = ResolvedVc::upcast::<Box<dyn TraitA>>(concrete_value);
         let as_b = ResolvedVc::try_sidecast::<Box<dyn TraitB>>(as_a);
@@ -132,7 +132,7 @@ async fn test_sidecast() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trait_ref_downcast() -> Result<()> {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let as_base: Vc<Box<dyn BaseTrait>> = Vc::upcast(ImplementsSubImplemented.cell());
         let ref_base = as_base.into_trait_ref().await?;
         // The concrete value implements SubImplemented, so downcasting the already-read

--- a/turbopack/crates/turbo-tasks-backend/tests/shrink_to_fit.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/shrink_to_fit.rs
@@ -13,7 +13,7 @@ struct Wrapper(Vec<u32>);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_shrink_to_fit() -> Result<()> {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         #[turbo_tasks::function(operation, root)]
         async fn capacity_operation(wrapper: ResolvedVc<Wrapper>) -> Result<Vc<usize>> {
             Ok(Vc::cell(wrapper.await?.capacity()))

--- a/turbopack/crates/turbo-tasks-backend/tests/top_level_task_consistency.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/top_level_task_consistency.rs
@@ -26,7 +26,7 @@ async fn returns_value_operation() -> Result<Vc<Value>> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[should_panic]
 async fn test_eventual_read_in_top_level_task_fails() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         // This should fail because we're in a top-level task (run_once)
         // and doing an eventually consistent read (default .await)
         returns_value_operation().connect().await
@@ -37,7 +37,7 @@ async fn test_eventual_read_in_top_level_task_fails() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_cell_read_in_top_level_task_succeeds() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let cell = returns_value_operation()
             .resolve()
             .strongly_consistent()
@@ -52,7 +52,7 @@ async fn test_cell_read_in_top_level_task_succeeds() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_manual_mark_unmark_top_level_task() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         // We're in a top-level task initially, but let's unmark it
         unmark_top_level_task_may_leak_eventually_consistent_state();
 
@@ -83,7 +83,7 @@ async fn test_manual_mark_top_level_task_causes_error() {
         Ok(Value { value: 42 }.cell())
     }
 
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         operation().read_strongly_consistent().await
     })
     .await

--- a/turbopack/crates/turbo-tasks-backend/tests/top_level_task_consistency.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/top_level_task_consistency.rs
@@ -83,9 +83,7 @@ async fn test_manual_mark_top_level_task_causes_error() {
         Ok(Value { value: 42 }.cell())
     }
 
-    run_once(&REGISTRATION, async || {
-        operation().read_strongly_consistent().await
-    })
-    .await
-    .unwrap()
+    run_once(&REGISTRATION, || operation().read_strongly_consistent())
+        .await
+        .unwrap()
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell.rs
@@ -15,7 +15,7 @@ static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn trait_ref() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
         let counter = Counter::cell(Counter {
             value: Mutex::new((0, Default::default())),

--- a/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell_mode.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell_mode.rs
@@ -13,7 +13,7 @@ static REGISTRATION: Registration = register!();
 // value is equal.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trait_ref_shared_cell_mode() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
         let input = CellIdSelector {
             value: 42,
@@ -49,7 +49,7 @@ async fn test_trait_ref_shared_cell_mode() {
 // value is equal.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trait_ref_new_cell_mode() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         unmark_top_level_task_may_leak_eventually_consistent_state();
         let input = CellIdSelector {
             value: 42,

--- a/turbopack/crates/turbo-tasks-backend/tests/turbofmt.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/turbofmt.rs
@@ -29,7 +29,7 @@ async fn turbobail_operation(value: ResolvedVc<FmtTest>) -> anyhow::Result<Vc<Rc
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_turbofmt() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let v = FmtTest {
             name: "foo".into(),
             count: 7,
@@ -47,7 +47,7 @@ async fn test_turbofmt() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_turbobail() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         let v = FmtTest {
             name: "bar".into(),
             count: 3,

--- a/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -186,7 +186,7 @@ fn get_issue_context() -> Vc<FileSystemPath> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn errors_on_failed_connection() {
     let _guard = GLOBAL_TEST_LOCK.lock().await;
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         #[turbo_tasks::value]
         struct FetchOutput(
             ReadRef<FetchErrorKind>,
@@ -204,12 +204,10 @@ async fn errors_on_failed_connection() {
             let err_kind = err.kind.await?;
             let err_url = err.url.owned().await?;
 
-            let issue_vc = err_vc.to_issue(IssueSeverity::Error, get_issue_context().owned().await?);
+            let issue_vc =
+                err_vc.to_issue(IssueSeverity::Error, get_issue_context().owned().await?);
             let issue = issue_vc.await?;
-            let issue_description = issue
-                .description()
-                .await?
-                .expect("description is not None");
+            let issue_description = issue.description().await?.expect("description is not None");
 
             Ok(FetchOutput(err_kind, err_url, issue, issue_description).cell())
         }
@@ -219,16 +217,18 @@ async fn errors_on_failed_connection() {
         // Other values (e.g. domain name, reserved IP address block) may result in long timeouts.
         let url = rcstr!("http://127.0.0.1:0/foo.woff");
         let FetchOutput(err_kind, err_url, issue, issue_description) =
-            &*fetch_operation(url.clone()).read_strongly_consistent().await?;
+            &*fetch_operation(url.clone())
+                .read_strongly_consistent()
+                .await?;
 
         assert!(matches!(**err_kind, FetchErrorKind::Connect));
         assert_eq!(*err_url, url);
 
         assert_eq!(issue.severity(), IssueSeverity::Error);
         assert_eq!(
-            issue_description.to_unstyled_string(),
-            "There was an issue establishing a connection while requesting http://127.0.0.1:0/foo.woff"
-        );
+        issue_description.to_unstyled_string(),
+        "There was an issue establishing a connection while requesting http://127.0.0.1:0/foo.woff"
+    );
         anyhow::Ok(())
     })
     .await

--- a/turbopack/crates/turbo-tasks-fs/src/disk.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/disk.rs
@@ -1144,7 +1144,7 @@ impl FileSystem for DiskFileSystem {
 
             async fn apply(&self) -> Result<(), turbo_tasks::ApplyError> {
                 let body = self.content.as_ref().map(|content| {
-                    || async { self.apply_inner(content).await.map_err(AnyhowWrapper::from) }
+                    async || self.apply_inner(content).await.map_err(AnyhowWrapper::from)
                 });
                 self.inner
                     .effect_state_storage
@@ -1347,7 +1347,7 @@ impl FileSystem for DiskFileSystem {
 
             async fn apply(&self) -> Result<(), turbo_tasks::ApplyError> {
                 let body = self.content.as_ref().map(|content| {
-                    || async { self.apply_inner(content).await.map_err(AnyhowWrapper::from) }
+                    async || self.apply_inner(content).await.map_err(AnyhowWrapper::from)
                 });
                 self.inner
                     .effect_state_storage

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/task_input.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/task_input.rs
@@ -22,7 +22,7 @@ fn one_unnamed_field(input: OneUnnamedField) -> Vc<Completion> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn tests() {
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         #[turbo_tasks::function(operation, root)]
         async fn equality_operation() -> Result<Vc<bool>> {
             Ok(Vc::cell(ReadRef::ptr_eq(
@@ -30,8 +30,7 @@ async fn tests() {
                 &Completion::immutable().await?,
             )))
         }
-        equality_operation().read_strongly_consistent().await?;
-        anyhow::Ok(())
+        equality_operation().read_strongly_consistent().await
     })
     .await
     .unwrap()

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/value_debug.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/value_debug.rs
@@ -21,7 +21,7 @@ async fn ignored_indexes() {
         i32,
     );
 
-    run_once(&REGISTRATION, || async {
+    run_once(&REGISTRATION, async || {
         #[turbo_tasks::function(operation, root)]
         async fn value_debug_format_operation() -> Result<Vc<RcStr>> {
             let input = IgnoredIndexes(-1, 2, -3);

--- a/turbopack/crates/turbo-tasks/benches/scope.rs
+++ b/turbopack/crates/turbo-tasks/benches/scope.rs
@@ -36,20 +36,13 @@ pub fn overhead(c: &mut Criterion) {
     let mut group = c.benchmark_group("scope_overhead");
     group.sample_size(20);
 
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .disable_lifo_slot()
-        .thread_name("tokio-thread")
-        .enable_all()
-        .build()
-        .unwrap();
-
     for (item_duration, item_count) in get_test_cases() {
         group.bench_with_input(
             BenchmarkId::new(format!("parallel {item_duration:?}"), item_count),
             &item_count,
             |b, &d| {
                 let items = (0..d).collect::<Vec<_>>();
-                b.to_async(&rt).iter(|| async {
+                b.iter(|| {
                     let result: Vec<_> =
                         parallel::map_collect(&items, |&i| black_box(busy_task(item_duration, i)));
                     result

--- a/turbopack/crates/turbo-tasks/benches/scope.rs
+++ b/turbopack/crates/turbo-tasks/benches/scope.rs
@@ -36,13 +36,20 @@ pub fn overhead(c: &mut Criterion) {
     let mut group = c.benchmark_group("scope_overhead");
     group.sample_size(20);
 
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .disable_lifo_slot()
+        .thread_name("tokio-thread")
+        .enable_all()
+        .build()
+        .unwrap();
+
     for (item_duration, item_count) in get_test_cases() {
         group.bench_with_input(
             BenchmarkId::new(format!("parallel {item_duration:?}"), item_count),
             &item_count,
             |b, &d| {
                 let items = (0..d).collect::<Vec<_>>();
-                b.iter(|| {
+                b.to_async(&rt).iter(|| async {
                     let result: Vec<_> =
                         parallel::map_collect(&items, |&i| black_box(busy_task(item_duration, i)));
                     result

--- a/turbopack/crates/turbo-tasks/src/completion.rs
+++ b/turbopack/crates/turbo-tasks/src/completion.rs
@@ -61,11 +61,11 @@ impl Completions {
         } else {
             self.0
                 .iter()
-                .map(|&c| async move {
-                    // Wraps the completion in a new completion. This makes it cheaper to restore
-                    // since it doesn't need to restore the original task resp task chain.
-                    wrap(*c).await?;
-                    Ok(())
+                .map(|&c| {
+                    // Wraps the completion in a new completion. This makes it cheaper to
+                    // restore since it doesn't need to restore the
+                    // original task resp task chain.
+                    wrap(*c)
                 })
                 .try_join()
                 .await?;

--- a/turbopack/crates/turbo-tasks/src/task/task_input.rs
+++ b/turbopack/crates/turbo-tasks/src/task/task_input.rs
@@ -509,8 +509,8 @@ where
 {
     fn resolve_input(&self) -> impl Future<Output = Result<Self>> + Send + '_ {
         self.as_ref().map_either(
-            |l| async move { anyhow::Ok(Self(Either::Left(l.resolve_input().await?))) },
-            |r| async move { anyhow::Ok(Self(Either::Right(r.resolve_input().await?))) },
+            async |l| anyhow::Ok(Self(Either::Left(l.resolve_input().await?))),
+            async |r| anyhow::Ok(Self(Either::Right(r.resolve_input().await?))),
         )
     }
 

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -116,11 +116,10 @@ pub async fn make_chunk_group(
     let async_loaders = async_modules
         .iter()
         .copied()
-        .map(async |module| {
+        .map(|module| {
             chunking_context
                 .async_loader_chunk_item(*module, *module_graph, async_availability_info)
                 .to_resolved()
-                .await
         })
         .try_join()
         .await?;

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -751,14 +751,13 @@ impl ImportTracer for ModuleGraphImportTracer {
                     // import/require/dynamic-import?)
                     let path = path
                         .into_iter()
-                        .map(async |n| {
+                        .map(|n| {
                             graph
                                 .graph
                                 .node_weight(n)
                                 .unwrap() // This is safe since `astar`` only returns indices from the graph
                                 .module()
                                 .ident()
-                                .await
                         })
                         .try_join()
                         .await?;

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups_graph/mod.rs
@@ -401,7 +401,7 @@ async fn collect_chunk_groups(
         // order.
         let mut ids: Vec<usize> = Vec::new();
         let mut seen: FxHashSet<usize> = FxHashSet::default();
-        let mut handle_module = async |module| -> Result<()> {
+        let mut handle_module = |module| {
             let id_slot = match module_id_map.entry(module) {
                 Entry::Occupied(e) => *e.get(),
                 Entry::Vacant(e) => {
@@ -420,19 +420,18 @@ async fn collect_chunk_groups(
             {
                 ids.push(id);
             }
-            Ok(())
         };
 
         for item in items_in_postorder {
             match item {
                 ModuleOrBatch::Batch(batch) => {
                     for &module in &batch.await?.modules {
-                        handle_module(module).await?;
+                        handle_module(module);
                     }
                 }
                 ModuleOrBatch::Module(module) => {
                     if let Some(chunkable_module) = ResolvedVc::try_downcast(module) {
-                        handle_module(chunkable_module).await?;
+                        handle_module(chunkable_module);
                     }
                 }
                 ModuleOrBatch::None(_) => {}

--- a/turbopack/crates/turbopack-core/src/output.rs
+++ b/turbopack/crates/turbopack-core/src/output.rs
@@ -278,8 +278,8 @@ pub async fn expand_output_assets(
     inner_output_assets: bool,
 ) -> Result<Vec<ResolvedVc<Box<dyn OutputAsset>>>> {
     let edges = AdjacencyMap::new()
-        .visit(inputs, async |input| {
-            get_referenced_assets(inner_output_assets, input).await
+        .visit(inputs, |input| {
+            get_referenced_assets(inner_output_assets, input)
         })
         .await
         .completed()?

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -549,7 +549,7 @@ impl ChunkType for CssChunkType {
         let content = CssChunkContent {
             chunk_items: chunk_items
                 .iter()
-                .map(async |ChunkItemWithAsyncModuleInfo { chunk_item, .. }| {
+                .map(|ChunkItemWithAsyncModuleInfo { chunk_item, .. }| {
                     let Some(chunk_item) =
                         ResolvedVc::try_downcast::<Box<dyn CssChunkItem>>(*chunk_item)
                     else {
@@ -558,8 +558,7 @@ impl ChunkType for CssChunkType {
                     // CSS doesn't need to care about async_info, so we can discard it
                     Ok(chunk_item)
                 })
-                .try_join()
-                .await?,
+                .collect::<Result<Vec<_>>>()?,
         }
         .cell();
         Ok(Vc::upcast(CssChunk::new(*chunking_context, content)))

--- a/turbopack/crates/turbopack-test-utils/src/snapshot.rs
+++ b/turbopack/crates/turbopack-test-utils/src/snapshot.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 use rustc_hash::{FxHashMap, FxHashSet};
 use similar::TextDiff;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ReadRef, TryJoinIterExt, Vc};
+use turbo_tasks::{ReadRef, Vc};
 use turbo_tasks_fs::{
     DirectoryContent, DirectoryEntry, File, FileContent, FileSystemEntryType, FileSystemPath,
 };
@@ -187,11 +187,7 @@ async fn diff_paths(
 ) -> Result<FxHashSet<FileSystemPath>> {
     let mut map = left
         .iter()
-        .map(async |p| Ok((p.path.clone(), p.clone())))
-        .try_join()
-        .await?
-        .iter()
-        .cloned()
+        .map(|p| (p.path.clone(), p.clone()))
         .collect::<FxHashMap<_, _>>();
     for p in right {
         map.remove(&p.path);


### PR DESCRIPTION
**View diff without whitespaces**

Fix remaining cases of https://github.com/vercel/next.js/pull/97666

- Mostly replacing async blocks with async closures
- And second commit: some more making closures sync where possible