### PR TITLE
fix(app-router): segment prefetch config overrides app-level partialPrefetching default

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1107,9 +1107,16 @@ async function generateStagedDynamicFlightRenderResultNode(
   // fill caches and then spawn a final runtime prerender whose result stream
   // is embedded in the RSC payload. This is gated because it adds extra server
   // processing and increases the response payload size.
+  //
+  // The app-level default is folded into the per-segment resolution inside
+  // anySegmentHasPartialPrefetchingEnabled (rather than OR'd in here), so a
+  // segment's own explicit `prefetch` export can override it either way, not
+  // just turn it on.
   if (
-    Boolean(renderOpts.partialPrefetching) ||
-    (await anySegmentHasPartialPrefetchingEnabled(loaderTree))
+    await anySegmentHasPartialPrefetchingEnabled(
+      loaderTree,
+      renderOpts.partialPrefetching ? 'partial' : undefined
+    )
   ) {
     // Create a mutable cache that gets filled during the dynamic render.
     const prerenderResumeDataCache = createPrerenderResumeDataCache()
@@ -3878,10 +3885,15 @@ async function renderToStream(
         // runtime-prefetchable content during hydration. This is enabled when
         // Partial Prefetching is on for the route, either per segment (a
         // `prefetch` of 'partial') or globally (the
-        // `partialPrefetching` config).
+        // `partialPrefetching` config). The app-level default is folded into
+        // the per-segment resolution inside
+        // anySegmentHasPartialPrefetchingEnabled, so a segment's own explicit
+        // `prefetch` export can override it either way, not just turn it on.
         if (
-          Boolean(renderOpts.partialPrefetching) ||
-          (await anySegmentHasPartialPrefetchingEnabled(tree))
+          await anySegmentHasPartialPrefetchingEnabled(
+            tree,
+            renderOpts.partialPrefetching ? 'partial' : undefined
+          )
         ) {
           const prerenderResumeDataCache = createPrerenderResumeDataCache()
           requestStore.resumeDataCache = prerenderResumeDataCache
@@ -5315,12 +5327,18 @@ async function getPrefetchingModeForPage(
   const debug =
     process.env.NEXT_PRIVATE_DEBUG_VALIDATION === '1' ? console.log : undefined
 
-  if (renderOpts.partialPrefetching) {
-    debug?.('using prefetching mode Partial because of next.config.js')
-    return PrefetchingMode.Partial
-  }
-  if (await anySegmentHasPartialPrefetchingEnabled(loaderTree)) {
-    debug?.('using prefetching mode Partial because of segment config')
+  // The app-level default is folded into the per-segment resolution inside
+  // anySegmentHasPartialPrefetchingEnabled (rather than checked here first),
+  // so a segment's own explicit `prefetch` export can override it either
+  // way, not just turn it on -- matching the actual runtime-prefetch-spawn
+  // decision this dev-only mode selection should stay consistent with.
+  if (
+    await anySegmentHasPartialPrefetchingEnabled(
+      loaderTree,
+      renderOpts.partialPrefetching ? 'partial' : undefined
+    )
+  ) {
+    debug?.('using prefetching mode Partial')
     return PrefetchingMode.Partial
   }
 

--- a/packages/next/src/server/app-render/instant-validation/instant-config.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-config.tsx
@@ -13,6 +13,7 @@ import type { Segment } from '../../../shared/lib/app-router-types'
 import type {
   AppSegmentConfig,
   InstantSample,
+  Prefetch,
 } from '../../../build/segment-config/app/app-segment-config'
 import {
   workAsyncStorage,
@@ -54,25 +55,60 @@ export function isFrameworkErrorRoute(route: string | undefined): boolean {
  * Matches the `prefetch` config that enables Partial Prefetching for the
  * segment: 'partial'. A route with Partial Prefetching enabled also
  * runtime-caches its navigations, so this gates the runtime prefetch spawn.
+ *
+ * `inheritedPrefetchConfig` is the effective config inherited from this
+ * segment's ancestors — the nearest ancestor's own explicit `prefetch` value
+ * if one exists, otherwise 'partial' if the app-level `partialPrefetching`
+ * default is on, otherwise undefined. Each segment resolves its OWN
+ * effective config as
+ * `mod.prefetch ?? inheritedPrefetchConfig` (the same resolution
+ * `computeSegmentPrefetchHints` already uses in
+ * create-transport-tree-from-loader-tree.ts to compute this segment's
+ * prefetch hints), then passes that resolved value down to its own children
+ * as the new inherited default — so an explicit `prefetch` export on any
+ * segment overrides whatever default it would otherwise have inherited, for
+ * every segment below it, per the documented contract. This must be checked
+ * leaf-by-leaf rather than stopping at the first segment found to resolve to
+ * 'partial': the outermost segments are almost always unconfigured, so they
+ * trivially inherit the app-level default whenever it's on, before ever
+ * reaching whichever segment actually has an opinion.
+ *
+ * A segment that explicitly opts out (`force-disabled`, or `auto`, which
+ * behaves the same way here) simply resolves to something other than
+ * 'partial' at that segment and everything below it (unless a descendant
+ * re-opts-in) — per `PrefetchHint.PrefetchDisabled`'s own contract, the
+ * opt-out is passive: it's never the reason a runtime prefetch spawns, but
+ * it doesn't veto an unrelated sibling subtree that does want one, so the
+ * search still continues into the rest of the tree.
  */
 export async function anySegmentHasPartialPrefetchingEnabled(
-  tree: LoaderTree
+  tree: LoaderTree,
+  inheritedPrefetchConfig: Prefetch | undefined
 ): Promise<boolean> {
   const { mod: layoutOrPageMod } = await getLayoutOrPageModule(tree)
 
   // TODO(restart-on-cache-miss): Does this work correctly for client page/layout modules?
-  const prefetchConfig = layoutOrPageMod
+  const explicitPrefetchConfig = layoutOrPageMod
     ? (layoutOrPageMod as AppSegmentConfig).prefetch
     : undefined
-  if (prefetchConfig === 'partial') {
-    return true
-  }
+  const resolvedPrefetchConfig =
+    explicitPrefetchConfig ?? inheritedPrefetchConfig
 
   const { parallelRoutes } = parseLoaderTree(tree)
-  for (const parallelRouteKey in parallelRoutes) {
+  const parallelRouteKeys = Object.keys(parallelRoutes)
+  if (parallelRouteKeys.length === 0) {
+    // Leaf segment (the page) — this is where the resolved config actually
+    // takes effect, since nothing further down could still override it.
+    return resolvedPrefetchConfig === 'partial'
+  }
+
+  for (const parallelRouteKey of parallelRouteKeys) {
     const parallelRoute = parallelRoutes[parallelRouteKey]
     const hasChildPartialPrefetching =
-      await anySegmentHasPartialPrefetchingEnabled(parallelRoute)
+      await anySegmentHasPartialPrefetchingEnabled(
+        parallelRoute,
+        resolvedPrefetchConfig
+      )
     if (hasChildPartialPrefetching) {
       return true
     }

--- a/test/unit/any-segment-has-partial-prefetching-enabled.test.ts
+++ b/test/unit/any-segment-has-partial-prefetching-enabled.test.ts
@@ -1,0 +1,121 @@
+import { anySegmentHasPartialPrefetchingEnabled } from 'next/dist/server/app-render/instant-validation/instant-config'
+import type { LoaderTree } from 'next/dist/server/lib/app-dir-module'
+
+// Fake `AppDirModules['page' | 'layout']` tuple: `getLayoutOrPageModule` only
+// reads element 0 (the loader) and element 1 (the file path, unused here) —
+// a real tuple also carries type info this test doesn't need.
+function moduleTuple(exports: {
+  prefetch?: 'partial' | 'auto' | 'force-disabled'
+}): any {
+  return [async () => exports, '/fake/module.tsx']
+}
+
+function pageTree(
+  segment: string,
+  exports: { prefetch?: 'partial' | 'auto' | 'force-disabled' } = {},
+  parallelRoutes: LoaderTree[1] = {}
+): LoaderTree {
+  return [segment, parallelRoutes, { page: moduleTuple(exports) }, null]
+}
+
+function layoutTree(
+  segment: string,
+  exports: { prefetch?: 'partial' | 'auto' | 'force-disabled' },
+  parallelRoutes: LoaderTree[1]
+): LoaderTree {
+  return [segment, parallelRoutes, { layout: moduleTuple(exports) }, null]
+}
+
+describe('anySegmentHasPartialPrefetchingEnabled', () => {
+  it('a segment with no explicit prefetch config inherits the app-level default (on)', async () => {
+    const tree = pageTree('page')
+    expect(await anySegmentHasPartialPrefetchingEnabled(tree, 'partial')).toBe(
+      true
+    )
+  })
+
+  it('a segment with no explicit prefetch config inherits the app-level default (off)', async () => {
+    const tree = pageTree('page')
+    expect(await anySegmentHasPartialPrefetchingEnabled(tree, undefined)).toBe(
+      false
+    )
+  })
+
+  it('an explicit prefetch = "partial" enables it even when the app-level default is off', async () => {
+    const tree = pageTree('page', { prefetch: 'partial' })
+    expect(await anySegmentHasPartialPrefetchingEnabled(tree, undefined)).toBe(
+      true
+    )
+  })
+
+  it('an explicit prefetch = "force-disabled" overrides an app-level default of on, on a single-segment route', async () => {
+    const tree = pageTree('page', { prefetch: 'force-disabled' })
+    expect(await anySegmentHasPartialPrefetchingEnabled(tree, 'partial')).toBe(
+      false
+    )
+  })
+
+  // 'auto' behaves the same way as 'force-disabled' here, mirroring
+  // computeSegmentPrefetchHints's identical `??` resolution
+  // (create-transport-tree-from-loader-tree.ts) for the same config.
+  it('an explicit prefetch = "auto" overrides an app-level default of on, on a single-segment route', async () => {
+    const tree = pageTree('page', { prefetch: 'auto' })
+    expect(await anySegmentHasPartialPrefetchingEnabled(tree, 'partial')).toBe(
+      false
+    )
+  })
+
+  // Regression test for https://github.com/vercel/next.js/issues/97386, and
+  // for the exact shape of a second bug caught while fixing the first: a
+  // *single-segment* tree where the one segment has an explicit override
+  // does not exercise the real bug, since there's no ancestor for the
+  // app-level default to trivially resolve against first. A real route is a
+  // root layout (almost always unconfigured) above the actual page, and the
+  // root's own inherited resolution ('partial', from the app-level default)
+  // must not be treated as the final answer before the page below it -- the
+  // segment that actually has an opinion -- is ever reached.
+  it('a page nested under an unconfigured root layout can still override an app-level default of on', async () => {
+    const tree = layoutTree(
+      '',
+      {},
+      {
+        children: pageTree('item', { prefetch: 'force-disabled' }),
+      }
+    )
+    expect(await anySegmentHasPartialPrefetchingEnabled(tree, 'partial')).toBe(
+      false
+    )
+  })
+
+  // The inheritance must work in the enabling direction too: a layout's own
+  // explicit opt-in should reach an unconfigured page below it, even with no
+  // app-level default at all.
+  it('a page nested under a layout with an explicit prefetch = "partial" inherits it', async () => {
+    const tree = layoutTree(
+      '',
+      { prefetch: 'partial' },
+      { children: pageTree('item') }
+    )
+    expect(await anySegmentHasPartialPrefetchingEnabled(tree, undefined)).toBe(
+      true
+    )
+  })
+
+  // PrefetchHint.PrefetchDisabled is documented as passive and segment-local
+  // (app-router-types.ts): an opt-out on one segment's branch must not veto
+  // an unrelated sibling parallel-route branch that still wants partial
+  // prefetching.
+  it('a "force-disabled" branch does not prevent a sibling parallel-route branch from enabling it', async () => {
+    const tree = layoutTree(
+      '',
+      {},
+      {
+        children: pageTree('item', { prefetch: 'force-disabled' }),
+        modal: pageTree('modal', { prefetch: 'partial' }),
+      }
+    )
+    expect(await anySegmentHasPartialPrefetchingEnabled(tree, undefined)).toBe(
+      true
+    )
+  })
+})


### PR DESCRIPTION
Fixes #97386

### What was wrong

`anySegmentHasPartialPrefetchingEnabled(tree)` was checking the app-level `partialPrefetching` setting before checking each segment. Because of that, if the app-level setting was enabled, it would immediately return `true` even when a specific page explicitly disabled prefetching.

### What this caused

A page with:

```ts
export const prefetch = 'force-disabled'
```

could still start and ship a runtime prefetch stream when `partialPrefetching` was enabled at the app level. This resulted in an unnecessary duplicate prefetch stream.

### What changed

The function now receives the inherited prefetch configuration as a second argument:

```ts
inheritedPrefetchConfig: Prefetch | undefined
```

For each segment, we resolve the configuration like this:

```ts
resolvedPrefetchConfig = explicitPrefetchConfig ?? inheritedPrefetchConfig
```

That resolved value is then passed down to the segment's children as their inherited default.

Importantly, we only check whether the resolved value is `'partial'` at the **leaf/page segment**, rather than at every level of the tree.

### Why the leaf-only check is important

Previously, the function walked from the root toward the page and returned `true` as soon as it found a segment resolving to `'partial'`.

Root and layout segments are usually not explicitly configured, so they would inherit the app-level `partialPrefetching` setting. That meant they could resolve to `'partial'` and cause the function to return before it ever reached the page's explicit `force-disabled` override.

We verified this with a live reproduction using the reporter's `damianfrizzi/next-runtime-prefetch-repro` repository. The bug still reproduced even after introducing the `??` configuration resolution, which confirmed that checking for `'partial'` at every ancestor was the underlying problem.

### Other call site

The third call site was fixed as well. `getPrefetchingModeForPage`, which is used for the dev-only `SyncIOMode` selection, had the same issue. It wasn't part of the original report, but leaving it inconsistent would have preserved the same bug there.

### Tests

Added `test/unit/any-segment-has-partial-prefetching-enabled.test.ts` with 8 test cases, including a regression test covering the exact reported scenario: a nested layout with an app-level default and a page-level `force-disabled` override.
