### PR TITLE
[test] Capture the dynamic routes a build passes to an adapter

### DIFF
--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -349,6 +349,7 @@
       "test/production/app-dir/actions-tree-shaking/reexport/reexport.test.ts",
       "test/production/app-dir/actions-tree-shaking/shared-module-actions/shared-module-actions-edge.test.ts",
       "test/production/app-dir/actions-tree-shaking/use-effect-actions/use-effect-actions-edge.test.ts",
+      "test/production/app-dir/adapter-dynamic-routes/dynamic-routes-legacy.test.ts",
       "test/production/app-dir/app-fetch-build-cache/app-fetch-build-cache.test.ts",
       "test/production/app-dir/build-output-tree-view/build-output-tree-view.test.ts",
       "test/production/app-dir/build-output/index.test.ts",

--- a/test/production/app-dir/adapter-dynamic-routes/cache-components/app/[lang]/[slug]/page.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/cache-components/app/[lang]/[slug]/page.tsx
@@ -1,0 +1,13 @@
+export function generateStaticParams() {
+  return [{ slug: 'one' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  return <p>{slug}</p>
+}

--- a/test/production/app-dir/adapter-dynamic-routes/cache-components/app/[lang]/fallback-shell/[slug]/page.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/cache-components/app/[lang]/fallback-shell/[slug]/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react'
+
+export function generateStaticParams() {
+  return [{ slug: 'two' }]
+}
+
+export default function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      {params.then(({ slug }) => (
+        <p>{slug}</p>
+      ))}
+    </Suspense>
+  )
+}

--- a/test/production/app-dir/adapter-dynamic-routes/cache-components/app/[lang]/layout.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/cache-components/app/[lang]/layout.tsx
@@ -1,0 +1,17 @@
+import { lang } from 'next/root-params'
+
+export function generateStaticParams() {
+  return [{ lang: 'en' }, { lang: 'de' }]
+}
+
+export default async function Root({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang={await lang()}>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/adapter-dynamic-routes/cache-components/app/[lang]/page.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/cache-components/app/[lang]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/adapter-dynamic-routes/cache-components/app/[lang]/ppr/page.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/cache-components/app/[lang]/ppr/page.tsx
@@ -1,0 +1,12 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      {cookies().then(() => (
+        <p>ppr</p>
+      ))}
+    </Suspense>
+  )
+}

--- a/test/production/app-dir/adapter-dynamic-routes/cache-components/app/[lang]/static/page.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/cache-components/app/[lang]/static/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>static</p>
+}

--- a/test/production/app-dir/adapter-dynamic-routes/cache-components/my-adapter.mjs
+++ b/test/production/app-dir/adapter-dynamic-routes/cache-components/my-adapter.mjs
@@ -1,0 +1,12 @@
+import fs from 'fs/promises'
+
+/** @type {import('next').NextAdapter} */
+export default {
+  name: 'route-table-probe',
+  async onBuildComplete(ctx) {
+    await fs.writeFile(
+      'build-complete.json',
+      JSON.stringify(ctx.routing, null, 2)
+    )
+  },
+}

