### PR TITLE
Support immutable static assets with `output: 'export'`

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -17,6 +17,7 @@ import {
 } from '../../shared/lib/router/utils/app-paths'
 import { AdapterOutputType, type PHASE_TYPE } from '../../shared/lib/constants'
 import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
+import { normalizePathSep } from '../../shared/lib/page-path/normalize-path-sep'
 import {
   convertRedirects,
   convertRewrites,
@@ -660,6 +661,16 @@ export async function handleBuildComplete({
       staticFiles: [],
     }
 
+    const clientHashes: Record<string, string> | undefined =
+      bundler === Bundler.Turbopack && config.supportsImmutableAssets
+        ? JSON.parse(
+            await fs.readFile(
+              path.join(distDir, 'immutable-static-hashes.json'),
+              'utf8'
+            )
+          )
+        : undefined
+
     if (config.output === 'export') {
       // collect export assets and provide as static files
       const exportFiles = await recursiveReadDir(configOutDir)
@@ -671,26 +682,17 @@ export async function handleBuildComplete({
 
         pathname = pathname.startsWith('/') ? pathname : `/${pathname}`
 
+        const immutableId = normalizePathSep(file).replace(/^\/?_next\//, '')
         outputs.staticFiles.push({
           id: file,
           pathname,
           filePath: path.join(configOutDir, file),
           type: AdapterOutputType.STATIC_FILE,
-          immutableHash: undefined,
+          immutableHash: clientHashes?.[immutableId],
         } satisfies AdapterOutput['STATIC_FILE'])
       }
     } else {
       const staticFiles = await recursiveReadDir(path.join(distDir, 'static'))
-
-      const clientHashes: Record<string, string> | undefined =
-        bundler === Bundler.Turbopack && config.supportsImmutableAssets
-          ? JSON.parse(
-              await fs.readFile(
-                path.join(distDir, 'immutable-static-hashes.json'),
-                'utf8'
-              )
-            )
-          : undefined
 
       for (const file of staticFiles) {
         const pathname = path.posix.join('/_next/static', file)

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1699,14 +1699,10 @@ function finalizeConfig(
     config.supportsImmutableAssets = false
   }
 
-  if (
-    config.supportsImmutableAssets &&
-    (config.output === 'export' || config.output === 'standalone')
-  ) {
-    // supportsImmutableAssets is designed to work with adapters. Disable it for output=export and
-    // output=standalone, which are currently using a non-adapter codepath.
-    // Particularly output=export should just run through the adapter, with only static assets.
-    // TODO remove again once output=export (and output=standalone) are using adapters.
+  if (config.supportsImmutableAssets && config.output === 'standalone') {
+    // supportsImmutableAssets is designed to work with adapters. Disable it for output=standalone,
+    // which is currently using a non-adapter codepath.
+    // TODO remove again once output=standalone is using adapters.
     config.supportsImmutableAssets = false
   }
 

--- a/test/production/export-immutable-assets/export-immutable-assets.test.ts
+++ b/test/production/export-immutable-assets/export-immutable-assets.test.ts
@@ -1,10 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
+import type { NextAdapter } from 'next'
 import { listClientChunks } from 'next-test-utils'
 
-// Immutable static files are only supported with Turbopack anywy
+// Immutable static files are only supported with Turbopack anyway
 ;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
-  'output: export - immutable assets disabled',
+  'output: export - immutable assets',
   () => {
     const { next } = nextTestSetup({
       files: __dirname,
@@ -13,19 +14,40 @@ import { listClientChunks } from 'next-test-utils'
       disableAutoSkewProtection: true,
     })
 
-    // supportsImmutableAssets is designed to work with adapters. It must be
-    // force-disabled for `output: 'export'`, so even though it is requested here
-    // the build should not emit any `_next/static/immutable` assets.
-    // We can loosen this requirement in the future when using output=export together with an adapter
-    it('does not emit any _next/static/immutable files', async () => {
+    it('emits immutable assets and reports their hashes', async () => {
       const { exitCode } = await next.build()
       expect(exitCode).toBe(0)
 
-      const files = await listClientChunks(join(next.testDir, next.distDir))
+      const files = await listClientChunks(join(next.testDir, 'out', '_next'))
+      expect(files).toContainEqual(expect.stringContaining('static/immutable/'))
+      expect(files).not.toContainEqual(
+        expect.stringMatching(/^static\/chunks\//)
+      )
 
-      expect(files).not.toBeEmpty()
-      expect(files).toSatisfyAll((f) => f.includes('static/'))
-      expect(files).toSatisfyAll((f) => !f.includes('static/immutable/'))
+      const html = await next.readFile('out/index.html')
+      expect(html).toContain('/_next/static/immutable/')
+      expect(html).not.toContain('?dpl=test-deployment-id')
+
+      const hashes = await next.readJSON(
+        join(next.distDir, 'immutable-static-hashes.json')
+      )
+      const staticFiles: Parameters<
+        NextAdapter['onBuildComplete']
+      >[0]['outputs']['staticFiles'] = await next.readJSON(
+        'build-complete.json'
+      )
+
+      let immutableFileCount = 0
+      for (const output of staticFiles) {
+        const id = output.id
+          .replace(/^[/\\]?_next[/\\]/, '')
+          .replaceAll('\\', '/')
+        expect(output.immutableHash).toBe(hashes[id])
+        if (output.immutableHash) {
+          immutableFileCount++
+        }
+      }
+      expect(immutableFileCount).toBeGreaterThan(0)
     })
   }
 )

--- a/test/production/export-immutable-assets/my-adapter.mjs
+++ b/test/production/export-immutable-assets/my-adapter.mjs
@@ -1,0 +1,19 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+/** @type {import('next').NextAdapter} */
+const adapter = {
+  name: 'export-immutable-assets-test-adapter',
+  modifyConfig(config) {
+    config.supportsImmutableAssets = true
+    return config
+  },
+  async onBuildComplete({ projectDir, outputs }) {
+    await fs.writeFile(
+      path.join(projectDir, 'build-complete.json'),
+      JSON.stringify(outputs.staticFiles)
+    )
+  },
+}
+
+export default adapter

--- a/test/production/export-immutable-assets/next.config.js
+++ b/test/production/export-immutable-assets/next.config.js
@@ -4,9 +4,7 @@
 const nextConfig = {
   output: 'export',
   deploymentId: 'test-deployment-id',
-  experimental: {
-    supportsImmutableAssets: true,
-  },
+  adapterPath: require.resolve('./my-adapter.mjs'),
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
There was no real reason why this wasn't done thus far.
`output: 'export'` already uses the adapter anyway.