### PR TITLE
Fix transient empty titles during optimistic navigation

### DIFF
--- a/packages/next/src/client/components/app-router-state.ts
+++ b/packages/next/src/client/components/app-router-state.ts
@@ -321,6 +321,7 @@ export function navigateToKnownRoute(
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
     scrollRef: null,
+    shouldWaitForStaticHead: false,
   }
   // We special case navigations to the exact same URL as the current location.
   // It's a common UI pattern for apps to refresh when you click a link to the

--- a/packages/next/src/client/components/render-tree.ts
+++ b/packages/next/src/client/components/render-tree.ts
@@ -138,6 +138,9 @@ export type NavigationRequestAccumulation = {
    * during a refresh where the route structure didn't change).
    */
   scrollRef: ScrollRef | null
+  // Route-level signal used by page leaves while constructing their head.
+  // Initialized on every accumulation object to keep its shape stable.
+  shouldWaitForStaticHead: boolean
 }
 
 /**
@@ -166,6 +169,7 @@ export function createInitialCacheNodeForHydration(
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
     scrollRef: null,
+    shouldWaitForStaticHead: false,
   }
   const restrictToShell = false
   const task = createCacheNodeOnNavigation(
@@ -233,6 +237,10 @@ export function startPPRNavigation(
   // entries. Always false outside the testing API. See navigation-testing-lock.
   restrictToShell: boolean
 ): NavigationTask | null {
+  accumulation.shouldWaitForStaticHead =
+    (newRouteTree.prefetchHints &
+      PrefetchHint.HeadShouldAttemptStaticPrefetch) !==
+    0
   const parentNeedsDynamicRequest = false
   const parentRefreshState = null
   const oldRootRefreshState: RefreshState = {
@@ -409,6 +417,7 @@ function updateCacheNodeOnNavigation(
         ? oldCacheNode.bfcacheId
         : generateBFCacheId(freshness),
       map,
+      accumulation.shouldWaitForStaticHead,
       restrictToShell
     )
     newCacheNode = result.cacheNode
@@ -696,6 +705,7 @@ function createCacheNodeOnNavigation(
     // bfcacheId.
     generateBFCacheId(freshness),
     map,
+    accumulation.shouldWaitForStaticHead,
     restrictToShell
   )
   const newCacheNode = result.cacheNode
@@ -960,6 +970,7 @@ function createCacheNodeForSegment(
   dynamicStaleAt: number,
   bfcacheId: number,
   map: CacheMap<SegmentCacheEntry>,
+  shouldWaitForStaticHead: boolean,
   // Instant Navigation Testing API only — restricts segment reads to shell
   // entries. Always false outside the testing API. See navigation-testing-lock.
   restrictToShell: boolean
@@ -1248,7 +1259,11 @@ function createCacheNodeForSegment(
       }
     }
 
-    if (process.env.__NEXT_OPTIMISTIC_ROUTING && isCachedHeadPartial) {
+    if (
+      process.env.__NEXT_OPTIMISTIC_ROUTING &&
+      isCachedHeadPartial &&
+      !shouldWaitForStaticHead
+    ) {
       // TODO: When optimistic routing is enabled, don't block on waiting for
       // the viewport to resolve. This is a temporary workaround until Vary
       // Params are tracked when rendering the metadata. We'll fix it before
@@ -1260,6 +1275,10 @@ function createCacheNodeForSegment(
       // it's unlikely that many people are relying on this behavior. Still,
       // will be fixed before stable. It's the very next step in the sequence of
       // work on this project.
+      //
+      // If the build-time head probe proved the head is static, keep the
+      // cached promise instead. Suspending on it retains the previous head
+      // until the destination head arrives, making that transition atomic.
       //
       // This line of code works because the App Router treats `null` as
       // "no renderable head available", rather than an empty head. React treats

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -52,6 +52,7 @@ export function restoreReducer(
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
     scrollRef: null,
+    shouldWaitForStaticHead: false,
   }
   const restoreSeed = createNavigationSeed(
     now,

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -1099,11 +1099,11 @@ function pingStaticHead(
   )
   if (
     headRequiresRuntimeCompleteness &&
-    // The head is not a tree node — it hangs off the route root — so the
-    // static-attempt hint is read from the root's node. (Segments read the
-    // bit from their own node; see the decision point in
-    // pingNewPartOfCacheComponentsTree.)
-    (route.tree.prefetchHints & PrefetchHint.ShouldAttemptStaticPrefetch) === 0
+    // The head is not a tree node — it hangs off the route root — so its
+    // independently measured static-attempt hint is stored on the root.
+    (route.tree.prefetchHints &
+      PrefetchHint.HeadShouldAttemptStaticPrefetch) ===
+      0
   ) {
     // No static attempt: the head arrives via the runtime request instead.
     addSpawnedRuntimePrefetch(task, route.metadata.requestKey)

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -10541,11 +10541,16 @@ async function collectSegmentData(
         ? prerenderStore.shouldAttemptStaticPrefetch
         : null
     const shouldAttemptStaticPrefetch = hintCell !== null && hintCell.current
-    if (prefetchInlining || shouldAttemptStaticPrefetch) {
+    const shouldCollectHeadPrefetchHint = prerenderStore.type === 'prerender'
+    if (
+      prefetchInlining ||
+      shouldAttemptStaticPrefetch ||
+      shouldCollectHeadPrefetchHint
+    ) {
       // Build time: compute fresh hints and store in metadata for the
-      // manifest. When prefetch inlining is disabled there are no sizes to
-      // measure, but the static-prefetch hint still rides the manifest —
-      // collectPrefetchHints then only builds the tree shape carrying it.
+      // manifest. Even when prefetch inlining is disabled and the route body
+      // requires runtime data, collectPrefetchHints probes the head
+      // independently so a complete static head can still be prefetched.
       hints = await ComponentMod.collectPrefetchHints(
         renderOpts.cacheComponents,
         fullPageDataBuffer,
@@ -10557,8 +10562,8 @@ async function collectSegmentData(
       )
       metadata.prefetchHints = hints
     } else {
-      // Inlining is disabled and the hint didn't qualify — there's nothing
-      // to record, so don't write a manifest entry for this route.
+      // Legacy prerender with inlining disabled and no static-prefetch hint:
+      // there's nothing to record, so don't write a manifest entry.
       hints = null
     }
   } else {

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -366,16 +366,18 @@ export async function collectSegmentData(
  *
  * `shouldAttemptStaticPrefetch` (computed by the caller from the prerender's
  * runtime-data tracking) is folded onto every node of the result, so the
- * manifest delivers it to every response like the other hint bits. It's
- * independent of the inlining feature: when `inlining` is false the sizing
- * pass is skipped entirely — no inlining bits are emitted — and only the
- * tree shape carrying the static-prefetch hint is built.
+ * manifest delivers it to every response like the other hint bits. The head
+ * is probed independently and its corresponding hint is stored on the root.
+ * Both are independent of the inlining feature: when `inlining` is false no
+ * inlining bits are emitted, but the head is still rendered to measure its
+ * completeness before the tree shape is returned.
  *
- * Both kinds of hint have the same structure and the same lifetime — one
- * bitmask per node of the route tree, measured once per build and constant
- * for the deployment. They differ only in what they're derived from: the
- * inlining bits from the size of each segment's encoded response, the
- * static-prefetch bit from what the decoded body turned out to access.
+ * All these hints have the same structure and lifetime — one bitmask per node
+ * of the route tree, measured once per build and constant for the deployment.
+ * They differ only in what they're derived from: the inlining bits come from
+ * encoded response sizes, the route static-prefetch bit comes from runtime
+ * data access tracking, and the head bit comes from its own completeness
+ * probe.
  */
 export async function collectPrefetchHints(
   isCacheComponentsEnabled: boolean,
@@ -417,15 +419,6 @@ export async function collectPrefetchHints(
     ? PrefetchHint.ShouldAttemptStaticPrefetch
     : 0
 
-  if (inlining === false) {
-    // Prefetch inlining is disabled: nothing to measure, and no inlining
-    // bits may be emitted (the client would act on them even though the
-    // responses aren't bundled). Just mirror the route tree's shape with
-    // the base hints on every node.
-    return createUniformHintTree(rootNode, baseHints)
-  }
-  const { maxSize, maxBundleSize } = inlining
-
   // Root params are forwarded once at the top level of each segment
   // response, same as the page response's own root vary params; the client
   // unions them into each segment's set at read time.
@@ -466,6 +459,7 @@ export async function collectPrefetchHints(
 
   // Measure the head (metadata/viewport) gzip size so the main traversal
   // can decide whether to inline it into a page's bundle.
+  let isHeadPartial = true
   const [, headBuffer] = await renderSegmentPrefetch(
     buildId,
     staleTimeIterable,
@@ -479,13 +473,38 @@ export async function collectPrefetchHints(
     // Fallback-ness doesn't affect size, so pass false.
     false,
     needsRuntimeRequest,
-    shellStageRelease
+    shellStageRelease,
+    (value) => {
+      isHeadPartial = value
+    }
   )
+
+  const headStaticPrefetchHint = !isHeadPartial
+    ? PrefetchHint.HeadShouldAttemptStaticPrefetch
+    : 0
+
+  if (inlining === false) {
+    // Prefetch inlining is disabled: no inlining bits may be emitted (the
+    // client would act on them even though the responses aren't bundled).
+    // Mirror the route tree's shape with the route-wide hints, then attach
+    // the independently measured head hint to the root.
+    const node = createUniformHintTree(rootNode, baseHints)
+    node.hints |= headStaticPrefetchHint
+    return node
+  }
+  const { maxSize, maxBundleSize } = inlining
   const headGzipSize = await getGzipSize(headBuffer)
 
   // Mutable accumulator: the first segment that accepts the head sets this
-  // to true. Once set, subsequent segments skip the check.
-  const headInlineState = { inlined: false }
+  // to true. Once set, subsequent segments skip the check. If the route body
+  // requires a runtime prefetch but the head is independently static, keep
+  // the head outlined: otherwise it could be bundled into a page response
+  // that the scheduler intentionally never requests statically.
+  const shouldKeepStaticHeadOutlined =
+    !shouldAttemptStaticPrefetch &&
+    !isHeadPartial &&
+    ((rootNode.h ?? 0) & PrefetchHint.SubtreeHasPartialPrefetching) !== 0
+  const headInlineState = { inlined: shouldKeepStaticHeadOutlined }
 
   // Walk the tree with the parent-first, child-decides algorithm.
   const { node } = await collectPrefetchHintsImpl(
@@ -507,9 +526,12 @@ export async function collectPrefetchHints(
     shellStageRelease
   )
 
-  if (!headInlineState.inlined) {
-    // No page could accept the head. Set HeadOutlined on the root so the
-    // client knows to fetch the head separately.
+  node.hints |= headStaticPrefetchHint
+
+  if (shouldKeepStaticHeadOutlined || !headInlineState.inlined) {
+    // No page accepted the head, either because it did not fit or because it
+    // was deliberately kept independent of the dynamic route body. Mark the
+    // root so the client fetches it separately.
     node.hints |= PrefetchHint.HeadOutlined
   }
 
@@ -1205,7 +1227,8 @@ async function renderSegmentPrefetch(
   clientModules: ManifestNode,
   isUpgradeableISRFallback: boolean,
   needsRuntimeRequest: Promise<boolean>,
-  shellStageRelease: Promise<boolean>
+  shellStageRelease: Promise<boolean>,
+  onCompleted?: (isPartial: boolean) => void
 ): Promise<[SegmentRequestKey, Buffer]> {
   const streamInfoStage = createPromiseWithResolvers<void>()
 
@@ -1219,6 +1242,8 @@ async function renderSegmentPrefetch(
   // entry is created). Every node carries the same prefetch hints the /_tree
   // response emits for it, so the tree is decodable like any other transport
   // tree (see SegmentSpine).
+  const requestedContentState =
+    onCompleted !== undefined ? { isComplete: false } : null
   let node: PartialTransportNode = { s: spine.segment }
   if (spine.prefetchHints !== 0) {
     node.h = spine.prefetchHints
@@ -1228,7 +1253,8 @@ async function renderSegmentPrefetch(
       terminal,
       staleTime,
       clientModules,
-      streamInfoStage.promise
+      streamInfoStage.promise,
+      requestedContentState
     )
   }
   let edgeParallelRouteKey = spine.parallelRouteKey
@@ -1247,7 +1273,8 @@ async function renderSegmentPrefetch(
           bundleNode.data,
           staleTime,
           clientModules,
-          streamInfoStage.promise
+          streamInfoStage.promise,
+          null
         )
       }
       bundleNode = bundleNode.next
@@ -1263,7 +1290,8 @@ async function renderSegmentPrefetch(
       head,
       staleTime,
       clientModules,
-      streamInfoStage.promise
+      streamInfoStage.promise,
+      terminal === null ? requestedContentState : null
     )
   }
 
@@ -1386,6 +1414,9 @@ async function renderSegmentPrefetch(
 
   // We're done writing, so we can abort the stream.
   abortController.abort()
+  if (onCompleted !== undefined && requestedContentState !== null) {
+    onCompleted(!requestedContentState.isComplete)
+  }
   return [responseKey, Buffer.concat(await chunksPromise)]
 }
 
@@ -1401,7 +1432,8 @@ function createStagedSegmentData(
   clientModules: ManifestNode,
   // The response's streamInfoStage gate; the completeness probe must not
   // start until it resolves, i.e. until the input stream is fully unblocked.
-  streamInfoStage: Promise<void>
+  streamInfoStage: Promise<void>,
+  requestedContentState: { isComplete: boolean } | null
 ): TransportSegmentData {
   const contentIsComplete = new Promise<void>(async (resolve) => {
     // Wait for the input stream to be fully unblocked before checking if
@@ -1415,6 +1447,9 @@ function createStagedSegmentData(
       filterStackFrame,
       onError() {},
     })
+    if (requestedContentState !== null) {
+      requestedContentState.isComplete = true
+    }
     resolve()
   })
   return {

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -278,6 +278,14 @@ export const enum PrefetchHint {
   // fallbacks — simply never carry it.) Set on every node of the tree, but
   // does not propagate.
   ShouldAttemptStaticPrefetch = 0b100000000000000,
+  // On the root hint node: the build-time head prefetch completed without
+  // suspending on runtime data, so the client should attempt to fetch it
+  // statically even if the rest of the route requires a runtime prefetch.
+  // Like ShouldAttemptStaticPrefetch, this is advisory; the head response's
+  // own `isPartial` signal still determines whether a runtime follow-up is
+  // needed. Unlike that route-wide hint, this is measured independently by
+  // rendering the head pseudo-segment (`/_head`).
+  HeadShouldAttemptStaticPrefetch = 0b1000000000000000,
 }
 
 /**

--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/app/layout.tsx
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/app/layout.tsx
@@ -1,4 +1,5 @@
-import { ReactNode } from 'react'
+import { headers } from 'next/headers'
+import { ReactNode, Suspense } from 'react'
 
 export const metadata = {
   // The root layout provides a default title and a template. While a child
@@ -8,10 +9,21 @@ export const metadata = {
   title: { default: 'Home Default', template: '%s | Site' },
 }
 
+async function DynamicLayoutContent() {
+  await headers()
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+  return <p id="dynamic-layout-content">Dynamic layout content</p>
+}
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <Suspense fallback={<p id="dynamic-layout-fallback">loading…</p>}>
+          <DynamicLayoutContent />
+        </Suspense>
+        {children}
+      </body>
     </html>
   )
 }

--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/app/page.tsx
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/app/page.tsx
@@ -10,7 +10,7 @@ export default function Home() {
         </li>
         <li>
           <LinkAccordion href="/static-meta">
-            static-meta (static metadata, dynamic body)
+            static-meta (static metadata, dynamic shared layout)
           </LinkAccordion>
         </li>
       </ul>

--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/app/static-meta/loading.tsx
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/app/static-meta/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="static-meta-loading">Loading static-meta page…</p>
+}

--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/app/static-meta/page.tsx
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/app/static-meta/page.tsx
@@ -1,23 +1,13 @@
-import { Suspense } from 'react'
-import { connection } from 'next/server'
-
-// STATIC metadata, but a dynamic body. The head is complete at prefetch time,
-// but the page segment is still fetched dynamically on navigation.
+// Static metadata on a static page. The shared layout is dynamic, so the route
+// response is still partial even though the head is complete at prefetch time.
 export const metadata = {
   title: 'Static Meta',
-}
-
-async function DynamicContent() {
-  await connection()
-  return <p id="static-meta-content">Static meta content</p>
 }
 
 export default function StaticMetaPage() {
   return (
     <main>
-      <Suspense fallback={<p id="static-meta-fallback">loading…</p>}>
-        <DynamicContent />
-      </Suspense>
+      <p id="static-meta-content">Static meta content</p>
     </main>
   )
 }

--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/metadata-soft-nav-cache-components.test.ts
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/metadata-soft-nav-cache-components.test.ts
@@ -55,7 +55,7 @@ describe('metadata-soft-nav-cache-components', () => {
     })
   })
 
-  it('does not blank a complete static title when navigating to a prefetched route with a dynamic body', async () => {
+  it('does not blank a complete static title while its prefetch is in flight', async () => {
     let page: Playwright.Page = null as any
     const browser = await next.browser('/', {
       beforePageLoad(p: Playwright.Page) {
@@ -67,17 +67,30 @@ describe('metadata-soft-nav-cache-components', () => {
     expect(await browser.eval(() => document.title)).toBe('Home Default')
 
     await act(async () => {
-      await browser
-        .elementByCss('input[data-link-accordion="/static-meta"]')
-        .click()
-    })
+      // Let the route tree prefetch complete, but hold both prefetch responses
+      // that contain the head: the App Shell response and the standalone
+      // static head response. This reproduces a click that races an in-flight
+      // static prefetch.
+      await act(async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/static-meta"]')
+          .click()
+      }, [
+        { includes: 'Static Meta', kind: 'static', block: true },
+        { includes: 'Static Meta', kind: 'runtime', block: true },
+      ])
 
-    await act(
-      async () => {
-        await browser.elementByCss('a[href="/static-meta"]').click()
-      },
-      { includes: 'Static meta content' }
-    )
+      // Hold the navigation response, too, so we can inspect the optimistic
+      // state before either source of the destination head is delivered.
+      await act(
+        async () => {
+          await browser.elementByCss('a[href="/static-meta"]').click()
+        },
+        { includes: 'Static meta content', block: true }
+      )
+
+      expect(await browser.eval(() => document.title)).toBe('Home Default')
+    })
 
     await browser.waitForElementByCss('#static-meta-content')
 


### PR DESCRIPTION
### What?

- Add a head-specific static-prefetch hint on the route root, measured independently from the route body.
- Use that hint to prefetch a complete static head even when an unrelated layout requires runtime data.
- Preserve the current head while the proven-static destination head is pending during an optimistic navigation.
- Add a controlled soft-navigation regression based on the reported reproduction.

### Why?

The head is a route-level pseudo-segment (`/_head`), but its scheduler decision reused the route body `ShouldAttemptStaticPrefetch` hint. An unrelated dynamic layout could therefore force a fully static head onto the runtime path. If navigation raced the pending prefetch, optimistic routing replaced that pending head with an empty string, transiently clearing `document.title`.

This keeps the existing dynamic-metadata behavior. Only a head whose independent build-time probe completed statically gets the new transition behavior; partial heads still use the runtime completion path.

Reproduction: https://github.com/aurorascharff/reproductions/tree/codex/transient-empty-title/cases/metadata-suspense-title-timing

### How?

- Reuse the segment response completeness probe while collecting build-time prefetch hints and store the result on the root hint node.
- Keep a static head outlined when the dynamic route body would prevent its inlined carrier from being requested statically.
- Thread the root hint through optimistic cache-node construction so a pending static head suspends instead of becoming an empty head.

### Verification

- `pnpm --filter=next types`
- Metadata soft-navigation e2e suite in Turbopack and webpack production modes

<!-- NEXT_JS_LLM -->