### PR TITLE
fix(telemetry): stop `detached-flush` evaluating `next.config`, and bound its lifetime

### DIFF
--- a/packages/next/src/telemetry/detached-flush.ts
+++ b/packages/next/src/telemetry/detached-flush.ts
@@ -2,52 +2,71 @@ import fs from 'fs'
 import path from 'path'
 import type { TelemetryEvent } from './storage'
 import { Telemetry } from './storage'
-import loadConfig from '../server/config'
+import { loadEnvConfig } from '@next/env'
 import { getProjectDir } from '../lib/get-project-dir'
-import { PHASE_DEVELOPMENT_SERVER } from '../shared/lib/constants'
+
+// This process is spawned `detached` with nothing supervising it, so it has to
+// terminate on its own under every outcome. Nothing here evaluates the user's
+// config, but the telemetry request is unbounded: `submitRecord` always passes
+// its own signal, so the 5s `AbortSignal.timeout` fallback in
+// `postNextTelemetryPayload` never applies. A request that never settles would
+// leave this process running forever, reparented to init. `unref()` stops the
+// timer from holding the process open; on the normal path the work finishes in
+// ~90ms and it never fires.
+//
+// Not armed under `NEXT_TELEMETRY_DEBUG`. That mode is spawned with `spawnSync`
+// and `detached: false`, so it is supervised and cannot be orphaned, and it is
+// the only mode that writes enough to stdio for an exit to truncate it.
+const EXIT_TIMEOUT_MS = 10_000
+if (!process.env.NEXT_TELEMETRY_DEBUG) {
+  setTimeout(() => process.exit(0), EXIT_TIMEOUT_MS).unref()
+}
 
 // this process should be started with following arg order
 // 1. mode e.g. dev, export, start
 // 2. project dir
-// 3. events filename (optional, defaults to _events.json)
+// 3. events filename
+// 4. dist dir (absolute)
 ;(async () => {
-  const args = [...process.argv]
-  const eventsFile = args.pop()
-  let dir = args.pop()
-  const mode = args.pop()
+  const [, , mode, dirArg, eventsFile, distDir] = process.argv
 
-  if (!dir || mode !== 'dev') {
+  if (!dirArg || mode !== 'dev' || !eventsFile || !distDir) {
     throw new Error(
-      `Invalid flags should be run as node detached-flush dev ./path-to/project [eventsFile]`
+      `Invariant: detached-flush must be invoked as: node detached-flush dev <projectDir> <eventsFile> <distDir>`
     )
   }
-  dir = getProjectDir(dir)
+  const dir = getProjectDir(dirArg)
 
-  const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, dir)
-  const distDir = path.join(dir, config.distDir || '.next')
-  // Support both old format (no eventsFile arg) and new format (with eventsFile arg)
-  const eventsPath = path.join(
-    distDir,
-    eventsFile && !eventsFile.includes('/') ? eventsFile : '_events.json'
-  )
+  // `.env` may set `NEXT_TELEMETRY_DISABLED`, and `Telemetry` reads it in its
+  // constructor, so the environment has to be loaded before that runs. Nothing
+  // else in this process loads it.
+  loadEnvConfig(dir, true, { info: () => {}, error: () => {} })
+
+  const eventsPath = path.join(distDir, eventsFile)
 
   let events: TelemetryEvent[]
   try {
     events = JSON.parse(fs.readFileSync(eventsPath, 'utf8'))
   } catch (err: any) {
     if (err.code === 'ENOENT') {
-      // no events to process we can exit now
-      process.exit(0)
+      // no events to process, and nothing holds the event loop open
+      return
     }
     throw err
   }
+
+  // Claim the batch up front rather than after the flush. The events are in
+  // memory and nothing re-reads the file, so unlinking here costs nothing, and
+  // if the watchdog fires mid-request the per-pid `_events_<pid>.json` is not
+  // left behind for good with nothing that would ever collect it.
+  fs.unlinkSync(eventsPath)
 
   const telemetry = new Telemetry({ distDir })
   await telemetry.record(events)
   await telemetry.flush()
 
-  // finished flushing events clean-up
-  fs.unlinkSync(eventsPath)
-  // Don't call process.exit() here - let Node.js exit naturally after
-  // all pending work completes (e.g., setTimeout in debug telemetry)
+  // Deliberately no `process.exit()` here: nothing in this process holds the
+  // event loop open, so it exits on its own once the pending stdio writes
+  // drain. Exiting explicitly would truncate the `NEXT_TELEMETRY_DEBUG` output
+  // when it exceeds the pipe buffer.
 })()

