### PR TITLE
Reduce Turbopack cache size with per-family compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10003,7 +10003,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
- "bincode 2.0.1",
  "bitfield",
  "byteorder",
  "codspeed-criterion-compat",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10030,6 +10030,7 @@ dependencies = [
  "turbo-tasks-malloc",
  "xxhash-rust",
  "zerocopy",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10003,6 +10003,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "auto-hash-map",
+ "bincode 2.0.1",
  "bitfield",
  "byteorder",
  "codspeed-criterion-compat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -358,6 +358,7 @@ tracing = "0.1.44"
 tracing-subscriber = "0.3.16"
 triomphe = { git = "https://github.com/sokra/triomphe", branch = "sokra/unstable" }
 xxhash-rust = { version = "0.8.12", features = ["xxh3"] }
+zstd = "0.13.2"
 unsize = "1.1.0"
 unty = "0.0.4"
 url = "2.2.2"

--- a/turbopack/crates/turbo-persistence-tools/src/main.rs
+++ b/turbopack/crates/turbo-persistence-tools/src/main.rs
@@ -3,7 +3,10 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
-use turbo_persistence::{DbConfig, MetaFileEntryInfo, SerialScheduler, TurboPersistence};
+use turbo_persistence::{
+    Compression, DbConfig, FamilyConfig, FamilyKind, MetaFileEntryInfo, SerialScheduler,
+    TurboPersistence,
+};
 
 fn main() -> Result<()> {
     // Get CLI argument
@@ -16,8 +19,33 @@ fn main() -> Result<()> {
         bail!("The provided path does not exist: {}", path.display());
     }
 
-    let db: TurboPersistence<SerialScheduler, 0> =
-        TurboPersistence::open_read_only_with_config(path, DbConfig::default())?;
+    let db: TurboPersistence<SerialScheduler, 4> = TurboPersistence::open_read_only_with_config(
+        path,
+        DbConfig {
+            family_configs: [
+                FamilyConfig {
+                    name: "Infra",
+                    kind: FamilyKind::SingleValue,
+                    compression: Compression::Lz4Hc(4),
+                },
+                FamilyConfig {
+                    name: "TaskMeta",
+                    kind: FamilyKind::SingleValue,
+                    compression: Compression::Lz4Hc(4),
+                },
+                FamilyConfig {
+                    name: "TaskData",
+                    kind: FamilyKind::SingleValue,
+                    compression: Compression::Zstd(3),
+                },
+                FamilyConfig {
+                    name: "TaskCache",
+                    kind: FamilyKind::MultiValue,
+                    compression: Compression::Lz4Hc(4),
+                },
+            ],
+        },
+    )?;
     let meta_info = db
         .meta_info()
         .context("Failed to retrieve meta information")?;

--- a/turbopack/crates/turbo-persistence-tools/src/main.rs
+++ b/turbopack/crates/turbo-persistence-tools/src/main.rs
@@ -3,10 +3,7 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
-use turbo_persistence::{
-    Compression, DbConfig, FamilyConfig, FamilyKind, MetaFileEntryInfo, SerialScheduler,
-    TurboPersistence,
-};
+use turbo_persistence::{DbConfig, MetaFileEntryInfo, SerialScheduler, TurboPersistence};
 
 fn main() -> Result<()> {
     // Get CLI argument
@@ -19,33 +16,8 @@ fn main() -> Result<()> {
         bail!("The provided path does not exist: {}", path.display());
     }
 
-    let db: TurboPersistence<SerialScheduler, 4> = TurboPersistence::open_read_only_with_config(
-        path,
-        DbConfig {
-            family_configs: [
-                FamilyConfig {
-                    name: "Infra",
-                    kind: FamilyKind::SingleValue,
-                    compression: Compression::Lz4Hc(4),
-                },
-                FamilyConfig {
-                    name: "TaskMeta",
-                    kind: FamilyKind::SingleValue,
-                    compression: Compression::Lz4Hc(4),
-                },
-                FamilyConfig {
-                    name: "TaskData",
-                    kind: FamilyKind::SingleValue,
-                    compression: Compression::Zstd(3),
-                },
-                FamilyConfig {
-                    name: "TaskCache",
-                    kind: FamilyKind::MultiValue,
-                    compression: Compression::Lz4Hc(4),
-                },
-            ],
-        },
-    )?;
+    let db: TurboPersistence<SerialScheduler, 0> =
+        TurboPersistence::open_read_only_with_config(path, DbConfig::default())?;
     let meta_info = db
         .meta_info()
         .context("Failed to retrieve meta information")?;

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -15,7 +15,6 @@ verbose_log = []
 [dependencies]
 anyhow = { workspace = true }
 auto-hash-map = { workspace = true }
-bincode = { workspace = true }
 bitfield = { workspace = true }
 byteorder = { workspace = true }
 crc32fast = { workspace = true }

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -38,6 +38,7 @@ smallvec = { workspace = true }
 thread_local = { workspace = true }
 tracing = { workspace = true }
 xxhash-rust = { workspace = true }
+zstd = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -15,6 +15,7 @@ verbose_log = []
 [dependencies]
 anyhow = { workspace = true }
 auto-hash-map = { workspace = true }
+bincode = { workspace = true }
 bitfield = { workspace = true }
 byteorder = { workspace = true }
 crc32fast = { workspace = true }

--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -54,8 +54,10 @@ Small value blocks are emitted once they accumulate at least `MIN_SMALL_VALUE_BL
 A meta file can contain metadata about multiple SST files. The metadata is stored in a single file to avoid having too many small files.
 
 - Header
-  - 4 bytes magic number (0xFE4ADA4A)
+  - 4 bytes magic number (0xFE4ADA4B)
   - 4 bytes key family
+  - 4 bytes compression codec tag (0: LZ4, 1: LZ4 HC, 2: zstd)
+  - 4 bytes signed compression level (0 for LZ4)
   - 4 bytes count of obsolete SST files
   - foreach obsolete SST file
     - 4 bytes sequence number of the obsolete SST file
@@ -88,7 +90,7 @@ The SST file contains only data without any header.
 
 #### Block Compression
 
-Blocks can be stored compressed or uncompressed. The compression algorithm is selected by the block's key-family configuration and is not encoded in the block. Changing a family's configured algorithm requires rewriting that database, consistent with the crate's no-cross-version-compatibility policy.
+Blocks can be stored compressed or uncompressed. The compression algorithm is recorded once in the containing SST's meta file and must match the key-family configuration used to open the database. It is not repeated in every block. Changing a family's configured algorithm requires rewriting that database, consistent with the crate's no-cross-version-compatibility policy.
 
 The 4-byte header distinguishes compressed from uncompressed storage:
 
@@ -227,7 +229,7 @@ The plain value compressed with dynamic compression. Each blob file has an 8-byt
 - 4 bytes: CRC32 checksum of the compressed data (u32 big-endian)
 - remaining bytes: value data compressed with the blob's key-family configuration
 
-The remaining bytes use the blob's key-family compression configuration. As with SST blocks, the algorithm is not encoded in the blob file. The checksum is verified on the compressed data **before** decompression when the blob is read.
+The codec is validated by the family's meta-file marker rather than repeated in each blob. The checksum is verified on the compressed data **before** decompression when the blob is read.
 
 ## Reading
 

--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -88,9 +88,11 @@ The SST file contains only data without any header.
 
 #### Block Compression
 
-Blocks can be stored compressed (LZ4) or uncompressed. The 4-byte header distinguishes them:
+Blocks can be stored compressed or uncompressed. The compression algorithm is selected by the block's key-family configuration and is not encoded in the block. Changing a family's configured algorithm requires rewriting that database, consistent with the crate's no-cross-version-compatibility policy.
 
-- **Header > 0**: Block is LZ4 compressed. Header value is the uncompressed length.
+The 4-byte header distinguishes compressed from uncompressed storage:
+
+- **Header > 0**: Block is compressed with the family's configured algorithm. Header value is the uncompressed length.
 - **Header = 0**: Block is stored uncompressed. Actual length is derived from block offsets.
 
 #### Block Checksum
@@ -223,9 +225,9 @@ The plain value compressed with dynamic compression. Each blob file has an 8-byt
 
 - 4 bytes: uncompressed length (u32 big-endian)
 - 4 bytes: CRC32 checksum of the compressed data (u32 big-endian)
-- remaining bytes: LZ4-compressed value data
+- remaining bytes: value data compressed with the blob's key-family configuration
 
-The checksum is verified on the compressed data **before** decompression when the blob is read.
+The remaining bytes use the blob's key-family compression configuration. As with SST blocks, the algorithm is not encoded in the blob file. The checksum is verified on the compressed data **before** decompression when the blob is read.
 
 ## Reading
 

--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -54,10 +54,10 @@ Small value blocks are emitted once they accumulate at least `MIN_SMALL_VALUE_BL
 A meta file can contain metadata about multiple SST files. The metadata is stored in a single file to avoid having too many small files.
 
 - Header
-  - 4 bytes magic number (0xFE4ADA4B)
+  - 4 bytes magic number (0xFE4ADA4A)
   - 4 bytes key family
-  - 4 bytes compression preset byte length
-  - `n` bytes bincode-encoded compression preset (standard config; variants in format order: LZ4, LZ4 HC4, zstd3)
+  - 4 bytes compression algorithm byte length
+  - `n` bytes bincode-encoded compression algorithm, which must match the configuration used to open the database
   - 4 bytes count of obsolete SST files
   - foreach obsolete SST file
     - 4 bytes sequence number of the obsolete SST file
@@ -90,7 +90,7 @@ The SST file contains only data without any header.
 
 #### Block Compression
 
-Blocks can be stored compressed or uncompressed. The compression algorithm is recorded once in the containing SST's meta file and must match the key-family configuration used to open the database. It is not repeated in every block. Changing a family's configured algorithm requires rewriting that database, consistent with the crate's no-cross-version-compatibility policy.
+Blocks can be stored compressed or uncompressed. The compression algorithm is specified in the meta file.
 
 The 4-byte header distinguishes compressed from uncompressed storage:
 
@@ -229,7 +229,7 @@ The plain value compressed with dynamic compression. Each blob file has an 8-byt
 - 4 bytes: CRC32 checksum of the compressed data (u32 big-endian)
 - remaining bytes: value data compressed with the blob's key-family configuration
 
-The codec is validated by the family's meta-file marker rather than repeated in each blob. The checksum is verified on the compressed data **before** decompression when the blob is read.
+The checksum is verified on the compressed data **before** decompression when the blob is read.
 
 ## Reading
 

--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -56,8 +56,8 @@ A meta file can contain metadata about multiple SST files. The metadata is store
 - Header
   - 4 bytes magic number (0xFE4ADA4B)
   - 4 bytes key family
-  - 4 bytes compression codec tag (0: LZ4, 1: LZ4 HC, 2: zstd)
-  - 4 bytes signed compression level (0 for LZ4)
+  - 4 bytes compression preset byte length
+  - `n` bytes bincode-encoded compression preset (standard config; variants in format order: LZ4, LZ4 HC4, zstd3)
   - 4 bytes count of obsolete SST files
   - foreach obsolete SST file
     - 4 bytes sequence number of the obsolete SST file

--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -56,8 +56,7 @@ A meta file can contain metadata about multiple SST files. The metadata is store
 - Header
   - 4 bytes magic number (0xFE4ADA4A)
   - 4 bytes key family
-  - 4 bytes compression algorithm byte length
-  - `n` bytes bincode-encoded compression algorithm, which must match the configuration used to open the database
+  - 1 byte compression algorithm, which must match the configuration used to open the database
   - 4 bytes count of obsolete SST files
   - foreach obsolete SST file
     - 4 bytes sequence number of the obsolete SST file

--- a/turbopack/crates/turbo-persistence/benches/mod.rs
+++ b/turbopack/crates/turbo-persistence/benches/mod.rs
@@ -1204,8 +1204,13 @@ fn bench_static_sorted_file_lookup(c: &mut Criterion) {
             // Create temp directory and write SST file
             let tempdir = tempfile::tempdir().unwrap();
             let sst_path = tempdir.path().join("00000001.sst");
-            let (meta, _file) =
-                write_static_stored_file(&entries, &sst_path, MetaEntryFlags::FRESH).unwrap();
+            let (meta, _file) = write_static_stored_file(
+                &entries,
+                &sst_path,
+                MetaEntryFlags::FRESH,
+                Compression::Lz4,
+            )
+            .unwrap();
 
             // Open the SST file
             let sst_meta = StaticSortedFileMetaData {

--- a/turbopack/crates/turbo-persistence/benches/mod.rs
+++ b/turbopack/crates/turbo-persistence/benches/mod.rs
@@ -622,7 +622,7 @@ fn prefill_multi_value_database(
         family_configs: [FamilyConfig {
             name: "test",
             kind: FamilyKind::MultiValue,
-            compression: Compression::lz4(),
+            compression: Compression::Lz4,
         }],
     };
     let db =
@@ -697,7 +697,7 @@ fn open_multi_value_db(path: &Path) -> TurboPersistence<SerialScheduler, 1> {
         family_configs: [FamilyConfig {
             name: "test",
             kind: FamilyKind::MultiValue,
-            compression: Compression::lz4(),
+            compression: Compression::Lz4,
         }],
     };
     TurboPersistence::<SerialScheduler, 1>::open_with_config(path.to_path_buf(), db_config).unwrap()
@@ -966,7 +966,7 @@ fn bench_write_multi_value(c: &mut Criterion) {
                             family_configs: [FamilyConfig {
                                 name: "test",
                                 kind: FamilyKind::MultiValue,
-                                compression: Compression::lz4(),
+                                compression: Compression::Lz4,
                             }],
                         };
                         let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(

--- a/turbopack/crates/turbo-persistence/benches/mod.rs
+++ b/turbopack/crates/turbo-persistence/benches/mod.rs
@@ -10,9 +10,9 @@ use quick_cache::sync::GuardResult;
 use rand::{RngExt, SeedableRng, rngs::SmallRng, seq::SliceRandom};
 use tempfile::TempDir;
 use turbo_persistence::{
-    ArcBytes, BlockCache, CompactConfig, DbConfig as TpDbConfig, Entry, EntryValue, FamilyConfig,
-    FamilyKind, MetaEntryFlags, SerialScheduler, StaticSortedFile, StaticSortedFileMetaData,
-    TurboPersistence, hash_key, write_static_stored_file,
+    ArcBytes, BlockCache, CompactConfig, Compression, DbConfig as TpDbConfig, Entry, EntryValue,
+    FamilyConfig, FamilyKind, MetaEntryFlags, SerialScheduler, StaticSortedFile,
+    StaticSortedFileMetaData, TurboPersistence, hash_key, write_static_stored_file,
 };
 use turbo_tasks_malloc::TurboMalloc;
 
@@ -74,12 +74,23 @@ struct DbConfig {
     entry_count: usize,
     commit_count: usize,
     compacted: bool,
+    compression: Compression,
 }
 
 const KEY_SHARED_PERCENTAGE: usize = 33;
 const KEY_COMPRESSIBLE_PERCENTAGE: usize = 33;
 const VALUE_SHARED_PERCENTAGE: usize = 33;
 const VALUE_COMPRESSIBLE_PERCENTAGE: usize = 33;
+
+fn single_family_config(compression: Compression) -> TpDbConfig<1> {
+    TpDbConfig {
+        family_configs: [FamilyConfig {
+            name: "benchmark",
+            kind: FamilyKind::SingleValue,
+            compression,
+        }],
+    }
+}
 
 /// Generate a random key of the specified size
 fn random_data(
@@ -137,7 +148,10 @@ fn random_value(rng: &mut SmallRng, size: usize) -> Box<[u8]> {
 
 /// Prefill a database with the given configuration and return the generated keys
 fn prefill_database(path: &Path, config: &DbConfig) -> Result<Vec<Box<[u8]>>> {
-    let db = TurboPersistence::<SerialScheduler, 1>::open(path.to_path_buf())?;
+    let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
+        path.to_path_buf(),
+        single_family_config(config.compression),
+    )?;
     let mut rng = SmallRng::seed_from_u64(42);
     // Bound prefill work unless `LARGE_DB` is set; `LARGE_DB` runs use the full count.
     let entry_count = scaled(config.entry_count);
@@ -342,6 +356,65 @@ fn bench_write(c: &mut Criterion) {
     group.finish();
 }
 
+/// Compares the write cost of the supported family compression configurations on identical data.
+fn bench_compression_write(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compression/write");
+    group.sample_size(10);
+    group.sampling_mode(SamplingMode::Flat);
+
+    let key_size = 4;
+    let value_size = 32 * 1024;
+    let full_entry_count = 32 * MB as usize / (key_size + value_size);
+    let entry_count = scaled(full_entry_count);
+
+    for (name, compression) in [
+        ("lz4", Compression::Lz4),
+        ("lz4_hc4", Compression::Lz4Hc(4)),
+        ("zstd3", Compression::Zstd(3)),
+    ] {
+        group.bench_function(name, |b| {
+            b.iter_batched(
+                || {
+                    let tempdir = tempfile::tempdir().unwrap();
+                    let mut rng = SmallRng::seed_from_u64(42);
+                    let entry_size = key_size + value_size;
+                    let mut data = vec![0u8; entry_count * entry_size];
+                    for (i, key) in unique_keys(&mut rng, key_size, entry_count)
+                        .iter()
+                        .enumerate()
+                    {
+                        let key_start = i * entry_size;
+                        data[key_start..key_start + key_size].copy_from_slice(key);
+                        data[key_start + key_size..(i + 1) * entry_size]
+                            .copy_from_slice(&random_value(&mut rng, value_size));
+                    }
+                    (tempdir, data)
+                },
+                |(tempdir, data)| {
+                    let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
+                        tempdir.path().to_path_buf(),
+                        single_family_config(compression),
+                    )
+                    .unwrap();
+                    let batch = db.write_batch().unwrap();
+                    let entry_size = key_size + value_size;
+                    for i in 0..entry_count {
+                        let key = &data[i * entry_size..i * entry_size + key_size];
+                        let value = &data[i * entry_size + key_size..(i + 1) * entry_size];
+                        batch.put(0, key, value.into()).unwrap();
+                    }
+                    db.commit_write_batch(batch).unwrap();
+                    db.shutdown().unwrap();
+                    tempdir
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+
+    group.finish();
+}
+
 // =============================================================================
 // Read Benchmarks - Single Get
 // =============================================================================
@@ -382,6 +455,7 @@ fn bench_read_get(c: &mut Criterion) {
                 entry_count,
                 commit_count,
                 compacted,
+                compression: Compression::Lz4,
             };
 
             let compacted_str = if compacted {
@@ -400,8 +474,11 @@ fn bench_read_get(c: &mut Criterion) {
 
             let db = LazyLock::new(|| {
                 let (tempdir, keys) = setup_prefilled_db(&config, &id).unwrap();
-                let db = TurboPersistence::<SerialScheduler, 1>::open(tempdir.path().to_path_buf())
-                    .unwrap();
+                let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
+                    tempdir.path().to_path_buf(),
+                    single_family_config(config.compression),
+                )
+                .unwrap();
                 let rng = Mutex::new(SmallRng::seed_from_u64(123));
                 (tempdir, db, keys, rng)
             });
@@ -485,6 +562,62 @@ fn bench_read_get(c: &mut Criterion) {
     group.finish();
 }
 
+/// Compares cached and uncached reads across family compression configurations.
+fn bench_compression_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("compression/read_get");
+    group.measurement_time(Duration::from_secs(10));
+
+    for (name, compression) in [
+        ("lz4", Compression::Lz4),
+        ("lz4_hc4", Compression::Lz4Hc(4)),
+        ("zstd3", Compression::Zstd(3)),
+    ] {
+        let config = DbConfig {
+            key_size: 4,
+            value_size: 32 * 1024,
+            entry_count: 32 * MB as usize / (4 + 32 * 1024),
+            commit_count: 1,
+            compacted: true,
+            compression,
+        };
+        let id = format!("{name}/value_32Ki");
+        let db = LazyLock::new(|| {
+            let (tempdir, keys) = setup_prefilled_db(&config, &id).unwrap();
+            let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
+                tempdir.path().to_path_buf(),
+                single_family_config(config.compression),
+            )
+            .unwrap();
+            let rng = Mutex::new(SmallRng::seed_from_u64(123));
+            (tempdir, db, keys, rng)
+        });
+
+        group.bench_function(format!("{name}/uncached"), |b| {
+            let (_, db, keys, rng) = &*db;
+            let mut rng = rng.lock();
+            iter_batched_with_init(
+                b,
+                |_| prepare_db_for_benchmarking(db),
+                |_| &keys[rng.random_range(0..keys.len())],
+                |key| black_box(db.get(0, key).unwrap()),
+                BatchSize::PerIteration,
+            );
+        });
+        group.bench_function(format!("{name}/cached"), |b| {
+            let (_, db, keys, _) = &*db;
+            iter_batched_with_init(
+                b,
+                |_| prepare_db_for_benchmarking(db),
+                |i| &keys[i as usize % keys.len()],
+                |key| black_box(db.get(0, key).unwrap()),
+                BatchSize::NumBatches(1),
+            );
+        });
+    }
+
+    group.finish();
+}
+
 // =============================================================================
 // Read Benchmarks - Batch Get
 // =============================================================================
@@ -511,6 +644,7 @@ fn bench_read_batch_get(c: &mut Criterion) {
                 entry_count,
                 commit_count,
                 compacted,
+                compression: Compression::Lz4,
             };
 
             let compacted_str = if compacted {
@@ -530,8 +664,11 @@ fn bench_read_batch_get(c: &mut Criterion) {
 
             let db = LazyLock::new(|| {
                 let (tempdir, stored_keys) = setup_prefilled_db(&config, &id).unwrap();
-                let db = TurboPersistence::<SerialScheduler, 1>::open(tempdir.path().to_path_buf())
-                    .unwrap();
+                let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
+                    tempdir.path().to_path_buf(),
+                    single_family_config(config.compression),
+                )
+                .unwrap();
                 let rng = Mutex::new(SmallRng::seed_from_u64(456));
                 (tempdir, db, stored_keys, rng)
             });
@@ -622,6 +759,7 @@ fn prefill_multi_value_database(
         family_configs: [FamilyConfig {
             name: "test",
             kind: FamilyKind::MultiValue,
+            compression: Compression::Lz4,
         }],
     };
     let db =
@@ -696,6 +834,7 @@ fn open_multi_value_db(path: &Path) -> TurboPersistence<SerialScheduler, 1> {
         family_configs: [FamilyConfig {
             name: "test",
             kind: FamilyKind::MultiValue,
+            compression: Compression::Lz4,
         }],
     };
     TurboPersistence::<SerialScheduler, 1>::open_with_config(path.to_path_buf(), db_config).unwrap()
@@ -872,10 +1011,14 @@ fn bench_compaction(c: &mut Criterion) {
                     entry_count,
                     commit_count,
                     compacted: false,
+                    compression: Compression::Lz4,
                 };
                 let (tempdir, _keys) = setup_prefilled_db(&config, &id).unwrap();
-                let db = TurboPersistence::<SerialScheduler, 1>::open(tempdir.path().to_path_buf())
-                    .unwrap();
+                let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
+                    tempdir.path().to_path_buf(),
+                    single_family_config(config.compression),
+                )
+                .unwrap();
                 (tempdir, db)
             };
 
@@ -964,6 +1107,7 @@ fn bench_write_multi_value(c: &mut Criterion) {
                             family_configs: [FamilyConfig {
                                 name: "test",
                                 kind: FamilyKind::MultiValue,
+                                compression: Compression::Lz4,
                             }],
                         };
                         let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
@@ -1482,6 +1626,6 @@ fn bench_block_cache(c: &mut Criterion) {
 criterion_group!(
     name = benches;
     config = Criterion::default();
-    targets = bench_write, bench_write_multi_value, bench_read_get, bench_read_batch_get, bench_read_get_multiple, bench_compaction, bench_compaction_multi_value, bench_qfilter, bench_static_sorted_file_lookup, bench_block_cache
+    targets = bench_write, bench_compression_write, bench_write_multi_value, bench_read_get, bench_compression_read, bench_read_batch_get, bench_read_get_multiple, bench_compaction, bench_compaction_multi_value, bench_qfilter, bench_static_sorted_file_lookup, bench_block_cache
 );
 criterion_main!(benches);

--- a/turbopack/crates/turbo-persistence/benches/mod.rs
+++ b/turbopack/crates/turbo-persistence/benches/mod.rs
@@ -74,23 +74,12 @@ struct DbConfig {
     entry_count: usize,
     commit_count: usize,
     compacted: bool,
-    compression: Compression,
 }
 
 const KEY_SHARED_PERCENTAGE: usize = 33;
 const KEY_COMPRESSIBLE_PERCENTAGE: usize = 33;
 const VALUE_SHARED_PERCENTAGE: usize = 33;
 const VALUE_COMPRESSIBLE_PERCENTAGE: usize = 33;
-
-fn single_family_config(compression: Compression) -> TpDbConfig<1> {
-    TpDbConfig {
-        family_configs: [FamilyConfig {
-            name: "benchmark",
-            kind: FamilyKind::SingleValue,
-            compression,
-        }],
-    }
-}
 
 /// Generate a random key of the specified size
 fn random_data(
@@ -148,10 +137,7 @@ fn random_value(rng: &mut SmallRng, size: usize) -> Box<[u8]> {
 
 /// Prefill a database with the given configuration and return the generated keys
 fn prefill_database(path: &Path, config: &DbConfig) -> Result<Vec<Box<[u8]>>> {
-    let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
-        path.to_path_buf(),
-        single_family_config(config.compression),
-    )?;
+    let db = TurboPersistence::<SerialScheduler, 1>::open(path.to_path_buf())?;
     let mut rng = SmallRng::seed_from_u64(42);
     // Bound prefill work unless `LARGE_DB` is set; `LARGE_DB` runs use the full count.
     let entry_count = scaled(config.entry_count);
@@ -356,65 +342,6 @@ fn bench_write(c: &mut Criterion) {
     group.finish();
 }
 
-/// Compares the write cost of the supported family compression configurations on identical data.
-fn bench_compression_write(c: &mut Criterion) {
-    let mut group = c.benchmark_group("compression/write");
-    group.sample_size(10);
-    group.sampling_mode(SamplingMode::Flat);
-
-    let key_size = 4;
-    let value_size = 32 * 1024;
-    let full_entry_count = 32 * MB as usize / (key_size + value_size);
-    let entry_count = scaled(full_entry_count);
-
-    for (name, compression) in [
-        ("lz4", Compression::Lz4),
-        ("lz4_hc4", Compression::Lz4Hc(4)),
-        ("zstd3", Compression::Zstd(3)),
-    ] {
-        group.bench_function(name, |b| {
-            b.iter_batched(
-                || {
-                    let tempdir = tempfile::tempdir().unwrap();
-                    let mut rng = SmallRng::seed_from_u64(42);
-                    let entry_size = key_size + value_size;
-                    let mut data = vec![0u8; entry_count * entry_size];
-                    for (i, key) in unique_keys(&mut rng, key_size, entry_count)
-                        .iter()
-                        .enumerate()
-                    {
-                        let key_start = i * entry_size;
-                        data[key_start..key_start + key_size].copy_from_slice(key);
-                        data[key_start + key_size..(i + 1) * entry_size]
-                            .copy_from_slice(&random_value(&mut rng, value_size));
-                    }
-                    (tempdir, data)
-                },
-                |(tempdir, data)| {
-                    let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
-                        tempdir.path().to_path_buf(),
-                        single_family_config(compression),
-                    )
-                    .unwrap();
-                    let batch = db.write_batch().unwrap();
-                    let entry_size = key_size + value_size;
-                    for i in 0..entry_count {
-                        let key = &data[i * entry_size..i * entry_size + key_size];
-                        let value = &data[i * entry_size + key_size..(i + 1) * entry_size];
-                        batch.put(0, key, value.into()).unwrap();
-                    }
-                    db.commit_write_batch(batch).unwrap();
-                    db.shutdown().unwrap();
-                    tempdir
-                },
-                BatchSize::PerIteration,
-            );
-        });
-    }
-
-    group.finish();
-}
-
 // =============================================================================
 // Read Benchmarks - Single Get
 // =============================================================================
@@ -455,7 +382,6 @@ fn bench_read_get(c: &mut Criterion) {
                 entry_count,
                 commit_count,
                 compacted,
-                compression: Compression::Lz4,
             };
 
             let compacted_str = if compacted {
@@ -474,11 +400,8 @@ fn bench_read_get(c: &mut Criterion) {
 
             let db = LazyLock::new(|| {
                 let (tempdir, keys) = setup_prefilled_db(&config, &id).unwrap();
-                let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
-                    tempdir.path().to_path_buf(),
-                    single_family_config(config.compression),
-                )
-                .unwrap();
+                let db = TurboPersistence::<SerialScheduler, 1>::open(tempdir.path().to_path_buf())
+                    .unwrap();
                 let rng = Mutex::new(SmallRng::seed_from_u64(123));
                 (tempdir, db, keys, rng)
             });
@@ -562,62 +485,6 @@ fn bench_read_get(c: &mut Criterion) {
     group.finish();
 }
 
-/// Compares cached and uncached reads across family compression configurations.
-fn bench_compression_read(c: &mut Criterion) {
-    let mut group = c.benchmark_group("compression/read_get");
-    group.measurement_time(Duration::from_secs(10));
-
-    for (name, compression) in [
-        ("lz4", Compression::Lz4),
-        ("lz4_hc4", Compression::Lz4Hc(4)),
-        ("zstd3", Compression::Zstd(3)),
-    ] {
-        let config = DbConfig {
-            key_size: 4,
-            value_size: 32 * 1024,
-            entry_count: 32 * MB as usize / (4 + 32 * 1024),
-            commit_count: 1,
-            compacted: true,
-            compression,
-        };
-        let id = format!("{name}/value_32Ki");
-        let db = LazyLock::new(|| {
-            let (tempdir, keys) = setup_prefilled_db(&config, &id).unwrap();
-            let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
-                tempdir.path().to_path_buf(),
-                single_family_config(config.compression),
-            )
-            .unwrap();
-            let rng = Mutex::new(SmallRng::seed_from_u64(123));
-            (tempdir, db, keys, rng)
-        });
-
-        group.bench_function(format!("{name}/uncached"), |b| {
-            let (_, db, keys, rng) = &*db;
-            let mut rng = rng.lock();
-            iter_batched_with_init(
-                b,
-                |_| prepare_db_for_benchmarking(db),
-                |_| &keys[rng.random_range(0..keys.len())],
-                |key| black_box(db.get(0, key).unwrap()),
-                BatchSize::PerIteration,
-            );
-        });
-        group.bench_function(format!("{name}/cached"), |b| {
-            let (_, db, keys, _) = &*db;
-            iter_batched_with_init(
-                b,
-                |_| prepare_db_for_benchmarking(db),
-                |i| &keys[i as usize % keys.len()],
-                |key| black_box(db.get(0, key).unwrap()),
-                BatchSize::NumBatches(1),
-            );
-        });
-    }
-
-    group.finish();
-}
-
 // =============================================================================
 // Read Benchmarks - Batch Get
 // =============================================================================
@@ -644,7 +511,6 @@ fn bench_read_batch_get(c: &mut Criterion) {
                 entry_count,
                 commit_count,
                 compacted,
-                compression: Compression::Lz4,
             };
 
             let compacted_str = if compacted {
@@ -664,11 +530,8 @@ fn bench_read_batch_get(c: &mut Criterion) {
 
             let db = LazyLock::new(|| {
                 let (tempdir, stored_keys) = setup_prefilled_db(&config, &id).unwrap();
-                let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
-                    tempdir.path().to_path_buf(),
-                    single_family_config(config.compression),
-                )
-                .unwrap();
+                let db = TurboPersistence::<SerialScheduler, 1>::open(tempdir.path().to_path_buf())
+                    .unwrap();
                 let rng = Mutex::new(SmallRng::seed_from_u64(456));
                 (tempdir, db, stored_keys, rng)
             });
@@ -759,7 +622,7 @@ fn prefill_multi_value_database(
         family_configs: [FamilyConfig {
             name: "test",
             kind: FamilyKind::MultiValue,
-            compression: Compression::Lz4,
+            compression: Compression::lz4(),
         }],
     };
     let db =
@@ -834,7 +697,7 @@ fn open_multi_value_db(path: &Path) -> TurboPersistence<SerialScheduler, 1> {
         family_configs: [FamilyConfig {
             name: "test",
             kind: FamilyKind::MultiValue,
-            compression: Compression::Lz4,
+            compression: Compression::lz4(),
         }],
     };
     TurboPersistence::<SerialScheduler, 1>::open_with_config(path.to_path_buf(), db_config).unwrap()
@@ -1011,14 +874,10 @@ fn bench_compaction(c: &mut Criterion) {
                     entry_count,
                     commit_count,
                     compacted: false,
-                    compression: Compression::Lz4,
                 };
                 let (tempdir, _keys) = setup_prefilled_db(&config, &id).unwrap();
-                let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
-                    tempdir.path().to_path_buf(),
-                    single_family_config(config.compression),
-                )
-                .unwrap();
+                let db = TurboPersistence::<SerialScheduler, 1>::open(tempdir.path().to_path_buf())
+                    .unwrap();
                 (tempdir, db)
             };
 
@@ -1107,7 +966,7 @@ fn bench_write_multi_value(c: &mut Criterion) {
                             family_configs: [FamilyConfig {
                                 name: "test",
                                 kind: FamilyKind::MultiValue,
-                                compression: Compression::Lz4,
+                                compression: Compression::lz4(),
                             }],
                         };
                         let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
@@ -1626,6 +1485,6 @@ fn bench_block_cache(c: &mut Criterion) {
 criterion_group!(
     name = benches;
     config = Criterion::default();
-    targets = bench_write, bench_compression_write, bench_write_multi_value, bench_read_get, bench_compression_read, bench_read_batch_get, bench_read_get_multiple, bench_compaction, bench_compaction_multi_value, bench_qfilter, bench_static_sorted_file_lookup, bench_block_cache
+    targets = bench_write, bench_write_multi_value, bench_read_get, bench_read_batch_get, bench_read_get_multiple, bench_compaction, bench_compaction_multi_value, bench_qfilter, bench_static_sorted_file_lookup, bench_block_cache
 );
 criterion_main!(benches);

--- a/turbopack/crates/turbo-persistence/benches/mod.rs
+++ b/turbopack/crates/turbo-persistence/benches/mod.rs
@@ -1212,7 +1212,7 @@ fn bench_static_sorted_file_lookup(c: &mut Criterion) {
                 sequence_number: 1,
                 block_count: meta.block_count,
             };
-            let sst = StaticSortedFile::open(tempdir.path(), sst_meta).unwrap();
+            let sst = StaticSortedFile::open(tempdir.path(), sst_meta, Compression::Lz4).unwrap();
 
             // Create block caches
             let key_block_cache: BlockCache = BlockCache::with(

--- a/turbopack/crates/turbo-persistence/src/arc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/arc_bytes.rs
@@ -10,7 +10,7 @@ use memmap2::Mmap;
 
 use crate::{
     Compression,
-    compression::{DecompressionPool, decompress_into_arc},
+    compression::{DecompressionContext, decompress_into_arc},
     shared_bytes::{SharedBytes, is_subslice_of},
 };
 /// The backing storage for an `ArcBytes`.
@@ -146,13 +146,13 @@ impl SharedBytes for ArcBytes {
     }
 
     fn from_decompressed(
-        pool: &DecompressionPool,
+        decompression_context: &DecompressionContext,
         compression: Compression,
         uncompressed_length: u32,
         block: &[u8],
     ) -> anyhow::Result<Self> {
         Ok(ArcBytes::from(decompress_into_arc(
-            pool,
+            decompression_context,
             compression,
             uncompressed_length,
             block,

--- a/turbopack/crates/turbo-persistence/src/arc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/arc_bytes.rs
@@ -10,7 +10,7 @@ use memmap2::Mmap;
 
 use crate::{
     Compression,
-    compression::decompress_into_arc,
+    compression::{DecompressionPool, decompress_into_arc},
     shared_bytes::{SharedBytes, is_subslice_of},
 };
 /// The backing storage for an `ArcBytes`.
@@ -146,11 +146,13 @@ impl SharedBytes for ArcBytes {
     }
 
     fn from_decompressed(
+        pool: &DecompressionPool,
         compression: Compression,
         uncompressed_length: u32,
         block: &[u8],
     ) -> anyhow::Result<Self> {
         Ok(ArcBytes::from(decompress_into_arc(
+            pool,
             compression,
             uncompressed_length,
             block,

--- a/turbopack/crates/turbo-persistence/src/arc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/arc_bytes.rs
@@ -9,6 +9,7 @@ use std::{
 use memmap2::Mmap;
 
 use crate::{
+    Compression,
     compression::decompress_into_arc,
     shared_bytes::{SharedBytes, is_subslice_of},
 };
@@ -144,8 +145,13 @@ impl SharedBytes for ArcBytes {
         }
     }
 
-    fn from_decompressed(uncompressed_length: u32, block: &[u8]) -> anyhow::Result<Self> {
+    fn from_decompressed(
+        compression: Compression,
+        uncompressed_length: u32,
+        block: &[u8],
+    ) -> anyhow::Result<Self> {
         Ok(ArcBytes::from(decompress_into_arc(
+            compression,
             uncompressed_length,
             block,
         )?))

--- a/turbopack/crates/turbo-persistence/src/arc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/arc_bytes.rs
@@ -10,7 +10,7 @@ use memmap2::Mmap;
 
 use crate::{
     Compression,
-    compression::{DecompressionContext, decompress_into_arc},
+    compression::decompress_into_arc,
     shared_bytes::{SharedBytes, is_subslice_of},
 };
 /// The backing storage for an `ArcBytes`.
@@ -146,13 +146,11 @@ impl SharedBytes for ArcBytes {
     }
 
     fn from_decompressed(
-        decompression_context: &DecompressionContext,
         compression: Compression,
         uncompressed_length: u32,
         block: &[u8],
     ) -> anyhow::Result<Self> {
         Ok(ArcBytes::from(decompress_into_arc(
-            decompression_context,
             compression,
             uncompressed_length,
             block,

--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -20,7 +20,7 @@ use fs_err::{self as fs, File};
 use lzzzz::lz4::decompress;
 use memmap2::Mmap;
 use turbo_persistence::{
-    BLOCK_HEADER_SIZE, MAX_INLINE_VALUE_SIZE, checksum_block,
+    BLOCK_HEADER_SIZE, Compression, MAX_INLINE_VALUE_SIZE, checksum_block,
     meta_file::MetaFile,
     mmap_helper::advise_mmap_for_persistence,
     read_current_version,
@@ -194,6 +194,18 @@ fn family_name(family: u32) -> &'static str {
     }
 }
 
+/// Compression configured by `turbo_tasks_backend::database::key_value_database::KeySpace`.
+/// Keep this mapping in sync when inspecting a Turbopack cache.
+fn family_compression(family: u32) -> Result<Compression> {
+    match family {
+        0 => Ok(Compression::Lz4Hc(4)), // Infra
+        1 => Ok(Compression::Lz4Hc(4)), // TaskMeta
+        2 => Ok(Compression::Zstd(3)),  // TaskData
+        3 => Ok(Compression::Lz4Hc(4)), // TaskCache
+        _ => bail!("No compression configuration for family {family}"),
+    }
+}
+
 /// Format a number with comma separators for readability
 fn format_number(n: u64) -> String {
     let s = n.to_string();
@@ -304,6 +316,7 @@ fn read_block(
     block_offsets_start: usize,
     block_index: u16,
     sequence_number: u32,
+    compression: Compression,
 ) -> Result<RawBlock> {
     let offset = block_offsets_start + block_index as usize * size_of::<u32>();
 
@@ -343,7 +356,13 @@ fn read_block(
 
     let data = if was_compressed {
         let mut buffer = vec![0u8; uncompressed_length as usize];
-        let bytes_written = decompress(compressed_data, &mut buffer)?;
+        let bytes_written = match compression {
+            Compression::Lz4 | Compression::Lz4Hc(_) => {
+                decompress(compressed_data, &mut buffer).context("LZ4 decompression failed")?
+            }
+            Compression::Zstd(_) => zstd::bulk::decompress_to_buffer(compressed_data, &mut buffer)
+                .context("zstd decompression failed")?,
+        };
         assert_eq!(
             bytes_written, uncompressed_length as usize,
             "Decompressed length does not match expected"
@@ -470,7 +489,7 @@ fn iter_key_block_entry_types(
 }
 
 /// Analyze an SST file and return entry type statistics
-fn analyze_sst_file(db_path: &Path, info: &SstInfo) -> Result<SstStats> {
+fn analyze_sst_file(db_path: &Path, info: &SstInfo, compression: Compression) -> Result<SstStats> {
     let filename = format!("{:08}.sst", info.sequence_number);
     let path = db_path.join(&filename);
 
@@ -496,6 +515,7 @@ fn analyze_sst_file(db_path: &Path, info: &SstInfo) -> Result<SstStats> {
         block_offsets_start,
         index_block_index,
         info.sequence_number,
+        compression,
     )?;
     let key_block_indices = parse_key_block_indices(&index_raw.data);
 
@@ -512,6 +532,7 @@ fn analyze_sst_file(db_path: &Path, info: &SstInfo) -> Result<SstStats> {
             block_offsets_start,
             block_index,
             info.sequence_number,
+            compression,
         ) {
             Ok(raw) => raw,
             Err(e) => {
@@ -930,13 +951,14 @@ fn main() -> Result<()> {
         db_path.display()
     );
 
-    // Analyze and report by family
+    // Analyze and report by family. This inspector targets Turbopack's four persistence families.
     for (family, sst_list) in &family_sst_info {
+        let compression = family_compression(*family)?;
         let mut family_stats = SstStats::default();
         let mut sst_stats_list: Vec<(u32, SstStats)> = Vec::new();
 
         for info in sst_list {
-            match analyze_sst_file(&db_path, info) {
+            match analyze_sst_file(&db_path, info, compression) {
                 Ok(stats) => {
                     family_stats.merge(&stats);
                     if verbose {

--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -347,10 +347,10 @@ fn read_block(
     let data = if was_compressed {
         let mut buffer = vec![0u8; uncompressed_length as usize];
         let bytes_written = match compression {
-            Compression::Lz4 | Compression::Lz4Hc(_) => {
+            Compression::Lz4 | Compression::Lz4Hc4 => {
                 decompress(compressed_data, &mut buffer).context("LZ4 decompression failed")?
             }
-            Compression::Zstd(_) => zstd::bulk::decompress_to_buffer(compressed_data, &mut buffer)
+            Compression::Zstd3 => zstd::bulk::decompress_to_buffer(compressed_data, &mut buffer)
                 .context("zstd decompression failed")?,
         };
         assert_eq!(

--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -347,7 +347,7 @@ fn read_block(
     let data = if was_compressed {
         let mut buffer = vec![0u8; uncompressed_length as usize];
         let bytes_written = match compression {
-            Compression::Lz4 | Compression::Lz4Hc4 => {
+            Compression::Lz4 => {
                 decompress(compressed_data, &mut buffer).context("LZ4 decompression failed")?
             }
             Compression::Zstd3 => zstd::bulk::decompress_to_buffer(compressed_data, &mut buffer)

--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -133,6 +133,7 @@ impl SstStats {
 struct SstInfo {
     sequence_number: u32,
     block_count: u16,
+    compression: Compression,
 }
 
 /// Accumulates statistics for a single entry of the given type.
@@ -191,18 +192,6 @@ fn family_name(family: u32) -> &'static str {
         2 => "TaskData",
         3 => "TaskCache",
         _ => "Unknown",
-    }
-}
-
-/// Compression configured by `turbo_tasks_backend::database::key_value_database::KeySpace`.
-/// Keep this mapping in sync when inspecting a Turbopack cache.
-fn family_compression(family: u32) -> Result<Compression> {
-    match family {
-        0 => Ok(Compression::Lz4Hc(4)), // Infra
-        1 => Ok(Compression::Lz4Hc(4)), // TaskMeta
-        2 => Ok(Compression::Zstd(3)),  // TaskData
-        3 => Ok(Compression::Lz4Hc(4)), // TaskCache
-        _ => bail!("No compression configuration for family {family}"),
     }
 }
 
@@ -295,6 +284,7 @@ fn collect_sst_info(db_path: &Path) -> Result<BTreeMap<u32, Vec<SstInfo>>> {
             family_sst_info.entry(family).or_default().push(SstInfo {
                 sequence_number: entry.sequence_number(),
                 block_count: entry.block_count(),
+                compression: meta.compression(),
             });
         }
     }
@@ -489,7 +479,8 @@ fn iter_key_block_entry_types(
 }
 
 /// Analyze an SST file and return entry type statistics
-fn analyze_sst_file(db_path: &Path, info: &SstInfo, compression: Compression) -> Result<SstStats> {
+fn analyze_sst_file(db_path: &Path, info: &SstInfo) -> Result<SstStats> {
+    let compression = info.compression;
     let filename = format!("{:08}.sst", info.sequence_number);
     let path = db_path.join(&filename);
 
@@ -951,14 +942,13 @@ fn main() -> Result<()> {
         db_path.display()
     );
 
-    // Analyze and report by family. This inspector targets Turbopack's four persistence families.
+    // Analyze and report by family.
     for (family, sst_list) in &family_sst_info {
-        let compression = family_compression(*family)?;
         let mut family_stats = SstStats::default();
         let mut sst_stats_list: Vec<(u32, SstStats)> = Vec::new();
 
         for info in sst_list {
-            match analyze_sst_file(&db_path, info, compression) {
+            match analyze_sst_file(&db_path, info) {
                 Ok(stats) => {
                     family_stats.merge(&stats);
                     if verbose {

--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -267,7 +267,8 @@ fn collect_sst_info(db_path: &Path) -> Result<BTreeMap<u32, Vec<SstInfo>>> {
     let mut meta_files: Vec<MetaFile> = meta_seqs
         .iter()
         .map(|&seq| {
-            MetaFile::open(db_path, seq).with_context(|| format!("Failed to open {seq:08}.meta"))
+            MetaFile::open(db_path, seq, None)
+                .with_context(|| format!("Failed to open {seq:08}.meta"))
         })
         .collect::<Result<_>>()?;
 

--- a/turbopack/crates/turbo-persistence/src/compression.rs
+++ b/turbopack/crates/turbo-persistence/src/compression.rs
@@ -1,25 +1,95 @@
-use std::{mem::MaybeUninit, rc::Rc, sync::Arc};
+use std::{cell::RefCell, mem::MaybeUninit, rc::Rc, sync::Arc};
 
-use anyhow::{Context, Result};
-use lzzzz::lz4::{self, decompress};
+use anyhow::{Context, Result, ensure};
+use lzzzz::{
+    lz4::{self, decompress},
+    lz4_hc,
+};
+
+thread_local! {
+    /// Zstd decompression contexts are reusable and relatively expensive to create. Reads can run
+    /// concurrently, so keep one context per thread rather than constructing one per block.
+    static ZSTD_DECOMPRESSOR: RefCell<zstd::bulk::Decompressor<'static>> = RefCell::new(
+        zstd::bulk::Decompressor::new().expect("zstd decompressor initialization should succeed")
+    );
+}
+
+/// Compression algorithm used for a family's SST blocks and blob values.
+///
+/// The algorithm is configuration, not part of the on-disk data. A database must be reopened with
+/// the same per-family compression configuration that was used to write it.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Compression {
+    /// Fast LZ4 compression using the default acceleration level.
+    #[default]
+    Lz4,
+    /// LZ4 high-compression mode at the given level (3 through 12).
+    Lz4Hc(i32),
+    /// Zstandard compression at the given level.
+    Zstd(i32),
+}
+
+impl Compression {
+    fn validate(self) -> Result<()> {
+        match self {
+            Compression::Lz4 => Ok(()),
+            Compression::Lz4Hc(level) => {
+                ensure!(
+                    (lz4_hc::CLEVEL_MIN..=lz4_hc::CLEVEL_MAX).contains(&level),
+                    "Invalid LZ4 HC compression level {level}; expected {} through {}",
+                    lz4_hc::CLEVEL_MIN,
+                    lz4_hc::CLEVEL_MAX
+                );
+                Ok(())
+            }
+            Compression::Zstd(level) => {
+                ensure!(
+                    zstd::compression_level_range().contains(&level),
+                    "Invalid zstd compression level {level}; expected {} through {}",
+                    zstd::compression_level_range().start(),
+                    zstd::compression_level_range().end()
+                );
+                Ok(())
+            }
+        }
+    }
+}
 
 /// Decompresses `block` into `dest`, verifying the output length matches `expected_len`.
-fn decompress_block(block: &[u8], dest: &mut [u8], expected_len: u32) -> Result<()> {
+fn decompress_block(
+    compression: Compression,
+    block: &[u8],
+    dest: &mut [u8],
+    expected_len: u32,
+) -> Result<()> {
     debug_assert!(
         expected_len > 0,
         "decompress_block called with uncompressed_length=0; uncompressed blocks should use \
          zero-copy mmap path"
     );
-    let bytes_written = decompress(block, dest).with_context(|| {
+    compression.validate()?;
+    let context = || {
         format!(
-            "Failed to decompress block ({} bytes compressed, {} bytes uncompressed)",
+            "Failed to decompress {compression:?} block ({} bytes compressed, {} bytes \
+             uncompressed)",
             block.len(),
             expected_len
         )
-    })?;
-    assert_eq!(
-        bytes_written, expected_len as usize,
-        "Decompressed length does not match expected length"
+    };
+    let bytes_written = match compression {
+        Compression::Lz4 | Compression::Lz4Hc(_) => {
+            decompress(block, dest).with_context(context)?
+        }
+        Compression::Zstd(_) => ZSTD_DECOMPRESSOR.with_borrow_mut(|decompressor| {
+            decompressor
+                .decompress_to_buffer(block, dest)
+                .with_context(context)
+        })?,
+    };
+    ensure!(
+        bytes_written == expected_len as usize,
+        "Decompressed length does not match expected length: wrote {bytes_written} bytes, \
+         expected {expected_len}"
     );
     Ok(())
 }
@@ -28,27 +98,35 @@ fn decompress_block(block: &[u8], dest: &mut [u8], expected_len: u32) -> Result<
 ///
 /// The caller must ensure `uncompressed_length > 0` (i.e., the block is actually compressed).
 /// Uncompressed blocks should be handled via zero-copy mmap slices before calling this.
-pub fn decompress_into_arc(uncompressed_length: u32, block: &[u8]) -> Result<Arc<[u8]>> {
+pub fn decompress_into_arc(
+    compression: Compression,
+    uncompressed_length: u32,
+    block: &[u8],
+) -> Result<Arc<[u8]>> {
     // Allocate directly into an Arc to avoid a copy. The buffer is uninitialized;
     // decompression will overwrite it completely (verified by decompress_block).
     let buffer: Arc<[MaybeUninit<u8>]> = Arc::new_uninit_slice(uncompressed_length as usize);
-    // Safety: decompression will fully initialize the buffer (verified by the assert in
+    // Safety: decompression will fully initialize the buffer (verified by the length check in
     // decompress_block).
     let mut buffer = unsafe { buffer.assume_init() };
     // We just created this Arc so refcount is 1; get_mut always succeeds.
     let dest = Arc::get_mut(&mut buffer).expect("Arc refcount should be 1");
-    decompress_block(block, dest, uncompressed_length)?;
+    decompress_block(compression, block, dest, uncompressed_length)?;
     Ok(buffer)
 }
 
 /// Like [`decompress_into_arc`] but returns an `Rc<[u8]>` for thread-local use.
-pub fn decompress_into_rc(uncompressed_length: u32, block: &[u8]) -> Result<Rc<[u8]>> {
+pub fn decompress_into_rc(
+    compression: Compression,
+    uncompressed_length: u32,
+    block: &[u8],
+) -> Result<Rc<[u8]>> {
     let buffer: Rc<[MaybeUninit<u8>]> = Rc::new_uninit_slice(uncompressed_length as usize);
-    // Safety: decompression will fully initialize the buffer (verified by the assert in
+    // Safety: decompression will fully initialize the buffer (verified by the length check in
     // decompress_block).
     let mut buffer = unsafe { buffer.assume_init() };
     let dest = Rc::get_mut(&mut buffer).expect("Rc refcount should be 1");
-    decompress_block(block, dest, uncompressed_length)?;
+    decompress_block(compression, block, dest, uncompressed_length)?;
     Ok(buffer)
 }
 
@@ -57,8 +135,90 @@ pub fn checksum_block(data: &[u8]) -> u32 {
     crc32fast::hash(data)
 }
 
-#[tracing::instrument(level = "trace", skip_all)]
-pub fn compress_into_buffer(block: &[u8], buffer: &mut Vec<u8>) -> Result<()> {
-    lz4::compress_to_vec(block, buffer, lz4::ACC_LEVEL_DEFAULT).context("Compression failed")?;
-    Ok(())
+/// Reusable compressor for a stream of blocks using the same family configuration.
+pub(crate) struct Compressor {
+    compression: Compression,
+    zstd: Option<zstd::bulk::Compressor<'static>>,
+}
+
+impl Compressor {
+    pub(crate) fn new(compression: Compression) -> Result<Self> {
+        compression.validate()?;
+        let zstd = match compression {
+            Compression::Zstd(level) => Some(
+                zstd::bulk::Compressor::new(level).context("Failed to create zstd compressor")?,
+            ),
+            Compression::Lz4 | Compression::Lz4Hc(_) => None,
+        };
+        Ok(Self { compression, zstd })
+    }
+
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub(crate) fn compress_into_buffer(
+        &mut self,
+        block: &[u8],
+        buffer: &mut Vec<u8>,
+    ) -> Result<()> {
+        match self.compression {
+            Compression::Lz4 => {
+                lz4::compress_to_vec(block, buffer, lz4::ACC_LEVEL_DEFAULT)
+                    .context("LZ4 compression failed")?;
+            }
+            Compression::Lz4Hc(level) => {
+                lz4_hc::compress_to_vec(block, buffer, level)
+                    .context("LZ4 HC compression failed")?;
+            }
+            Compression::Zstd(_) => {
+                buffer.reserve(zstd::zstd_safe::compress_bound(block.len()));
+                self.zstd
+                    .as_mut()
+                    .expect("zstd compressor initialized")
+                    .compress_to_buffer(block, buffer)
+                    .context("zstd compression failed")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn compress_into_buffer(
+    compression: Compression,
+    block: &[u8],
+    buffer: &mut Vec<u8>,
+) -> Result<()> {
+    Compressor::new(compression)?.compress_into_buffer(block, buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compression_round_trips() {
+        let input = b"turbo persistence compression ".repeat(1024);
+        for compression in [
+            Compression::Lz4,
+            Compression::Lz4Hc(4),
+            Compression::Zstd(3),
+        ] {
+            let mut compressed = Vec::new();
+            compress_into_buffer(compression, &input, &mut compressed).unwrap();
+            let output = decompress_into_arc(compression, input.len() as u32, &compressed).unwrap();
+            assert_eq!(&*output, input);
+        }
+    }
+
+    #[test]
+    fn invalid_compression_levels_are_rejected() {
+        let mut output = Vec::new();
+        assert!(compress_into_buffer(Compression::Lz4Hc(2), b"data", &mut output).is_err());
+        assert!(
+            compress_into_buffer(
+                Compression::Zstd(*zstd::compression_level_range().end() + 1),
+                b"data",
+                &mut output,
+            )
+            .is_err()
+        );
+    }
 }

--- a/turbopack/crates/turbo-persistence/src/compression.rs
+++ b/turbopack/crates/turbo-persistence/src/compression.rs
@@ -2,10 +2,7 @@ use std::{cell::RefCell, mem::MaybeUninit, rc::Rc, sync::Arc};
 
 use anyhow::{Context, Result, ensure};
 use bincode::{Decode, Encode};
-use lzzzz::{
-    lz4::{self, decompress},
-    lz4_hc,
-};
+use lzzzz::lz4::{self, decompress};
 
 /// Compression preset used for a family's SST blocks and blob values.
 ///
@@ -16,8 +13,6 @@ pub enum Compression {
     /// Fast LZ4 compression using the default acceleration level.
     #[default]
     Lz4,
-    /// LZ4 high-compression mode at level 4.
-    Lz4Hc4,
     /// Zstandard compression at level 3.
     Zstd3,
 }
@@ -62,9 +57,7 @@ fn decompress_block(
          zero-copy mmap path"
     );
     let result: Result<usize> = match compression {
-        Compression::Lz4 | Compression::Lz4Hc4 => {
-            decompress(block, dest).map_err(anyhow::Error::from)
-        }
+        Compression::Lz4 => decompress(block, dest).map_err(anyhow::Error::from),
         Compression::Zstd3 => ZSTD_DECOMPRESSOR.with_borrow_mut(|decompressor| {
             decompressor
                 .decompress_to_buffer(block, dest)
@@ -140,7 +133,7 @@ impl Compressor {
             Compression::Zstd3 => {
                 Some(zstd::bulk::Compressor::new(3).context("Failed to create zstd compressor")?)
             }
-            Compression::Lz4 | Compression::Lz4Hc4 => None,
+            Compression::Lz4 => None,
         };
         Ok(Self { compression, zstd })
     }
@@ -155,9 +148,6 @@ impl Compressor {
             Compression::Lz4 => {
                 lz4::compress_to_vec(block, buffer, lz4::ACC_LEVEL_DEFAULT)
                     .context("LZ4 compression failed")?;
-            }
-            Compression::Lz4Hc4 => {
-                lz4_hc::compress_to_vec(block, buffer, 4).context("LZ4 HC compression failed")?;
             }
             Compression::Zstd3 => {
                 buffer.reserve(zstd::zstd_safe::compress_bound(block.len()));
@@ -187,7 +177,7 @@ mod tests {
     #[test]
     fn compression_round_trips() {
         let input = b"turbo persistence compression ".repeat(1024);
-        for compression in [Compression::Lz4, Compression::Lz4Hc4, Compression::Zstd3] {
+        for compression in [Compression::Lz4, Compression::Zstd3] {
             let mut compressed = Vec::new();
             compress_into_buffer(compression, &input, &mut compressed).unwrap();
             let output = decompress_into_arc(compression, input.len() as u32, &compressed).unwrap();

--- a/turbopack/crates/turbo-persistence/src/compression.rs
+++ b/turbopack/crates/turbo-persistence/src/compression.rs
@@ -1,23 +1,26 @@
-use std::{cell::RefCell, mem::MaybeUninit, rc::Rc, sync::Arc};
+use std::{
+    io,
+    mem::MaybeUninit,
+    ops::{Deref, DerefMut},
+    rc::Rc,
+    sync::Arc,
+};
 
 use anyhow::{Context, Result, ensure};
 use lzzzz::{
     lz4::{self, decompress},
     lz4_hc,
 };
+use parking_lot::Mutex;
 
-thread_local! {
-    /// Zstd decompression contexts are reusable and relatively expensive to create. Reads can run
-    /// concurrently, so keep one context per thread rather than constructing one per block.
-    static ZSTD_DECOMPRESSOR: RefCell<zstd::bulk::Decompressor<'static>> = RefCell::new(
-        zstd::bulk::Decompressor::new().expect("zstd decompressor initialization should succeed")
-    );
-}
+const COMPRESSION_TAG_LZ4: u32 = 0;
+const COMPRESSION_TAG_LZ4_HC: u32 = 1;
+const COMPRESSION_TAG_ZSTD: u32 = 2;
 
 /// Compression algorithm used for a family's SST blocks and blob values.
 ///
-/// The algorithm is configuration, not part of the on-disk data. A database must be reopened with
-/// the same per-family compression configuration that was used to write it.
+/// The configuration is recorded once in each meta file and must match the runtime family
+/// configuration used to open the database.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Compression {
     /// Fast LZ4 compression using the default acceleration level.
@@ -25,12 +28,15 @@ pub enum Compression {
     Lz4,
     /// LZ4 high-compression mode at the given level (3 through 12).
     Lz4Hc(i32),
-    /// Zstandard compression at the given level.
+    /// Zstandard compression at a level in [`zstd::compression_level_range`].
+    ///
+    /// The range is currently -131072 through 22. Level 0 asks zstd to use its default level
+    /// (currently 3).
     Zstd(i32),
 }
 
 impl Compression {
-    fn validate(self) -> Result<()> {
+    pub(crate) fn validate(self) -> Result<()> {
         match self {
             Compression::Lz4 => Ok(()),
             Compression::Lz4Hc(level) => {
@@ -43,20 +49,124 @@ impl Compression {
                 Ok(())
             }
             Compression::Zstd(level) => {
+                let range = zstd::compression_level_range();
                 ensure!(
-                    zstd::compression_level_range().contains(&level),
+                    range.contains(&level),
                     "Invalid zstd compression level {level}; expected {} through {}",
-                    zstd::compression_level_range().start(),
-                    zstd::compression_level_range().end()
+                    range.start(),
+                    range.end()
                 );
                 Ok(())
             }
         }
     }
+
+    pub(crate) fn to_meta_fields(self) -> Result<(u32, i32)> {
+        self.validate()?;
+        Ok(match self {
+            Compression::Lz4 => (COMPRESSION_TAG_LZ4, 0),
+            Compression::Lz4Hc(level) => (COMPRESSION_TAG_LZ4_HC, level),
+            Compression::Zstd(level) => (COMPRESSION_TAG_ZSTD, level),
+        })
+    }
+
+    pub(crate) fn from_meta_fields(tag: u32, level: i32) -> Result<Self> {
+        let compression = match tag {
+            COMPRESSION_TAG_LZ4 => {
+                ensure!(
+                    level == 0,
+                    "LZ4 compression must store level 0, got {level}"
+                );
+                Compression::Lz4
+            }
+            COMPRESSION_TAG_LZ4_HC => Compression::Lz4Hc(level),
+            COMPRESSION_TAG_ZSTD => Compression::Zstd(level),
+            _ => anyhow::bail!("Unknown compression tag {tag}"),
+        };
+        compression.validate()?;
+        Ok(compression)
+    }
+}
+
+/// Reusable zstd decompression contexts owned by a database.
+///
+/// A context is about 96 KiB with the linked zstd version. The pool grows only to peak concurrent
+/// zstd reads, and all retained contexts are released when the database is dropped.
+#[derive(Default)]
+pub(crate) struct DecompressionPool {
+    zstd: Mutex<Vec<zstd::bulk::Decompressor<'static>>>,
+    #[cfg(test)]
+    zstd_contexts_created: std::sync::atomic::AtomicUsize,
+}
+
+impl DecompressionPool {
+    fn checkout_zstd(&self) -> io::Result<PooledZstdDecompressor<'_>> {
+        let decompressor = match self.zstd.lock().pop() {
+            Some(decompressor) => decompressor,
+            None => {
+                #[cfg(test)]
+                self.zstd_contexts_created
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                zstd::bulk::Decompressor::new()?
+            }
+        };
+        Ok(PooledZstdDecompressor {
+            pool: self,
+            decompressor: Some(decompressor),
+        })
+    }
+
+    fn decompress_zstd(&self, block: &[u8], dest: &mut [u8]) -> io::Result<usize> {
+        self.checkout_zstd()?.decompress_to_buffer(block, dest)
+    }
+
+    #[cfg(test)]
+    fn zstd_contexts_created(&self) -> usize {
+        self.zstd_contexts_created
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    fn available_zstd_contexts(&self) -> usize {
+        self.zstd.lock().len()
+    }
+}
+
+struct PooledZstdDecompressor<'a> {
+    pool: &'a DecompressionPool,
+    decompressor: Option<zstd::bulk::Decompressor<'static>>,
+}
+
+impl Deref for PooledZstdDecompressor<'_> {
+    type Target = zstd::bulk::Decompressor<'static>;
+
+    fn deref(&self) -> &Self::Target {
+        self.decompressor
+            .as_ref()
+            .expect("decompressor checked out")
+    }
+}
+
+impl DerefMut for PooledZstdDecompressor<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.decompressor
+            .as_mut()
+            .expect("decompressor checked out")
+    }
+}
+
+impl Drop for PooledZstdDecompressor<'_> {
+    fn drop(&mut self) {
+        self.pool
+            .zstd
+            .lock()
+            .push(self.decompressor.take().expect("decompressor checked out"));
+    }
 }
 
 /// Decompresses `block` into `dest`, verifying the output length matches `expected_len`.
 fn decompress_block(
+    pool: &DecompressionPool,
     compression: Compression,
     block: &[u8],
     dest: &mut [u8],
@@ -68,24 +178,22 @@ fn decompress_block(
          zero-copy mmap path"
     );
     compression.validate()?;
-    let context = || {
+    let result: Result<usize> = match compression {
+        Compression::Lz4 | Compression::Lz4Hc(_) => {
+            decompress(block, dest).map_err(anyhow::Error::from)
+        }
+        Compression::Zstd(_) => pool
+            .decompress_zstd(block, dest)
+            .map_err(anyhow::Error::from),
+    };
+    let bytes_written = result.with_context(|| {
         format!(
             "Failed to decompress {compression:?} block ({} bytes compressed, {} bytes \
              uncompressed)",
             block.len(),
             expected_len
         )
-    };
-    let bytes_written = match compression {
-        Compression::Lz4 | Compression::Lz4Hc(_) => {
-            decompress(block, dest).with_context(context)?
-        }
-        Compression::Zstd(_) => ZSTD_DECOMPRESSOR.with_borrow_mut(|decompressor| {
-            decompressor
-                .decompress_to_buffer(block, dest)
-                .with_context(context)
-        })?,
-    };
+    })?;
     ensure!(
         bytes_written == expected_len as usize,
         "Decompressed length does not match expected length: wrote {bytes_written} bytes, \
@@ -98,7 +206,8 @@ fn decompress_block(
 ///
 /// The caller must ensure `uncompressed_length > 0` (i.e., the block is actually compressed).
 /// Uncompressed blocks should be handled via zero-copy mmap slices before calling this.
-pub fn decompress_into_arc(
+pub(crate) fn decompress_into_arc(
+    pool: &DecompressionPool,
     compression: Compression,
     uncompressed_length: u32,
     block: &[u8],
@@ -111,12 +220,13 @@ pub fn decompress_into_arc(
     let mut buffer = unsafe { buffer.assume_init() };
     // We just created this Arc so refcount is 1; get_mut always succeeds.
     let dest = Arc::get_mut(&mut buffer).expect("Arc refcount should be 1");
-    decompress_block(compression, block, dest, uncompressed_length)?;
+    decompress_block(pool, compression, block, dest, uncompressed_length)?;
     Ok(buffer)
 }
 
 /// Like [`decompress_into_arc`] but returns an `Rc<[u8]>` for thread-local use.
-pub fn decompress_into_rc(
+pub(crate) fn decompress_into_rc(
+    pool: &DecompressionPool,
     compression: Compression,
     uncompressed_length: u32,
     block: &[u8],
@@ -126,7 +236,7 @@ pub fn decompress_into_rc(
     // decompress_block).
     let mut buffer = unsafe { buffer.assume_init() };
     let dest = Rc::get_mut(&mut buffer).expect("Rc refcount should be 1");
-    decompress_block(compression, block, dest, uncompressed_length)?;
+    decompress_block(pool, compression, block, dest, uncompressed_length)?;
     Ok(buffer)
 }
 
@@ -181,7 +291,7 @@ impl Compressor {
     }
 }
 
-pub fn compress_into_buffer(
+pub(crate) fn compress_into_buffer(
     compression: Compression,
     block: &[u8],
     buffer: &mut Vec<u8>,
@@ -196,6 +306,7 @@ mod tests {
     #[test]
     fn compression_round_trips() {
         let input = b"turbo persistence compression ".repeat(1024);
+        let pool = DecompressionPool::default();
         for compression in [
             Compression::Lz4,
             Compression::Lz4Hc(4),
@@ -203,9 +314,29 @@ mod tests {
         ] {
             let mut compressed = Vec::new();
             compress_into_buffer(compression, &input, &mut compressed).unwrap();
-            let output = decompress_into_arc(compression, input.len() as u32, &compressed).unwrap();
+            let output =
+                decompress_into_arc(&pool, compression, input.len() as u32, &compressed).unwrap();
             assert_eq!(&*output, input);
         }
+    }
+
+    #[test]
+    fn compression_meta_fields_round_trip() {
+        for compression in [
+            Compression::Lz4,
+            Compression::Lz4Hc(3),
+            Compression::Lz4Hc(12),
+            Compression::Zstd(0),
+            Compression::Zstd(3),
+        ] {
+            let (tag, level) = compression.to_meta_fields().unwrap();
+            assert_eq!(
+                Compression::from_meta_fields(tag, level).unwrap(),
+                compression
+            );
+        }
+        assert!(Compression::from_meta_fields(99, 0).is_err());
+        assert!(Compression::from_meta_fields(COMPRESSION_TAG_LZ4, 1).is_err());
     }
 
     #[test]
@@ -220,5 +351,28 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn decompression_pool_reuses_and_releases_contexts() {
+        let pool = Arc::new(DecompressionPool::default());
+
+        {
+            let first = pool.checkout_zstd().unwrap();
+            let second = pool.checkout_zstd().unwrap();
+            assert_eq!(pool.zstd_contexts_created(), 2);
+            assert_eq!(pool.available_zstd_contexts(), 0);
+            drop((first, second));
+        }
+        assert_eq!(pool.available_zstd_contexts(), 2);
+
+        let reused = pool.checkout_zstd().unwrap();
+        assert_eq!(pool.zstd_contexts_created(), 2);
+        drop(reused);
+        assert_eq!(pool.available_zstd_contexts(), 2);
+
+        let weak = Arc::downgrade(&pool);
+        drop(pool);
+        assert!(weak.upgrade().is_none());
     }
 }

--- a/turbopack/crates/turbo-persistence/src/compression.rs
+++ b/turbopack/crates/turbo-persistence/src/compression.rs
@@ -4,9 +4,6 @@ use anyhow::{Context, Result, ensure};
 use lzzzz::lz4::{self, decompress};
 
 /// Compression algorithm used for a family's SST blocks and blob values.
-///
-/// The discriminants are stored in meta files, so existing values must not be changed. New
-/// algorithms get a new discriminant.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Compression {

--- a/turbopack/crates/turbo-persistence/src/compression.rs
+++ b/turbopack/crates/turbo-persistence/src/compression.rs
@@ -6,7 +6,6 @@ use lzzzz::{
     lz4::{self, decompress},
     lz4_hc,
 };
-use thread_local::ThreadLocal;
 
 /// Compression preset used for a family's SST blocks and blob values.
 ///
@@ -24,18 +23,6 @@ pub enum Compression {
 }
 
 impl Compression {
-    pub const fn lz4() -> Self {
-        Self::Lz4
-    }
-
-    pub const fn lz4_hc4() -> Self {
-        Self::Lz4Hc4
-    }
-
-    pub const fn zstd_3() -> Self {
-        Self::Zstd3
-    }
-
     pub(crate) fn encode(self) -> Result<Vec<u8>> {
         bincode::encode_to_vec(self, bincode::config::standard())
             .context("Failed to encode compression preset")
@@ -54,41 +41,16 @@ impl Compression {
     }
 }
 
-/// Reusable zstd decompression contexts owned by one database.
-///
-/// A context is about 96 KiB with the linked zstd version. Each participating thread lazily creates
-/// one lock-free context, and dropping this object releases all of them.
-#[derive(Default)]
-pub(crate) struct DecompressionContext {
-    zstd: ThreadLocal<RefCell<zstd::bulk::Decompressor<'static>>>,
-    #[cfg(test)]
-    zstd_contexts_created: std::sync::atomic::AtomicUsize,
-}
-
-impl DecompressionContext {
-    fn decompress_zstd(&self, block: &[u8], dest: &mut [u8]) -> std::io::Result<usize> {
-        let decompressor = self.zstd.get_or_try(|| {
-            #[cfg(test)]
-            self.zstd_contexts_created
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            zstd::bulk::Decompressor::new().map(RefCell::new)
-        })?;
-        decompressor
-            .try_borrow_mut()
-            .expect("zstd decompressor used recursively")
-            .decompress_to_buffer(block, dest)
-    }
-
-    #[cfg(test)]
-    fn zstd_contexts_created(&self) -> usize {
-        self.zstd_contexts_created
-            .load(std::sync::atomic::Ordering::Relaxed)
-    }
+thread_local! {
+    /// Zstd decompression contexts are reusable and relatively expensive to create. Keep one per
+    /// worker thread to avoid allocation on every block read without a global lock.
+    static ZSTD_DECOMPRESSOR: RefCell<zstd::bulk::Decompressor<'static>> = RefCell::new(
+        zstd::bulk::Decompressor::new().expect("zstd decompressor initialization should succeed")
+    );
 }
 
 /// Decompresses `block` into `dest`, verifying the output length matches `expected_len`.
 fn decompress_block(
-    decompression_context: &DecompressionContext,
     compression: Compression,
     block: &[u8],
     dest: &mut [u8],
@@ -103,9 +65,11 @@ fn decompress_block(
         Compression::Lz4 | Compression::Lz4Hc4 => {
             decompress(block, dest).map_err(anyhow::Error::from)
         }
-        Compression::Zstd3 => decompression_context
-            .decompress_zstd(block, dest)
-            .map_err(anyhow::Error::from),
+        Compression::Zstd3 => ZSTD_DECOMPRESSOR.with_borrow_mut(|decompressor| {
+            decompressor
+                .decompress_to_buffer(block, dest)
+                .map_err(anyhow::Error::from)
+        }),
     };
     let bytes_written = result.with_context(|| {
         format!(
@@ -128,7 +92,6 @@ fn decompress_block(
 /// The caller must ensure `uncompressed_length > 0` (i.e., the block is actually compressed).
 /// Uncompressed blocks should be handled via zero-copy mmap slices before calling this.
 pub(crate) fn decompress_into_arc(
-    decompression_context: &DecompressionContext,
     compression: Compression,
     uncompressed_length: u32,
     block: &[u8],
@@ -141,19 +104,12 @@ pub(crate) fn decompress_into_arc(
     let mut buffer = unsafe { buffer.assume_init() };
     // We just created this Arc so refcount is 1; get_mut always succeeds.
     let dest = Arc::get_mut(&mut buffer).expect("Arc refcount should be 1");
-    decompress_block(
-        decompression_context,
-        compression,
-        block,
-        dest,
-        uncompressed_length,
-    )?;
+    decompress_block(compression, block, dest, uncompressed_length)?;
     Ok(buffer)
 }
 
 /// Like [`decompress_into_arc`] but returns an `Rc<[u8]>` for thread-local use.
 pub(crate) fn decompress_into_rc(
-    decompression_context: &DecompressionContext,
     compression: Compression,
     uncompressed_length: u32,
     block: &[u8],
@@ -163,13 +119,7 @@ pub(crate) fn decompress_into_rc(
     // decompress_block).
     let mut buffer = unsafe { buffer.assume_init() };
     let dest = Rc::get_mut(&mut buffer).expect("Rc refcount should be 1");
-    decompress_block(
-        decompression_context,
-        compression,
-        block,
-        dest,
-        uncompressed_length,
-    )?;
+    decompress_block(compression, block, dest, uncompressed_length)?;
     Ok(buffer)
 }
 
@@ -232,87 +182,16 @@ pub(crate) fn compress_into_buffer(
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Barrier, thread};
-
     use super::*;
 
     #[test]
     fn compression_round_trips() {
         let input = b"turbo persistence compression ".repeat(1024);
-        let decompression_context = DecompressionContext::default();
-        for compression in [
-            Compression::lz4(),
-            Compression::lz4_hc4(),
-            Compression::zstd_3(),
-        ] {
+        for compression in [Compression::Lz4, Compression::Lz4Hc4, Compression::Zstd3] {
             let mut compressed = Vec::new();
             compress_into_buffer(compression, &input, &mut compressed).unwrap();
-            let output = decompress_into_arc(
-                &decompression_context,
-                compression,
-                input.len() as u32,
-                &compressed,
-            )
-            .unwrap();
+            let output = decompress_into_arc(compression, input.len() as u32, &compressed).unwrap();
             assert_eq!(&*output, input);
         }
-    }
-
-    #[test]
-    fn compression_bincode_round_trip() {
-        for compression in [
-            Compression::lz4(),
-            Compression::lz4_hc4(),
-            Compression::zstd_3(),
-        ] {
-            let encoded = compression.encode().unwrap();
-            assert_eq!(Compression::decode(&encoded).unwrap(), compression);
-        }
-        assert!(Compression::decode(&[99]).is_err());
-        assert!(Compression::decode(&[0, 0]).is_err());
-    }
-
-    #[test]
-    fn decompression_context_is_reused_per_thread_and_released() {
-        let input = b"thread local zstd context".repeat(1024);
-        let mut compressed = Vec::new();
-        compress_into_buffer(Compression::zstd_3(), &input, &mut compressed).unwrap();
-        let compressed = Arc::new(compressed);
-        let decompression_context = Arc::new(DecompressionContext::default());
-
-        let mut output = vec![0; input.len()];
-        decompression_context
-            .decompress_zstd(&compressed, &mut output)
-            .unwrap();
-        decompression_context
-            .decompress_zstd(&compressed, &mut output)
-            .unwrap();
-        assert_eq!(decompression_context.zstd_contexts_created(), 1);
-
-        let barrier = Arc::new(Barrier::new(3));
-        let threads = (0..2)
-            .map(|_| {
-                let decompression_context = decompression_context.clone();
-                let compressed = compressed.clone();
-                let barrier = barrier.clone();
-                let output_len = input.len();
-                thread::spawn(move || {
-                    let mut output = vec![0; output_len];
-                    decompression_context
-                        .decompress_zstd(&compressed, &mut output)
-                        .unwrap();
-                    barrier.wait();
-                })
-            })
-            .collect::<Vec<_>>();
-        barrier.wait();
-        for thread in threads {
-            thread.join().unwrap();
-        }
-        assert_eq!(decompression_context.zstd_contexts_created(), 3);
-
-        let weak = Arc::downgrade(&decompression_context);
-        drop(decompression_context);
-        assert!(weak.upgrade().is_none());
     }
 }

--- a/turbopack/crates/turbo-persistence/src/compression.rs
+++ b/turbopack/crates/turbo-persistence/src/compression.rs
@@ -1,123 +1,82 @@
-use std::{
-    io,
-    mem::MaybeUninit,
-    ops::{Deref, DerefMut},
-    rc::Rc,
-    sync::Arc,
-};
+use std::{cell::RefCell, mem::MaybeUninit, rc::Rc, sync::Arc};
 
 use anyhow::{Context, Result, ensure};
+use bincode::{Decode, Encode};
 use lzzzz::{
     lz4::{self, decompress},
     lz4_hc,
 };
-use parking_lot::Mutex;
+use thread_local::ThreadLocal;
 
-const COMPRESSION_TAG_LZ4: u32 = 0;
-const COMPRESSION_TAG_LZ4_HC: u32 = 1;
-const COMPRESSION_TAG_ZSTD: u32 = 2;
-
-/// Compression algorithm used for a family's SST blocks and blob values.
+/// Compression preset used for a family's SST blocks and blob values.
 ///
-/// The configuration is recorded once in each meta file and must match the runtime family
-/// configuration used to open the database.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+/// Variant order is part of the meta-file format. New presets must be appended without reordering
+/// existing variants.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Encode, Decode)]
 pub enum Compression {
     /// Fast LZ4 compression using the default acceleration level.
     #[default]
     Lz4,
-    /// LZ4 high-compression mode at the given level (3 through 12).
-    Lz4Hc(i32),
-    /// Zstandard compression at a level in [`zstd::compression_level_range`].
-    ///
-    /// The range is currently -131072 through 22. Level 0 asks zstd to use its default level
-    /// (currently 3).
-    Zstd(i32),
+    /// LZ4 high-compression mode at level 4.
+    Lz4Hc4,
+    /// Zstandard compression at level 3.
+    Zstd3,
 }
 
 impl Compression {
-    pub(crate) fn validate(self) -> Result<()> {
-        match self {
-            Compression::Lz4 => Ok(()),
-            Compression::Lz4Hc(level) => {
-                ensure!(
-                    (lz4_hc::CLEVEL_MIN..=lz4_hc::CLEVEL_MAX).contains(&level),
-                    "Invalid LZ4 HC compression level {level}; expected {} through {}",
-                    lz4_hc::CLEVEL_MIN,
-                    lz4_hc::CLEVEL_MAX
-                );
-                Ok(())
-            }
-            Compression::Zstd(level) => {
-                let range = zstd::compression_level_range();
-                ensure!(
-                    range.contains(&level),
-                    "Invalid zstd compression level {level}; expected {} through {}",
-                    range.start(),
-                    range.end()
-                );
-                Ok(())
-            }
-        }
+    pub const fn lz4() -> Self {
+        Self::Lz4
     }
 
-    pub(crate) fn to_meta_fields(self) -> Result<(u32, i32)> {
-        self.validate()?;
-        Ok(match self {
-            Compression::Lz4 => (COMPRESSION_TAG_LZ4, 0),
-            Compression::Lz4Hc(level) => (COMPRESSION_TAG_LZ4_HC, level),
-            Compression::Zstd(level) => (COMPRESSION_TAG_ZSTD, level),
-        })
+    pub const fn lz4_hc4() -> Self {
+        Self::Lz4Hc4
     }
 
-    pub(crate) fn from_meta_fields(tag: u32, level: i32) -> Result<Self> {
-        let compression = match tag {
-            COMPRESSION_TAG_LZ4 => {
-                ensure!(
-                    level == 0,
-                    "LZ4 compression must store level 0, got {level}"
-                );
-                Compression::Lz4
-            }
-            COMPRESSION_TAG_LZ4_HC => Compression::Lz4Hc(level),
-            COMPRESSION_TAG_ZSTD => Compression::Zstd(level),
-            _ => anyhow::bail!("Unknown compression tag {tag}"),
-        };
-        compression.validate()?;
+    pub const fn zstd_3() -> Self {
+        Self::Zstd3
+    }
+
+    pub(crate) fn encode(self) -> Result<Vec<u8>> {
+        bincode::encode_to_vec(self, bincode::config::standard())
+            .context("Failed to encode compression preset")
+    }
+
+    pub(crate) fn decode(bytes: &[u8]) -> Result<Self> {
+        let (compression, consumed) =
+            bincode::decode_from_slice(bytes, bincode::config::standard())
+                .context("Failed to decode compression preset")?;
+        ensure!(
+            consumed == bytes.len(),
+            "Compression preset has {} trailing bytes",
+            bytes.len() - consumed
+        );
         Ok(compression)
     }
 }
 
-/// Reusable zstd decompression contexts owned by a database.
+/// Reusable zstd decompression contexts owned by one database.
 ///
-/// A context is about 96 KiB with the linked zstd version. The pool grows only to peak concurrent
-/// zstd reads, and all retained contexts are released when the database is dropped.
+/// A context is about 96 KiB with the linked zstd version. Each participating thread lazily creates
+/// one lock-free context, and dropping this object releases all of them.
 #[derive(Default)]
-pub(crate) struct DecompressionPool {
-    zstd: Mutex<Vec<zstd::bulk::Decompressor<'static>>>,
+pub(crate) struct DecompressionContext {
+    zstd: ThreadLocal<RefCell<zstd::bulk::Decompressor<'static>>>,
     #[cfg(test)]
     zstd_contexts_created: std::sync::atomic::AtomicUsize,
 }
 
-impl DecompressionPool {
-    fn checkout_zstd(&self) -> io::Result<PooledZstdDecompressor<'_>> {
-        let decompressor = match self.zstd.lock().pop() {
-            Some(decompressor) => decompressor,
-            None => {
-                #[cfg(test)]
-                self.zstd_contexts_created
-                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                zstd::bulk::Decompressor::new()?
-            }
-        };
-        Ok(PooledZstdDecompressor {
-            pool: self,
-            decompressor: Some(decompressor),
-        })
-    }
-
-    fn decompress_zstd(&self, block: &[u8], dest: &mut [u8]) -> io::Result<usize> {
-        self.checkout_zstd()?.decompress_to_buffer(block, dest)
+impl DecompressionContext {
+    fn decompress_zstd(&self, block: &[u8], dest: &mut [u8]) -> std::io::Result<usize> {
+        let decompressor = self.zstd.get_or_try(|| {
+            #[cfg(test)]
+            self.zstd_contexts_created
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            zstd::bulk::Decompressor::new().map(RefCell::new)
+        })?;
+        decompressor
+            .try_borrow_mut()
+            .expect("zstd decompressor used recursively")
+            .decompress_to_buffer(block, dest)
     }
 
     #[cfg(test)]
@@ -125,48 +84,11 @@ impl DecompressionPool {
         self.zstd_contexts_created
             .load(std::sync::atomic::Ordering::Relaxed)
     }
-
-    #[cfg(test)]
-    fn available_zstd_contexts(&self) -> usize {
-        self.zstd.lock().len()
-    }
-}
-
-struct PooledZstdDecompressor<'a> {
-    pool: &'a DecompressionPool,
-    decompressor: Option<zstd::bulk::Decompressor<'static>>,
-}
-
-impl Deref for PooledZstdDecompressor<'_> {
-    type Target = zstd::bulk::Decompressor<'static>;
-
-    fn deref(&self) -> &Self::Target {
-        self.decompressor
-            .as_ref()
-            .expect("decompressor checked out")
-    }
-}
-
-impl DerefMut for PooledZstdDecompressor<'_> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.decompressor
-            .as_mut()
-            .expect("decompressor checked out")
-    }
-}
-
-impl Drop for PooledZstdDecompressor<'_> {
-    fn drop(&mut self) {
-        self.pool
-            .zstd
-            .lock()
-            .push(self.decompressor.take().expect("decompressor checked out"));
-    }
 }
 
 /// Decompresses `block` into `dest`, verifying the output length matches `expected_len`.
 fn decompress_block(
-    pool: &DecompressionPool,
+    decompression_context: &DecompressionContext,
     compression: Compression,
     block: &[u8],
     dest: &mut [u8],
@@ -177,12 +99,11 @@ fn decompress_block(
         "decompress_block called with uncompressed_length=0; uncompressed blocks should use \
          zero-copy mmap path"
     );
-    compression.validate()?;
     let result: Result<usize> = match compression {
-        Compression::Lz4 | Compression::Lz4Hc(_) => {
+        Compression::Lz4 | Compression::Lz4Hc4 => {
             decompress(block, dest).map_err(anyhow::Error::from)
         }
-        Compression::Zstd(_) => pool
+        Compression::Zstd3 => decompression_context
             .decompress_zstd(block, dest)
             .map_err(anyhow::Error::from),
     };
@@ -207,7 +128,7 @@ fn decompress_block(
 /// The caller must ensure `uncompressed_length > 0` (i.e., the block is actually compressed).
 /// Uncompressed blocks should be handled via zero-copy mmap slices before calling this.
 pub(crate) fn decompress_into_arc(
-    pool: &DecompressionPool,
+    decompression_context: &DecompressionContext,
     compression: Compression,
     uncompressed_length: u32,
     block: &[u8],
@@ -220,13 +141,19 @@ pub(crate) fn decompress_into_arc(
     let mut buffer = unsafe { buffer.assume_init() };
     // We just created this Arc so refcount is 1; get_mut always succeeds.
     let dest = Arc::get_mut(&mut buffer).expect("Arc refcount should be 1");
-    decompress_block(pool, compression, block, dest, uncompressed_length)?;
+    decompress_block(
+        decompression_context,
+        compression,
+        block,
+        dest,
+        uncompressed_length,
+    )?;
     Ok(buffer)
 }
 
 /// Like [`decompress_into_arc`] but returns an `Rc<[u8]>` for thread-local use.
 pub(crate) fn decompress_into_rc(
-    pool: &DecompressionPool,
+    decompression_context: &DecompressionContext,
     compression: Compression,
     uncompressed_length: u32,
     block: &[u8],
@@ -236,7 +163,13 @@ pub(crate) fn decompress_into_rc(
     // decompress_block).
     let mut buffer = unsafe { buffer.assume_init() };
     let dest = Rc::get_mut(&mut buffer).expect("Rc refcount should be 1");
-    decompress_block(pool, compression, block, dest, uncompressed_length)?;
+    decompress_block(
+        decompression_context,
+        compression,
+        block,
+        dest,
+        uncompressed_length,
+    )?;
     Ok(buffer)
 }
 
@@ -253,12 +186,11 @@ pub(crate) struct Compressor {
 
 impl Compressor {
     pub(crate) fn new(compression: Compression) -> Result<Self> {
-        compression.validate()?;
         let zstd = match compression {
-            Compression::Zstd(level) => Some(
-                zstd::bulk::Compressor::new(level).context("Failed to create zstd compressor")?,
-            ),
-            Compression::Lz4 | Compression::Lz4Hc(_) => None,
+            Compression::Zstd3 => {
+                Some(zstd::bulk::Compressor::new(3).context("Failed to create zstd compressor")?)
+            }
+            Compression::Lz4 | Compression::Lz4Hc4 => None,
         };
         Ok(Self { compression, zstd })
     }
@@ -274,15 +206,14 @@ impl Compressor {
                 lz4::compress_to_vec(block, buffer, lz4::ACC_LEVEL_DEFAULT)
                     .context("LZ4 compression failed")?;
             }
-            Compression::Lz4Hc(level) => {
-                lz4_hc::compress_to_vec(block, buffer, level)
-                    .context("LZ4 HC compression failed")?;
+            Compression::Lz4Hc4 => {
+                lz4_hc::compress_to_vec(block, buffer, 4).context("LZ4 HC compression failed")?;
             }
-            Compression::Zstd(_) => {
+            Compression::Zstd3 => {
                 buffer.reserve(zstd::zstd_safe::compress_bound(block.len()));
                 self.zstd
                     .as_mut()
-                    .expect("zstd compressor initialized")
+                    .expect("zstd compressor not initialized")
                     .compress_to_buffer(block, buffer)
                     .context("zstd compression failed")?;
             }
@@ -301,78 +232,87 @@ pub(crate) fn compress_into_buffer(
 
 #[cfg(test)]
 mod tests {
+    use std::{sync::Barrier, thread};
+
     use super::*;
 
     #[test]
     fn compression_round_trips() {
         let input = b"turbo persistence compression ".repeat(1024);
-        let pool = DecompressionPool::default();
+        let decompression_context = DecompressionContext::default();
         for compression in [
-            Compression::Lz4,
-            Compression::Lz4Hc(4),
-            Compression::Zstd(3),
+            Compression::lz4(),
+            Compression::lz4_hc4(),
+            Compression::zstd_3(),
         ] {
             let mut compressed = Vec::new();
             compress_into_buffer(compression, &input, &mut compressed).unwrap();
-            let output =
-                decompress_into_arc(&pool, compression, input.len() as u32, &compressed).unwrap();
+            let output = decompress_into_arc(
+                &decompression_context,
+                compression,
+                input.len() as u32,
+                &compressed,
+            )
+            .unwrap();
             assert_eq!(&*output, input);
         }
     }
 
     #[test]
-    fn compression_meta_fields_round_trip() {
+    fn compression_bincode_round_trip() {
         for compression in [
-            Compression::Lz4,
-            Compression::Lz4Hc(3),
-            Compression::Lz4Hc(12),
-            Compression::Zstd(0),
-            Compression::Zstd(3),
+            Compression::lz4(),
+            Compression::lz4_hc4(),
+            Compression::zstd_3(),
         ] {
-            let (tag, level) = compression.to_meta_fields().unwrap();
-            assert_eq!(
-                Compression::from_meta_fields(tag, level).unwrap(),
-                compression
-            );
+            let encoded = compression.encode().unwrap();
+            assert_eq!(Compression::decode(&encoded).unwrap(), compression);
         }
-        assert!(Compression::from_meta_fields(99, 0).is_err());
-        assert!(Compression::from_meta_fields(COMPRESSION_TAG_LZ4, 1).is_err());
+        assert!(Compression::decode(&[99]).is_err());
+        assert!(Compression::decode(&[0, 0]).is_err());
     }
 
     #[test]
-    fn invalid_compression_levels_are_rejected() {
-        let mut output = Vec::new();
-        assert!(compress_into_buffer(Compression::Lz4Hc(2), b"data", &mut output).is_err());
-        assert!(
-            compress_into_buffer(
-                Compression::Zstd(*zstd::compression_level_range().end() + 1),
-                b"data",
-                &mut output,
-            )
-            .is_err()
-        );
-    }
+    fn decompression_context_is_reused_per_thread_and_released() {
+        let input = b"thread local zstd context".repeat(1024);
+        let mut compressed = Vec::new();
+        compress_into_buffer(Compression::zstd_3(), &input, &mut compressed).unwrap();
+        let compressed = Arc::new(compressed);
+        let decompression_context = Arc::new(DecompressionContext::default());
 
-    #[test]
-    fn decompression_pool_reuses_and_releases_contexts() {
-        let pool = Arc::new(DecompressionPool::default());
+        let mut output = vec![0; input.len()];
+        decompression_context
+            .decompress_zstd(&compressed, &mut output)
+            .unwrap();
+        decompression_context
+            .decompress_zstd(&compressed, &mut output)
+            .unwrap();
+        assert_eq!(decompression_context.zstd_contexts_created(), 1);
 
-        {
-            let first = pool.checkout_zstd().unwrap();
-            let second = pool.checkout_zstd().unwrap();
-            assert_eq!(pool.zstd_contexts_created(), 2);
-            assert_eq!(pool.available_zstd_contexts(), 0);
-            drop((first, second));
+        let barrier = Arc::new(Barrier::new(3));
+        let threads = (0..2)
+            .map(|_| {
+                let decompression_context = decompression_context.clone();
+                let compressed = compressed.clone();
+                let barrier = barrier.clone();
+                let output_len = input.len();
+                thread::spawn(move || {
+                    let mut output = vec![0; output_len];
+                    decompression_context
+                        .decompress_zstd(&compressed, &mut output)
+                        .unwrap();
+                    barrier.wait();
+                })
+            })
+            .collect::<Vec<_>>();
+        barrier.wait();
+        for thread in threads {
+            thread.join().unwrap();
         }
-        assert_eq!(pool.available_zstd_contexts(), 2);
+        assert_eq!(decompression_context.zstd_contexts_created(), 3);
 
-        let reused = pool.checkout_zstd().unwrap();
-        assert_eq!(pool.zstd_contexts_created(), 2);
-        drop(reused);
-        assert_eq!(pool.available_zstd_contexts(), 2);
-
-        let weak = Arc::downgrade(&pool);
-        drop(pool);
+        let weak = Arc::downgrade(&decompression_context);
+        drop(decompression_context);
         assert!(weak.upgrade().is_none());
     }
 }

--- a/turbopack/crates/turbo-persistence/src/compression.rs
+++ b/turbopack/crates/turbo-persistence/src/compression.rs
@@ -1,39 +1,20 @@
 use std::{cell::RefCell, mem::MaybeUninit, rc::Rc, sync::Arc};
 
 use anyhow::{Context, Result, ensure};
-use bincode::{Decode, Encode};
 use lzzzz::lz4::{self, decompress};
 
-/// Compression preset used for a family's SST blocks and blob values.
+/// Compression algorithm used for a family's SST blocks and blob values.
 ///
-/// Variant order is part of the meta-file format. New presets must be appended without reordering
-/// existing variants.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Encode, Decode)]
+/// The discriminants are stored in meta files, so existing values must not be changed. New
+/// algorithms get a new discriminant.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(u8)]
 pub enum Compression {
     /// Fast LZ4 compression using the default acceleration level.
     #[default]
-    Lz4,
+    Lz4 = 0,
     /// Zstandard compression at level 3.
-    Zstd3,
-}
-
-impl Compression {
-    pub(crate) fn encode(self) -> Result<Vec<u8>> {
-        bincode::encode_to_vec(self, bincode::config::standard())
-            .context("Failed to encode compression preset")
-    }
-
-    pub(crate) fn decode(bytes: &[u8]) -> Result<Self> {
-        let (compression, consumed) =
-            bincode::decode_from_slice(bytes, bincode::config::standard())
-                .context("Failed to decode compression preset")?;
-        ensure!(
-            consumed == bytes.len(),
-            "Compression preset has {} trailing bytes",
-            bytes.len() - consumed
-        );
-        Ok(compression)
-    }
+    Zstd3 = 1,
 }
 
 thread_local! {
@@ -56,15 +37,15 @@ fn decompress_block(
         "decompress_block called with uncompressed_length=0; uncompressed blocks should use \
          zero-copy mmap path"
     );
-    let result: Result<usize> = match compression {
+    let bytes_written = match compression {
         Compression::Lz4 => decompress(block, dest).map_err(anyhow::Error::from),
         Compression::Zstd3 => ZSTD_DECOMPRESSOR.with_borrow_mut(|decompressor| {
             decompressor
                 .decompress_to_buffer(block, dest)
                 .map_err(anyhow::Error::from)
         }),
-    };
-    let bytes_written = result.with_context(|| {
+    }
+    .with_context(|| {
         format!(
             "Failed to decompress {compression:?} block ({} bytes compressed, {} bytes \
              uncompressed)",

--- a/turbopack/crates/turbo-persistence/src/compression.rs
+++ b/turbopack/crates/turbo-persistence/src/compression.rs
@@ -52,7 +52,7 @@ fn decompress_block(
     })?;
     ensure!(
         bytes_written == expected_len as usize,
-        "Decompressed length does not match expected length: wrote {bytes_written} bytes, \
+        "Decompressed length does not match expected length: decompressed {bytes_written} bytes, \
          expected {expected_len}"
     );
     Ok(())
@@ -140,14 +140,6 @@ impl Compressor {
     }
 }
 
-pub(crate) fn compress_into_buffer(
-    compression: Compression,
-    block: &[u8],
-    buffer: &mut Vec<u8>,
-) -> Result<()> {
-    Compressor::new(compression)?.compress_into_buffer(block, buffer)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -156,8 +148,11 @@ mod tests {
     fn compression_round_trips() {
         let input = b"turbo persistence compression ".repeat(1024);
         for compression in [Compression::Lz4, Compression::Zstd3] {
+            let mut compressor = Compressor::new(compression).unwrap();
             let mut compressed = Vec::new();
-            compress_into_buffer(compression, &input, &mut compressed).unwrap();
+            compressor
+                .compress_into_buffer(&input, &mut compressed)
+                .unwrap();
             let output = decompress_into_arc(compression, input.len() as u32, &compressed).unwrap();
             assert_eq!(&*output, input);
         }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -8,7 +8,7 @@ use std::{
     ops::RangeInclusive,
     path::{Path, PathBuf},
     sync::{
-        OnceLock,
+        Arc, OnceLock,
         atomic::{AtomicBool, AtomicU32, Ordering},
     },
 };
@@ -32,7 +32,7 @@ use crate::{
     Compression, DbConfig, FamilyKind, QueryKey,
     arc_bytes::ArcBytes,
     compaction::selector::{Compactable, get_merge_segments},
-    compression::{checksum_block, decompress_into_arc},
+    compression::{DecompressionPool, checksum_block, decompress_into_arc},
     constants::{
         DATA_THRESHOLD_PER_COMPACTED_FILE, KEY_BLOCK_AVG_SIZE, KEY_BLOCK_CACHE_SIZE,
         MAX_ENTRIES_PER_COMPACTED_FILE, VALUE_BLOCK_AVG_SIZE, VALUE_BLOCK_CACHE_SIZE,
@@ -326,6 +326,8 @@ pub struct TurboPersistence<S: ParallelScheduler, const FAMILIES: usize> {
     value_block_cache: OnceLock<BlockCache>,
     /// Per-family storage configuration.
     config: DbConfig<FAMILIES>,
+    /// Reusable zstd decompression contexts owned by this database.
+    decompression_pool: Arc<DecompressionPool>,
     /// Statistics for the database.
     #[cfg(feature = "stats")]
     stats: TrackedStats,
@@ -452,6 +454,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             key_block_cache: OnceLock::new(),
             value_block_cache: OnceLock::new(),
             config,
+            decompression_pool: Arc::new(DecompressionPool::default()),
             #[cfg(feature = "stats")]
             stats: TrackedStats::default(),
         }
@@ -634,10 +637,13 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         let mut meta_files = self
             .parallel_scheduler
             .parallel_map_collect::<_, _, Result<Vec<MetaFile>>>(&meta_files, |&seq| {
+                let family_configs =
+                    (FAMILIES > 0).then_some(self.config.family_configs.as_slice());
                 let meta_file = MetaFile::open_with_family_configs(
                     &self.path,
                     seq,
-                    Some(&self.config.family_configs),
+                    family_configs,
+                    self.decompression_pool.clone(),
                 )?;
                 Ok(meta_file)
             })?;
@@ -690,8 +696,18 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             );
         }
 
-        let buffer = decompress_into_arc(compression, uncompressed_length, reader)?;
+        let buffer = decompress_into_arc(
+            &self.decompression_pool,
+            compression,
+            uncompressed_length,
+            reader,
+        )?;
         Ok(ArcBytes::from(buffer))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn decompression_pool_weak(&self) -> std::sync::Weak<DecompressionPool> {
+        Arc::downgrade(&self.decompression_pool)
     }
 
     /// Returns true if the database is empty.
@@ -930,10 +946,13 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             .parallel_map_collect_owned::<_, _, Result<Vec<_>>>(sync_items, |item| match item {
                 SyncItem::Meta(seq, file) => {
                     file.sync_data()?;
+                    let family_configs =
+                        (FAMILIES > 0).then_some(self.config.family_configs.as_slice());
                     let meta_file = MetaFile::open_with_family_configs(
                         &self.path,
                         seq,
-                        Some(&self.config.family_configs),
+                        family_configs,
+                        self.decompression_pool.clone(),
                     )?;
                     Ok(SyncResult::Meta(meta_file))
                 }
@@ -1605,6 +1624,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         path,
                                         entry.sst_metadata(),
                                         self.config.family_configs[family as usize].compression,
+                                        self.decompression_pool.clone(),
                                     )
                                 })
                                 .collect::<Result<Vec<_>>>()?;
@@ -1853,7 +1873,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                     let mut blob_seq_numbers_to_delete = Vec::with_capacity(blob_delete_len);
 
                     let meta_seq = sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
-                    let mut meta_file_builder = MetaFileBuilder::new(family);
+                    let mut meta_file_builder = MetaFileBuilder::new(
+                        family,
+                        self.config.family_configs[family as usize].compression,
+                    );
 
                     let mut keys_written = 0;
                     self.parallel_scheduler.block_in_place(|| {

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1651,7 +1651,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         let seq =
                                             sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
                                         let sst_path = path.join(format!("{seq:08}.sst"));
-                                        let writer = StreamingSstWriter::new_with_compression(
+                                        let writer = StreamingSstWriter::new(
                                             &sst_path,
                                             self.flags,
                                             MAX_ENTRIES_PER_COMPACTED_FILE as u64,

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1601,7 +1601,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     let meta_index = ssts_with_ranges[index].meta_index;
                                     let index_in_meta = ssts_with_ranges[index].index_in_meta;
                                     let entry = meta_files[meta_index].entry(index_in_meta);
-                                    StaticSortedFileIter::open_with_compression(
+                                    StaticSortedFileIter::open(
                                         path,
                                         entry.sst_metadata(),
                                         self.config.family_configs[family as usize].compression,

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -8,7 +8,7 @@ use std::{
     ops::RangeInclusive,
     path::{Path, PathBuf},
     sync::{
-        Arc, OnceLock,
+        OnceLock,
         atomic::{AtomicBool, AtomicU32, Ordering},
     },
 };
@@ -32,7 +32,7 @@ use crate::{
     Compression, DbConfig, FamilyKind, QueryKey,
     arc_bytes::ArcBytes,
     compaction::selector::{Compactable, get_merge_segments},
-    compression::{DecompressionContext, checksum_block, decompress_into_arc},
+    compression::{checksum_block, decompress_into_arc},
     constants::{
         DATA_THRESHOLD_PER_COMPACTED_FILE, KEY_BLOCK_AVG_SIZE, KEY_BLOCK_CACHE_SIZE,
         MAX_ENTRIES_PER_COMPACTED_FILE, VALUE_BLOCK_AVG_SIZE, VALUE_BLOCK_CACHE_SIZE,
@@ -326,8 +326,6 @@ pub struct TurboPersistence<S: ParallelScheduler, const FAMILIES: usize> {
     value_block_cache: OnceLock<BlockCache>,
     /// Per-family storage configuration.
     config: DbConfig<FAMILIES>,
-    /// Reusable zstd decompression contexts owned by this database.
-    decompression_context: Arc<DecompressionContext>,
     /// Statistics for the database.
     #[cfg(feature = "stats")]
     stats: TrackedStats,
@@ -454,7 +452,6 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             key_block_cache: OnceLock::new(),
             value_block_cache: OnceLock::new(),
             config,
-            decompression_context: Arc::new(DecompressionContext::default()),
             #[cfg(feature = "stats")]
             stats: TrackedStats::default(),
         }
@@ -637,13 +634,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         let mut meta_files = self
             .parallel_scheduler
             .parallel_map_collect::<_, _, Result<Vec<MetaFile>>>(&meta_files, |&seq| {
-                let family_configs =
-                    (FAMILIES > 0).then_some(self.config.family_configs.as_slice());
                 let meta_file = MetaFile::open_with_family_configs(
                     &self.path,
                     seq,
-                    family_configs,
-                    self.decompression_context.clone(),
+                    Some(&self.config.family_configs),
                 )?;
                 Ok(meta_file)
             })?;
@@ -696,18 +690,8 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             );
         }
 
-        let buffer = decompress_into_arc(
-            &self.decompression_context,
-            compression,
-            uncompressed_length,
-            reader,
-        )?;
+        let buffer = decompress_into_arc(compression, uncompressed_length, reader)?;
         Ok(ArcBytes::from(buffer))
-    }
-
-    #[cfg(test)]
-    pub(crate) fn decompression_context_weak(&self) -> std::sync::Weak<DecompressionContext> {
-        Arc::downgrade(&self.decompression_context)
     }
 
     /// Returns true if the database is empty.
@@ -946,13 +930,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             .parallel_map_collect_owned::<_, _, Result<Vec<_>>>(sync_items, |item| match item {
                 SyncItem::Meta(seq, file) => {
                     file.sync_data()?;
-                    let family_configs =
-                        (FAMILIES > 0).then_some(self.config.family_configs.as_slice());
                     let meta_file = MetaFile::open_with_family_configs(
                         &self.path,
                         seq,
-                        family_configs,
-                        self.decompression_context.clone(),
+                        Some(&self.config.family_configs),
                     )?;
                     Ok(SyncResult::Meta(meta_file))
                 }
@@ -1624,7 +1605,6 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         path,
                                         entry.sst_metadata(),
                                         self.config.family_configs[family as usize].compression,
-                                        self.decompression_context.clone(),
                                     )
                                 })
                                 .collect::<Result<Vec<_>>>()?;

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -32,7 +32,7 @@ use crate::{
     Compression, DbConfig, FamilyKind, QueryKey,
     arc_bytes::ArcBytes,
     compaction::selector::{Compactable, get_merge_segments},
-    compression::{DecompressionPool, checksum_block, decompress_into_arc},
+    compression::{DecompressionContext, checksum_block, decompress_into_arc},
     constants::{
         DATA_THRESHOLD_PER_COMPACTED_FILE, KEY_BLOCK_AVG_SIZE, KEY_BLOCK_CACHE_SIZE,
         MAX_ENTRIES_PER_COMPACTED_FILE, VALUE_BLOCK_AVG_SIZE, VALUE_BLOCK_CACHE_SIZE,
@@ -327,7 +327,7 @@ pub struct TurboPersistence<S: ParallelScheduler, const FAMILIES: usize> {
     /// Per-family storage configuration.
     config: DbConfig<FAMILIES>,
     /// Reusable zstd decompression contexts owned by this database.
-    decompression_pool: Arc<DecompressionPool>,
+    decompression_context: Arc<DecompressionContext>,
     /// Statistics for the database.
     #[cfg(feature = "stats")]
     stats: TrackedStats,
@@ -454,7 +454,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             key_block_cache: OnceLock::new(),
             value_block_cache: OnceLock::new(),
             config,
-            decompression_pool: Arc::new(DecompressionPool::default()),
+            decompression_context: Arc::new(DecompressionContext::default()),
             #[cfg(feature = "stats")]
             stats: TrackedStats::default(),
         }
@@ -643,7 +643,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                     &self.path,
                     seq,
                     family_configs,
-                    self.decompression_pool.clone(),
+                    self.decompression_context.clone(),
                 )?;
                 Ok(meta_file)
             })?;
@@ -697,7 +697,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         }
 
         let buffer = decompress_into_arc(
-            &self.decompression_pool,
+            &self.decompression_context,
             compression,
             uncompressed_length,
             reader,
@@ -706,8 +706,8 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     }
 
     #[cfg(test)]
-    pub(crate) fn decompression_pool_weak(&self) -> std::sync::Weak<DecompressionPool> {
-        Arc::downgrade(&self.decompression_pool)
+    pub(crate) fn decompression_context_weak(&self) -> std::sync::Weak<DecompressionContext> {
+        Arc::downgrade(&self.decompression_context)
     }
 
     /// Returns true if the database is empty.
@@ -952,7 +952,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                         &self.path,
                         seq,
                         family_configs,
-                        self.decompression_pool.clone(),
+                        self.decompression_context.clone(),
                     )?;
                     Ok(SyncResult::Meta(meta_file))
                 }
@@ -1624,7 +1624,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         path,
                                         entry.sst_metadata(),
                                         self.config.family_configs[family as usize].compression,
-                                        self.decompression_pool.clone(),
+                                        self.decompression_context.clone(),
                                     )
                                 })
                                 .collect::<Result<Vec<_>>>()?;

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -29,7 +29,7 @@ use tracing::span::EnteredSpan;
 
 pub use crate::compaction::selector::CompactConfig;
 use crate::{
-    DbConfig, FamilyKind, QueryKey,
+    Compression, DbConfig, FamilyKind, QueryKey,
     arc_bytes::ArcBytes,
     compaction::selector::{Compactable, get_merge_segments},
     compression::{checksum_block, decompress_into_arc},
@@ -324,7 +324,7 @@ pub struct TurboPersistence<S: ParallelScheduler, const FAMILIES: usize> {
     /// A cache for decompressed value blocks. Allocated lazily on first read via
     /// [`Self::value_block_cache`]; see [`Self::key_block_cache`].
     value_block_cache: OnceLock<BlockCache>,
-    /// Per-family configuration for file limits.
+    /// Per-family storage configuration.
     config: DbConfig<FAMILIES>,
     /// Statistics for the database.
     #[cfg(feature = "stats")]
@@ -634,7 +634,11 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         let mut meta_files = self
             .parallel_scheduler
             .parallel_map_collect::<_, _, Result<Vec<MetaFile>>>(&meta_files, |&seq| {
-                let meta_file = MetaFile::open(&self.path, seq)?;
+                let meta_file = MetaFile::open_with_family_configs(
+                    &self.path,
+                    seq,
+                    Some(&self.config.family_configs),
+                )?;
                 Ok(meta_file)
             })?;
 
@@ -653,7 +657,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
     /// Reads and decompresses a blob file. This is not backed by any cache.
     #[tracing::instrument(level = "info", name = "reading database blob", skip_all)]
-    fn read_blob(&self, seq: u32) -> Result<ArcBytes> {
+    fn read_blob(&self, seq: u32, compression: Compression) -> Result<ArcBytes> {
         let path = self.path.join(format!("{seq:08}.blob"));
         let file = File::open(&path)?;
         let mmap = unsafe { Mmap::map(file.file()) }.with_context(|| {
@@ -686,7 +690,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             );
         }
 
-        let buffer = decompress_into_arc(uncompressed_length, reader)?;
+        let buffer = decompress_into_arc(compression, uncompressed_length, reader)?;
         Ok(ArcBytes::from(buffer))
     }
 
@@ -926,7 +930,11 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             .parallel_map_collect_owned::<_, _, Result<Vec<_>>>(sync_items, |item| match item {
                 SyncItem::Meta(seq, file) => {
                     file.sync_data()?;
-                    let meta_file = MetaFile::open(&self.path, seq)?;
+                    let meta_file = MetaFile::open_with_family_configs(
+                        &self.path,
+                        seq,
+                        Some(&self.config.family_configs),
+                    )?;
                     Ok(SyncResult::Meta(meta_file))
                 }
                 SyncItem::Sst(file) => {
@@ -1593,7 +1601,11 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     let meta_index = ssts_with_ranges[index].meta_index;
                                     let index_in_meta = ssts_with_ranges[index].index_in_meta;
                                     let entry = meta_files[meta_index].entry(index_in_meta);
-                                    StaticSortedFileIter::open(path, entry.sst_metadata())
+                                    StaticSortedFileIter::open_with_compression(
+                                        path,
+                                        entry.sst_metadata(),
+                                        self.config.family_configs[family as usize].compression,
+                                    )
                                 })
                                 .collect::<Result<Vec<_>>>()?;
 
@@ -1610,6 +1622,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                 /// used set).
                                 writer: Option<(u32, StreamingSstWriter<LookupEntry>)>,
                                 flags: MetaEntryFlags,
+                                compression: Compression,
                                 new_sst_files:
                                     Vec<(u32, File, StaticSortedFileBuilderMeta<'static>)>,
                                 /// Hash of the last key added. Used to ensure we only split
@@ -1617,10 +1630,11 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                 last_hash: Option<u64>,
                             }
                             impl Collector {
-                                fn new(flags: MetaEntryFlags) -> Self {
+                                fn new(flags: MetaEntryFlags, compression: Compression) -> Self {
                                     Self {
                                         writer: None,
                                         flags,
+                                        compression,
                                         new_sst_files: Vec::new(),
                                         last_hash: None,
                                     }
@@ -1637,10 +1651,11 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         let seq =
                                             sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
                                         let sst_path = path.join(format!("{seq:08}.sst"));
-                                        let writer = StreamingSstWriter::new(
+                                        let writer = StreamingSstWriter::new_with_compression(
                                             &sst_path,
                                             self.flags,
                                             MAX_ENTRIES_PER_COMPACTED_FILE as u64,
+                                            self.compression,
                                         )?;
                                         self.writer = Some((seq, writer));
                                     }
@@ -1700,8 +1715,12 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     }
                                 }
                             }
-                            let mut used_collector = Collector::new(MetaEntryFlags::WARM);
-                            let mut unused_collector = Collector::new(MetaEntryFlags::COLD);
+                            let compression =
+                                self.config.family_configs[family as usize].compression;
+                            let mut used_collector =
+                                Collector::new(MetaEntryFlags::WARM, compression);
+                            let mut unused_collector =
+                                Collector::new(MetaEntryFlags::COLD, compression);
                             let mut current_key: Option<RcBytes> = None;
                             let mut keys_written = 0;
 
@@ -2091,7 +2110,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                 LookupValue::Blob { sequence_number } => {
                                     #[cfg(feature = "stats")]
                                     self.stats.hits_blob.fetch_add(1, Ordering::Relaxed);
-                                    let blob = self.read_blob(sequence_number)?;
+                                    let blob = self.read_blob(
+                                        sequence_number,
+                                        self.config.family_configs[family].compression,
+                                    )?;
                                     if deleted_values.iter().any(|d| **d == *blob) {
                                         continue;
                                     }
@@ -2230,7 +2252,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                     LookupValue::Blob { sequence_number } => {
                         #[cfg(feature = "stats")]
                         self.stats.hits_blob.fetch_add(1, Ordering::Relaxed);
-                        let blob = self.read_blob(sequence_number)?;
+                        let blob = self.read_blob(
+                            sequence_number,
+                            self.config.family_configs[family].compression,
+                        )?;
                         result_size += blob.len();
                         Some(blob)
                     }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -634,11 +634,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         let mut meta_files = self
             .parallel_scheduler
             .parallel_map_collect::<_, _, Result<Vec<MetaFile>>>(&meta_files, |&seq| {
-                let meta_file = MetaFile::open_with_family_configs(
-                    &self.path,
-                    seq,
-                    Some(&self.config.family_configs),
-                )?;
+                let meta_file = MetaFile::open(&self.path, seq, Some(&self.config.family_configs))?;
                 Ok(meta_file)
             })?;
 
@@ -930,11 +926,8 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             .parallel_map_collect_owned::<_, _, Result<Vec<_>>>(sync_items, |item| match item {
                 SyncItem::Meta(seq, file) => {
                     file.sync_data()?;
-                    let meta_file = MetaFile::open_with_family_configs(
-                        &self.path,
-                        seq,
-                        Some(&self.config.family_configs),
-                    )?;
+                    let meta_file =
+                        MetaFile::open(&self.path, seq, Some(&self.config.family_configs))?;
                     Ok(SyncResult::Meta(meta_file))
                 }
                 SyncItem::Sst(file) => {

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -29,7 +29,7 @@ mod write_batch;
 mod tests;
 
 pub use arc_bytes::ArcBytes;
-pub use compression::checksum_block;
+pub use compression::{Compression, checksum_block};
 pub use db::{
     CommitStats, CompactConfig, CurrentDbVersion, MetaFileEntryInfo, MetaFileInfo,
     TurboPersistence, read_current_version,
@@ -54,12 +54,14 @@ pub enum FamilyKind {
 pub struct FamilyConfig {
     pub name: &'static str,
     pub kind: FamilyKind,
+    /// Compression used for this family's SST blocks and blob values.
+    pub compression: Compression,
 }
 
-/// Database-wide configuration with per-family settings.
+/// Database-wide configuration with per-family storage settings.
 ///
-/// Each family (keyspace) can have different file size limits to optimize
-/// for its specific access patterns and data characteristics.
+/// Each family (keyspace) can select storage behavior suited to its access patterns and data
+/// characteristics.
 #[derive(Clone, Debug)]
 pub struct DbConfig<const FAMILIES: usize> {
     pub family_configs: [FamilyConfig; FAMILIES],
@@ -71,6 +73,7 @@ impl<const FAMILIES: usize> Default for DbConfig<FAMILIES> {
             family_configs: [FamilyConfig {
                 name: "unknown",
                 kind: FamilyKind::SingleValue,
+                compression: Compression::Lz4,
             }; FAMILIES],
         }
     }

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -73,7 +73,7 @@ impl<const FAMILIES: usize> Default for DbConfig<FAMILIES> {
             family_configs: [FamilyConfig {
                 name: "unknown",
                 kind: FamilyKind::SingleValue,
-                compression: Compression::lz4(),
+                compression: Compression::Lz4,
             }; FAMILIES],
         }
     }

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -73,7 +73,7 @@ impl<const FAMILIES: usize> Default for DbConfig<FAMILIES> {
             family_configs: [FamilyConfig {
                 name: "unknown",
                 kind: FamilyKind::SingleValue,
-                compression: Compression::Lz4,
+                compression: Compression::lz4(),
             }; FAMILIES],
         }
     }

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -54,7 +54,6 @@ pub enum FamilyKind {
 pub struct FamilyConfig {
     pub name: &'static str,
     pub kind: FamilyKind,
-    /// Compression used for this family's SST blocks and blob values.
     pub compression: Compression,
 }
 

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -155,13 +155,14 @@ impl MetaEntry {
 
     fn sst(&self, meta: &MetaFile) -> Result<&StaticSortedFile> {
         self.sst.get_or_try_init(|| {
-            StaticSortedFile::open_with_compression(&meta.db_path, self.sst_data, self.compression)
-                .with_context(|| {
+            StaticSortedFile::open(&meta.db_path, self.sst_data, self.compression).with_context(
+                || {
                     format!(
                         "Unable to open static sorted file referenced from {:08}.meta",
                         meta.sequence_number()
                     )
-                })
+                },
+            )
         })
     }
 

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -270,10 +270,8 @@ pub struct MetaFile {
 }
 
 impl MetaFile {
-    /// Opens a meta file and uses its recorded compression configuration for referenced SSTs.
-    /// Memory maps the entire file and eagerly deserializes all AMQF filters as zero-copy
-    /// [`qfilter::FilterRef`]s that borrow from the mmap. Database opens use the internal
-    /// constructor to also validate the marker against the runtime family configuration.
+    /// Opens a meta file at the given path. Memory maps the entire file and eagerly deserializes
+    /// all AMQF filters as zero-copy [`qfilter::FilterRef`]s that borrow from the mmap.
     pub fn open(db_path: &Path, sequence_number: u32) -> Result<Self> {
         Self::open_with_family_configs(db_path, sequence_number, None)
     }
@@ -313,13 +311,11 @@ impl MetaFile {
             bail!("Invalid magic number");
         }
         let family = reader.read_u32::<BE>()?;
-        let compression_len = reader.read_u32::<BE>()? as usize;
-        let compression_bytes = reader
-            .get(..compression_len)
-            .context("Compression configuration out of bounds")?;
-        reader = &reader[compression_len..];
-        let compression = Compression::decode(compression_bytes)
-            .context("Invalid compression configuration in meta file")?;
+        let compression = match reader.read_u8()? {
+            value if value == Compression::Lz4 as u8 => Compression::Lz4,
+            value if value == Compression::Zstd3 as u8 => Compression::Zstd3,
+            value => bail!("Invalid compression algorithm {value}"),
+        };
         if let Some(configs) = family_configs {
             let configured = configs
                 .get(family as usize)

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -2,10 +2,10 @@ use std::{
     cmp::Ordering,
     fmt::Display,
     path::{Path, PathBuf},
-    sync::OnceLock,
+    sync::{Arc, OnceLock},
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, bail, ensure};
 use bitfield::bitfield;
 use byteorder::{BE, ReadBytesExt};
 use fs_err::File;
@@ -15,6 +15,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref, big_endian as 
 
 use crate::{
     Compression, FamilyConfig, QueryKey,
+    compression::DecompressionPool,
     lookup_entry::LookupValue,
     mmap_helper::advise_mmap_for_persistence,
     static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile, StaticSortedFileMetaData},
@@ -50,7 +51,7 @@ impl Display for MetaEntryFlags {
 }
 
 /// Magic number identifying a `.meta` file.
-pub(crate) const META_FILE_MAGIC: u32 = 0xFE4ADA4A;
+pub(crate) const META_FILE_MAGIC: u32 = 0xFE4ADA4B;
 
 /// On-disk layout of a single entry header in the `.meta` file.
 ///
@@ -117,8 +118,10 @@ pub struct MetaEntry {
     ///
     /// The `'static` lifetime is transmuted — the actual borrow is from `MetaFile::mmap`.
     amqf: qfilter::FilterRef<'static>,
-    /// Compression configured for this entry's family.
+    /// Compression recorded in this entry's meta file.
     compression: Compression,
+    /// Database-owned decompression context pool.
+    decompression_pool: Arc<DecompressionPool>,
     /// The static sorted file that is lazily loaded
     sst: OnceLock<StaticSortedFile>,
 }
@@ -155,13 +158,18 @@ impl MetaEntry {
 
     fn sst(&self, meta: &MetaFile) -> Result<&StaticSortedFile> {
         self.sst.get_or_try_init(|| {
-            StaticSortedFile::open_with_compression(&meta.db_path, self.sst_data, self.compression)
-                .with_context(|| {
-                    format!(
-                        "Unable to open static sorted file referenced from {:08}.meta",
-                        meta.sequence_number()
-                    )
-                })
+            StaticSortedFile::open_with_compression(
+                &meta.db_path,
+                self.sst_data,
+                self.compression,
+                self.decompression_pool.clone(),
+            )
+            .with_context(|| {
+                format!(
+                    "Unable to open static sorted file referenced from {:08}.meta",
+                    meta.sequence_number()
+                )
+            })
         })
     }
 
@@ -247,6 +255,8 @@ pub struct MetaFile {
     sequence_number: u32,
     /// The key family of the SST files in this meta file.
     family: u32,
+    /// Compression recorded for this family.
+    compression: Compression,
     /// The entries of the file. Dropped before `mmap` (field declaration order).
     entries: Vec<MetaEntry>,
     /// The entries that have been marked as obsolete.
@@ -267,18 +277,24 @@ pub struct MetaFile {
 }
 
 impl MetaFile {
-    /// Opens a meta file whose SST entries use LZ4 compression. Memory maps the entire file and
-    /// eagerly deserializes all AMQF filters as zero-copy [`qfilter::FilterRef`]s that borrow from
-    /// the mmap. Databases with per-family compression use the configuration-aware internal
-    /// constructor instead.
+    /// Opens a meta file and uses its recorded compression configuration for referenced SSTs.
+    /// Memory maps the entire file and eagerly deserializes all AMQF filters as zero-copy
+    /// [`qfilter::FilterRef`]s that borrow from the mmap. Database opens use the internal
+    /// constructor to also validate the marker against the runtime family configuration.
     pub fn open(db_path: &Path, sequence_number: u32) -> Result<Self> {
-        Self::open_with_family_configs(db_path, sequence_number, None)
+        Self::open_with_family_configs(
+            db_path,
+            sequence_number,
+            None,
+            Arc::new(DecompressionPool::default()),
+        )
     }
 
     pub(crate) fn open_with_family_configs(
         db_path: &Path,
         sequence_number: u32,
         family_configs: Option<&[FamilyConfig]>,
+        decompression_pool: Arc<DecompressionPool>,
     ) -> Result<Self> {
         let filename = format!("{sequence_number:08}.meta");
         let path = db_path.join(&filename);
@@ -287,6 +303,7 @@ impl MetaFile {
             sequence_number,
             &path,
             family_configs,
+            decompression_pool,
         )
         .with_context(|| format!("Unable to open meta file {filename}"))
     }
@@ -296,6 +313,7 @@ impl MetaFile {
         sequence_number: u32,
         path: &Path,
         family_configs: Option<&[FamilyConfig]>,
+        decompression_pool: Arc<DecompressionPool>,
     ) -> Result<Self> {
         let file = File::open(path)?;
         let mmap = unsafe { MmapOptions::new().map(file.file()) }.context("Failed to mmap")?;
@@ -310,15 +328,21 @@ impl MetaFile {
             bail!("Invalid magic number");
         }
         let family = reader.read_u32::<BE>()?;
-        let compression = match family_configs {
-            Some(configs) => {
-                configs
-                    .get(family as usize)
-                    .with_context(|| format!("No configuration for family {family}"))?
-                    .compression
-            }
-            None => Compression::Lz4,
-        };
+        let compression_tag = reader.read_u32::<BE>()?;
+        let compression_level = reader.read_i32::<BE>()?;
+        let compression = Compression::from_meta_fields(compression_tag, compression_level)
+            .context("Invalid compression configuration in meta file")?;
+        if let Some(configs) = family_configs {
+            let configured = configs
+                .get(family as usize)
+                .with_context(|| format!("No configuration for family {family}"))?
+                .compression;
+            ensure!(
+                compression == configured,
+                "Compression configuration mismatch for family {family}: meta file uses \
+                 {compression:?}, runtime config uses {configured:?}"
+            );
+        }
         let obsolete_count = reader.read_u32::<BE>()?;
         let mut obsolete_sst_files = Vec::with_capacity(obsolete_count as usize);
         for _ in 0..obsolete_count {
@@ -377,6 +401,7 @@ impl MetaFile {
                 amqf_data_offset: start_of_amqf_data_offset..end_of_amqf_data_offset,
                 amqf,
                 compression,
+                decompression_pool: decompression_pool.clone(),
                 sst: OnceLock::new(),
             });
             start_of_amqf_data_offset = end_of_amqf_data_offset;
@@ -389,6 +414,7 @@ impl MetaFile {
             db_path,
             sequence_number,
             family,
+            compression,
             entries,
             obsolete_entries: Vec::new(),
             obsolete_sst_files,
@@ -417,6 +443,10 @@ impl MetaFile {
 
     pub fn family(&self) -> u32 {
         self.family
+    }
+
+    pub fn compression(&self) -> Compression {
+        self.compression
     }
 
     /// The on-disk size of this meta file in bytes (the length of its memory map).

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -2,7 +2,7 @@ use std::{
     cmp::Ordering,
     fmt::Display,
     path::{Path, PathBuf},
-    sync::{Arc, OnceLock},
+    sync::OnceLock,
 };
 
 use anyhow::{Context, Result, bail, ensure};
@@ -15,7 +15,6 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref, big_endian as 
 
 use crate::{
     Compression, FamilyConfig, QueryKey,
-    compression::DecompressionContext,
     lookup_entry::LookupValue,
     mmap_helper::advise_mmap_for_persistence,
     static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile, StaticSortedFileMetaData},
@@ -51,7 +50,7 @@ impl Display for MetaEntryFlags {
 }
 
 /// Magic number identifying a `.meta` file.
-pub(crate) const META_FILE_MAGIC: u32 = 0xFE4ADA4B;
+pub(crate) const META_FILE_MAGIC: u32 = 0xFE4ADA4A;
 
 /// On-disk layout of a single entry header in the `.meta` file.
 ///
@@ -120,8 +119,6 @@ pub struct MetaEntry {
     amqf: qfilter::FilterRef<'static>,
     /// Compression recorded in this entry's meta file.
     compression: Compression,
-    /// Database-owned decompression context pool.
-    decompression_context: Arc<DecompressionContext>,
     /// The static sorted file that is lazily loaded
     sst: OnceLock<StaticSortedFile>,
 }
@@ -158,18 +155,13 @@ impl MetaEntry {
 
     fn sst(&self, meta: &MetaFile) -> Result<&StaticSortedFile> {
         self.sst.get_or_try_init(|| {
-            StaticSortedFile::open_with_compression(
-                &meta.db_path,
-                self.sst_data,
-                self.compression,
-                self.decompression_context.clone(),
-            )
-            .with_context(|| {
-                format!(
-                    "Unable to open static sorted file referenced from {:08}.meta",
-                    meta.sequence_number()
-                )
-            })
+            StaticSortedFile::open_with_compression(&meta.db_path, self.sst_data, self.compression)
+                .with_context(|| {
+                    format!(
+                        "Unable to open static sorted file referenced from {:08}.meta",
+                        meta.sequence_number()
+                    )
+                })
         })
     }
 
@@ -282,19 +274,13 @@ impl MetaFile {
     /// [`qfilter::FilterRef`]s that borrow from the mmap. Database opens use the internal
     /// constructor to also validate the marker against the runtime family configuration.
     pub fn open(db_path: &Path, sequence_number: u32) -> Result<Self> {
-        Self::open_with_family_configs(
-            db_path,
-            sequence_number,
-            None,
-            Arc::new(DecompressionContext::default()),
-        )
+        Self::open_with_family_configs(db_path, sequence_number, None)
     }
 
     pub(crate) fn open_with_family_configs(
         db_path: &Path,
         sequence_number: u32,
         family_configs: Option<&[FamilyConfig]>,
-        decompression_context: Arc<DecompressionContext>,
     ) -> Result<Self> {
         let filename = format!("{sequence_number:08}.meta");
         let path = db_path.join(&filename);
@@ -303,7 +289,6 @@ impl MetaFile {
             sequence_number,
             &path,
             family_configs,
-            decompression_context,
         )
         .with_context(|| format!("Unable to open meta file {filename}"))
     }
@@ -313,7 +298,6 @@ impl MetaFile {
         sequence_number: u32,
         path: &Path,
         family_configs: Option<&[FamilyConfig]>,
-        decompression_context: Arc<DecompressionContext>,
     ) -> Result<Self> {
         let file = File::open(path)?;
         let mmap = unsafe { MmapOptions::new().map(file.file()) }.context("Failed to mmap")?;
@@ -404,7 +388,6 @@ impl MetaFile {
                 amqf_data_offset: start_of_amqf_data_offset..end_of_amqf_data_offset,
                 amqf,
                 compression,
-                decompression_context: decompression_context.clone(),
                 sst: OnceLock::new(),
             });
             start_of_amqf_data_offset = end_of_amqf_data_offset;

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -15,7 +15,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref, big_endian as 
 
 use crate::{
     Compression, FamilyConfig, QueryKey,
-    compression::DecompressionPool,
+    compression::DecompressionContext,
     lookup_entry::LookupValue,
     mmap_helper::advise_mmap_for_persistence,
     static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile, StaticSortedFileMetaData},
@@ -121,7 +121,7 @@ pub struct MetaEntry {
     /// Compression recorded in this entry's meta file.
     compression: Compression,
     /// Database-owned decompression context pool.
-    decompression_pool: Arc<DecompressionPool>,
+    decompression_context: Arc<DecompressionContext>,
     /// The static sorted file that is lazily loaded
     sst: OnceLock<StaticSortedFile>,
 }
@@ -162,7 +162,7 @@ impl MetaEntry {
                 &meta.db_path,
                 self.sst_data,
                 self.compression,
-                self.decompression_pool.clone(),
+                self.decompression_context.clone(),
             )
             .with_context(|| {
                 format!(
@@ -286,7 +286,7 @@ impl MetaFile {
             db_path,
             sequence_number,
             None,
-            Arc::new(DecompressionPool::default()),
+            Arc::new(DecompressionContext::default()),
         )
     }
 
@@ -294,7 +294,7 @@ impl MetaFile {
         db_path: &Path,
         sequence_number: u32,
         family_configs: Option<&[FamilyConfig]>,
-        decompression_pool: Arc<DecompressionPool>,
+        decompression_context: Arc<DecompressionContext>,
     ) -> Result<Self> {
         let filename = format!("{sequence_number:08}.meta");
         let path = db_path.join(&filename);
@@ -303,7 +303,7 @@ impl MetaFile {
             sequence_number,
             &path,
             family_configs,
-            decompression_pool,
+            decompression_context,
         )
         .with_context(|| format!("Unable to open meta file {filename}"))
     }
@@ -313,7 +313,7 @@ impl MetaFile {
         sequence_number: u32,
         path: &Path,
         family_configs: Option<&[FamilyConfig]>,
-        decompression_pool: Arc<DecompressionPool>,
+        decompression_context: Arc<DecompressionContext>,
     ) -> Result<Self> {
         let file = File::open(path)?;
         let mmap = unsafe { MmapOptions::new().map(file.file()) }.context("Failed to mmap")?;
@@ -328,9 +328,12 @@ impl MetaFile {
             bail!("Invalid magic number");
         }
         let family = reader.read_u32::<BE>()?;
-        let compression_tag = reader.read_u32::<BE>()?;
-        let compression_level = reader.read_i32::<BE>()?;
-        let compression = Compression::from_meta_fields(compression_tag, compression_level)
+        let compression_len = reader.read_u32::<BE>()? as usize;
+        let compression_bytes = reader
+            .get(..compression_len)
+            .context("Compression configuration out of bounds")?;
+        reader = &reader[compression_len..];
+        let compression = Compression::decode(compression_bytes)
             .context("Invalid compression configuration in meta file")?;
         if let Some(configs) = family_configs {
             let configured = configs
@@ -401,7 +404,7 @@ impl MetaFile {
                 amqf_data_offset: start_of_amqf_data_offset..end_of_amqf_data_offset,
                 amqf,
                 compression,
-                decompression_pool: decompression_pool.clone(),
+                decompression_context: decompression_context.clone(),
                 sst: OnceLock::new(),
             });
             start_of_amqf_data_offset = end_of_amqf_data_offset;

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -14,7 +14,7 @@ use smallvec::SmallVec;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref, big_endian as be};
 
 use crate::{
-    QueryKey,
+    Compression, FamilyConfig, QueryKey,
     lookup_entry::LookupValue,
     mmap_helper::advise_mmap_for_persistence,
     static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile, StaticSortedFileMetaData},
@@ -117,6 +117,8 @@ pub struct MetaEntry {
     ///
     /// The `'static` lifetime is transmuted — the actual borrow is from `MetaFile::mmap`.
     amqf: qfilter::FilterRef<'static>,
+    /// Compression configured for this entry's family.
+    compression: Compression,
     /// The static sorted file that is lazily loaded
     sst: OnceLock<StaticSortedFile>,
 }
@@ -153,12 +155,13 @@ impl MetaEntry {
 
     fn sst(&self, meta: &MetaFile) -> Result<&StaticSortedFile> {
         self.sst.get_or_try_init(|| {
-            StaticSortedFile::open(&meta.db_path, self.sst_data).with_context(|| {
-                format!(
-                    "Unable to open static sorted file referenced from {:08}.meta",
-                    meta.sequence_number()
-                )
-            })
+            StaticSortedFile::open_with_compression(&meta.db_path, self.sst_data, self.compression)
+                .with_context(|| {
+                    format!(
+                        "Unable to open static sorted file referenced from {:08}.meta",
+                        meta.sequence_number()
+                    )
+                })
         })
     }
 
@@ -264,16 +267,36 @@ pub struct MetaFile {
 }
 
 impl MetaFile {
-    /// Opens a meta file at the given path. Memory maps the entire file and eagerly deserializes
-    /// all AMQF filters as zero-copy [`qfilter::FilterRef`]s that borrow from the mmap.
+    /// Opens a meta file whose SST entries use LZ4 compression. Memory maps the entire file and
+    /// eagerly deserializes all AMQF filters as zero-copy [`qfilter::FilterRef`]s that borrow from
+    /// the mmap. Databases with per-family compression use the configuration-aware internal
+    /// constructor instead.
     pub fn open(db_path: &Path, sequence_number: u32) -> Result<Self> {
-        let filename = format!("{sequence_number:08}.meta");
-        let path = db_path.join(&filename);
-        Self::open_internal(db_path.to_path_buf(), sequence_number, &path)
-            .with_context(|| format!("Unable to open meta file {filename}"))
+        Self::open_with_family_configs(db_path, sequence_number, None)
     }
 
-    fn open_internal(db_path: PathBuf, sequence_number: u32, path: &Path) -> Result<Self> {
+    pub(crate) fn open_with_family_configs(
+        db_path: &Path,
+        sequence_number: u32,
+        family_configs: Option<&[FamilyConfig]>,
+    ) -> Result<Self> {
+        let filename = format!("{sequence_number:08}.meta");
+        let path = db_path.join(&filename);
+        Self::open_internal(
+            db_path.to_path_buf(),
+            sequence_number,
+            &path,
+            family_configs,
+        )
+        .with_context(|| format!("Unable to open meta file {filename}"))
+    }
+
+    fn open_internal(
+        db_path: PathBuf,
+        sequence_number: u32,
+        path: &Path,
+        family_configs: Option<&[FamilyConfig]>,
+    ) -> Result<Self> {
         let file = File::open(path)?;
         let mmap = unsafe { MmapOptions::new().map(file.file()) }.context("Failed to mmap")?;
         #[cfg(unix)]
@@ -287,6 +310,15 @@ impl MetaFile {
             bail!("Invalid magic number");
         }
         let family = reader.read_u32::<BE>()?;
+        let compression = match family_configs {
+            Some(configs) => {
+                configs
+                    .get(family as usize)
+                    .with_context(|| format!("No configuration for family {family}"))?
+                    .compression
+            }
+            None => Compression::Lz4,
+        };
         let obsolete_count = reader.read_u32::<BE>()?;
         let mut obsolete_sst_files = Vec::with_capacity(obsolete_count as usize);
         for _ in 0..obsolete_count {
@@ -344,6 +376,7 @@ impl MetaFile {
                 flags,
                 amqf_data_offset: start_of_amqf_data_offset..end_of_amqf_data_offset,
                 amqf,
+                compression,
                 sst: OnceLock::new(),
             });
             start_of_amqf_data_offset = end_of_amqf_data_offset;

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -272,11 +272,7 @@ pub struct MetaFile {
 impl MetaFile {
     /// Opens a meta file at the given path. Memory maps the entire file and eagerly deserializes
     /// all AMQF filters as zero-copy [`qfilter::FilterRef`]s that borrow from the mmap.
-    pub fn open(db_path: &Path, sequence_number: u32) -> Result<Self> {
-        Self::open_with_family_configs(db_path, sequence_number, None)
-    }
-
-    pub(crate) fn open_with_family_configs(
+    pub fn open(
         db_path: &Path,
         sequence_number: u32,
         family_configs: Option<&[FamilyConfig]>,

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -62,12 +62,9 @@ impl<'a> MetaFileBuilder<'a> {
         let mut file = CountingWriter::new(BufWriter::new(File::create(file)?));
         file.write_u32::<BE>(META_FILE_MAGIC)?; // Magic number
         file.write_u32::<BE>(self.family)?;
-        let (compression_tag, compression_level) = self
-            .compression
-            .to_meta_fields()
-            .map_err(io::Error::other)?;
-        file.write_u32::<BE>(compression_tag)?;
-        file.write_i32::<BE>(compression_level)?;
+        let compression = self.compression.encode().map_err(io::Error::other)?;
+        file.write_u32::<BE>(compression.len() as u32)?;
+        file.write_all(&compression)?;
 
         self.obsolete_sst_files.sort();
         file.write_u32::<BE>(self.obsolete_sst_files.len() as u32)?;
@@ -169,10 +166,9 @@ mod tests {
     #[test]
     fn compression_configuration_round_trips_through_meta_file() {
         for compression in [
-            Compression::Lz4,
-            Compression::Lz4Hc(4),
-            Compression::Zstd(0),
-            Compression::Zstd(3),
+            Compression::lz4(),
+            Compression::lz4_hc4(),
+            Compression::zstd_3(),
         ] {
             let (tempdir, _) = write_empty_meta(compression);
             let meta = MetaFile::open(tempdir.path(), 1).unwrap();
@@ -182,7 +178,7 @@ mod tests {
 
     #[test]
     fn invalid_meta_compression_headers_are_rejected() {
-        let (tempdir, path) = write_empty_meta(Compression::Zstd(3));
+        let (tempdir, path) = write_empty_meta(Compression::zstd_3());
         let original = std::fs::read(&path).unwrap();
 
         let mut bytes = original.clone();
@@ -191,19 +187,11 @@ mod tests {
         assert!(MetaFile::open(tempdir.path(), 1).is_err());
 
         let mut bytes = original.clone();
-        BE::write_u32(&mut bytes[8..12], 99);
+        bytes[12] = 99;
         std::fs::write(&path, &bytes).unwrap();
         assert!(MetaFile::open(tempdir.path(), 1).is_err());
 
-        let mut bytes = original.clone();
-        BE::write_i32(
-            &mut bytes[12..16],
-            *zstd::compression_level_range().end() + 1,
-        );
-        std::fs::write(&path, &bytes).unwrap();
-        assert!(MetaFile::open(tempdir.path(), 1).is_err());
-
-        std::fs::write(&path, &original[..10]).unwrap();
+        std::fs::write(&path, &original[..12]).unwrap();
         assert!(MetaFile::open(tempdir.path(), 1).is_err());
     }
 }

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -62,9 +62,7 @@ impl<'a> MetaFileBuilder<'a> {
         let mut file = CountingWriter::new(BufWriter::new(File::create(file)?));
         file.write_u32::<BE>(META_FILE_MAGIC)?; // Magic number
         file.write_u32::<BE>(self.family)?;
-        let compression = self.compression.encode().map_err(io::Error::other)?;
-        file.write_u32::<BE>(compression.len() as u32)?;
-        file.write_all(&compression)?;
+        file.write_u8(self.compression as u8)?;
 
         self.obsolete_sst_files.sort();
         file.write_u32::<BE>(self.obsolete_sst_files.len() as u32)?;
@@ -143,42 +141,5 @@ impl<W: Write> Write for CountingWriter<W> {
 
     fn flush(&mut self) -> io::Result<()> {
         self.inner.flush()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use byteorder::{BE, ByteOrder};
-
-    use super::*;
-    use crate::meta_file::MetaFile;
-
-    fn write_empty_meta(compression: Compression) -> (tempfile::TempDir, std::path::PathBuf) {
-        let tempdir = tempfile::tempdir().unwrap();
-        let (file, _) = MetaFileBuilder::new(0, compression)
-            .write(tempdir.path(), 1)
-            .unwrap();
-        drop(file);
-        let path = tempdir.path().join("00000001.meta");
-        (tempdir, path)
-    }
-
-    #[test]
-    fn invalid_meta_compression_headers_are_rejected() {
-        let (tempdir, path) = write_empty_meta(Compression::Zstd3);
-        let original = std::fs::read(&path).unwrap();
-
-        let mut bytes = original.clone();
-        BE::write_u32(&mut bytes[0..4], META_FILE_MAGIC.wrapping_sub(1));
-        std::fs::write(&path, &bytes).unwrap();
-        assert!(MetaFile::open(tempdir.path(), 1).is_err());
-
-        let mut bytes = original.clone();
-        bytes[12] = 99;
-        std::fs::write(&path, &bytes).unwrap();
-        assert!(MetaFile::open(tempdir.path(), 1).is_err());
-
-        std::fs::write(&path, &original[..12]).unwrap();
-        assert!(MetaFile::open(tempdir.path(), 1).is_err());
     }
 }

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -164,21 +164,8 @@ mod tests {
     }
 
     #[test]
-    fn compression_configuration_round_trips_through_meta_file() {
-        for compression in [
-            Compression::lz4(),
-            Compression::lz4_hc4(),
-            Compression::zstd_3(),
-        ] {
-            let (tempdir, _) = write_empty_meta(compression);
-            let meta = MetaFile::open(tempdir.path(), 1).unwrap();
-            assert_eq!(meta.compression(), compression);
-        }
-    }
-
-    #[test]
     fn invalid_meta_compression_headers_are_rejected() {
-        let (tempdir, path) = write_empty_meta(Compression::zstd_3());
+        let (tempdir, path) = write_empty_meta(Compression::Zstd3);
         let original = std::fs::read(&path).unwrap();
 
         let mut bytes = original.clone();

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -10,12 +10,14 @@ use qfilter::Filter;
 use zerocopy::IntoBytes;
 
 use crate::{
+    Compression,
     meta_file::{EntryHeader, META_FILE_MAGIC},
     static_sorted_file_builder::StaticSortedFileBuilderMeta,
 };
 
 pub struct MetaFileBuilder<'a> {
     family: u32,
+    compression: Compression,
     /// Entries in the meta file, tuples of (sequence_number, StaticSortedFileBuilderMetaResult)
     entries: Vec<(u32, StaticSortedFileBuilderMeta<'a>)>,
     /// Obsolete SST files, represented by their sequence numbers
@@ -25,9 +27,10 @@ pub struct MetaFileBuilder<'a> {
 }
 
 impl<'a> MetaFileBuilder<'a> {
-    pub fn new(family: u32) -> Self {
+    pub fn new(family: u32, compression: Compression) -> Self {
         Self {
             family,
+            compression,
             entries: Vec::new(),
             obsolete_sst_files: Vec::new(),
             used_key_hashes_amqf: None,
@@ -59,6 +62,12 @@ impl<'a> MetaFileBuilder<'a> {
         let mut file = CountingWriter::new(BufWriter::new(File::create(file)?));
         file.write_u32::<BE>(META_FILE_MAGIC)?; // Magic number
         file.write_u32::<BE>(self.family)?;
+        let (compression_tag, compression_level) = self
+            .compression
+            .to_meta_fields()
+            .map_err(io::Error::other)?;
+        file.write_u32::<BE>(compression_tag)?;
+        file.write_i32::<BE>(compression_level)?;
 
         self.obsolete_sst_files.sort();
         file.write_u32::<BE>(self.obsolete_sst_files.len() as u32)?;
@@ -137,5 +146,64 @@ impl<W: Write> Write for CountingWriter<W> {
 
     fn flush(&mut self) -> io::Result<()> {
         self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use byteorder::{BE, ByteOrder};
+
+    use super::*;
+    use crate::meta_file::MetaFile;
+
+    fn write_empty_meta(compression: Compression) -> (tempfile::TempDir, std::path::PathBuf) {
+        let tempdir = tempfile::tempdir().unwrap();
+        let (file, _) = MetaFileBuilder::new(0, compression)
+            .write(tempdir.path(), 1)
+            .unwrap();
+        drop(file);
+        let path = tempdir.path().join("00000001.meta");
+        (tempdir, path)
+    }
+
+    #[test]
+    fn compression_configuration_round_trips_through_meta_file() {
+        for compression in [
+            Compression::Lz4,
+            Compression::Lz4Hc(4),
+            Compression::Zstd(0),
+            Compression::Zstd(3),
+        ] {
+            let (tempdir, _) = write_empty_meta(compression);
+            let meta = MetaFile::open(tempdir.path(), 1).unwrap();
+            assert_eq!(meta.compression(), compression);
+        }
+    }
+
+    #[test]
+    fn invalid_meta_compression_headers_are_rejected() {
+        let (tempdir, path) = write_empty_meta(Compression::Zstd(3));
+        let original = std::fs::read(&path).unwrap();
+
+        let mut bytes = original.clone();
+        BE::write_u32(&mut bytes[0..4], META_FILE_MAGIC.wrapping_sub(1));
+        std::fs::write(&path, &bytes).unwrap();
+        assert!(MetaFile::open(tempdir.path(), 1).is_err());
+
+        let mut bytes = original.clone();
+        BE::write_u32(&mut bytes[8..12], 99);
+        std::fs::write(&path, &bytes).unwrap();
+        assert!(MetaFile::open(tempdir.path(), 1).is_err());
+
+        let mut bytes = original.clone();
+        BE::write_i32(
+            &mut bytes[12..16],
+            *zstd::compression_level_range().end() + 1,
+        );
+        std::fs::write(&path, &bytes).unwrap();
+        assert!(MetaFile::open(tempdir.path(), 1).is_err());
+
+        std::fs::write(&path, &original[..10]).unwrap();
+        assert!(MetaFile::open(tempdir.path(), 1).is_err());
     }
 }

--- a/turbopack/crates/turbo-persistence/src/rc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/rc_bytes.rs
@@ -10,7 +10,7 @@ use memmap2::Mmap;
 
 use crate::{
     Compression,
-    compression::{DecompressionPool, decompress_into_rc},
+    compression::{DecompressionContext, decompress_into_rc},
     shared_bytes::{SharedBytes, is_subslice_of},
 };
 
@@ -126,13 +126,13 @@ impl SharedBytes for RcBytes {
     }
 
     fn from_decompressed(
-        pool: &DecompressionPool,
+        decompression_context: &DecompressionContext,
         compression: Compression,
         uncompressed_length: u32,
         block: &[u8],
     ) -> anyhow::Result<Self> {
         Ok(RcBytes::from(decompress_into_rc(
-            pool,
+            decompression_context,
             compression,
             uncompressed_length,
             block,

--- a/turbopack/crates/turbo-persistence/src/rc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/rc_bytes.rs
@@ -10,7 +10,7 @@ use memmap2::Mmap;
 
 use crate::{
     Compression,
-    compression::{DecompressionContext, decompress_into_rc},
+    compression::decompress_into_rc,
     shared_bytes::{SharedBytes, is_subslice_of},
 };
 
@@ -126,13 +126,11 @@ impl SharedBytes for RcBytes {
     }
 
     fn from_decompressed(
-        decompression_context: &DecompressionContext,
         compression: Compression,
         uncompressed_length: u32,
         block: &[u8],
     ) -> anyhow::Result<Self> {
         Ok(RcBytes::from(decompress_into_rc(
-            decompression_context,
             compression,
             uncompressed_length,
             block,

--- a/turbopack/crates/turbo-persistence/src/rc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/rc_bytes.rs
@@ -9,6 +9,7 @@ use std::{
 use memmap2::Mmap;
 
 use crate::{
+    Compression,
     compression::decompress_into_rc,
     shared_bytes::{SharedBytes, is_subslice_of},
 };
@@ -124,8 +125,13 @@ impl SharedBytes for RcBytes {
         }
     }
 
-    fn from_decompressed(uncompressed_length: u32, block: &[u8]) -> anyhow::Result<Self> {
+    fn from_decompressed(
+        compression: Compression,
+        uncompressed_length: u32,
+        block: &[u8],
+    ) -> anyhow::Result<Self> {
         Ok(RcBytes::from(decompress_into_rc(
+            compression,
             uncompressed_length,
             block,
         )?))

--- a/turbopack/crates/turbo-persistence/src/rc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/rc_bytes.rs
@@ -10,7 +10,7 @@ use memmap2::Mmap;
 
 use crate::{
     Compression,
-    compression::decompress_into_rc,
+    compression::{DecompressionPool, decompress_into_rc},
     shared_bytes::{SharedBytes, is_subslice_of},
 };
 
@@ -126,11 +126,13 @@ impl SharedBytes for RcBytes {
     }
 
     fn from_decompressed(
+        pool: &DecompressionPool,
         compression: Compression,
         uncompressed_length: u32,
         block: &[u8],
     ) -> anyhow::Result<Self> {
         Ok(RcBytes::from(decompress_into_rc(
+            pool,
             compression,
             uncompressed_length,
             block,

--- a/turbopack/crates/turbo-persistence/src/shared_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/shared_bytes.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, Range};
 
 use memmap2::Mmap;
 
-use crate::{Compression, compression::DecompressionContext};
+use crate::Compression;
 
 /// Trait abstracting over `ArcBytes` and `RcBytes`.
 ///
@@ -39,7 +39,6 @@ pub trait SharedBytes: Clone + Deref<Target = [u8]> + Sized {
 
     /// Creates an instance from a decompressed block.
     fn from_decompressed(
-        decompression_context: &DecompressionContext,
         compression: Compression,
         uncompressed_length: u32,
         block: &[u8],

--- a/turbopack/crates/turbo-persistence/src/shared_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/shared_bytes.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, Range};
 
 use memmap2::Mmap;
 
-use crate::Compression;
+use crate::{Compression, compression::DecompressionPool};
 
 /// Trait abstracting over `ArcBytes` and `RcBytes`.
 ///
@@ -39,6 +39,7 @@ pub trait SharedBytes: Clone + Deref<Target = [u8]> + Sized {
 
     /// Creates an instance from a decompressed block.
     fn from_decompressed(
+        pool: &DecompressionPool,
         compression: Compression,
         uncompressed_length: u32,
         block: &[u8],

--- a/turbopack/crates/turbo-persistence/src/shared_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/shared_bytes.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, Range};
 
 use memmap2::Mmap;
 
-use crate::{Compression, compression::DecompressionPool};
+use crate::{Compression, compression::DecompressionContext};
 
 /// Trait abstracting over `ArcBytes` and `RcBytes`.
 ///
@@ -39,7 +39,7 @@ pub trait SharedBytes: Clone + Deref<Target = [u8]> + Sized {
 
     /// Creates an instance from a decompressed block.
     fn from_decompressed(
-        pool: &DecompressionPool,
+        decompression_context: &DecompressionContext,
         compression: Compression,
         uncompressed_length: u32,
         block: &[u8],

--- a/turbopack/crates/turbo-persistence/src/shared_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/shared_bytes.rs
@@ -2,6 +2,8 @@ use std::ops::{Deref, Range};
 
 use memmap2::Mmap;
 
+use crate::Compression;
+
 /// Trait abstracting over `ArcBytes` and `RcBytes`.
 ///
 /// Both types are owned byte slices backed by either a ref-counted heap
@@ -36,7 +38,11 @@ pub trait SharedBytes: Clone + Deref<Target = [u8]> + Sized {
     unsafe fn from_mmap(mmap: &Self::MmapHandle, subslice: &[u8]) -> Self;
 
     /// Creates an instance from a decompressed block.
-    fn from_decompressed(uncompressed_length: u32, block: &[u8]) -> anyhow::Result<Self>;
+    fn from_decompressed(
+        compression: Compression,
+        uncompressed_length: u32,
+        block: &[u8],
+    ) -> anyhow::Result<Self>;
 }
 
 /// Returns `true` if `subslice` lies entirely within `backing`.

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -155,6 +155,7 @@ trait ValueBlockCache<B: SharedBytes> {
         mmap: &B::MmapHandle,
         meta: &StaticSortedFileMetaData,
         block_index: u16,
+        compression: Compression,
     ) -> Result<B>;
 }
 
@@ -164,7 +165,6 @@ trait ValueBlockCache<B: SharedBytes> {
 struct ArcBlockCacheReader<'a> {
     cache: &'a BlockCache,
     verified_blocks: &'a [AtomicU64],
-    compression: Compression,
 }
 
 /// Lookup-path: concurrent `BlockCache` with uncompressed-bypass and
@@ -175,6 +175,7 @@ impl ValueBlockCache<ArcBytes> for ArcBlockCacheReader<'_> {
         mmap: &Arc<Mmap>,
         meta: &StaticSortedFileMetaData,
         block_index: u16,
+        compression: Compression,
     ) -> Result<ArcBytes> {
         get_or_cache_block(
             mmap,
@@ -182,7 +183,7 @@ impl ValueBlockCache<ArcBytes> for ArcBlockCacheReader<'_> {
             block_index,
             self.cache,
             self.verified_blocks,
-            self.compression,
+            compression,
         )
     }
 }
@@ -190,7 +191,6 @@ impl ValueBlockCache<ArcBytes> for ArcBlockCacheReader<'_> {
 /// Iteration-path: lightweight single-entry cache for sequential reads.
 struct RcBlockCacheReader<'a> {
     cache: &'a mut Option<(u16, RcBytes)>,
-    compression: Compression,
 }
 
 impl ValueBlockCache<RcBytes> for RcBlockCacheReader<'_> {
@@ -199,13 +199,14 @@ impl ValueBlockCache<RcBytes> for RcBlockCacheReader<'_> {
         mmap: &Rc<Mmap>,
         meta: &StaticSortedFileMetaData,
         block_index: u16,
+        compression: Compression,
     ) -> Result<RcBytes> {
         if let Some((idx, block)) = self.cache.as_ref()
             && *idx == block_index
         {
             return Ok(block.clone());
         }
-        let block: RcBytes = read_block_generic(mmap, meta, block_index, self.compression)?;
+        let block: RcBytes = read_block_generic(mmap, meta, block_index, compression)?;
         *self.cache = Some((block_index, block.clone()));
         Ok(block)
     }
@@ -315,7 +316,6 @@ impl StaticSortedFile {
         let reader = ArcBlockCacheReader {
             cache: value_block_cache,
             verified_blocks: &self.verified_blocks,
-            compression: self.compression,
         };
         let block_type = be::read_u8(&key_block_arc);
         match block_type {
@@ -749,7 +749,7 @@ fn handle_key_match_generic<B: SharedBytes>(
             let size = be::read_u16(&val[2..]) as usize;
             let position = be::read_u32(&val[4..]) as usize;
             let value = reader
-                .get_or_read(mmap, meta, block)?
+                .get_or_read(mmap, meta, block, compression)?
                 .slice(position..position + size);
             LookupValue::Slice { value }
         }
@@ -1009,7 +1009,6 @@ impl StaticSortedFileIter {
                         self.compression,
                         RcBlockCacheReader {
                             cache: &mut self.value_block_cache,
-                            compression: self.compression,
                         },
                     )?
                     .into()

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -20,7 +20,7 @@ use crate::{
     Compression, QueryKey,
     arc_bytes::ArcBytes,
     be,
-    compression::{DecompressionPool, checksum_block},
+    compression::{DecompressionContext, checksum_block},
     constants::MAX_INLINE_VALUE_SIZE,
     lookup_entry::{IterValue, LookupEntry, LookupValue},
     mmap_helper::advise_mmap_for_persistence,
@@ -165,7 +165,7 @@ struct ArcBlockCacheReader<'a> {
     cache: &'a BlockCache,
     verified_blocks: &'a [AtomicU64],
     compression: Compression,
-    decompression_pool: &'a DecompressionPool,
+    decompression_context: &'a DecompressionContext,
 }
 
 /// Lookup-path: concurrent `BlockCache` with uncompressed-bypass and
@@ -184,7 +184,7 @@ impl ValueBlockCache<ArcBytes> for ArcBlockCacheReader<'_> {
             self.cache,
             self.verified_blocks,
             self.compression,
-            self.decompression_pool,
+            self.decompression_context,
         )
     }
 }
@@ -193,7 +193,7 @@ impl ValueBlockCache<ArcBytes> for ArcBlockCacheReader<'_> {
 struct RcBlockCacheReader<'a> {
     cache: &'a mut Option<(u16, RcBytes)>,
     compression: Compression,
-    decompression_pool: &'a DecompressionPool,
+    decompression_context: &'a DecompressionContext,
 }
 
 impl ValueBlockCache<RcBytes> for RcBlockCacheReader<'_> {
@@ -213,7 +213,7 @@ impl ValueBlockCache<RcBytes> for RcBlockCacheReader<'_> {
             meta,
             block_index,
             self.compression,
-            self.decompression_pool,
+            self.decompression_context,
         )?;
         *self.cache = Some((block_index, block.clone()));
         Ok(block)
@@ -249,7 +249,7 @@ pub struct StaticSortedFile {
     /// suffices: racing first-time verifications are idempotent.
     verified_blocks: Box<[AtomicU64]>,
     compression: Compression,
-    decompression_pool: Arc<DecompressionPool>,
+    decompression_context: Arc<DecompressionContext>,
 }
 
 impl StaticSortedFile {
@@ -260,8 +260,8 @@ impl StaticSortedFile {
         Self::open_with_compression(
             db_path,
             meta,
-            Compression::Lz4,
-            Arc::new(DecompressionPool::default()),
+            Compression::lz4(),
+            Arc::new(DecompressionContext::default()),
         )
     }
 
@@ -269,7 +269,7 @@ impl StaticSortedFile {
         db_path: &Path,
         meta: StaticSortedFileMetaData,
         compression: Compression,
-        decompression_pool: Arc<DecompressionPool>,
+        decompression_context: Arc<DecompressionContext>,
     ) -> Result<Self> {
         let filename = format!("{:08}.sst", meta.sequence_number);
         let path = db_path.join(&filename);
@@ -297,7 +297,7 @@ impl StaticSortedFile {
             mmap: Arc::new(mmap),
             verified_blocks,
             compression,
-            decompression_pool,
+            decompression_context,
         })
     }
 
@@ -323,7 +323,7 @@ impl StaticSortedFile {
             key_block_cache,
             &self.verified_blocks,
             self.compression,
-            &self.decompression_pool,
+            &self.decompression_context,
         )?;
         let key_block_index = self.lookup_index_block(&index_block, key_hash)?;
 
@@ -334,13 +334,13 @@ impl StaticSortedFile {
             key_block_cache,
             &self.verified_blocks,
             self.compression,
-            &self.decompression_pool,
+            &self.decompression_context,
         )?;
         let reader = ArcBlockCacheReader {
             cache: value_block_cache,
             verified_blocks: &self.verified_blocks,
             compression: self.compression,
-            decompression_pool: &self.decompression_pool,
+            decompression_context: &self.decompression_context,
         };
         let block_type = be::read_u8(&key_block_arc);
         match block_type {
@@ -545,7 +545,7 @@ impl StaticSortedFile {
             val,
             key_block_arc,
             self.compression,
-            &self.decompression_pool,
+            &self.decompression_context,
             reader,
         )
     }
@@ -566,7 +566,7 @@ fn get_or_cache_block(
     cache: &BlockCache,
     verified_blocks: &[AtomicU64],
     compression: Compression,
-    decompression_pool: &DecompressionPool,
+    decompression_context: &DecompressionContext,
 ) -> Result<ArcBytes> {
     let (uncompressed_length, checksum, block_data) = get_raw_block_slice(mmap, meta, block_index)
         .with_context(|| {
@@ -592,7 +592,7 @@ fn get_or_cache_block(
                 // benefits from the bitmap to skip redundant CRC verification.
                 verify_checksum_once(meta, block_data, checksum, block_index, verified_blocks)?;
                 let block = ArcBytes::from_decompressed(
-                    decompression_pool,
+                    decompression_context,
                     compression,
                     uncompressed_length,
                     block_data,
@@ -737,7 +737,7 @@ fn read_block_generic<B: SharedBytes>(
     meta: &StaticSortedFileMetaData,
     block_index: u16,
     compression: Compression,
-    decompression_pool: &DecompressionPool,
+    decompression_context: &DecompressionContext,
 ) -> Result<B> {
     let (uncompressed_length, expected_checksum, block) =
         get_raw_block_slice(mmap, meta, block_index).with_context(|| {
@@ -754,13 +754,18 @@ fn read_block_generic<B: SharedBytes>(
         return Ok(unsafe { B::from_mmap(mmap, block) });
     }
 
-    let buffer = B::from_decompressed(decompression_pool, compression, uncompressed_length, block)
-        .with_context(|| {
-            format!(
-                "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
-                block_index, meta.sequence_number, uncompressed_length
-            )
-        })?;
+    let buffer = B::from_decompressed(
+        decompression_context,
+        compression,
+        uncompressed_length,
+        block,
+    )
+    .with_context(|| {
+        format!(
+            "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
+            block_index, meta.sequence_number, uncompressed_length
+        )
+    })?;
     Ok(buffer)
 }
 
@@ -772,7 +777,7 @@ fn handle_key_match_generic<B: SharedBytes>(
     val: &[u8],
     key_block: &B,
     compression: Compression,
-    decompression_pool: &DecompressionPool,
+    decompression_context: &DecompressionContext,
     reader: impl ValueBlockCache<B>,
 ) -> Result<LookupValue<B>> {
     Ok(match ty {
@@ -787,7 +792,7 @@ fn handle_key_match_generic<B: SharedBytes>(
         }
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
             let block = be::read_u16(val);
-            let value = read_block_generic(mmap, meta, block, compression, decompression_pool)?;
+            let value = read_block_generic(mmap, meta, block, compression, decompression_context)?;
             LookupValue::Slice { value }
         }
         KEY_BLOCK_ENTRY_TYPE_BLOB => {
@@ -832,7 +837,7 @@ pub struct StaticSortedFileIter {
     /// just the current one avoids redundant decompression.
     value_block_cache: Option<(u16, RcBytes)>,
     compression: Compression,
-    decompression_pool: Arc<DecompressionPool>,
+    decompression_context: Arc<DecompressionContext>,
 }
 
 enum CurrentKeyBlockKind {
@@ -874,8 +879,8 @@ impl StaticSortedFileIter {
         Self::open_with_compression(
             db_path,
             meta,
-            Compression::Lz4,
-            Arc::new(DecompressionPool::default()),
+            Compression::lz4(),
+            Arc::new(DecompressionContext::default()),
         )
     }
 
@@ -883,7 +888,7 @@ impl StaticSortedFileIter {
         db_path: &Path,
         meta: StaticSortedFileMetaData,
         compression: Compression,
-        decompression_pool: Arc<DecompressionPool>,
+        decompression_context: Arc<DecompressionContext>,
     ) -> Result<Self> {
         let filename = format!("{:08}.sst", meta.sequence_number);
         let path = db_path.join(&filename);
@@ -898,7 +903,7 @@ impl StaticSortedFileIter {
         #[cfg(unix)]
         mmap.advise(memmap2::Advice::Sequential)?;
         advise_mmap_for_persistence(&mmap)?;
-        Self::new(Rc::new(mmap), meta, compression, decompression_pool)
+        Self::new(Rc::new(mmap), meta, compression, decompression_context)
             .with_context(|| format!("Unable to open static sorted file {filename}"))
     }
 
@@ -906,7 +911,7 @@ impl StaticSortedFileIter {
         mmap: Rc<Mmap>,
         meta: StaticSortedFileMetaData,
         compression: Compression,
-        decompression_pool: Arc<DecompressionPool>,
+        decompression_context: Arc<DecompressionContext>,
     ) -> Result<Self> {
         let root_block_index = meta.block_count - 1;
         let block: RcBytes = read_block_generic(
@@ -914,7 +919,7 @@ impl StaticSortedFileIter {
             &meta,
             root_block_index,
             compression,
-            &decompression_pool,
+            &decompression_context,
         )?;
         let block_type = block[0];
 
@@ -934,8 +939,13 @@ impl StaticSortedFileIter {
             - size_of::<u16>())
             / INDEX_BLOCK_ENTRY_SIZE;
 
-        let current_key_block =
-            Self::parse_key_block(&mmap, &meta, first_child, compression, &decompression_pool)?;
+        let current_key_block = Self::parse_key_block(
+            &mmap,
+            &meta,
+            first_child,
+            compression,
+            &decompression_context,
+        )?;
         Ok(StaticSortedFileIter {
             mmap,
             meta,
@@ -945,7 +955,7 @@ impl StaticSortedFileIter {
             current_key_block,
             value_block_cache: None,
             compression,
-            decompression_pool,
+            decompression_context,
         })
     }
 
@@ -955,10 +965,10 @@ impl StaticSortedFileIter {
         meta: &StaticSortedFileMetaData,
         block_index: u16,
         compression: Compression,
-        decompression_pool: &DecompressionPool,
+        decompression_context: &DecompressionContext,
     ) -> Result<CurrentKeyBlock> {
         let block: RcBytes =
-            read_block_generic(mmap, meta, block_index, compression, decompression_pool)?;
+            read_block_generic(mmap, meta, block_index, compression, decompression_context)?;
         let data = &*block;
         ensure!(data.len() >= 4, "key block too short");
         let block_type = data[0];
@@ -1062,11 +1072,11 @@ impl StaticSortedFileIter {
                         val,
                         &kb.entries,
                         self.compression,
-                        &self.decompression_pool,
+                        &self.decompression_context,
                         RcBlockCacheReader {
                             cache: &mut self.value_block_cache,
                             compression: self.compression,
-                            decompression_pool: &self.decompression_pool,
+                            decompression_context: &self.decompression_context,
                         },
                     )?
                     .into()
@@ -1088,7 +1098,7 @@ impl StaticSortedFileIter {
                     &self.meta,
                     block_index,
                     self.compression,
-                    &self.decompression_pool,
+                    &self.decompression_context,
                 )?;
             } else {
                 return Ok(None);

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -17,7 +17,7 @@ use rustc_hash::FxHasher;
 use smallvec::SmallVec;
 
 use crate::{
-    QueryKey,
+    Compression, QueryKey,
     arc_bytes::ArcBytes,
     be,
     compression::checksum_block,
@@ -164,6 +164,7 @@ trait ValueBlockCache<B: SharedBytes> {
 struct ArcBlockCacheReader<'a> {
     cache: &'a BlockCache,
     verified_blocks: &'a [AtomicU64],
+    compression: Compression,
 }
 
 /// Lookup-path: concurrent `BlockCache` with uncompressed-bypass and
@@ -175,25 +176,37 @@ impl ValueBlockCache<ArcBytes> for ArcBlockCacheReader<'_> {
         meta: &StaticSortedFileMetaData,
         block_index: u16,
     ) -> Result<ArcBytes> {
-        get_or_cache_block(mmap, meta, block_index, self.cache, self.verified_blocks)
+        get_or_cache_block(
+            mmap,
+            meta,
+            block_index,
+            self.cache,
+            self.verified_blocks,
+            self.compression,
+        )
     }
 }
 
 /// Iteration-path: lightweight single-entry cache for sequential reads.
-impl ValueBlockCache<RcBytes> for &mut Option<(u16, RcBytes)> {
+struct RcBlockCacheReader<'a> {
+    cache: &'a mut Option<(u16, RcBytes)>,
+    compression: Compression,
+}
+
+impl ValueBlockCache<RcBytes> for RcBlockCacheReader<'_> {
     fn get_or_read(
         self,
         mmap: &Rc<Mmap>,
         meta: &StaticSortedFileMetaData,
         block_index: u16,
     ) -> Result<RcBytes> {
-        if let Some((idx, block)) = self.as_ref()
+        if let Some((idx, block)) = self.cache.as_ref()
             && *idx == block_index
         {
             return Ok(block.clone());
         }
-        let block: RcBytes = read_block_generic(mmap, meta, block_index)?;
-        *self = Some((block_index, block.clone()));
+        let block: RcBytes = read_block_generic(mmap, meta, block_index, self.compression)?;
+        *self.cache = Some((block_index, block.clone()));
         Ok(block)
     }
 }
@@ -226,12 +239,22 @@ pub struct StaticSortedFile {
     /// bitmap the CRC would be re-computed on every access. `Relaxed` ordering
     /// suffices: racing first-time verifications are idempotent.
     verified_blocks: Box<[AtomicU64]>,
+    compression: Compression,
 }
 
 impl StaticSortedFile {
-    /// Opens an SST file at the given path. This memory maps the file, but does not read it yet.
-    /// It's lazy read on demand.
+    /// Opens an LZ4-compressed SST file at the given path. This memory maps the file, but does not
+    /// read it yet. Databases with per-family compression use the configuration-aware internal
+    /// constructor instead.
     pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
+        Self::open_with_compression(db_path, meta, Compression::Lz4)
+    }
+
+    pub(crate) fn open_with_compression(
+        db_path: &Path,
+        meta: StaticSortedFileMetaData,
+        compression: Compression,
+    ) -> Result<Self> {
         let filename = format!("{:08}.sst", meta.sequence_number);
         let path = db_path.join(&filename);
         let file = File::open(&path)?;
@@ -257,6 +280,7 @@ impl StaticSortedFile {
             meta,
             mmap: Arc::new(mmap),
             verified_blocks,
+            compression,
         })
     }
 
@@ -281,6 +305,7 @@ impl StaticSortedFile {
             index_block_index,
             key_block_cache,
             &self.verified_blocks,
+            self.compression,
         )?;
         let key_block_index = self.lookup_index_block(&index_block, key_hash)?;
 
@@ -290,10 +315,12 @@ impl StaticSortedFile {
             key_block_index,
             key_block_cache,
             &self.verified_blocks,
+            self.compression,
         )?;
         let reader = ArcBlockCacheReader {
             cache: value_block_cache,
             verified_blocks: &self.verified_blocks,
+            compression: self.compression,
         };
         let block_type = be::read_u8(&key_block_arc);
         match block_type {
@@ -491,7 +518,15 @@ impl StaticSortedFile {
         key_block_arc: &ArcBytes,
         reader: ArcBlockCacheReader<'_>,
     ) -> Result<LookupValue> {
-        handle_key_match_generic(&self.mmap, &self.meta, ty, val, key_block_arc, reader)
+        handle_key_match_generic(
+            &self.mmap,
+            &self.meta,
+            ty,
+            val,
+            key_block_arc,
+            self.compression,
+            reader,
+        )
     }
 }
 
@@ -509,6 +544,7 @@ fn get_or_cache_block(
     block_index: u16,
     cache: &BlockCache,
     verified_blocks: &[AtomicU64],
+    compression: Compression,
 ) -> Result<ArcBytes> {
     let (uncompressed_length, checksum, block_data) = get_raw_block_slice(mmap, meta, block_index)
         .with_context(|| {
@@ -533,13 +569,15 @@ fn get_or_cache_block(
                 // A cached block may have been evicted, so re-reading still
                 // benefits from the bitmap to skip redundant CRC verification.
                 verify_checksum_once(meta, block_data, checksum, block_index, verified_blocks)?;
-                let block = ArcBytes::from_decompressed(uncompressed_length, block_data)
-                    .with_context(|| {
-                        format!(
-                            "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
-                            block_index, meta.sequence_number, uncompressed_length
-                        )
-                    })?;
+                let block =
+                    ArcBytes::from_decompressed(compression, uncompressed_length, block_data)
+                        .with_context(|| {
+                            format!(
+                                "Failed to decompress block {} from {:08}.sst ({} bytes \
+                                 uncompressed)",
+                                block_index, meta.sequence_number, uncompressed_length
+                            )
+                        })?;
                 let _ = guard.insert(block.clone());
                 block
             }
@@ -673,6 +711,7 @@ fn read_block_generic<B: SharedBytes>(
     mmap: &B::MmapHandle,
     meta: &StaticSortedFileMetaData,
     block_index: u16,
+    compression: Compression,
 ) -> Result<B> {
     let (uncompressed_length, expected_checksum, block) =
         get_raw_block_slice(mmap, meta, block_index).with_context(|| {
@@ -689,12 +728,13 @@ fn read_block_generic<B: SharedBytes>(
         return Ok(unsafe { B::from_mmap(mmap, block) });
     }
 
-    let buffer = B::from_decompressed(uncompressed_length, block).with_context(|| {
-        format!(
-            "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
-            block_index, meta.sequence_number, uncompressed_length
-        )
-    })?;
+    let buffer =
+        B::from_decompressed(compression, uncompressed_length, block).with_context(|| {
+            format!(
+                "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
+                block_index, meta.sequence_number, uncompressed_length
+            )
+        })?;
     Ok(buffer)
 }
 
@@ -705,6 +745,7 @@ fn handle_key_match_generic<B: SharedBytes>(
     ty: u8,
     val: &[u8],
     key_block: &B,
+    compression: Compression,
     reader: impl ValueBlockCache<B>,
 ) -> Result<LookupValue<B>> {
     Ok(match ty {
@@ -719,7 +760,7 @@ fn handle_key_match_generic<B: SharedBytes>(
         }
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
             let block = be::read_u16(val);
-            let value = read_block_generic(mmap, meta, block)?;
+            let value = read_block_generic(mmap, meta, block, compression)?;
             LookupValue::Slice { value }
         }
         KEY_BLOCK_ENTRY_TYPE_BLOB => {
@@ -763,6 +804,7 @@ pub struct StaticSortedFileIter {
     /// value blocks sequentially and don't revisit earlier blocks, so caching
     /// just the current one avoids redundant decompression.
     value_block_cache: Option<(u16, RcBytes)>,
+    compression: Compression,
 }
 
 enum CurrentKeyBlockKind {
@@ -796,10 +838,19 @@ impl Iterator for StaticSortedFileIter {
 }
 
 impl StaticSortedFileIter {
-    /// Opens an SST file for sequential iteration. Uses `MADV_SEQUENTIAL` for
-    /// read-ahead and wraps the mmap in `Rc<Mmap>` directly (no `Arc`),
-    /// eliminating all atomic refcounting during iteration.
+    /// Opens an LZ4-compressed SST file for sequential iteration. Uses `MADV_SEQUENTIAL` for
+    /// read-ahead and wraps the mmap in `Rc<Mmap>` directly (no `Arc`), eliminating all atomic
+    /// refcounting during iteration. Database compaction uses the configuration-aware internal
+    /// constructor instead.
     pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
+        Self::open_with_compression(db_path, meta, Compression::Lz4)
+    }
+
+    pub(crate) fn open_with_compression(
+        db_path: &Path,
+        meta: StaticSortedFileMetaData,
+        compression: Compression,
+    ) -> Result<Self> {
         let filename = format!("{:08}.sst", meta.sequence_number);
         let path = db_path.join(&filename);
         let file = File::open(&path)?;
@@ -813,13 +864,17 @@ impl StaticSortedFileIter {
         #[cfg(unix)]
         mmap.advise(memmap2::Advice::Sequential)?;
         advise_mmap_for_persistence(&mmap)?;
-        Self::new(Rc::new(mmap), meta)
+        Self::new(Rc::new(mmap), meta, compression)
             .with_context(|| format!("Unable to open static sorted file {filename}"))
     }
 
-    fn new(mmap: Rc<Mmap>, meta: StaticSortedFileMetaData) -> Result<Self> {
+    fn new(
+        mmap: Rc<Mmap>,
+        meta: StaticSortedFileMetaData,
+        compression: Compression,
+    ) -> Result<Self> {
         let root_block_index = meta.block_count - 1;
-        let block: RcBytes = read_block_generic(&mmap, &meta, root_block_index)?;
+        let block: RcBytes = read_block_generic(&mmap, &meta, root_block_index, compression)?;
         let block_type = block[0];
 
         // The builder always writes an index block as the root block.
@@ -838,7 +893,7 @@ impl StaticSortedFileIter {
             - size_of::<u16>())
             / INDEX_BLOCK_ENTRY_SIZE;
 
-        let current_key_block = Self::parse_key_block(&mmap, &meta, first_child)?;
+        let current_key_block = Self::parse_key_block(&mmap, &meta, first_child, compression)?;
         Ok(StaticSortedFileIter {
             mmap,
             meta,
@@ -847,6 +902,7 @@ impl StaticSortedFileIter {
             index_pos: 1,
             current_key_block,
             value_block_cache: None,
+            compression,
         })
     }
 
@@ -855,8 +911,9 @@ impl StaticSortedFileIter {
         mmap: &Rc<Mmap>,
         meta: &StaticSortedFileMetaData,
         block_index: u16,
+        compression: Compression,
     ) -> Result<CurrentKeyBlock> {
-        let block: RcBytes = read_block_generic(mmap, meta, block_index)?;
+        let block: RcBytes = read_block_generic(mmap, meta, block_index, compression)?;
         let data = &*block;
         ensure!(data.len() >= 4, "key block too short");
         let block_type = data[0];
@@ -959,7 +1016,11 @@ impl StaticSortedFileIter {
                         ty,
                         val,
                         &kb.entries,
-                        &mut self.value_block_cache,
+                        self.compression,
+                        RcBlockCacheReader {
+                            cache: &mut self.value_block_cache,
+                            compression: self.compression,
+                        },
                     )?
                     .into()
                 };
@@ -976,7 +1037,7 @@ impl StaticSortedFileIter {
                 let block_index = be::read_u16(&self.index_entries[base..]);
                 self.index_pos += 1;
                 self.current_key_block =
-                    Self::parse_key_block(&self.mmap, &self.meta, block_index)?;
+                    Self::parse_key_block(&self.mmap, &self.meta, block_index, self.compression)?;
             } else {
                 return Ok(None);
             }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -20,7 +20,7 @@ use crate::{
     Compression, QueryKey,
     arc_bytes::ArcBytes,
     be,
-    compression::checksum_block,
+    compression::{DecompressionPool, checksum_block},
     constants::MAX_INLINE_VALUE_SIZE,
     lookup_entry::{IterValue, LookupEntry, LookupValue},
     mmap_helper::advise_mmap_for_persistence,
@@ -165,6 +165,7 @@ struct ArcBlockCacheReader<'a> {
     cache: &'a BlockCache,
     verified_blocks: &'a [AtomicU64],
     compression: Compression,
+    decompression_pool: &'a DecompressionPool,
 }
 
 /// Lookup-path: concurrent `BlockCache` with uncompressed-bypass and
@@ -183,6 +184,7 @@ impl ValueBlockCache<ArcBytes> for ArcBlockCacheReader<'_> {
             self.cache,
             self.verified_blocks,
             self.compression,
+            self.decompression_pool,
         )
     }
 }
@@ -191,6 +193,7 @@ impl ValueBlockCache<ArcBytes> for ArcBlockCacheReader<'_> {
 struct RcBlockCacheReader<'a> {
     cache: &'a mut Option<(u16, RcBytes)>,
     compression: Compression,
+    decompression_pool: &'a DecompressionPool,
 }
 
 impl ValueBlockCache<RcBytes> for RcBlockCacheReader<'_> {
@@ -205,7 +208,13 @@ impl ValueBlockCache<RcBytes> for RcBlockCacheReader<'_> {
         {
             return Ok(block.clone());
         }
-        let block: RcBytes = read_block_generic(mmap, meta, block_index, self.compression)?;
+        let block: RcBytes = read_block_generic(
+            mmap,
+            meta,
+            block_index,
+            self.compression,
+            self.decompression_pool,
+        )?;
         *self.cache = Some((block_index, block.clone()));
         Ok(block)
     }
@@ -240,6 +249,7 @@ pub struct StaticSortedFile {
     /// suffices: racing first-time verifications are idempotent.
     verified_blocks: Box<[AtomicU64]>,
     compression: Compression,
+    decompression_pool: Arc<DecompressionPool>,
 }
 
 impl StaticSortedFile {
@@ -247,13 +257,19 @@ impl StaticSortedFile {
     /// read it yet. Databases with per-family compression use the configuration-aware internal
     /// constructor instead.
     pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
-        Self::open_with_compression(db_path, meta, Compression::Lz4)
+        Self::open_with_compression(
+            db_path,
+            meta,
+            Compression::Lz4,
+            Arc::new(DecompressionPool::default()),
+        )
     }
 
     pub(crate) fn open_with_compression(
         db_path: &Path,
         meta: StaticSortedFileMetaData,
         compression: Compression,
+        decompression_pool: Arc<DecompressionPool>,
     ) -> Result<Self> {
         let filename = format!("{:08}.sst", meta.sequence_number);
         let path = db_path.join(&filename);
@@ -281,6 +297,7 @@ impl StaticSortedFile {
             mmap: Arc::new(mmap),
             verified_blocks,
             compression,
+            decompression_pool,
         })
     }
 
@@ -306,6 +323,7 @@ impl StaticSortedFile {
             key_block_cache,
             &self.verified_blocks,
             self.compression,
+            &self.decompression_pool,
         )?;
         let key_block_index = self.lookup_index_block(&index_block, key_hash)?;
 
@@ -316,11 +334,13 @@ impl StaticSortedFile {
             key_block_cache,
             &self.verified_blocks,
             self.compression,
+            &self.decompression_pool,
         )?;
         let reader = ArcBlockCacheReader {
             cache: value_block_cache,
             verified_blocks: &self.verified_blocks,
             compression: self.compression,
+            decompression_pool: &self.decompression_pool,
         };
         let block_type = be::read_u8(&key_block_arc);
         match block_type {
@@ -525,6 +545,7 @@ impl StaticSortedFile {
             val,
             key_block_arc,
             self.compression,
+            &self.decompression_pool,
             reader,
         )
     }
@@ -545,6 +566,7 @@ fn get_or_cache_block(
     cache: &BlockCache,
     verified_blocks: &[AtomicU64],
     compression: Compression,
+    decompression_pool: &DecompressionPool,
 ) -> Result<ArcBytes> {
     let (uncompressed_length, checksum, block_data) = get_raw_block_slice(mmap, meta, block_index)
         .with_context(|| {
@@ -569,15 +591,18 @@ fn get_or_cache_block(
                 // A cached block may have been evicted, so re-reading still
                 // benefits from the bitmap to skip redundant CRC verification.
                 verify_checksum_once(meta, block_data, checksum, block_index, verified_blocks)?;
-                let block =
-                    ArcBytes::from_decompressed(compression, uncompressed_length, block_data)
-                        .with_context(|| {
-                            format!(
-                                "Failed to decompress block {} from {:08}.sst ({} bytes \
-                                 uncompressed)",
-                                block_index, meta.sequence_number, uncompressed_length
-                            )
-                        })?;
+                let block = ArcBytes::from_decompressed(
+                    decompression_pool,
+                    compression,
+                    uncompressed_length,
+                    block_data,
+                )
+                .with_context(|| {
+                    format!(
+                        "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
+                        block_index, meta.sequence_number, uncompressed_length
+                    )
+                })?;
                 let _ = guard.insert(block.clone());
                 block
             }
@@ -712,6 +737,7 @@ fn read_block_generic<B: SharedBytes>(
     meta: &StaticSortedFileMetaData,
     block_index: u16,
     compression: Compression,
+    decompression_pool: &DecompressionPool,
 ) -> Result<B> {
     let (uncompressed_length, expected_checksum, block) =
         get_raw_block_slice(mmap, meta, block_index).with_context(|| {
@@ -728,8 +754,8 @@ fn read_block_generic<B: SharedBytes>(
         return Ok(unsafe { B::from_mmap(mmap, block) });
     }
 
-    let buffer =
-        B::from_decompressed(compression, uncompressed_length, block).with_context(|| {
+    let buffer = B::from_decompressed(decompression_pool, compression, uncompressed_length, block)
+        .with_context(|| {
             format!(
                 "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
                 block_index, meta.sequence_number, uncompressed_length
@@ -746,6 +772,7 @@ fn handle_key_match_generic<B: SharedBytes>(
     val: &[u8],
     key_block: &B,
     compression: Compression,
+    decompression_pool: &DecompressionPool,
     reader: impl ValueBlockCache<B>,
 ) -> Result<LookupValue<B>> {
     Ok(match ty {
@@ -760,7 +787,7 @@ fn handle_key_match_generic<B: SharedBytes>(
         }
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
             let block = be::read_u16(val);
-            let value = read_block_generic(mmap, meta, block, compression)?;
+            let value = read_block_generic(mmap, meta, block, compression, decompression_pool)?;
             LookupValue::Slice { value }
         }
         KEY_BLOCK_ENTRY_TYPE_BLOB => {
@@ -805,6 +832,7 @@ pub struct StaticSortedFileIter {
     /// just the current one avoids redundant decompression.
     value_block_cache: Option<(u16, RcBytes)>,
     compression: Compression,
+    decompression_pool: Arc<DecompressionPool>,
 }
 
 enum CurrentKeyBlockKind {
@@ -843,13 +871,19 @@ impl StaticSortedFileIter {
     /// refcounting during iteration. Database compaction uses the configuration-aware internal
     /// constructor instead.
     pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
-        Self::open_with_compression(db_path, meta, Compression::Lz4)
+        Self::open_with_compression(
+            db_path,
+            meta,
+            Compression::Lz4,
+            Arc::new(DecompressionPool::default()),
+        )
     }
 
     pub(crate) fn open_with_compression(
         db_path: &Path,
         meta: StaticSortedFileMetaData,
         compression: Compression,
+        decompression_pool: Arc<DecompressionPool>,
     ) -> Result<Self> {
         let filename = format!("{:08}.sst", meta.sequence_number);
         let path = db_path.join(&filename);
@@ -864,7 +898,7 @@ impl StaticSortedFileIter {
         #[cfg(unix)]
         mmap.advise(memmap2::Advice::Sequential)?;
         advise_mmap_for_persistence(&mmap)?;
-        Self::new(Rc::new(mmap), meta, compression)
+        Self::new(Rc::new(mmap), meta, compression, decompression_pool)
             .with_context(|| format!("Unable to open static sorted file {filename}"))
     }
 
@@ -872,9 +906,16 @@ impl StaticSortedFileIter {
         mmap: Rc<Mmap>,
         meta: StaticSortedFileMetaData,
         compression: Compression,
+        decompression_pool: Arc<DecompressionPool>,
     ) -> Result<Self> {
         let root_block_index = meta.block_count - 1;
-        let block: RcBytes = read_block_generic(&mmap, &meta, root_block_index, compression)?;
+        let block: RcBytes = read_block_generic(
+            &mmap,
+            &meta,
+            root_block_index,
+            compression,
+            &decompression_pool,
+        )?;
         let block_type = block[0];
 
         // The builder always writes an index block as the root block.
@@ -893,7 +934,8 @@ impl StaticSortedFileIter {
             - size_of::<u16>())
             / INDEX_BLOCK_ENTRY_SIZE;
 
-        let current_key_block = Self::parse_key_block(&mmap, &meta, first_child, compression)?;
+        let current_key_block =
+            Self::parse_key_block(&mmap, &meta, first_child, compression, &decompression_pool)?;
         Ok(StaticSortedFileIter {
             mmap,
             meta,
@@ -903,6 +945,7 @@ impl StaticSortedFileIter {
             current_key_block,
             value_block_cache: None,
             compression,
+            decompression_pool,
         })
     }
 
@@ -912,8 +955,10 @@ impl StaticSortedFileIter {
         meta: &StaticSortedFileMetaData,
         block_index: u16,
         compression: Compression,
+        decompression_pool: &DecompressionPool,
     ) -> Result<CurrentKeyBlock> {
-        let block: RcBytes = read_block_generic(mmap, meta, block_index, compression)?;
+        let block: RcBytes =
+            read_block_generic(mmap, meta, block_index, compression, decompression_pool)?;
         let data = &*block;
         ensure!(data.len() >= 4, "key block too short");
         let block_type = data[0];
@@ -1017,9 +1062,11 @@ impl StaticSortedFileIter {
                         val,
                         &kb.entries,
                         self.compression,
+                        &self.decompression_pool,
                         RcBlockCacheReader {
                             cache: &mut self.value_block_cache,
                             compression: self.compression,
+                            decompression_pool: &self.decompression_pool,
                         },
                     )?
                     .into()
@@ -1036,8 +1083,13 @@ impl StaticSortedFileIter {
                 let base = self.index_pos * INDEX_BLOCK_ENTRY_SIZE;
                 let block_index = be::read_u16(&self.index_entries[base..]);
                 self.index_pos += 1;
-                self.current_key_block =
-                    Self::parse_key_block(&self.mmap, &self.meta, block_index, self.compression)?;
+                self.current_key_block = Self::parse_key_block(
+                    &self.mmap,
+                    &self.meta,
+                    block_index,
+                    self.compression,
+                    &self.decompression_pool,
+                )?;
             } else {
                 return Ok(None);
             }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -243,14 +243,9 @@ pub struct StaticSortedFile {
 }
 
 impl StaticSortedFile {
-    /// Opens an LZ4-compressed SST file at the given path. This memory maps the file, but does not
-    /// read it yet. Databases with per-family compression use the configuration-aware internal
-    /// constructor instead.
-    pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
-        Self::open_with_compression(db_path, meta, Compression::Lz4)
-    }
-
-    pub(crate) fn open_with_compression(
+    /// Opens an SST file at the given path with the compression algorithm specified by its meta
+    /// file. This memory maps the file, but does not read it yet.
+    pub fn open(
         db_path: &Path,
         meta: StaticSortedFileMetaData,
         compression: Compression,
@@ -838,15 +833,10 @@ impl Iterator for StaticSortedFileIter {
 }
 
 impl StaticSortedFileIter {
-    /// Opens an LZ4-compressed SST file for sequential iteration. Uses `MADV_SEQUENTIAL` for
-    /// read-ahead and wraps the mmap in `Rc<Mmap>` directly (no `Arc`), eliminating all atomic
-    /// refcounting during iteration. Database compaction uses the configuration-aware internal
-    /// constructor instead.
-    pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
-        Self::open_with_compression(db_path, meta, Compression::Lz4)
-    }
-
-    pub(crate) fn open_with_compression(
+    /// Opens an SST file for sequential iteration with the compression algorithm specified by its
+    /// meta file. Uses `MADV_SEQUENTIAL` for read-ahead and wraps the mmap in `Rc<Mmap>` directly
+    /// (no `Arc`), eliminating all atomic refcounting during iteration.
+    pub fn open(
         db_path: &Path,
         meta: StaticSortedFileMetaData,
         compression: Compression,

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -20,7 +20,7 @@ use crate::{
     Compression, QueryKey,
     arc_bytes::ArcBytes,
     be,
-    compression::{DecompressionContext, checksum_block},
+    compression::checksum_block,
     constants::MAX_INLINE_VALUE_SIZE,
     lookup_entry::{IterValue, LookupEntry, LookupValue},
     mmap_helper::advise_mmap_for_persistence,
@@ -165,7 +165,6 @@ struct ArcBlockCacheReader<'a> {
     cache: &'a BlockCache,
     verified_blocks: &'a [AtomicU64],
     compression: Compression,
-    decompression_context: &'a DecompressionContext,
 }
 
 /// Lookup-path: concurrent `BlockCache` with uncompressed-bypass and
@@ -184,7 +183,6 @@ impl ValueBlockCache<ArcBytes> for ArcBlockCacheReader<'_> {
             self.cache,
             self.verified_blocks,
             self.compression,
-            self.decompression_context,
         )
     }
 }
@@ -193,7 +191,6 @@ impl ValueBlockCache<ArcBytes> for ArcBlockCacheReader<'_> {
 struct RcBlockCacheReader<'a> {
     cache: &'a mut Option<(u16, RcBytes)>,
     compression: Compression,
-    decompression_context: &'a DecompressionContext,
 }
 
 impl ValueBlockCache<RcBytes> for RcBlockCacheReader<'_> {
@@ -208,13 +205,7 @@ impl ValueBlockCache<RcBytes> for RcBlockCacheReader<'_> {
         {
             return Ok(block.clone());
         }
-        let block: RcBytes = read_block_generic(
-            mmap,
-            meta,
-            block_index,
-            self.compression,
-            self.decompression_context,
-        )?;
+        let block: RcBytes = read_block_generic(mmap, meta, block_index, self.compression)?;
         *self.cache = Some((block_index, block.clone()));
         Ok(block)
     }
@@ -249,7 +240,6 @@ pub struct StaticSortedFile {
     /// suffices: racing first-time verifications are idempotent.
     verified_blocks: Box<[AtomicU64]>,
     compression: Compression,
-    decompression_context: Arc<DecompressionContext>,
 }
 
 impl StaticSortedFile {
@@ -257,19 +247,13 @@ impl StaticSortedFile {
     /// read it yet. Databases with per-family compression use the configuration-aware internal
     /// constructor instead.
     pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
-        Self::open_with_compression(
-            db_path,
-            meta,
-            Compression::lz4(),
-            Arc::new(DecompressionContext::default()),
-        )
+        Self::open_with_compression(db_path, meta, Compression::Lz4)
     }
 
     pub(crate) fn open_with_compression(
         db_path: &Path,
         meta: StaticSortedFileMetaData,
         compression: Compression,
-        decompression_context: Arc<DecompressionContext>,
     ) -> Result<Self> {
         let filename = format!("{:08}.sst", meta.sequence_number);
         let path = db_path.join(&filename);
@@ -297,7 +281,6 @@ impl StaticSortedFile {
             mmap: Arc::new(mmap),
             verified_blocks,
             compression,
-            decompression_context,
         })
     }
 
@@ -323,7 +306,6 @@ impl StaticSortedFile {
             key_block_cache,
             &self.verified_blocks,
             self.compression,
-            &self.decompression_context,
         )?;
         let key_block_index = self.lookup_index_block(&index_block, key_hash)?;
 
@@ -334,13 +316,11 @@ impl StaticSortedFile {
             key_block_cache,
             &self.verified_blocks,
             self.compression,
-            &self.decompression_context,
         )?;
         let reader = ArcBlockCacheReader {
             cache: value_block_cache,
             verified_blocks: &self.verified_blocks,
             compression: self.compression,
-            decompression_context: &self.decompression_context,
         };
         let block_type = be::read_u8(&key_block_arc);
         match block_type {
@@ -545,7 +525,6 @@ impl StaticSortedFile {
             val,
             key_block_arc,
             self.compression,
-            &self.decompression_context,
             reader,
         )
     }
@@ -566,7 +545,6 @@ fn get_or_cache_block(
     cache: &BlockCache,
     verified_blocks: &[AtomicU64],
     compression: Compression,
-    decompression_context: &DecompressionContext,
 ) -> Result<ArcBytes> {
     let (uncompressed_length, checksum, block_data) = get_raw_block_slice(mmap, meta, block_index)
         .with_context(|| {
@@ -591,18 +569,15 @@ fn get_or_cache_block(
                 // A cached block may have been evicted, so re-reading still
                 // benefits from the bitmap to skip redundant CRC verification.
                 verify_checksum_once(meta, block_data, checksum, block_index, verified_blocks)?;
-                let block = ArcBytes::from_decompressed(
-                    decompression_context,
-                    compression,
-                    uncompressed_length,
-                    block_data,
-                )
-                .with_context(|| {
-                    format!(
-                        "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
-                        block_index, meta.sequence_number, uncompressed_length
-                    )
-                })?;
+                let block =
+                    ArcBytes::from_decompressed(compression, uncompressed_length, block_data)
+                        .with_context(|| {
+                            format!(
+                                "Failed to decompress block {} from {:08}.sst ({} bytes \
+                                 uncompressed)",
+                                block_index, meta.sequence_number, uncompressed_length
+                            )
+                        })?;
                 let _ = guard.insert(block.clone());
                 block
             }
@@ -737,7 +712,6 @@ fn read_block_generic<B: SharedBytes>(
     meta: &StaticSortedFileMetaData,
     block_index: u16,
     compression: Compression,
-    decompression_context: &DecompressionContext,
 ) -> Result<B> {
     let (uncompressed_length, expected_checksum, block) =
         get_raw_block_slice(mmap, meta, block_index).with_context(|| {
@@ -754,18 +728,13 @@ fn read_block_generic<B: SharedBytes>(
         return Ok(unsafe { B::from_mmap(mmap, block) });
     }
 
-    let buffer = B::from_decompressed(
-        decompression_context,
-        compression,
-        uncompressed_length,
-        block,
-    )
-    .with_context(|| {
-        format!(
-            "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
-            block_index, meta.sequence_number, uncompressed_length
-        )
-    })?;
+    let buffer =
+        B::from_decompressed(compression, uncompressed_length, block).with_context(|| {
+            format!(
+                "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
+                block_index, meta.sequence_number, uncompressed_length
+            )
+        })?;
     Ok(buffer)
 }
 
@@ -777,7 +746,6 @@ fn handle_key_match_generic<B: SharedBytes>(
     val: &[u8],
     key_block: &B,
     compression: Compression,
-    decompression_context: &DecompressionContext,
     reader: impl ValueBlockCache<B>,
 ) -> Result<LookupValue<B>> {
     Ok(match ty {
@@ -792,7 +760,7 @@ fn handle_key_match_generic<B: SharedBytes>(
         }
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
             let block = be::read_u16(val);
-            let value = read_block_generic(mmap, meta, block, compression, decompression_context)?;
+            let value = read_block_generic(mmap, meta, block, compression)?;
             LookupValue::Slice { value }
         }
         KEY_BLOCK_ENTRY_TYPE_BLOB => {
@@ -837,7 +805,6 @@ pub struct StaticSortedFileIter {
     /// just the current one avoids redundant decompression.
     value_block_cache: Option<(u16, RcBytes)>,
     compression: Compression,
-    decompression_context: Arc<DecompressionContext>,
 }
 
 enum CurrentKeyBlockKind {
@@ -876,19 +843,13 @@ impl StaticSortedFileIter {
     /// refcounting during iteration. Database compaction uses the configuration-aware internal
     /// constructor instead.
     pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
-        Self::open_with_compression(
-            db_path,
-            meta,
-            Compression::lz4(),
-            Arc::new(DecompressionContext::default()),
-        )
+        Self::open_with_compression(db_path, meta, Compression::Lz4)
     }
 
     pub(crate) fn open_with_compression(
         db_path: &Path,
         meta: StaticSortedFileMetaData,
         compression: Compression,
-        decompression_context: Arc<DecompressionContext>,
     ) -> Result<Self> {
         let filename = format!("{:08}.sst", meta.sequence_number);
         let path = db_path.join(&filename);
@@ -903,7 +864,7 @@ impl StaticSortedFileIter {
         #[cfg(unix)]
         mmap.advise(memmap2::Advice::Sequential)?;
         advise_mmap_for_persistence(&mmap)?;
-        Self::new(Rc::new(mmap), meta, compression, decompression_context)
+        Self::new(Rc::new(mmap), meta, compression)
             .with_context(|| format!("Unable to open static sorted file {filename}"))
     }
 
@@ -911,16 +872,9 @@ impl StaticSortedFileIter {
         mmap: Rc<Mmap>,
         meta: StaticSortedFileMetaData,
         compression: Compression,
-        decompression_context: Arc<DecompressionContext>,
     ) -> Result<Self> {
         let root_block_index = meta.block_count - 1;
-        let block: RcBytes = read_block_generic(
-            &mmap,
-            &meta,
-            root_block_index,
-            compression,
-            &decompression_context,
-        )?;
+        let block: RcBytes = read_block_generic(&mmap, &meta, root_block_index, compression)?;
         let block_type = block[0];
 
         // The builder always writes an index block as the root block.
@@ -939,13 +893,7 @@ impl StaticSortedFileIter {
             - size_of::<u16>())
             / INDEX_BLOCK_ENTRY_SIZE;
 
-        let current_key_block = Self::parse_key_block(
-            &mmap,
-            &meta,
-            first_child,
-            compression,
-            &decompression_context,
-        )?;
+        let current_key_block = Self::parse_key_block(&mmap, &meta, first_child, compression)?;
         Ok(StaticSortedFileIter {
             mmap,
             meta,
@@ -955,7 +903,6 @@ impl StaticSortedFileIter {
             current_key_block,
             value_block_cache: None,
             compression,
-            decompression_context,
         })
     }
 
@@ -965,10 +912,8 @@ impl StaticSortedFileIter {
         meta: &StaticSortedFileMetaData,
         block_index: u16,
         compression: Compression,
-        decompression_context: &DecompressionContext,
     ) -> Result<CurrentKeyBlock> {
-        let block: RcBytes =
-            read_block_generic(mmap, meta, block_index, compression, decompression_context)?;
+        let block: RcBytes = read_block_generic(mmap, meta, block_index, compression)?;
         let data = &*block;
         ensure!(data.len() >= 4, "key block too short");
         let block_type = data[0];
@@ -1072,11 +1017,9 @@ impl StaticSortedFileIter {
                         val,
                         &kb.entries,
                         self.compression,
-                        &self.decompression_context,
                         RcBlockCacheReader {
                             cache: &mut self.value_block_cache,
                             compression: self.compression,
-                            decompression_context: &self.decompression_context,
                         },
                     )?
                     .into()
@@ -1093,13 +1036,8 @@ impl StaticSortedFileIter {
                 let base = self.index_pos * INDEX_BLOCK_ENTRY_SIZE;
                 let block_index = be::read_u16(&self.index_entries[base..]);
                 self.index_pos += 1;
-                self.current_key_block = Self::parse_key_block(
-                    &self.mmap,
-                    &self.meta,
-                    block_index,
-                    self.compression,
-                    &self.decompression_context,
-                )?;
+                self.current_key_block =
+                    Self::parse_key_block(&self.mmap, &self.meta, block_index, self.compression)?;
             } else {
                 return Ok(None);
             }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -10,7 +10,8 @@ use byteorder::{BE, ByteOrder, WriteBytesExt};
 use fs_err::File;
 
 use crate::{
-    compression::{checksum_block, compress_into_buffer},
+    Compression,
+    compression::{Compressor, checksum_block},
     constants::{MAX_INLINE_VALUE_SIZE, MAX_SMALL_VALUE_SIZE, MIN_SMALL_VALUE_BLOCK_SIZE},
     meta_file::MetaEntryFlags,
     static_sorted_file::{
@@ -299,10 +300,11 @@ pub struct StaticSortedFileBuilderMeta<'a> {
     pub entries: u64,
 }
 
-/// Writes an SST file from a pre-sorted slice of entries.
+/// Writes an LZ4-compressed SST file from a pre-sorted slice of entries.
 ///
 /// This is a convenience wrapper around [`StreamingSstWriter`] for callers that already have all
-/// entries in memory.
+/// entries in memory. Databases with per-family compression use the configuration-aware internal
+/// wrapper instead.
 // TODO: Consider adding a variant that takes ownership (Vec<E> or drain iterator)
 // to free entry memory as blocks are written.
 pub fn write_static_stored_file<E: Entry>(
@@ -310,8 +312,18 @@ pub fn write_static_stored_file<E: Entry>(
     file: &Path,
     flags: MetaEntryFlags,
 ) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
+    write_static_stored_file_with_compression(entries, file, flags, Compression::Lz4)
+}
+
+pub(crate) fn write_static_stored_file_with_compression<E: Entry>(
+    entries: &[E],
+    file: &Path,
+    flags: MetaEntryFlags,
+    compression: Compression,
+) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
     debug_assert!(entries.iter().map(|e| e.key_hash()).is_sorted());
-    let mut writer = StreamingSstWriter::new(file, flags, entries.len() as u64)?;
+    let mut writer =
+        StreamingSstWriter::new_with_compression(file, flags, entries.len() as u64, compression)?;
     for entry in entries {
         writer.add(entry)?;
     }
@@ -363,9 +375,10 @@ fn write_block_to_file(
     block_offsets: &mut Vec<u32>,
     block: &[u8],
     try_compress: bool,
+    compressor: &mut Compressor,
 ) -> Result<u16> {
     let (uncompressed_size, data_to_write): (u32, &[u8]) = if try_compress {
-        compress_into_buffer(block, compress_buffer)?;
+        compressor.compress_into_buffer(block, compress_buffer)?;
         // Same threshold as LevelDB/RocksDB: require at least 12.5% savings.
         if compress_buffer.len() < block.len() - (block.len() / 8) {
             (block.len().try_into().unwrap(), compress_buffer.as_slice())
@@ -505,6 +518,7 @@ pub struct StreamingSstWriter<E: Entry> {
     file: Option<BufWriter<File>>,
     compress_buffer: Vec<u8>,
     block_offsets: Vec<u32>,
+    compressor: Compressor,
 
     /// Pending key entries waiting to be flushed as key blocks.
     ///
@@ -575,11 +589,22 @@ pub struct StreamingSstWriter<E: Entry> {
 }
 
 impl<E: Entry> StreamingSstWriter<E> {
-    /// Creates a new streaming SST writer.
+    /// Creates a new streaming SST writer using LZ4 compression.
     ///
-    /// `max_entry_count` is used to pre-allocate buffers and estimate block counts.
+    /// `max_entry_count` is used to pre-allocate buffers and estimate block counts. Databases with
+    /// per-family compression use the configuration-aware internal constructor instead.
     pub fn new(file: &Path, flags: MetaEntryFlags, max_entry_count: u64) -> Result<Self> {
+        Self::new_with_compression(file, flags, max_entry_count, Compression::Lz4)
+    }
+
+    pub(crate) fn new_with_compression(
+        file: &Path,
+        flags: MetaEntryFlags,
+        max_entry_count: u64,
+        compression: Compression,
+    ) -> Result<Self> {
         let file = BufWriter::new(File::create(file)?);
+        let compressor = Compressor::new(compression)?;
 
         // Estimate number of key blocks based on max entry count.
         // Each key block holds up to MAX_KEY_BLOCK_ENTRIES entries.
@@ -598,6 +623,7 @@ impl<E: Entry> StreamingSstWriter<E> {
             file: Some(file),
             compress_buffer: Vec::with_capacity(MIN_SMALL_VALUE_BLOCK_SIZE + MAX_SMALL_VALUE_SIZE),
             block_offsets: Vec::with_capacity(estimated_total_blocks),
+            compressor,
             pending_keys: VecDeque::with_capacity(entries_per_value_block),
             first_pending_small_index: 0,
             #[cfg(debug_assertions)]
@@ -681,6 +707,7 @@ impl<E: Entry> StreamingSstWriter<E> {
                     &mut self.block_offsets,
                     value,
                     true,
+                    &mut self.compressor,
                 )
                 .context("Failed to write value block")?;
                 ValueRef::Medium { block_index }
@@ -838,6 +865,7 @@ impl<E: Entry> StreamingSstWriter<E> {
             &mut self.block_offsets,
             &self.pending_small_value_block,
             true,
+            &mut self.compressor,
         )
         .context("Failed to write small value block")?;
 
@@ -930,6 +958,7 @@ impl<E: Entry> StreamingSstWriter<E> {
             &mut self.block_offsets,
             &self.key_buffer,
             try_compress,
+            &mut self.compressor,
         )
         .context("Failed to write key block")?;
         self.key_block_boundaries.push((first_hash, block_index));

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -1461,6 +1461,7 @@ mod tests {
                 sequence_number: seq,
                 block_count: meta.block_count,
             },
+            Compression::Lz4,
         )
     }
 
@@ -1798,6 +1799,7 @@ mod tests {
                 sequence_number: 1,
                 block_count: meta1.block_count,
             },
+            Compression::Lz4,
         )?;
         let sst2 = StaticSortedFile::open(
             dir.path(),
@@ -1805,6 +1807,7 @@ mod tests {
                 sequence_number: 2,
                 block_count: meta2.block_count,
             },
+            Compression::Lz4,
         )?;
         let kc = make_cache();
         let vc = make_cache();

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -300,30 +300,20 @@ pub struct StaticSortedFileBuilderMeta<'a> {
     pub entries: u64,
 }
 
-/// Writes an LZ4-compressed SST file from a pre-sorted slice of entries.
+/// Writes an SST file from a pre-sorted slice of entries.
 ///
 /// This is a convenience wrapper around [`StreamingSstWriter`] for callers that already have all
-/// entries in memory. Databases with per-family compression use the configuration-aware internal
-/// wrapper instead.
+/// entries in memory.
 // TODO: Consider adding a variant that takes ownership (Vec<E> or drain iterator)
 // to free entry memory as blocks are written.
 pub fn write_static_stored_file<E: Entry>(
     entries: &[E],
     file: &Path,
     flags: MetaEntryFlags,
-) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
-    write_static_stored_file_with_compression(entries, file, flags, Compression::Lz4)
-}
-
-pub(crate) fn write_static_stored_file_with_compression<E: Entry>(
-    entries: &[E],
-    file: &Path,
-    flags: MetaEntryFlags,
     compression: Compression,
 ) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
     debug_assert!(entries.iter().map(|e| e.key_hash()).is_sorted());
-    let mut writer =
-        StreamingSstWriter::new_with_compression(file, flags, entries.len() as u64, compression)?;
+    let mut writer = StreamingSstWriter::new(file, flags, entries.len() as u64, compression)?;
     for entry in entries {
         writer.add(entry)?;
     }
@@ -589,15 +579,10 @@ pub struct StreamingSstWriter<E: Entry> {
 }
 
 impl<E: Entry> StreamingSstWriter<E> {
-    /// Creates a new streaming SST writer using LZ4 compression.
+    /// Creates a new streaming SST writer.
     ///
-    /// `max_entry_count` is used to pre-allocate buffers and estimate block counts. Databases with
-    /// per-family compression use the configuration-aware internal constructor instead.
-    pub fn new(file: &Path, flags: MetaEntryFlags, max_entry_count: u64) -> Result<Self> {
-        Self::new_with_compression(file, flags, max_entry_count, Compression::Lz4)
-    }
-
-    pub(crate) fn new_with_compression(
+    /// `max_entry_count` is used to pre-allocate buffers and estimate block counts.
+    pub fn new(
         file: &Path,
         flags: MetaEntryFlags,
         max_entry_count: u64,
@@ -1473,7 +1458,8 @@ mod tests {
         flags: MetaEntryFlags,
     ) -> Result<StaticSortedFileBuilderMeta<'static>> {
         let sst_path = dir.join(format!("{seq:08}.sst"));
-        let mut writer = StreamingSstWriter::new(&sst_path, flags, entries.len() as u64)?;
+        let mut writer =
+            StreamingSstWriter::new(&sst_path, flags, entries.len() as u64, Compression::Lz4)?;
         for entry in entries {
             writer.add(entry)?;
         }
@@ -1709,7 +1695,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sst_path = dir.path().join("test.sst");
         let mut writer =
-            StreamingSstWriter::new(&sst_path, MetaEntryFlags::default(), 100).unwrap();
+            StreamingSstWriter::new(&sst_path, MetaEntryFlags::default(), 100, Compression::Lz4)
+                .unwrap();
 
         let max_entries = 50;
         for i in 0..max_entries {
@@ -1735,7 +1722,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let sst_path = dir.path().join("test.sst");
         let mut writer =
-            StreamingSstWriter::new(&sst_path, MetaEntryFlags::default(), 100).unwrap();
+            StreamingSstWriter::new(&sst_path, MetaEntryFlags::default(), 100, Compression::Lz4)
+                .unwrap();
 
         let value = vec![0u8; 1000];
         for i in 0..10 {
@@ -1771,8 +1759,12 @@ mod tests {
 
         // Write via convenience function
         let batch_path = dir.path().join("00000001.sst");
-        let (meta1, _) =
-            write_static_stored_file(&entries, &batch_path, MetaEntryFlags::default())?;
+        let (meta1, _) = write_static_stored_file(
+            &entries,
+            &batch_path,
+            MetaEntryFlags::default(),
+            Compression::Lz4,
+        )?;
 
         // Write via streaming API
         let streaming_path = dir.path().join("00000002.sst");
@@ -1780,6 +1772,7 @@ mod tests {
             &streaming_path,
             MetaEntryFlags::default(),
             entries.len() as u64,
+            Compression::Lz4,
         )?;
         for entry in &entries {
             writer.add(entry)?;
@@ -1862,8 +1855,13 @@ mod tests {
     fn close_empty_writer_panics() {
         let dir = tempfile::tempdir().unwrap();
         let sst_path = dir.path().join("empty.sst");
-        let writer =
-            StreamingSstWriter::<TestEntry>::new(&sst_path, MetaEntryFlags::default(), 0).unwrap();
+        let writer = StreamingSstWriter::<TestEntry>::new(
+            &sst_path,
+            MetaEntryFlags::default(),
+            0,
+            Compression::Lz4,
+        )
+        .unwrap();
         writer.close().unwrap();
     }
 

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -312,7 +312,7 @@ pub fn write_static_stored_file<E: Entry>(
     file: &Path,
     flags: MetaEntryFlags,
 ) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
-    write_static_stored_file_with_compression(entries, file, flags, Compression::lz4())
+    write_static_stored_file_with_compression(entries, file, flags, Compression::Lz4)
 }
 
 pub(crate) fn write_static_stored_file_with_compression<E: Entry>(
@@ -594,7 +594,7 @@ impl<E: Entry> StreamingSstWriter<E> {
     /// `max_entry_count` is used to pre-allocate buffers and estimate block counts. Databases with
     /// per-family compression use the configuration-aware internal constructor instead.
     pub fn new(file: &Path, flags: MetaEntryFlags, max_entry_count: u64) -> Result<Self> {
-        Self::new_with_compression(file, flags, max_entry_count, Compression::lz4())
+        Self::new_with_compression(file, flags, max_entry_count, Compression::Lz4)
     }
 
     pub(crate) fn new_with_compression(

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -312,7 +312,7 @@ pub fn write_static_stored_file<E: Entry>(
     file: &Path,
     flags: MetaEntryFlags,
 ) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
-    write_static_stored_file_with_compression(entries, file, flags, Compression::Lz4)
+    write_static_stored_file_with_compression(entries, file, flags, Compression::lz4())
 }
 
 pub(crate) fn write_static_stored_file_with_compression<E: Entry>(
@@ -594,7 +594,7 @@ impl<E: Entry> StreamingSstWriter<E> {
     /// `max_entry_count` is used to pre-allocate buffers and estimate block counts. Databases with
     /// per-family compression use the configuration-aware internal constructor instead.
     pub fn new(file: &Path, flags: MetaEntryFlags, max_entry_count: u64) -> Result<Self> {
-        Self::new_with_compression(file, flags, max_entry_count, Compression::Lz4)
+        Self::new_with_compression(file, flags, max_entry_count, Compression::lz4())
     }
 
     pub(crate) fn new_with_compression(

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -1114,9 +1114,9 @@ fn batch_get_across_families() -> Result<()> {
 
     let mut config = DbConfig::default();
     config.family_configs[0].compression = Compression::Lz4;
-    config.family_configs[1].compression = Compression::Lz4Hc4;
+    config.family_configs[1].compression = Compression::Lz4;
     config.family_configs[2].compression = Compression::Zstd3;
-    config.family_configs[3].compression = Compression::Lz4Hc4;
+    config.family_configs[3].compression = Compression::Lz4;
     let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
         path.to_path_buf(),
         config.clone(),

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -2513,7 +2513,7 @@ fn count_tombstones(
                 sequence_number: entry.sequence_number,
                 block_count: entry.block_count,
             };
-            for item in StaticSortedFileIter::open(path, sst)? {
+            for item in StaticSortedFileIter::open(path, sst, Compression::Lz4)? {
                 if matches!(
                     item?.value,
                     IterValue::KeyDeleted | IterValue::KeyValueDeleted { .. }

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -1056,7 +1056,7 @@ fn batch_get_different_sizes() -> Result<()> {
     let path = tempdir.path();
 
     let mut config = DbConfig::default();
-    config.family_configs[0].compression = Compression::Zstd(3);
+    config.family_configs[0].compression = Compression::zstd_3();
     let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
         path.to_path_buf(),
         config,
@@ -1113,10 +1113,10 @@ fn batch_get_across_families() -> Result<()> {
     let path = tempdir.path();
 
     let mut config = DbConfig::default();
-    config.family_configs[0].compression = Compression::Lz4;
-    config.family_configs[1].compression = Compression::Lz4Hc(4);
-    config.family_configs[2].compression = Compression::Zstd(3);
-    config.family_configs[3].compression = Compression::Lz4Hc(4);
+    config.family_configs[0].compression = Compression::lz4();
+    config.family_configs[1].compression = Compression::lz4_hc4();
+    config.family_configs[2].compression = Compression::zstd_3();
+    config.family_configs[3].compression = Compression::lz4_hc4();
     let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
         path.to_path_buf(),
         config.clone(),
@@ -1163,10 +1163,10 @@ fn batch_get_across_families() -> Result<()> {
     // Same keys, but different values per family
     assert_ne!(results_f0[0].as_deref(), results_f1[0].as_deref());
 
-    let decompression_pool = db.decompression_pool_weak();
+    let decompression_context = db.decompression_context_weak();
     db.shutdown()?;
     drop(db);
-    assert!(decompression_pool.upgrade().is_none());
+    assert!(decompression_context.upgrade().is_none());
 
     // Reopen with the same family configuration recorded in the meta files.
     let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
@@ -1198,7 +1198,7 @@ fn batch_get_after_compaction() -> Result<()> {
     let path = tempdir.path();
 
     let mut config = DbConfig::default();
-    config.family_configs[0].compression = Compression::Zstd(3);
+    config.family_configs[0].compression = Compression::zstd_3();
     let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
         path.to_path_buf(),
         config,
@@ -1570,7 +1570,7 @@ fn multi_value_config() -> DbConfig<1> {
     config.family_configs[0] = FamilyConfig {
         name: "test",
         kind: FamilyKind::MultiValue,
-        compression: Compression::Lz4,
+        compression: Compression::lz4(),
     };
     config
 }
@@ -2150,7 +2150,7 @@ fn compaction_deletes_blob_multi_value_tombstone() -> Result<()> {
         family_configs: [FamilyConfig {
             name: "test",
             kind: FamilyKind::MultiValue,
-            compression: Compression::Lz4,
+            compression: Compression::lz4(),
         }],
     };
 

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -1163,10 +1163,12 @@ fn batch_get_across_families() -> Result<()> {
     // Same keys, but different values per family
     assert_ne!(results_f0[0].as_deref(), results_f1[0].as_deref());
 
+    let decompression_pool = db.decompression_pool_weak();
     db.shutdown()?;
     drop(db);
+    assert!(decompression_pool.upgrade().is_none());
 
-    // Reopen with the same family configuration. Compression is not signaled on disk.
+    // Reopen with the same family configuration recorded in the meta files.
     let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
         path.to_path_buf(),
         config,
@@ -1178,15 +1180,15 @@ fn batch_get_across_families() -> Result<()> {
     db.shutdown()?;
     drop(db);
 
-    // Reopening with the wrong codec must fail clearly when a compressed block is read.
-    let db =
+    // Reopening with the wrong codec must fail while validating the meta files.
+    assert!(
         TurboPersistence::<RayonParallelScheduler, 16>::open_with_config_and_parallel_scheduler(
             path.to_path_buf(),
             DbConfig::default(),
             RayonParallelScheduler,
-        )?;
-    assert!(db.get(2, &vec![7u8]).is_err());
-    db.shutdown()?;
+        )
+        .is_err()
+    );
     Ok(())
 }
 

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -1056,7 +1056,7 @@ fn batch_get_different_sizes() -> Result<()> {
     let path = tempdir.path();
 
     let mut config = DbConfig::default();
-    config.family_configs[0].compression = Compression::zstd_3();
+    config.family_configs[0].compression = Compression::Zstd3;
     let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
         path.to_path_buf(),
         config,
@@ -1113,10 +1113,10 @@ fn batch_get_across_families() -> Result<()> {
     let path = tempdir.path();
 
     let mut config = DbConfig::default();
-    config.family_configs[0].compression = Compression::lz4();
-    config.family_configs[1].compression = Compression::lz4_hc4();
-    config.family_configs[2].compression = Compression::zstd_3();
-    config.family_configs[3].compression = Compression::lz4_hc4();
+    config.family_configs[0].compression = Compression::Lz4;
+    config.family_configs[1].compression = Compression::Lz4Hc4;
+    config.family_configs[2].compression = Compression::Zstd3;
+    config.family_configs[3].compression = Compression::Lz4Hc4;
     let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
         path.to_path_buf(),
         config.clone(),
@@ -1163,10 +1163,8 @@ fn batch_get_across_families() -> Result<()> {
     // Same keys, but different values per family
     assert_ne!(results_f0[0].as_deref(), results_f1[0].as_deref());
 
-    let decompression_context = db.decompression_context_weak();
     db.shutdown()?;
     drop(db);
-    assert!(decompression_context.upgrade().is_none());
 
     // Reopen with the same family configuration recorded in the meta files.
     let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
@@ -1198,7 +1196,7 @@ fn batch_get_after_compaction() -> Result<()> {
     let path = tempdir.path();
 
     let mut config = DbConfig::default();
-    config.family_configs[0].compression = Compression::zstd_3();
+    config.family_configs[0].compression = Compression::Zstd3;
     let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
         path.to_path_buf(),
         config,
@@ -1570,7 +1568,7 @@ fn multi_value_config() -> DbConfig<1> {
     config.family_configs[0] = FamilyConfig {
         name: "test",
         kind: FamilyKind::MultiValue,
-        compression: Compression::lz4(),
+        compression: Compression::Lz4,
     };
     config
 }
@@ -2150,7 +2148,7 @@ fn compaction_deletes_blob_multi_value_tombstone() -> Result<()> {
         family_configs: [FamilyConfig {
             name: "test",
             kind: FamilyKind::MultiValue,
-            compression: Compression::lz4(),
+            compression: Compression::Lz4,
         }],
     };
 

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -1113,10 +1113,8 @@ fn batch_get_across_families() -> Result<()> {
     let path = tempdir.path();
 
     let mut config = DbConfig::default();
-    config.family_configs[0].compression = Compression::Lz4;
-    config.family_configs[1].compression = Compression::Lz4;
+    // set zstd on an arbitrary family, lz4 is used by default
     config.family_configs[2].compression = Compression::Zstd3;
-    config.family_configs[3].compression = Compression::Lz4;
     let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
         path.to_path_buf(),
         config.clone(),

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::{
-    DbConfig, FamilyConfig, FamilyKind,
+    Compression, DbConfig, FamilyConfig, FamilyKind,
     constants::{MAX_INLINE_VALUE_SIZE, MAX_MEDIUM_VALUE_SIZE, MAX_SMALL_VALUE_SIZE},
     db::{CompactConfig, TurboPersistence, read_current_version},
     lookup_entry::IterValue,
@@ -1055,8 +1055,11 @@ fn batch_get_different_sizes() -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+    let mut config = DbConfig::default();
+    config.family_configs[0].compression = Compression::Zstd(3);
+    let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
         path.to_path_buf(),
+        config,
         RayonParallelScheduler,
     )?;
 
@@ -1109,16 +1112,24 @@ fn batch_get_across_families() -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+    let mut config = DbConfig::default();
+    config.family_configs[0].compression = Compression::Lz4;
+    config.family_configs[1].compression = Compression::Lz4Hc(4);
+    config.family_configs[2].compression = Compression::Zstd(3);
+    config.family_configs[3].compression = Compression::Lz4Hc(4);
+    let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
         path.to_path_buf(),
+        config.clone(),
         RayonParallelScheduler,
     )?;
 
-    // Write to multiple families
+    // Write compressible values to multiple families so every configured codec is exercised.
     let batch = db.write_batch()?;
     for family in 0..4u32 {
         for i in 0..20u8 {
-            batch.put(family, vec![i], vec![family as u8, i].into())?;
+            let mut value = vec![family as u8; 1024];
+            value[0] = i;
+            batch.put(family, vec![i], value.into())?;
         }
     }
     db.commit_write_batch(batch)?;
@@ -1132,7 +1143,13 @@ fn batch_get_across_families() -> Result<()> {
         for (i, result) in results.iter().enumerate() {
             assert_eq!(
                 result.as_deref(),
-                Some(&vec![family as u8, i as u8][..]),
+                Some(
+                    &{
+                        let mut value = vec![family as u8; 1024];
+                        value[0] = i as u8;
+                        value
+                    }[..]
+                ),
                 "Failed at family {family}, index {i}"
             );
         }
@@ -1147,6 +1164,29 @@ fn batch_get_across_families() -> Result<()> {
     assert_ne!(results_f0[0].as_deref(), results_f1[0].as_deref());
 
     db.shutdown()?;
+    drop(db);
+
+    // Reopen with the same family configuration. Compression is not signaled on disk.
+    let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
+        path.to_path_buf(),
+        config,
+        RayonParallelScheduler,
+    )?;
+    let value = db.get(2, &vec![7u8])?.expect("zstd family value exists");
+    assert_eq!(value[0], 7);
+    assert!(value[1..].iter().all(|byte| *byte == 2));
+    db.shutdown()?;
+    drop(db);
+
+    // Reopening with the wrong codec must fail clearly when a compressed block is read.
+    let db =
+        TurboPersistence::<RayonParallelScheduler, 16>::open_with_config_and_parallel_scheduler(
+            path.to_path_buf(),
+            DbConfig::default(),
+            RayonParallelScheduler,
+        )?;
+    assert!(db.get(2, &vec![7u8]).is_err());
+    db.shutdown()?;
     Ok(())
 }
 
@@ -1155,8 +1195,11 @@ fn batch_get_after_compaction() -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
+    let mut config = DbConfig::default();
+    config.family_configs[0].compression = Compression::Zstd(3);
+    let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
         path.to_path_buf(),
+        config,
         RayonParallelScheduler,
     )?;
 
@@ -1174,7 +1217,7 @@ fn batch_get_after_compaction() -> Result<()> {
     let keys_to_fetch: Vec<Vec<u8>> = (0..100u8).map(|i| vec![i]).collect();
     let results_before = db.batch_get(0, &keys_to_fetch)?;
 
-    // Compact database
+    // Compact database using zstd to cover recompression with a non-default codec.
     db.full_compact()?;
 
     // Fetch after compaction
@@ -1525,6 +1568,7 @@ fn multi_value_config() -> DbConfig<1> {
     config.family_configs[0] = FamilyConfig {
         name: "test",
         kind: FamilyKind::MultiValue,
+        compression: Compression::Lz4,
     };
     config
 }
@@ -2104,6 +2148,7 @@ fn compaction_deletes_blob_multi_value_tombstone() -> Result<()> {
         family_configs: [FamilyConfig {
             name: "test",
             kind: FamilyKind::MultiValue,
+            compression: Compression::Lz4,
         }],
     };
 

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -547,7 +547,7 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
             };
 
             file.sync_all()?;
-            let sst = StaticSortedFile::open_with_compression(
+            let sst = StaticSortedFile::open(
                 &self.db_path,
                 StaticSortedFileMetaData {
                     sequence_number: seq,

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -539,7 +539,7 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
 
             use crate::{
                 collector_entry::CollectorEntryValue,
-                compression::DecompressionPool,
+                compression::DecompressionContext,
                 key::hash_key,
                 lookup_entry::LookupValue,
                 static_sorted_file::{
@@ -556,7 +556,7 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
                     block_count: meta.block_count,
                 },
                 self.family_configs[usize_from_u32(family)].compression,
-                Arc::new(DecompressionPool::default()),
+                Arc::new(DecompressionContext::default()),
             )?;
             let cache2 = BlockCache::with(
                 10,

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -535,11 +535,9 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
         #[cfg(feature = "verify_sst_content")]
         {
             use core::panic;
-            use std::sync::Arc;
 
             use crate::{
                 collector_entry::CollectorEntryValue,
-                compression::DecompressionContext,
                 key::hash_key,
                 lookup_entry::LookupValue,
                 static_sorted_file::{
@@ -556,7 +554,6 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
                     block_count: meta.block_count,
                 },
                 self.family_configs[usize_from_u32(family)].compression,
-                Arc::new(DecompressionContext::default()),
             )?;
             let cache2 = BlockCache::with(
                 10,

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -25,9 +25,7 @@ use crate::{
     meta_file::MetaEntryFlags,
     meta_file_builder::MetaFileBuilder,
     parallel_scheduler::ParallelScheduler,
-    static_sorted_file_builder::{
-        StaticSortedFileBuilderMeta, write_static_stored_file_with_compression,
-    },
+    static_sorted_file_builder::{StaticSortedFileBuilderMeta, write_static_stored_file},
 };
 
 /// A newly created database file (meta, SST, or blob), carrying its on-disk size so commit can sum
@@ -523,7 +521,7 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
         let (meta, file) = self
             .parallel_scheduler
             .block_in_place(|| {
-                write_static_stored_file_with_compression(
+                write_static_stored_file(
                     entries,
                     &path,
                     MetaEntryFlags::FRESH,

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -25,7 +25,9 @@ use crate::{
     meta_file::MetaEntryFlags,
     meta_file_builder::MetaFileBuilder,
     parallel_scheduler::ParallelScheduler,
-    static_sorted_file_builder::{StaticSortedFileBuilderMeta, write_static_stored_file},
+    static_sorted_file_builder::{
+        StaticSortedFileBuilderMeta, write_static_stored_file_with_compression,
+    },
 };
 
 /// A newly created database file (meta, SST, or blob), carrying its on-disk size so commit can sum
@@ -79,7 +81,7 @@ pub struct WriteBatch<'db, K: StoreKey + Send, S: ParallelScheduler, const FAMIL
     parallel_scheduler: S,
     /// The database path
     db_path: PathBuf,
-    /// Per-family configuration (kind: SingleValue/MultiValue).
+    /// Per-family storage configuration.
     #[cfg_attr(not(feature = "verify_sst_content"), allow(dead_code))]
     family_configs: [FamilyConfig; FAMILIES],
     /// The current sequence number counter. Increased for every new SST file or blob file.
@@ -238,7 +240,7 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
         if value.len() <= MAX_MEDIUM_VALUE_SIZE {
             collector.put(key, value);
         } else {
-            let blob = self.create_blob(&value)?;
+            let blob = self.create_blob(family, &value)?;
             collector.put_blob(key, blob.seq);
             state.new_blob_files.push(blob);
         }
@@ -484,10 +486,11 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
 
     /// Creates a new blob file with the given value.
     #[tracing::instrument(level = "trace", skip(self, value), fields(value_len = value.len()))]
-    fn create_blob(&self, value: &[u8]) -> Result<NewFile> {
+    fn create_blob(&self, family: u32, value: &[u8]) -> Result<NewFile> {
         let seq = self.current_sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
         let mut compressed = Vec::new();
-        compress_into_buffer(value, &mut compressed)
+        let compression = self.family_configs[usize_from_u32(family)].compression;
+        compress_into_buffer(compression, value, &mut compressed)
             .context("Compression of value for blob file failed")?;
 
         let mut buffer = Vec::with_capacity(8 + compressed.len());
@@ -516,7 +519,14 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
         let path = self.db_path.join(format!("{seq:08}.sst"));
         let (meta, file) = self
             .parallel_scheduler
-            .block_in_place(|| write_static_stored_file(entries, &path, MetaEntryFlags::FRESH))
+            .block_in_place(|| {
+                write_static_stored_file_with_compression(
+                    entries,
+                    &path,
+                    MetaEntryFlags::FRESH,
+                    self.family_configs[usize_from_u32(family)].compression,
+                )
+            })
             .with_context(|| format!("Unable to write SST file {seq:08}.sst"))?;
 
         #[cfg(feature = "verify_sst_content")]
@@ -534,12 +544,13 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
             };
 
             file.sync_all()?;
-            let sst = StaticSortedFile::open(
+            let sst = StaticSortedFile::open_with_compression(
                 &self.db_path,
                 StaticSortedFileMetaData {
                     sequence_number: seq,
                     block_count: meta.block_count,
                 },
+                self.family_configs[usize_from_u32(family)].compression,
             )?;
             let cache2 = BlockCache::with(
                 10,

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -459,7 +459,10 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
                 |(family, sst_files)| {
                     let family = family as u32;
                     let mut entries = 0;
-                    let mut builder = MetaFileBuilder::new(family);
+                    let mut builder = MetaFileBuilder::new(
+                        family,
+                        self.family_configs[usize_from_u32(family)].compression,
+                    );
                     for (seq, sst) in sst_files {
                         entries += sst.entries;
                         builder.add(seq, sst);
@@ -532,9 +535,11 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
         #[cfg(feature = "verify_sst_content")]
         {
             use core::panic;
+            use std::sync::Arc;
 
             use crate::{
                 collector_entry::CollectorEntryValue,
+                compression::DecompressionPool,
                 key::hash_key,
                 lookup_entry::LookupValue,
                 static_sorted_file::{
@@ -551,6 +556,7 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
                     block_count: meta.block_count,
                 },
                 self.family_configs[usize_from_u32(family)].compression,
+                Arc::new(DecompressionPool::default()),
             )?;
             let cache2 = BlockCache::with(
                 10,

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -18,7 +18,7 @@ use crate::{
     FamilyConfig, FamilyKind, ValueBuffer,
     collector::Collector,
     collector_entry::CollectorEntry,
-    compression::{checksum_block, compress_into_buffer},
+    compression::{Compressor, checksum_block},
     constants::{MAX_INLINE_VALUE_SIZE, MAX_MEDIUM_VALUE_SIZE, THREAD_LOCAL_SIZE_SHIFT},
     db::WriteOperationGuard,
     key::StoreKey,
@@ -318,14 +318,13 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
             })?;
 
         // Now we flush the global collector(s).
-        let mut collector_state = self.collectors[usize_from_u32(family)].lock();
+        let family_usize = usize_from_u32(family);
+        let mut collector_state = self.collectors[family_usize].lock();
+        let family_config = self.family_configs[family_usize];
         match &mut *collector_state {
             GlobalCollectorState::Unsharded(collector) => {
                 if !collector.is_empty() {
-                    let sst = self.create_sst_file(
-                        family,
-                        collector.sorted(self.family_configs[usize_from_u32(family)].kind),
-                    )?;
+                    let sst = self.create_sst_file(family, collector.sorted(family_config.kind))?;
                     collector.clear();
                     self.new_sst_files.lock().push(sst);
                 }
@@ -340,10 +339,8 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
                 self.parallel_scheduler
                     .try_parallel_for_each_mut(&mut shards, |collector| {
                         if !collector.is_empty() {
-                            let sst = self.create_sst_file(
-                                family,
-                                collector.sorted(self.family_configs[usize_from_u32(family)].kind),
-                            )?;
+                            let sst =
+                                self.create_sst_file(family, collector.sorted(family_config.kind))?;
                             collector.clear();
                             self.new_sst_files.lock().push(sst);
                             collector.drop_contents();
@@ -491,7 +488,8 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
         let seq = self.current_sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
         let mut compressed = Vec::new();
         let compression = self.family_configs[usize_from_u32(family)].compression;
-        compress_into_buffer(compression, value, &mut compressed)
+        Compressor::new(compression)?
+            .compress_into_buffer(value, &mut compressed)
             .context("Compression of value for blob file failed")?;
 
         let mut buffer = Vec::with_capacity(8 + compressed.len());

--- a/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
@@ -38,7 +38,7 @@ impl KeySpace {
             KeySpace::Infra | KeySpace::TaskMeta => FamilyConfig {
                 name: self.name(),
                 kind: FamilyKind::SingleValue,
-                compression: Compression::Lz4Hc4,
+                compression: Compression::Lz4,
             },
             KeySpace::TaskData => FamilyConfig {
                 name: self.name(),
@@ -49,7 +49,7 @@ impl KeySpace {
                 name: self.name(),
                 // TaskCache uses hash-based lookups with potential collisions.
                 kind: FamilyKind::MultiValue,
-                compression: Compression::Lz4Hc4,
+                compression: Compression::Lz4,
             },
         }
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
@@ -38,44 +38,19 @@ impl KeySpace {
             KeySpace::Infra | KeySpace::TaskMeta => FamilyConfig {
                 name: self.name(),
                 kind: FamilyKind::SingleValue,
-                compression: Compression::Lz4Hc(4),
+                compression: Compression::lz4_hc4(),
             },
             KeySpace::TaskData => FamilyConfig {
                 name: self.name(),
                 kind: FamilyKind::SingleValue,
-                compression: Compression::Zstd(3),
+                compression: Compression::zstd_3(),
             },
             KeySpace::TaskCache => FamilyConfig {
                 name: self.name(),
                 // TaskCache uses hash-based lookups with potential collisions.
                 kind: FamilyKind::MultiValue,
-                compression: Compression::Lz4Hc(4),
+                compression: Compression::lz4_hc4(),
             },
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn keyspace_compression_configuration() {
-        assert_eq!(
-            KeySpace::Infra.family_config().compression,
-            Compression::Lz4Hc(4)
-        );
-        assert_eq!(
-            KeySpace::TaskMeta.family_config().compression,
-            Compression::Lz4Hc(4)
-        );
-        assert_eq!(
-            KeySpace::TaskData.family_config().compression,
-            Compression::Zstd(3)
-        );
-        assert_eq!(
-            KeySpace::TaskCache.family_config().compression,
-            Compression::Lz4Hc(4)
-        );
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
@@ -1,4 +1,4 @@
-use turbo_persistence::{FamilyConfig, FamilyKind};
+use turbo_persistence::{Compression, FamilyConfig, FamilyKind};
 
 #[derive(Debug, Clone, Copy)]
 pub enum KeySpace {
@@ -35,15 +35,47 @@ impl KeySpace {
     /// Returns the persistence configuration for this keyspace.
     pub const fn family_config(&self) -> FamilyConfig {
         match self {
-            KeySpace::Infra | KeySpace::TaskMeta | KeySpace::TaskData => FamilyConfig {
+            KeySpace::Infra | KeySpace::TaskMeta => FamilyConfig {
                 name: self.name(),
                 kind: FamilyKind::SingleValue,
+                compression: Compression::Lz4Hc(4),
+            },
+            KeySpace::TaskData => FamilyConfig {
+                name: self.name(),
+                kind: FamilyKind::SingleValue,
+                compression: Compression::Zstd(3),
             },
             KeySpace::TaskCache => FamilyConfig {
                 name: self.name(),
                 // TaskCache uses hash-based lookups with potential collisions.
                 kind: FamilyKind::MultiValue,
+                compression: Compression::Lz4Hc(4),
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keyspace_compression_configuration() {
+        assert_eq!(
+            KeySpace::Infra.family_config().compression,
+            Compression::Lz4Hc(4)
+        );
+        assert_eq!(
+            KeySpace::TaskMeta.family_config().compression,
+            Compression::Lz4Hc(4)
+        );
+        assert_eq!(
+            KeySpace::TaskData.family_config().compression,
+            Compression::Zstd(3)
+        );
+        assert_eq!(
+            KeySpace::TaskCache.family_config().compression,
+            Compression::Lz4Hc(4)
+        );
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/key_value_database.rs
@@ -38,18 +38,18 @@ impl KeySpace {
             KeySpace::Infra | KeySpace::TaskMeta => FamilyConfig {
                 name: self.name(),
                 kind: FamilyKind::SingleValue,
-                compression: Compression::lz4_hc4(),
+                compression: Compression::Lz4Hc4,
             },
             KeySpace::TaskData => FamilyConfig {
                 name: self.name(),
                 kind: FamilyKind::SingleValue,
-                compression: Compression::zstd_3(),
+                compression: Compression::Zstd3,
             },
             KeySpace::TaskCache => FamilyConfig {
                 name: self.name(),
                 // TaskCache uses hash-based lookups with potential collisions.
                 kind: FamilyKind::MultiValue,
-                compression: Compression::lz4_hc4(),
+                compression: Compression::Lz4Hc4,
             },
         }
     }


### PR DESCRIPTION
## What?

Adds per-family compression configuration to `turbo-persistence` and configures the Turbopack filesystem cache according to each keyspace's access pattern:

| Family | Compression | Reason |
| --- | --- | --- |
| Infra | LZ4 | Preserve the existing fast encode/decode path |
| TaskMeta | LZ4 | Avoid HC encode CPU for a marginal whole-cache size gain |
| TaskCache | LZ4 | Values are inline and no value blocks compressed in measured caches |
| TaskData | zstd level 3 | Prioritize the dominant disk-size opportunity |

Each meta file records the family's compression algorithm as one explicit byte, which is validated against `FamilyConfig` when the database opens. SST block and blob layouts remain unchanged.

## Why?

LZ4 decode performance is important for cache query latency, but using one codec for every keyspace leaves a substantial disk-size opportunity in `TaskData`. The final split keeps Infra, TaskMeta, and TaskCache on the existing ordinary LZ4 path, while `TaskData` spends modestly more CPU to reduce persistent cache size.

LZ4 HC4 was evaluated and removed before finalizing: across three real caches it made TaskMeta compression **4.24× slower** for only **1.51%** total cache-directory savings. Infra and TaskCache made no compression calls. Removing HC4 does not affect reads because HC4 and ordinary LZ4 use the same decoder.

## How?

### Real (tiny) Next.js cache A/B test

Final results after removing HC4, using three cold and five warm runs per workload:

| Workload | Cache size | Cold/write | Warm/read |
| --- | ---: | ---:| ---: |
| `test/e2e/filesystem-cache` | **-19.45%** | +2.38% | +3.98% |
| `test/e2e/app-dir/app-rendering` | **-18.87%** | -0.81% | -2.69% |
| `test/e2e/app-dir/client-reference-chunking` | **-19.84%** | -0.80% | -3.70% |
| Combined medians | **-19.41%** (96.79 → 78.00 MiB) | **+0.23%** | **-1.19%** |

The mixed warm result on the smallest fixture and apparent improvements elsewhere are treated as noise; combined measurements show no material write/read regression.

### Temporary crate benchmark instrumentation

To demonstrate the cost of the retained codecs, temporary write/read benchmarks applied each codec to identical synthetic data. The benchmark code is not included in the final patch.

| Codec | Synthetic write | vs LZ4 | Uncached get | Cached get | DB size |
| --- | ---: | ---: | ---: | ---: | ---: |
| LZ4 | 38.173 ms | baseline | 7.3004 µs | 10.735 µs | 21.59 MiB |
| zstd3 | 57.790 ms | **+51.4%** | 6.2460 µs | 9.5323 µs | 21.49 MiB |

LZ4 HC4 was also evaluated during development: the same write benchmark took 256.31 ms (**+571.7%** vs LZ4), which motivated dropping it after the real-cache family breakdown showed little total-size benefit.

### Native binary size

For Linux x64 GNU, using `build-native-release` followed by the release pipeline's `strip -x`:

- base: 103,140,384 bytes
- final PR: 103,663,432 bytes
- delta: **+523,048 bytes (+0.507%)**

Removing HC4 saved **73,248 installed bytes** versus the earlier PR state; replacing bincode framing with the explicit codec byte saved another **18,048 bytes**. Together those review simplifications removed **91,296 installed bytes** (24,420 gzip bytes) from the earlier branch state.

## Vercel Site real application

> These measurements were captured before HC4 was removed. The final TaskData-only configuration should give up a small amount of size reduction and improve write CPU; the final small-app A/B above measures that configuration directly.

### Size

2.9G	canary
2.2G	this PR

a 25% savings!!!

### Performance

Cold build (n=5), warm build (n=3), medians:

| Scenario | Metric | Canary | Compression | Δ |
|---|---|---|---|---|
| **Cold** | wall (s) | 71.28 | 72.86 | +2.2% |
| | user (s) | 555.21 | 570.23 | +2.7% |
| | sys (s) | 94.49 | 95.00 | +0.5% |
| | maxRSS (GB) | 17.95 | 17.98 | +0.2% |
| **Warm** | wall (s) | 15.00 | 15.32 | +2.1% |
| | user (s) | 7.59 | 9.98 | +31% |
| | sys (s) | 12.79 | 12.87 | +0.6% |
| | maxRSS (GB) | 3.78 | 3.86 | +2.0% |

maxRSS converted at 1 GB = 2^30 bytes.

Looking at tracing data i see in a cold build `persist` span went from 5.06s duration using 63s cpu time to 6.04s using 73s cpu time, a ~20% regression.  Which explains the cpu regression and the time progression.

Because the time regression is in the `persist` span during shutdown the added latency is somewhat hidden.

Of course we also see a small wall/user time regression in warm builds due to the extra decompression costs for zstd.


<!-- NEXT_JS_LLM -->


<!-- fleet 621238c3-5a53-431b-8661-8c5b2920d55d -->

