### PR TITLE
Stop emitting a redundant route per prefetch segment

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -2122,6 +2122,10 @@ export async function handleBuildComplete({
           route.page
         ) + getDestinationQuery(route.routeKeys)
 
+      // This route serves two kinds of request for the page: a request for the
+      // `.rsc` payload, and a per-segment prefetch request. The suffix group
+      // accepts both forms, and the destination copies the matched suffix, so
+      // each request resolves to the artifact that it asks for.
       if (appPageKeys && appPageKeys.length > 0) {
         dynamicRoutes.push({
           source: route.page + '.rsc',
@@ -2147,22 +2151,27 @@ export async function handleBuildComplete({
         missing: undefined,
       })
 
-      for (const segmentRoute of route.prefetchSegmentDataRoutes || []) {
-        dynamicSegmentRoutes.push({
-          source: route.page,
-          sourceRegex: segmentRoute.source.replace(
-            '^',
-            `^${config.basePath && config.basePath !== '/' ? path.posix.join('/', config.basePath || '') : ''}[/]?`
-          ),
-          destination: path.posix.join(
-            '/',
-            config.basePath,
-            segmentRoute.destination +
-              getDestinationQuery(segmentRoute.routeKeys)
-          ),
-          has: undefined,
-          missing: undefined,
-        })
+      // The `.rsc` route above resolves a per-segment request on its own. A
+      // build that turns the collapse off emits a dedicated route for each
+      // segment, and the table lists those before that `.rsc` route.
+      if (!config.experimental.collapseAdapterRoutes) {
+        for (const segmentRoute of route.prefetchSegmentDataRoutes || []) {
+          dynamicSegmentRoutes.push({
+            source: route.page,
+            sourceRegex: segmentRoute.source.replace(
+              '^',
+              `^${config.basePath && config.basePath !== '/' ? path.posix.join('/', config.basePath || '') : ''}[/]?`
+            ),
+            destination: path.posix.join(
+              '/',
+              config.basePath,
+              segmentRoute.destination +
+                getDestinationQuery(segmentRoute.routeKeys)
+            ),
+            has: undefined,
+            missing: undefined,
+          })
+        }
       }
     }
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -197,6 +197,7 @@ export const experimentalSchema = {
   after: z.boolean().optional(),
   appNavFailHandling: z.boolean().optional(),
   coldCacheBadge: z.boolean().optional(),
+  collapseAdapterRoutes: z.boolean().optional(),
   preloadEntriesOnStart: z.boolean().optional(),
   allowedRevalidateHeaderKeys: z.array(z.string()).optional(),
   staleTimes: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -498,6 +498,18 @@ export interface ExperimentalConfig {
    * regardless of this flag.
    */
   coldCacheBadge?: boolean
+  /**
+   * Whether a build may serve several dynamic routes from one entry in the
+   * route table that it passes to an adapter. Several routes of an app can
+   * differ only in a part that a single pattern also matches, and one entry for
+   * them keeps the table smaller.
+   *
+   * A collapsed entry resolves each request to the same output as the entries
+   * that it replaces.
+   *
+   * @default true
+   */
+  collapseAdapterRoutes?: boolean
   useSkewCookie?: boolean
   /** @deprecated use top-level `cacheHandlers` instead */
   cacheHandlers?: NextConfig['cacheHandlers']
@@ -2229,6 +2241,7 @@ export const defaultConfig = Object.freeze({
   adapterPath: process.env.NEXT_ADAPTER_PATH || undefined,
   experimental: {
     coldCacheBadge: false,
+    collapseAdapterRoutes: true,
     devValidationWorker: true,
     useSkewCookie: false,
     cssChunking: true,

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-base-path.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-base-path.test.ts
@@ -30,7 +30,7 @@ describe(`adapter dynamic routes (cache components, base path ${basePath})`, () 
     const routing: AdapterRouting = await next.readJSON('build-complete.json')
 
     // A base path prefixes the entries. It does not add or remove any.
-    expect(routing.dynamicRoutes).toHaveLength(27)
+    expect(routing.dynamicRoutes).toHaveLength(18)
 
     for (const route of routing.dynamicRoutes) {
       expect(route.sourceRegex.startsWith(`^${basePath}`)).toBe(true)

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-cache-components.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-cache-components.test.ts
@@ -21,9 +21,8 @@ import {
 // The fixture holds the shape that grows with the number of root param
 // combinations. `generateStaticParams` on the root layout produces one
 // fallback shell for each combination. Each manifest entry then produces
-// three adapter entries:
+// two adapter entries:
 //
-// - A dedicated segment route.
 // - An `.rsc` route.
 // - A plain route.
 describe('adapter dynamic routes (cache components)', () => {
@@ -41,43 +40,7 @@ describe('adapter dynamic routes (cache components)', () => {
 
     expect(serializeDynamicRoutes(routing.dynamicRoutes))
       .toMatchInlineSnapshot(`
-     "27 entries
-
-     /[lang]
-       ^[/]?/(?<nxtPlang>[^/]+?)\\.segments/\\$d\\$lang(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
-       -> /[lang].segments/$d$lang$segment?nxtPlang=$nxtPlang
-
-     /de/fallback-shell/[slug]
-       ^[/]?/de/fallback\\-shell/(?<nxtPslug>[^/]+?)\\.segments/\\$d\\$lang/fallback\\-shell/\\$d\\$slug(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
-       -> /de/fallback-shell/[slug].segments/$d$lang/fallback-shell/$d$slug$segment?nxtPslug=$nxtPslug
-
-     /en/fallback-shell/[slug]
-       ^[/]?/en/fallback\\-shell/(?<nxtPslug>[^/]+?)\\.segments/\\$d\\$lang/fallback\\-shell/\\$d\\$slug(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
-       -> /en/fallback-shell/[slug].segments/$d$lang/fallback-shell/$d$slug$segment?nxtPslug=$nxtPslug
-
-     /[lang]/fallback-shell/[slug]
-       ^[/]?/(?<nxtPlang>[^/]+?)/fallback\\-shell/(?<nxtPslug>[^/]+?)\\.segments/\\$d\\$lang/fallback\\-shell/\\$d\\$slug(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
-       -> /[lang]/fallback-shell/[slug].segments/$d$lang/fallback-shell/$d$slug$segment?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug
-
-     /[lang]/ppr
-       ^[/]?/(?<nxtPlang>[^/]+?)/ppr\\.segments/\\$d\\$lang/ppr(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
-       -> /[lang]/ppr.segments/$d$lang/ppr$segment?nxtPlang=$nxtPlang
-
-     /[lang]/static
-       ^[/]?/(?<nxtPlang>[^/]+?)/static\\.segments/\\$d\\$lang/static(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
-       -> /[lang]/static.segments/$d$lang/static$segment?nxtPlang=$nxtPlang
-
-     /de/[slug]
-       ^[/]?/de/(?<nxtPslug>[^/]+?)\\.segments/\\$d\\$lang/\\$d\\$slug(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
-       -> /de/[slug].segments/$d$lang/$d$slug$segment?nxtPslug=$nxtPslug
-
-     /en/[slug]
-       ^[/]?/en/(?<nxtPslug>[^/]+?)\\.segments/\\$d\\$lang/\\$d\\$slug(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
-       -> /en/[slug].segments/$d$lang/$d$slug$segment?nxtPslug=$nxtPslug
-
-     /[lang]/[slug]
-       ^[/]?/(?<nxtPlang>[^/]+?)/(?<nxtPslug>[^/]+?)\\.segments/\\$d\\$lang/\\$d\\$slug(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$
-       -> /[lang]/[slug].segments/$d$lang/$d$slug$segment?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug
+     "18 entries
 
      /[lang].rsc
        ^[/]?/(?<nxtPlang>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$


### PR DESCRIPTION
For a dynamic app page that has a fallback shell, say `/[lang]/[slug]` with a shell for the root param value `de`, the build emits three routes to an adapter. Simplified, with the request pattern on the left and the artifact it resolves to on the right:

```diff
- /de/<slug>.segments/$d$lang/$d$slug<seg>   ->  /de/[slug].segments/$d$lang/$d$slug<seg>
  /de/<slug><.rsc|.segments/*.segment.rsc>   ->  /de/[slug]<matched suffix>
  /de/<slug>                                 ->  /de/[slug]
```

This change removes the first one. The second already covers it: its suffix group accepts `.segments/<path>.segment.rsc` as well as `.rsc`, and it copies the matched suffix into the destination, so a per-segment request resolves to the same artifact either way.

That second route is also the only one that ever answered `_tree` and `_full` requests, because a per-segment route pins one literal segment path in its regex. A `_tree` prefetch for `/de/<slug>` resolves to `/de/[slug].segments/_tree.segment.rsc`, which the per-segment route cannot produce. So this removes a duplicate, not a mechanism.

Only fallback shells emit per-segment routes, because their artifacts sit under an unresolved param and need a rewrite to reach. Segment artifacts for a concrete prerendered path need none, since a request for that path matches them directly. Apps with many shells therefore lose close to a third of their routes. We measured an in-progress feature branch of the v0 chat app, which enumerates precomputed flag, locale and device permutations in `generateStaticParams` for a top-level dynamic segment and so multiplies every route below it. Building that branch before and after the change removes 32% of its routes, adds none, and changes nothing else once the build ID is normalized.

This also adds `experimental.collapseAdapterRoutes`. It defaults to `true`, and it controls this collapse together with the ones that follow in this stack. A build that sets it to `false` emits the same route table as a build without any change in this stack.

`prefetchSegmentDataRoutes` stays in `routes-manifest.json`. A build that does not use the adapter reads the field from that manifest and derives the same routes from it. This change therefore leaves that path alone.

**Verified upstack with a [full deploy test run](https://github.com/vercel/next.js/actions/runs/32540912007).**