--- a/test/production/app-dir/adapter-dynamic-routes/cache-components/next.config.js
+++ b/test/production/app-dir/adapter-dynamic-routes/cache-components/next.config.js
@@ -1,0 +1,19 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  // A build ID that reaches an entry changes the snapshot on every run. A
+  // fixed build ID keeps the snapshot independent of the run.
+  generateBuildId: () => 'test-build-id',
+  adapterPath: require.resolve('./my-adapter.mjs'),
+}
+
+// `dynamic-routes-base-path.test.ts` sets this variable and builds the fixture a
+// second time under a base path. The value arrives through `nextTestSetup`'s
+// `env`, so it reaches a local build and a deployed build alike.
+if (process.env.BASE_PATH) {
+  nextConfig.basePath = process.env.BASE_PATH
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-base-path.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-base-path.test.ts
@@ -1,0 +1,46 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { type AdapterRouting } from './dynamic-routes-snapshot'
+
+const basePath = '/base'
+
+// This suite builds the Cache Components fixture a second time under a base
+// path.
+//
+// A base path belongs to the request, not to the route. The build writes
+// artifacts under the route's own path. The adapter prefixes the entries that
+// match incoming requests.
+//
+// A collapse rewrites the source regex and the destination of an entry, and
+// both carry the prefix. A collapse can therefore drop the prefix or add it
+// twice. This suite asserts the prefix as a property of every entry. It does
+// not snapshot the table a second time.
+describe(`adapter dynamic routes (cache components, base path ${basePath})`, () => {
+  const { next } = nextTestSetup({
+    files: path.join(__dirname, 'cache-components'),
+    env: { BASE_PATH: basePath },
+    // The fixture sets `generateBuildId`, and this option lets that value
+    // take effect. The harness otherwise assigns a new build ID for each run.
+    // A build ID that reaches an entry then changes the assertions on every
+    // run.
+    disableAutoSkewProtection: true,
+  })
+
+  it('prefixes every entry with the base path', async () => {
+    const routing: AdapterRouting = await next.readJSON('build-complete.json')
+
+    // A base path prefixes the entries. It does not add or remove any.
+    expect(routing.dynamicRoutes).toHaveLength(27)
+
+    for (const route of routing.dynamicRoutes) {
+      expect(route.sourceRegex.startsWith(`^${basePath}`)).toBe(true)
+      expect(route.destination.startsWith(`${basePath}/`)).toBe(true)
+
+      // The prefix appears exactly once. An entry that carries the prefix
+      // twice still starts with it, so a check on the start alone accepts
+      // that entry. The two occurrences also do not have to be adjacent.
+      expect(route.sourceRegex).toIncludeRepeated(basePath, 1)
+      expect(route.destination).toIncludeRepeated(basePath, 1)
+    }
+  })
+})

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-cache-components.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-cache-components.test.ts
@@ -1,0 +1,155 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  serializeDynamicRoutes,
+  type AdapterRouting,
+} from './dynamic-routes-snapshot'
+
+// This suite pins the dynamic routes that a build passes to an adapter for
+// a Cache Components app. The root layout of the fixture returns two root
+// params.
+//
+// Each entry in the snapshot becomes one route in the routes document of a
+// deployment. The snapshot covers the routes that this app shape contributes.
+// A deployment also carries a fixed set of adapter routes, and it carries one
+// route for each rewrite that the app config declares.
+//
+// A route without a dynamic segment contributes no entry. A request for that
+// route matches an output during the filesystem check, so it needs no
+// rewrite.
+//
+// The fixture holds the shape that grows with the number of root param
+// combinations. `generateStaticParams` on the root layout produces one
+// fallback shell for each combination. Each manifest entry then produces
+// three adapter entries:
+//
+// - A dedicated segment route.
+// - An `.rsc` route.
+// - A plain route.
+describe('adapter dynamic routes (cache components)', () => {
+  const { next } = nextTestSetup({
+    files: path.join(__dirname, 'cache-components'),
+    // The fixture sets `generateBuildId`, and this option lets that value
+    // take effect. The harness otherwise assigns a new build ID for each run.
+    // A build ID that reaches an entry then changes the assertions on every
+    // run.
+    disableAutoSkewProtection: true,
+  })
+
+  it('emits the expected dynamic routes', async () => {
+    const routing: AdapterRouting = await next.readJSON('build-complete.json')
+
+    expect(serializeDynamicRoutes(routing.dynamicRoutes))
+      .toMatchInlineSnapshot(`
+     "27 entries
+
+     /[lang]
+       ^[/]?/(?<nxtPlang>[^/]+?)\\.segments/\\$d\\$lang(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
+       -> /[lang].segments/$d$lang$segment?nxtPlang=$nxtPlang
+
+     /de/fallback-shell/[slug]
+       ^[/]?/de/fallback\\-shell/(?<nxtPslug>[^/]+?)\\.segments/\\$d\\$lang/fallback\\-shell/\\$d\\$slug(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
+       -> /de/fallback-shell/[slug].segments/$d$lang/fallback-shell/$d$slug$segment?nxtPslug=$nxtPslug
+
+     /en/fallback-shell/[slug]
+       ^[/]?/en/fallback\\-shell/(?<nxtPslug>[^/]+?)\\.segments/\\$d\\$lang/fallback\\-shell/\\$d\\$slug(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
+       -> /en/fallback-shell/[slug].segments/$d$lang/fallback-shell/$d$slug$segment?nxtPslug=$nxtPslug
+
+     /[lang]/fallback-shell/[slug]
+       ^[/]?/(?<nxtPlang>[^/]+?)/fallback\\-shell/(?<nxtPslug>[^/]+?)\\.segments/\\$d\\$lang/fallback\\-shell/\\$d\\$slug(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
+       -> /[lang]/fallback-shell/[slug].segments/$d$lang/fallback-shell/$d$slug$segment?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug
+
+     /[lang]/ppr
+       ^[/]?/(?<nxtPlang>[^/]+?)/ppr\\.segments/\\$d\\$lang/ppr(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
+       -> /[lang]/ppr.segments/$d$lang/ppr$segment?nxtPlang=$nxtPlang
+
+     /[lang]/static
+       ^[/]?/(?<nxtPlang>[^/]+?)/static\\.segments/\\$d\\$lang/static(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
+       -> /[lang]/static.segments/$d$lang/static$segment?nxtPlang=$nxtPlang
+
+     /de/[slug]
+       ^[/]?/de/(?<nxtPslug>[^/]+?)\\.segments/\\$d\\$lang/\\$d\\$slug(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
+       -> /de/[slug].segments/$d$lang/$d$slug$segment?nxtPslug=$nxtPslug
+
+     /en/[slug]
+       ^[/]?/en/(?<nxtPslug>[^/]+?)\\.segments/\\$d\\$lang/\\$d\\$slug(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
+       -> /en/[slug].segments/$d$lang/$d$slug$segment?nxtPslug=$nxtPslug
+
+     /[lang]/[slug]
+       ^[/]?/(?<nxtPlang>[^/]+?)/(?<nxtPslug>[^/]+?)\\.segments/\\$d\\$lang/\\$d\\$slug(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
+       -> /[lang]/[slug].segments/$d$lang/$d$slug$segment?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug
+
+     /[lang].rsc
+       ^[/]?/(?<nxtPlang>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /[lang]$rscSuffix?nxtPlang=$nxtPlang
+
+     /[lang]
+       ^[/]?/(?<nxtPlang>[^/]+?)(?:/)?$
+       -> /[lang]?nxtPlang=$nxtPlang
+
+     /de/fallback-shell/[slug].rsc
+       ^[/]?/de/fallback\\-shell/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /de/fallback-shell/[slug]$rscSuffix?nxtPslug=$nxtPslug
+
+     /de/fallback-shell/[slug]
+       ^[/]?/de/fallback\\-shell/(?<nxtPslug>[^/]+?)(?:/)?$
+       -> /de/fallback-shell/[slug]?nxtPslug=$nxtPslug
+
+     /en/fallback-shell/[slug].rsc
+       ^[/]?/en/fallback\\-shell/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /en/fallback-shell/[slug]$rscSuffix?nxtPslug=$nxtPslug
+
+     /en/fallback-shell/[slug]
+       ^[/]?/en/fallback\\-shell/(?<nxtPslug>[^/]+?)(?:/)?$
+       -> /en/fallback-shell/[slug]?nxtPslug=$nxtPslug
+
+     /[lang]/fallback-shell/[slug].rsc
+       ^[/]?/(?<nxtPlang>[^/]+?)/fallback\\-shell/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /[lang]/fallback-shell/[slug]$rscSuffix?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug
+
+     /[lang]/fallback-shell/[slug]
+       ^[/]?/(?<nxtPlang>[^/]+?)/fallback\\-shell/(?<nxtPslug>[^/]+?)(?:/)?$
+       -> /[lang]/fallback-shell/[slug]?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug
+
+     /[lang]/ppr.rsc
+       ^[/]?/(?<nxtPlang>[^/]+?)/ppr(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /[lang]/ppr$rscSuffix?nxtPlang=$nxtPlang
+
+     /[lang]/ppr
+       ^[/]?/(?<nxtPlang>[^/]+?)/ppr(?:/)?$
+       -> /[lang]/ppr?nxtPlang=$nxtPlang
+
+     /[lang]/static.rsc
+       ^[/]?/(?<nxtPlang>[^/]+?)/static(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /[lang]/static$rscSuffix?nxtPlang=$nxtPlang
+
+     /[lang]/static
+       ^[/]?/(?<nxtPlang>[^/]+?)/static(?:/)?$
+       -> /[lang]/static?nxtPlang=$nxtPlang
+
+     /de/[slug].rsc
+       ^[/]?/de/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /de/[slug]$rscSuffix?nxtPslug=$nxtPslug
+
+     /de/[slug]
+       ^[/]?/de/(?<nxtPslug>[^/]+?)(?:/)?$
+       -> /de/[slug]?nxtPslug=$nxtPslug
+
+     /en/[slug].rsc
+       ^[/]?/en/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /en/[slug]$rscSuffix?nxtPslug=$nxtPslug
+
+     /en/[slug]
+       ^[/]?/en/(?<nxtPslug>[^/]+?)(?:/)?$
+       -> /en/[slug]?nxtPslug=$nxtPslug
+
+     /[lang]/[slug].rsc
+       ^[/]?/(?<nxtPlang>[^/]+?)/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /[lang]/[slug]$rscSuffix?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug
+
+     /[lang]/[slug]
+       ^[/]?/(?<nxtPlang>[^/]+?)/(?<nxtPslug>[^/]+?)(?:/)?$
+       -> /[lang]/[slug]?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug"
+    `)
+  })
+})

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-legacy.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-legacy.test.ts
@@ -1,0 +1,100 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  serializeDynamicRoutes,
+  type AdapterRouting,
+} from './dynamic-routes-snapshot'
+
+// This suite pins the dynamic routes that a build passes to an adapter for
+// an app router project without Cache Components. The fixture also holds one
+// pages router route.
+//
+// The fixture covers the parts of this output that do not depend on Cache
+// Components:
+//
+// - The `.rsc` entry and the plain entry that each dynamic app page receives.
+// - The entries that a route handler receives.
+// - Several pages that share one shape and differ in a static last segment.
+// - A pages router route that sets `fallback: false`.
+// - Two static pages router pages, next to a proxy.
+//
+// The `fallback: false` route decides whether a merge is possible. Its plain
+// entry carries a preview bypass condition. Its `.rsc` entry does not carry
+// that condition.
+//
+// A proxy next to a pages router adds one entry for each static pages router
+// page. That entry maps the `_next/data` URL of the page to the page itself.
+// The count of those entries grows with the number of pages rather than with
+// the number of route shapes.
+describe('adapter dynamic routes (legacy)', () => {
+  const { next } = nextTestSetup({
+    files: path.join(__dirname, 'legacy'),
+    // The fixture sets `generateBuildId`, and this option lets that value
+    // take effect. The harness otherwise assigns a new build ID for each run.
+    // The source regex of a pages router data route holds the build ID.
+    disableAutoSkewProtection: true,
+  })
+
+  it('emits the expected dynamic routes', async () => {
+    const routing: AdapterRouting = await next.readJSON('build-complete.json')
+
+    expect(serializeDynamicRoutes(routing.dynamicRoutes))
+      .toMatchInlineSnapshot(`
+     "13 entries
+
+     /legacy/[id]
+       ^/_next/data/test\\-build\\-id[/]?/legacy/(?<nxtPid>[^/]+?)\\.json(?:/)?$
+       -> /_next/data/test-build-id/legacy/[id].json?nxtPid=$nxtPid
+       [has cookie __prerender_bypass, has cookie __next_preview_data]
+
+     /static-one
+       ^/_next/data/test\\-build\\-id[/]?/static\\-one\\.json(?:/)?$
+       -> /static-one
+
+     /static-two
+       ^/_next/data/test\\-build\\-id[/]?/static\\-two\\.json(?:/)?$
+       -> /static-two
+
+     /blog/[slug].rsc
+       ^[/]?/blog/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /blog/[slug]$rscSuffix?nxtPslug=$nxtPslug
+
+     /blog/[slug]
+       ^[/]?/blog/(?<nxtPslug>[^/]+?)(?:/)?$
+       -> /blog/[slug]?nxtPslug=$nxtPslug
+
+     /docs/[lang]/accounts.rsc
+       ^[/]?/docs/(?<nxtPlang>[^/]+?)/accounts(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /docs/[lang]/accounts$rscSuffix?nxtPlang=$nxtPlang
+
+     /docs/[lang]/accounts
+       ^[/]?/docs/(?<nxtPlang>[^/]+?)/accounts(?:/)?$
+       -> /docs/[lang]/accounts?nxtPlang=$nxtPlang
+
+     /docs/[lang]/functions.rsc
+       ^[/]?/docs/(?<nxtPlang>[^/]+?)/functions(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /docs/[lang]/functions$rscSuffix?nxtPlang=$nxtPlang
+
+     /docs/[lang]/functions
+       ^[/]?/docs/(?<nxtPlang>[^/]+?)/functions(?:/)?$
+       -> /docs/[lang]/functions?nxtPlang=$nxtPlang
+
+     /docs/[lang]/guide.rsc
+       ^[/]?/docs/(?<nxtPlang>[^/]+?)/guide(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /docs/[lang]/guide$rscSuffix?nxtPlang=$nxtPlang
+
+     /docs/[lang]/guide
+       ^[/]?/docs/(?<nxtPlang>[^/]+?)/guide(?:/)?$
+       -> /docs/[lang]/guide?nxtPlang=$nxtPlang
+
+     /legacy/[id].rsc
+       ^[/]?/legacy/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+       -> /legacy/[id]$rscSuffix?nxtPid=$nxtPid
+
+     /legacy/[id]
+       ^[/]?/legacy/(?<nxtPid>[^/]+?)(?:/)?$
+       -> /legacy/[id]?nxtPid=$nxtPid
+       [has cookie __prerender_bypass, has cookie __next_preview_data]"
+    `)
+  })
+})

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-snapshot.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-snapshot.ts
@@ -1,0 +1,55 @@
+type RouteCondition = {
+  type: string
+  key: string
+  value?: string
+}
+
+export type DynamicRouteEntry = {
+  source: string
+  sourceRegex: string
+  destination: string
+  has?: RouteCondition[]
+  missing?: RouteCondition[]
+}
+
+export type AdapterRouting = {
+  dynamicRoutes: DynamicRouteEntry[]
+}
+
+/**
+ * Formats the dynamic routes as one block per entry.
+ *
+ * The output carries three things:
+ *
+ * - The entry count.
+ * - The fields that a collapse rewrites: `sourceRegex` and `destination`.
+ * - The conditions that allow a merge: `has` and `missing`.
+ *
+ * The output omits every other field of the adapter payload. An unrelated
+ * change to the build output then leaves the snapshot alone.
+ *
+ * The entries keep the order that the build emits. That order is part of the
+ * contract:
+ *
+ * - A fallback shell comes before its source page.
+ * - A static segment comes before a dynamic segment in the same position.
+ */
+export function serializeDynamicRoutes(routes: DynamicRouteEntry[]): string {
+  const blocks = routes.map((route) => {
+    const conditions = [
+      ...(route.has ?? []).map(
+        (condition) => `has ${condition.type} ${condition.key}`
+      ),
+      ...(route.missing ?? []).map(
+        (condition) => `missing ${condition.type} ${condition.key}`
+      ),
+    ]
+
+    const conditionLine =
+      conditions.length > 0 ? `\n  [${conditions.join(', ')}]` : ''
+
+    return `${route.source}\n  ${route.sourceRegex}\n  -> ${route.destination}${conditionLine}`
+  })
+
+  return `${routes.length} entries\n\n${blocks.join('\n\n')}`
+}

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/app/api/data/route.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/app/api/data/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ from: 'route-handler' })
+}

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/app/blog/[slug]/page.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/app/blog/[slug]/page.tsx
@@ -1,0 +1,13 @@
+export function generateStaticParams() {
+  return [{ slug: 'one' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  return <p>{slug}</p>
+}

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/app/docs/[lang]/accounts/page.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/app/docs/[lang]/accounts/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>accounts</p>
+}

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/app/docs/[lang]/functions/page.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/app/docs/[lang]/functions/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>functions</p>
+}

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/app/docs/[lang]/guide/page.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/app/docs/[lang]/guide/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>guide</p>
+}

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/app/layout.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/my-adapter.mjs
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/my-adapter.mjs
@@ -1,0 +1,12 @@
+import fs from 'fs/promises'
+
+/** @type {import('next').NextAdapter} */
+export default {
+  name: 'route-table-probe',
+  async onBuildComplete(ctx) {
+    await fs.writeFile(
+      'build-complete.json',
+      JSON.stringify(ctx.routing, null, 2)
+    )
+  },
+}

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/next.config.js
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/next.config.js
@@ -1,0 +1,16 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  // This value is explicit, not omitted. CI exports
+  // `__NEXT_CACHE_COMPONENTS=true` for the Cache Components matrices, and
+  // that variable overrides a config that omits the field. An omitted field
+  // would let that matrix turn Cache Components on for this fixture.
+  cacheComponents: false,
+  // The source regex of a pages router data route holds the build ID. A fixed
+  // build ID keeps the snapshot independent of the run.
+  generateBuildId: () => 'test-build-id',
+  adapterPath: require.resolve('./my-adapter.mjs'),
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/pages/legacy/[id].tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/pages/legacy/[id].tsx
@@ -1,0 +1,13 @@
+import type { GetStaticPaths, GetStaticProps } from 'next'
+
+export const getStaticPaths: GetStaticPaths = () => {
+  return { paths: [{ params: { id: '1' } }], fallback: false }
+}
+
+export const getStaticProps: GetStaticProps<{ id: string }> = ({ params }) => {
+  return { props: { id: String(params?.id) } }
+}
+
+export default function Page({ id }: { id: string }) {
+  return <p>legacy {id}</p>
+}

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/pages/static-one.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/pages/static-one.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>static one</p>
+}

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/pages/static-two.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/pages/static-two.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>static two</p>
+}

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/proxy.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/proxy.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server'
+
+export default function proxy() {
+  return NextResponse.next()
+}


### PR DESCRIPTION
We are about to reduce the number of these entries, and each of those changes should arrive with a diff that shows which ones it removes or merges. That is what these fixtures record. The existing behavioral suites stay responsible for regressions, and they do detect a routing change of this kind, e.g. a build that dropped the `.rsc` entries of fallback shells would fail a root param case in `segment-cache/prefetch-app-shell`. These snapshots add the part those suites may not distinguish, since an entry that collapses into a less specific match can still serve a response that renders the same content.

One fixture covers Cache Components with root params, the shape that grows with the number of root param combinations. The other covers what does not depend on Cache Components: the `.rsc` and plain entry pair that every dynamic app page receives, a route handler, pages that share one shape and differ in a static last segment, and a `fallback: false` pages router route whose plain entry carries a preview bypass condition that its `.rsc` sibling does not. It also holds a proxy next to static pages router pages, which adds one entry per page and is the only case here whose count grows with the number of pages rather than with the number of route shapes. A third test builds the first fixture again under a base path and asserts the prefix on every entry.

The projection stays narrow so that unrelated build output leaves it alone. Both fixtures pin `cacheComponents` and `generateBuildId`, because CI would otherwise vary them.