--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -261,7 +261,17 @@ export class Telemetry {
 
     spawn(
       process.execPath,
-      [require.resolve('./detached-flush'), mode, dir, eventsFile],
+      // `this.distDir` is passed explicitly so the child does not have to
+      // evaluate the user's `next.config` to discover it. That evaluation runs
+      // dev-phase config plugins (watchers, bundler services) inside a
+      // detached, unsupervised process, which is what left orphans behind.
+      [
+        require.resolve('./detached-flush'),
+        mode,
+        dir,
+        eventsFile,
+        this.distDir,
+      ],
       {
         detached: !this.NEXT_TELEMETRY_DEBUG,
         windowsHide: true,

--- a/test/unit/telemetry-detached-flush.test.ts
+++ b/test/unit/telemetry-detached-flush.test.ts
@@ -1,0 +1,239 @@
+import { spawn } from 'child_process'
+import { existsSync, mkdirSync, writeFileSync } from 'fs'
+import path from 'path'
+import { useTempDir } from '../lib/use-temp-dir'
+
+/**
+ * `detached-flush` is spawned with `detached: true` and nothing supervises it,
+ * so it has to terminate under every outcome or it is reparented to init and
+ * leaks: one process per `next dev` shutdown, holding whatever its work left
+ * behind.
+ *
+ * It used to discover `distDir` by calling `loadConfig()`, which evaluates the
+ * user's `next.config` in the development-server phase. Config plugins
+ * legitimately start file watchers and bundler services there, and those keep
+ * the process alive forever. `distDir` is a required argument and no config
+ * is evaluated here at all, with an unref'd watchdog bounding the one thing
+ * left that can hang: an unbounded telemetry request.
+ */
+const FLUSH_SCRIPT = require.resolve('next/dist/telemetry/detached-flush')
+
+const EVENTS_FILE = '_events_test.json'
+
+const RUN_TIMEOUT_MS = 30_000
+
+/** Past the child's 10s watchdog, so a watchdog exit would be observable. */
+const SLOW_READER_MS = 12_000
+
+/** Marker written by the fixture config, so a test can assert it never ran. */
+const CONFIG_MARKER = 'config-was-evaluated'
+
+/**
+ * Fills a directory from `useTempDir` with the smallest project this script
+ * accepts, and returns the dist dir the events file was written to.
+ */
+function createProject(
+  dir: string,
+  nextConfig: string | ((dir: string) => string)
+): string {
+  writeFileSync(
+    path.join(dir, 'next.config.js'),
+    typeof nextConfig === 'function' ? nextConfig(dir) : nextConfig
+  )
+  writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: 'detached-flush-fixture', version: '0.0.0' })
+  )
+
+  // The dev-phase distDir is `.next/dev`, not `.next`. Writing the events file
+  // to `.next` makes `detached-flush` take its ENOENT branch, which returns on
+  // its own, so the process would exit for the wrong reason and these tests
+  // would pass against the unfixed code.
+  const distDir = path.join(dir, '.next', 'dev')
+  mkdirSync(distDir, { recursive: true })
+  writeFileSync(
+    path.join(distDir, EVENTS_FILE),
+    JSON.stringify([{ eventName: 'testEvent', payload: {} }])
+  )
+  return distDir
+}
+
+/**
+ * `runNextCommand` is not reusable here: it resolves and spawns `dist/bin/next`
+ * specifically, and these cases invoke the flush script directly, one of them
+ * with a `-r` preload.
+ */
+function runDetachedFlush(
+  dir: string,
+  distDir?: string,
+  { preload }: { preload?: string } = {}
+): Promise<{ code: number | null; timedOut: boolean; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const args = preload ? ['-r', preload] : []
+    args.push(FLUSH_SCRIPT, 'dev', dir, EVENTS_FILE)
+    if (distDir) args.push(distDir)
+
+    const child = spawn(process.execPath, args, {
+      env: {
+        ...process.env,
+        NODE_ENV: 'development',
+        // The leak is independent of the opt-out: nothing here consults it
+        // before the work that used to hang.
+        NEXT_TELEMETRY_DISABLED: '1',
+      },
+      // stderr is captured so a failing case can be asserted on its message
+      // rather than only on a non-zero exit, which any crash would satisfy.
+      // It is drained as it arrives: these cases write far less than a pipe
+      // buffer, but an undrained pipe would deadlock the child if they grew.
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+
+    let stderr = ''
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk) => (stderr += chunk))
+
+    let timedOut = false
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, RUN_TIMEOUT_MS)
+
+    // Without this an infrastructure failure surfaces as a misattributed
+    // timeout rather than the actual error.
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+    // `close` rather than `exit`: it waits for stderr to reach EOF, so the
+    // collected output is complete before it is asserted on.
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      resolve({ code, timedOut, stderr })
+    })
+  })
+}
+
+describe('telemetry detached-flush', () => {
+  it('should exit, and not evaluate next.config, when given distDir', async () => {
+    await useTempDir(async (dir) => {
+      // The config writes a marker when evaluated, so its absence is proof the
+      // child never ran it. The consumed events file is the control: it shows
+      // the child ran to completion, so the missing marker is not just an early
+      // exit.
+      const distDir = createProject(
+        dir,
+        (d) =>
+          "require('fs').writeFileSync(" +
+          JSON.stringify(path.join(d, CONFIG_MARKER)) +
+          ", '')\nmodule.exports = {}\n"
+      )
+
+      const { code, timedOut } = await runDetachedFlush(dir, distDir)
+
+      expect(timedOut).toBe(false)
+      expect(code).toBe(0)
+      // The whole point: the child does not run the user's config.
+      expect(existsSync(path.join(dir, CONFIG_MARKER))).toBe(false)
+      expect(existsSync(path.join(distDir, EVENTS_FILE))).toBe(false)
+    })
+  })
+
+  it('should reject an invocation that omits distDir', async () => {
+    await useTempDir(async (dir) => {
+      // `distDir` is required so there is no argument shape that falls back to
+      // evaluating the config. `Telemetry#flushDetached` is the only caller and
+      // resolves this file from its own package, so parent and child are always
+      // the same build and there is no older invocation to stay compatible
+      // with.
+      const distDir = createProject(dir, 'module.exports = {}\n')
+
+      const { code, timedOut, stderr } = await runDetachedFlush(dir)
+
+      expect(timedOut).toBe(false)
+      // Node exits 1 on an unhandled rejection; pinned rather than
+      // `not.toBe(0)` so a change to some other failure mode is visible.
+      expect(code).toBe(1)
+      // Asserted on the message, not just a non-zero exit: a missing module or
+      // a syntax error would also exit non-zero, and this case exists to prove
+      // the argument check is what rejected it.
+      expect(stderr).toContain(
+        'Invariant: detached-flush must be invoked as: node detached-flush dev <projectDir> <eventsFile> <distDir>'
+      )
+      // It failed before doing any work rather than silently flushing.
+      expect(existsSync(path.join(distDir, EVENTS_FILE))).toBe(true)
+    })
+  })
+
+  it('should exit when a pending handle would otherwise keep it alive', async () => {
+    await useTempDir(async (dir) => {
+      // Stands in for a telemetry request that never settles, the one thing
+      // left that can hang this process, since `submitRecord` always passes its
+      // own signal and the 5s `AbortSignal.timeout` fallback never applies.
+      // Without the watchdog this is reparented to init and stays there.
+      const distDir = createProject(dir, 'module.exports = {}\n')
+      const preload = path.join(dir, 'hold-open.js')
+      writeFileSync(preload, 'setInterval(() => {}, 1000)\n')
+
+      const started = Date.now()
+      const { code, timedOut } = await runDetachedFlush(dir, distDir, {
+        preload,
+      })
+
+      expect(timedOut).toBe(false)
+      expect(code).toBe(0)
+      // The watchdog ended it, rather than the event loop emptying on its own.
+      expect(Date.now() - started).toBeGreaterThan(5_000)
+    })
+  })
+
+  it('should not truncate NEXT_TELEMETRY_DEBUG output when the reader is slow', async () => {
+    await useTempDir(async (dir) => {
+      // Enough records to exceed the OS pipe buffer, with nothing draining it
+      // until after the watchdog window. `process.exit()`, whether at the end
+      // of the flush, as before #85867, or from the watchdog, discards the
+      // writes still queued behind that buffer.
+      const N = 300
+      const distDir = createProject(dir, 'module.exports = {}\n')
+      writeFileSync(
+        path.join(distDir, EVENTS_FILE),
+        JSON.stringify(
+          Array.from({ length: N }, (_, i) => ({
+            eventName: 'testEvent',
+            payload: { i, filler: 'x'.repeat(64) },
+          }))
+        )
+      )
+
+      const child = spawn(
+        process.execPath,
+        [FLUSH_SCRIPT, 'dev', dir, EVENTS_FILE, distDir],
+        {
+          env: {
+            ...process.env,
+            NODE_ENV: 'development',
+            NEXT_TELEMETRY_DEBUG: '1',
+            // Debug output is produced before the opt-out is consulted, so this
+            // keeps the test off the network without affecting what it asserts.
+            NEXT_TELEMETRY_DISABLED: '1',
+          },
+          stdio: ['ignore', 'ignore', 'pipe'],
+        }
+      )
+
+      // No listener yet, so nothing is read and the child blocks on write. A
+      // plain sleep rather than `waitFor` from `next-test-utils`: that module
+      // pulls in express, node-fetch and the Next server, which is a lot of
+      // weight for a unit test that only needs to wait.
+      await new Promise((resolve) => setTimeout(resolve, SLOW_READER_MS))
+      let out = ''
+      child.stderr.setEncoding('utf8')
+      child.stderr.on('data', (chunk) => (out += chunk))
+
+      // `close` rather than `exit`: it waits for stdio to reach EOF.
+      const code = await new Promise((resolve) => child.on('close', resolve))
+
+      expect(code).toBe(0)
+      expect((out.match(/\[telemetry\]/g) || []).length).toBe(N)
+    })
+  })
+})

