### PR TITLE
Turbopack: Use serde_json's new RawValue::from_string_unchecked API in manifest and source map processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7295,9 +7295,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.13.0",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -332,7 +332,7 @@ rustc-hash = "2.1.1"
 scattered-collect = "0.10.0"
 semver = "1.0.16"
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde_json = "1.0.151"
 serde_path_to_error = "0.1.20"
 serde_qs = "1.1.1"
 serde_with = "3.18.0"

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -208,8 +208,14 @@ impl Asset for BuildManifest {
             pages_chunk_group_bootstrap_params: self
                 .pages_chunk_group_bootstrap_params
                 .iter()
-                .map(|(k, v)| Ok((k.clone(), RawValue::from_string(v.to_string())?)))
-                .collect::<Result<FxIndexMap<_, _>>>()?,
+                .map(|(k, v)| {
+                    // SAFETY: These values are produced by `serde_json::to_string` in
+                    // `EvaluateChunk::chunk_group_bootstrap_params`.
+                    (k.clone(), unsafe {
+                        RawValue::from_string_unchecked(v.to_string())
+                    })
+                })
+                .collect(),
             chunk_loading_global: self.chunk_loading_global.clone(),
             ..Default::default()
         };

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -216,11 +216,10 @@ pub async fn resolve_source_map_sources(
 }
 
 fn unencoded_str_to_raw_value(unencoded: &str) -> Box<RawValue> {
-    RawValue::from_string(
-        serde_json::to_string(unencoded)
-            .expect("serialization of a utf-8 string should always succeed"),
-    )
-    .expect("serde_json::to_string should produce valid JSON")
+    let encoded = serde_json::to_string(unencoded)
+        .expect("serialization of a utf-8 string should always succeed");
+    // SAFETY: `encoded` was just produced by `serde_json::to_string`.
+    unsafe { RawValue::from_string_unchecked(encoded) }
 }
 
 fn uri_encode_path(path: &str) -> String {


### PR DESCRIPTION
This is a new API added in: https://github.com/serde-rs/json/pull/1331

Without this, serde_json re-parses the value we just encoded to verify that it's valid JSON.