--- a/test/unit/telemetry-detached-flush.test.ts
+++ b/test/unit/telemetry-detached-flush.test.ts
@@ -220,6 +220,13 @@ describe('telemetry detached-flush', () => {
         }
       )
 
+      // `close` rather than `exit`: it waits for stdio to reach EOF. Awaited
+      // at the end, but registered here: `close` fires once, so a listener
+      // attached after the pause below would miss a child that ended during
+      // it, and the test would hang to the Jest timeout instead of failing on
+      // the record count.
+      const closed = new Promise((resolve) => child.once('close', resolve))
+
       // No listener yet, so nothing is read and the child blocks on write. A
       // plain sleep rather than `waitFor` from `next-test-utils`: that module
       // pulls in express, node-fetch and the Next server, which is a lot of
@@ -229,8 +236,7 @@ describe('telemetry detached-flush', () => {
       child.stderr.setEncoding('utf8')
       child.stderr.on('data', (chunk) => (out += chunk))
 
-      // `close` rather than `exit`: it waits for stdio to reach EOF.
-      const code = await new Promise((resolve) => child.on('close', resolve))
+      const code = await closed
 
       expect(code).toBe(0)
       expect((out.match(/\[telemetry\]/g) || []).length).toBe(N)


### PR DESCRIPTION
Fixes #97716

### What

`detached-flush` is spawned `detached` with nothing supervising it, so it has to terminate under every outcome. If it does not, the parent's exit leaves it reparented to init, still running, with nothing left that would ever shut it down.

It discovered `distDir` by calling `loadConfig()`, which evaluates the user's `next.config` **in the development-server phase**. Config plugins legitimately start file watchers and bundler services during that evaluation, and those hold ref'd libuv handles, so the process never exited. One orphan leaked per `next dev` shutdown — plus any process the config itself spawned — on every release since **16.0.3**, regardless of the telemetry setting, because `loadConfig()` runs long before any enablement check.

I accumulated 63 of them in ~27 hours: 18.9 GB RSS and ~350% CPU, each holding an `esbuild --service` grandchild.

### The change

`flushDetached` already knows `distDir` — it writes the events file into it one line before spawning — so it now passes it as a **required** argument. `Telemetry#flushDetached` is the only caller, and it resolves this file with a package-relative `require.resolve('./detached-flush')`, so parent and child are always the same build and there is no older invocation to stay compatible with.

That makes the `loadConfig` import unnecessary, and it is gone. No config is evaluated in this process at all — which means no watcher, no bundler service, and no grandchild to leak. The orphan class is structurally unreachable rather than bounded after the fact. An invocation without `distDir` now exits non-zero instead of silently falling back to the path that leaked.

Three supporting details:

- **`loadEnvConfig()` is now called explicitly.** `.env` can set `NEXT_TELEMETRY_DISABLED`, and `Telemetry` reads it in its constructor (`storage.ts:64`, with a comment saying as much), so dropping that side effect silently would have re-enabled telemetry for opted-out users. See the note under *Behaviour change* below for the part this does **not** cover.
- **An unref'd watchdog bounds the one thing left that can hang this process: the telemetry request.** That request is genuinely unbounded — `submitRecord` always passes its own signal (`storage.ts:341`), so the `if (!signal)` fallback that would apply `AbortSignal.timeout(5000)` in `post-telemetry-payload.ts:19` is dead code on every production path. The watchdog is therefore the only bound on the POST. It is **not** armed under `NEXT_TELEMETRY_DEBUG`: that mode is spawned with `spawnSync` and `detached: false`, so it is supervised and cannot be orphaned, and it is the only mode that writes enough to stdio for an exit to truncate it.
- **The events file is unlinked before the request rather than after.** The events are already in memory and nothing re-reads the file, so this costs nothing — and it means a watchdog exit cannot strand a per-pid `_events_<pid>.json`, which nothing would ever collect.

Argument parsing is also positional now rather than `pop()`-based. The old form mis-assigned every argument when the optional events filename was absent; `eventsFile.includes('/')` was papering over that.

### Why not simply restore the `process.exit(0)` removed in ad93e452

That was my first attempt, and it is wrong. #85867's stated reason for removing the line was correct: exiting there discards whatever `NEXT_TELEMETRY_DEBUG` output is still queued behind a full pipe buffer.

| 300 records, stderr to a pipe whose reader stalls | records delivered |
|---|---|
| with `process.exit(0)` | **117 / 300** (the first ~64 KB) |
| without | 300 / 300 |

This is also why the watchdog is not armed in debug mode — an exit from the watchdog truncates exactly the same way. Restoring the line is incomplete besides: it sits *after* the unbounded `await loadConfig()`, so it never runs in the never-settles case, and it does nothing about grandchildren spawned during evaluation. Removing the evaluation removes all of it at once.

### Verification

Built from source at `canary` `8c7ed006b8`.

| case | before | after |
|---|---|---|
| config with a live handle (`setInterval`) | never exits | **exits, 100 ms** |
| async config that never settles | never exits | **never evaluated** |
| grandchild process spawned by config | leaked (survives) | **never spawned** |
| invocation without `distDir` | silently evaluated the config | **rejected, exit 1** |
| pending handle with nothing else to end it | — | **exits, 10.1 s (watchdog)** |
| `NEXT_TELEMETRY_DEBUG`, 300 events, stalled reader | 300/300 | **300/300** |
| `.env` `NEXT_TELEMETRY_DISABLED` | honoured | **honoured** |

Also verified end to end against a real-world config — a Next app whose `next.config.ts` composes three plugin wrappers, one of which runs a bundler build during evaluation. On stock 16.3.1 the child is still alive at 30 s (SIGKILL, exit 137); with this change on the production argv it exits at 0 s with the events consumed.

Then backported to that app's installed 16.3.1 build (both files) and run as its actual dev server rather than a harness: `next dev`, real traffic, `SIGINT`. The flush child spawns and is gone **0.27 s** later, leaving no orphan and no stale `_events_<pid>.json`. The same cycle before the patch left a ~370 MB process at `PPID 1`; four had accumulated in a day. That app is opted out of telemetry via `next telemetry disable`, which is also direct confirmation that the opt-out does not prevent the spawn.

Standalone reproduction of the bug this fixes: https://github.com/gesposito/nextjs-detached-flush-orphan — scaffolded from `create-next-app -e reproduction-template`, and it reproduces on `16.4.0-canary.0`, which `next info` reports as the latest available.

Reproducing by hand: the dev-phase `distDir` is `.next/dev`. Placing the events file in `.next` hits the ENOENT branch, which returns on its own, and the test passes for the wrong reason.

### Test

Adds `test/unit/telemetry-detached-flush.test.ts` — no fixture app, no dev server, no network. `detached-flush` had **no test coverage anywhere in the repo** before this; the only other reference is a filename in the `next-server-nft` file-trace snapshot, which never executes it. That is plausibly why a removed `process.exit(0)` shipped and survived nine releases.

Four cases, each checked against a mutation of the code it guards rather than only against the fix:

| mutation | caught by |
|---|---|
| re-add `process.exit(0)` after the flush | watchdog + truncation tests |
| arm the watchdog unconditionally | truncation test |
| remove the watchdog | watchdog test |
| make `distDir` optional again | contract test |
| throw a different error from the `distDir` guard | contract test |
| evaluate the config despite `distDir` | config test |

The suite that shipped in my first draft of this change passed all six — including the re-added `process.exit(0)`, the regression it most needed to catch. These four fail on each.

### Behaviour change worth flagging

`loadConfig()` had **two** env-mutating side effects, not one. Besides `loadEnvConfig`, it evaluated the config module itself, whose body can mutate `process.env` — directly, or via something like `require('dotenv').config({ path: '../../.env' })`. Replacing it with `loadEnvConfig` covers `<dir>/.env*` only, so a `NEXT_TELEMETRY_DISABLED` set **inside `next.config.js`** no longer reaches this process when it is spawned from the `next dev` CLI parent, which deliberately never loads the config (`next-dev.ts:210-211`).

The documented opt-outs (`next telemetry disable`, the environment variable, `.env`) are unaffected. Closing the config-file case properly means carrying the resolved flag over the existing `start-server.ts` → `next-dev.ts` IPC message that already passes `distDir`; happy to do that here or separately, whichever you prefer.

### Notes for review

- The diff adds one import (`loadEnvConfig` from `@next/env`, already a dependency of this package), removes two (`loadConfig`, `PHASE_DEVELOPMENT_SERVER`), and does not change the file-trace list that `test/production/next-server-nft` snapshots. The argument check's message uses the `Invariant:` prefix that the rest of the repo's internal-contract errors use. Rebased onto canary after #97687, so there is no `errors.json` entry to add.
- The `distDir` guard is unreachable from the only caller, so it is a guard against a future change to `flushDetached` rather than a user-facing diagnostic — and it is worth being precise about where its message would actually appear. The normal path spawns with no `stdio` option, so the child's stderr is a pipe with no reader attached to a parent that is already exiting; the non-zero exit is the observable part, not the text. Under `NEXT_TELEMETRY_DEBUG` (`stdio: 'inherit'`) it is visible. The test asserts on the message rather than only the exit code, so an unrelated crash cannot satisfy it.
- The `test/e2e/telemetry` suite does not exercise this path — all three files are build-oriented (`skipStart: true`, `isNextStart`-gated assertions) and none of them reference the detached flush.
- Two pre-existing defects noticed while working here, both out of scope and neither introduced by this change: `storage.ts:212` is a self-assignment (`;(prom as any)._controller = (prom as any)._controller`), so `flushDetached`'s `item._controller?.abort()` is always a no-op; and `storage.ts:12` imports `AbortController` from the `@edge-runtime` ponyfill, whose signal native `fetch` rejects with `TypeError: Expected signal ... to be an instance of AbortSignal` — so the telemetry POST currently fails before opening a socket on any Node with a modern undici. `post-telemetry-payload.test.ts` misses it because it mocks `global.fetch` and calls the function with no signal, testing the one branch production never takes. Happy to file both.

### Environment

Verified against a from-source build of `canary` `8c7ed006b8` on Node 25.8.0, macOS 26.3.1 arm64. The mechanism is platform-independent, but stdio flush behaviour is not — I have only tested macOS.
