### PR TITLE
Stop emitting a separate route entry for a dynamic route's RSC form

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -2122,38 +2122,82 @@ export async function handleBuildComplete({
           route.page
         ) + getDestinationQuery(route.routeKeys)
 
-      // This route serves two kinds of request for the page: a request for the
-      // `.rsc` payload, and a per-segment prefetch request. The suffix group
-      // accepts both forms, and the destination copies the matched suffix, so
-      // each request resolves to the artifact that it asks for.
-      if (appPageKeys && appPageKeys.length > 0) {
+      const hasAppPages = Boolean(appPageKeys && appPageKeys.length > 0)
+
+      const suffixedHas =
+        isFallbackFalse && !pageKeys.includes(route.page)
+          ? fallbackFalseHasCondition
+          : undefined
+      const plainHas = isFallbackFalse ? fallbackFalseHasCondition : undefined
+
+      // A single entry can serve both forms of the request only when both carry
+      // the same conditions. A pages router route with `fallback: false` is the
+      // one case where they differ: it requires the preview cookies on the
+      // plain form, and not on the suffixed form. An entry holds one set of
+      // conditions, so that case keeps a separate entry per form.
+      const canMergeSuffixedAndPlain =
+        config.experimental.collapseAdapterRoutes &&
+        hasAppPages &&
+        suffixedHas === plainHas
+
+      if (canMergeSuffixedAndPlain) {
+        // One entry serves every form of a request for this page:
+        //
+        // - The document at the page path.
+        // - The `.rsc` payload.
+        // - A per-segment prefetch.
+        //
+        // The suffix group ends with an empty alternative. The group therefore
+        // always matches, and it captures an empty string for a request that
+        // carries no suffix. The destination copies what the group captured.
+        //
+        // An optional group is unsafe here. An adapter, or the router that
+        // consumes its output, can resolve the placeholders in a destination
+        // from the match result rather than from the pattern. A group that does
+        // not match is then absent from that result, and the literal text
+        // `$rscSuffix` stays in the destination.
         dynamicRoutes.push({
-          source: route.page + '.rsc',
+          source: route.page,
           sourceRegex: sourceRegex.replace(
             new RegExp(escapeStringRegexp('(?:/)?$')),
-            '(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$'
+            '(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$'
           ),
           destination: destination?.replace(/($|\?)/, '$rscSuffix$1'),
-          has:
-            isFallbackFalse && !pageKeys.includes(route.page)
-              ? fallbackFalseHasCondition
-              : undefined,
+          has: plainHas,
+          missing: undefined,
+        })
+      } else {
+        // This route serves two kinds of request for the page: a request for
+        // the `.rsc` payload, and a per-segment prefetch request. The suffix
+        // group accepts both forms, and the destination copies the matched
+        // suffix, so each request resolves to the artifact that it asks for.
+        if (hasAppPages) {
+          dynamicRoutes.push({
+            source: route.page + '.rsc',
+            sourceRegex: sourceRegex.replace(
+              new RegExp(escapeStringRegexp('(?:/)?$')),
+              '(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$'
+            ),
+            destination: destination?.replace(/($|\?)/, '$rscSuffix$1'),
+            has: suffixedHas,
+            missing: undefined,
+          })
+        }
+
+        // needs basePath and locale handling if pages router
+        dynamicRoutes.push({
+          source: route.page,
+          sourceRegex,
+          destination,
+          has: plainHas,
           missing: undefined,
         })
       }
 
-      // needs basePath and locale handling if pages router
-      dynamicRoutes.push({
-        source: route.page,
-        sourceRegex,
-        destination,
-        has: isFallbackFalse ? fallbackFalseHasCondition : undefined,
-        missing: undefined,
-      })
-
-      // The `.rsc` route above resolves a per-segment request on its own. A
-      // build that turns the collapse off emits a dedicated route for each
-      // segment, and the table lists those before that `.rsc` route.
+      // The entry above resolves a per-segment request on its own, because its
+      // suffix group accepts a segment path. A build that turns the collapse
+      // off emits a dedicated route for each segment, and the table lists those
+      // before that entry.
       if (!config.experimental.collapseAdapterRoutes) {
         for (const segmentRoute of route.prefetchSegmentDataRoutes || []) {
           dynamicSegmentRoutes.push({

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-base-path.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-base-path.test.ts
@@ -30,7 +30,7 @@ describe(`adapter dynamic routes (cache components, base path ${basePath})`, () 
     const routing: AdapterRouting = await next.readJSON('build-complete.json')
 
     // A base path prefixes the entries. It does not add or remove any.
-    expect(routing.dynamicRoutes).toHaveLength(18)
+    expect(routing.dynamicRoutes).toHaveLength(9)
 
     for (const route of routing.dynamicRoutes) {
       expect(route.sourceRegex.startsWith(`^${basePath}`)).toBe(true)

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-cache-components.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-cache-components.test.ts
@@ -40,79 +40,43 @@ describe('adapter dynamic routes (cache components)', () => {
 
     expect(serializeDynamicRoutes(routing.dynamicRoutes))
       .toMatchInlineSnapshot(`
-     "18 entries
-
-     /[lang].rsc
-       ^[/]?/(?<nxtPlang>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
-       -> /[lang]$rscSuffix?nxtPlang=$nxtPlang
+     "9 entries
 
      /[lang]
-       ^[/]?/(?<nxtPlang>[^/]+?)(?:/)?$
-       -> /[lang]?nxtPlang=$nxtPlang
-
-     /de/fallback-shell/[slug].rsc
-       ^[/]?/de/fallback\\-shell/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
-       -> /de/fallback-shell/[slug]$rscSuffix?nxtPslug=$nxtPslug
+       ^[/]?/(?<nxtPlang>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /[lang]$rscSuffix?nxtPlang=$nxtPlang
 
      /de/fallback-shell/[slug]
-       ^[/]?/de/fallback\\-shell/(?<nxtPslug>[^/]+?)(?:/)?$
-       -> /de/fallback-shell/[slug]?nxtPslug=$nxtPslug
-
-     /en/fallback-shell/[slug].rsc
-       ^[/]?/en/fallback\\-shell/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
-       -> /en/fallback-shell/[slug]$rscSuffix?nxtPslug=$nxtPslug
+       ^[/]?/de/fallback\\-shell/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /de/fallback-shell/[slug]$rscSuffix?nxtPslug=$nxtPslug
 
      /en/fallback-shell/[slug]
-       ^[/]?/en/fallback\\-shell/(?<nxtPslug>[^/]+?)(?:/)?$
-       -> /en/fallback-shell/[slug]?nxtPslug=$nxtPslug
-
-     /[lang]/fallback-shell/[slug].rsc
-       ^[/]?/(?<nxtPlang>[^/]+?)/fallback\\-shell/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
-       -> /[lang]/fallback-shell/[slug]$rscSuffix?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug
+       ^[/]?/en/fallback\\-shell/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /en/fallback-shell/[slug]$rscSuffix?nxtPslug=$nxtPslug
 
      /[lang]/fallback-shell/[slug]
-       ^[/]?/(?<nxtPlang>[^/]+?)/fallback\\-shell/(?<nxtPslug>[^/]+?)(?:/)?$
-       -> /[lang]/fallback-shell/[slug]?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug
-
-     /[lang]/ppr.rsc
-       ^[/]?/(?<nxtPlang>[^/]+?)/ppr(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
-       -> /[lang]/ppr$rscSuffix?nxtPlang=$nxtPlang
+       ^[/]?/(?<nxtPlang>[^/]+?)/fallback\\-shell/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /[lang]/fallback-shell/[slug]$rscSuffix?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug
 
      /[lang]/ppr
-       ^[/]?/(?<nxtPlang>[^/]+?)/ppr(?:/)?$
-       -> /[lang]/ppr?nxtPlang=$nxtPlang
-
-     /[lang]/static.rsc
-       ^[/]?/(?<nxtPlang>[^/]+?)/static(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
-       -> /[lang]/static$rscSuffix?nxtPlang=$nxtPlang
+       ^[/]?/(?<nxtPlang>[^/]+?)/ppr(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /[lang]/ppr$rscSuffix?nxtPlang=$nxtPlang
 
      /[lang]/static
-       ^[/]?/(?<nxtPlang>[^/]+?)/static(?:/)?$
-       -> /[lang]/static?nxtPlang=$nxtPlang
-
-     /de/[slug].rsc
-       ^[/]?/de/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
-       -> /de/[slug]$rscSuffix?nxtPslug=$nxtPslug
+       ^[/]?/(?<nxtPlang>[^/]+?)/static(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /[lang]/static$rscSuffix?nxtPlang=$nxtPlang
 
      /de/[slug]
-       ^[/]?/de/(?<nxtPslug>[^/]+?)(?:/)?$
-       -> /de/[slug]?nxtPslug=$nxtPslug
-
-     /en/[slug].rsc
-       ^[/]?/en/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
-       -> /en/[slug]$rscSuffix?nxtPslug=$nxtPslug
+       ^[/]?/de/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /de/[slug]$rscSuffix?nxtPslug=$nxtPslug
 
      /en/[slug]
-       ^[/]?/en/(?<nxtPslug>[^/]+?)(?:/)?$
-       -> /en/[slug]?nxtPslug=$nxtPslug
-
-     /[lang]/[slug].rsc
-       ^[/]?/(?<nxtPlang>[^/]+?)/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
-       -> /[lang]/[slug]$rscSuffix?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug
+       ^[/]?/en/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /en/[slug]$rscSuffix?nxtPslug=$nxtPslug
 
      /[lang]/[slug]
-       ^[/]?/(?<nxtPlang>[^/]+?)/(?<nxtPslug>[^/]+?)(?:/)?$
-       -> /[lang]/[slug]?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug"
+       ^[/]?/(?<nxtPlang>[^/]+?)/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /[lang]/[slug]$rscSuffix?nxtPlang=$nxtPlang&nxtPslug=$nxtPslug"
     `)
   })
 })

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-legacy.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-legacy.test.ts
@@ -40,7 +40,7 @@ describe('adapter dynamic routes (legacy)', () => {
 
     expect(serializeDynamicRoutes(routing.dynamicRoutes))
       .toMatchInlineSnapshot(`
-     "13 entries
+     "9 entries
 
      /legacy/[id]
        ^/_next/data/test\\-build\\-id[/]?/legacy/(?<nxtPid>[^/]+?)\\.json(?:/)?$
@@ -55,37 +55,21 @@ describe('adapter dynamic routes (legacy)', () => {
        ^/_next/data/test\\-build\\-id[/]?/static\\-two\\.json(?:/)?$
        -> /static-two
 
-     /blog/[slug].rsc
-       ^[/]?/blog/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+     /blog/[slug]
+       ^[/]?/blog/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
        -> /blog/[slug]$rscSuffix?nxtPslug=$nxtPslug
 
-     /blog/[slug]
-       ^[/]?/blog/(?<nxtPslug>[^/]+?)(?:/)?$
-       -> /blog/[slug]?nxtPslug=$nxtPslug
-
-     /docs/[lang]/accounts.rsc
-       ^[/]?/docs/(?<nxtPlang>[^/]+?)/accounts(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+     /docs/[lang]/accounts
+       ^[/]?/docs/(?<nxtPlang>[^/]+?)/accounts(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
        -> /docs/[lang]/accounts$rscSuffix?nxtPlang=$nxtPlang
 
-     /docs/[lang]/accounts
-       ^[/]?/docs/(?<nxtPlang>[^/]+?)/accounts(?:/)?$
-       -> /docs/[lang]/accounts?nxtPlang=$nxtPlang
-
-     /docs/[lang]/functions.rsc
-       ^[/]?/docs/(?<nxtPlang>[^/]+?)/functions(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
+     /docs/[lang]/functions
+       ^[/]?/docs/(?<nxtPlang>[^/]+?)/functions(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
        -> /docs/[lang]/functions$rscSuffix?nxtPlang=$nxtPlang
 
-     /docs/[lang]/functions
-       ^[/]?/docs/(?<nxtPlang>[^/]+?)/functions(?:/)?$
-       -> /docs/[lang]/functions?nxtPlang=$nxtPlang
-
-     /docs/[lang]/guide.rsc
-       ^[/]?/docs/(?<nxtPlang>[^/]+?)/guide(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$
-       -> /docs/[lang]/guide$rscSuffix?nxtPlang=$nxtPlang
-
      /docs/[lang]/guide
-       ^[/]?/docs/(?<nxtPlang>[^/]+?)/guide(?:/)?$
-       -> /docs/[lang]/guide?nxtPlang=$nxtPlang
+       ^[/]?/docs/(?<nxtPlang>[^/]+?)/guide(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /docs/[lang]/guide$rscSuffix?nxtPlang=$nxtPlang
 
      /legacy/[id].rsc
        ^[/]?/legacy/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$


### PR DESCRIPTION
A dynamic app page in an app with an app directory needs two routes today. One matches a request for the page, and one matches a request for its `.rsc` payload or a per-segment prefetch. Simplified, with the request pattern on the left and the artifact it resolves to on the right:

```diff
- /de/<slug><.rsc|.segments/*.segment.rsc>    ->  /de/[slug]<matched suffix>
- /de/<slug>                                  ->  /de/[slug]
+ /de/<slug><.rsc|.segments/*.segment.rsc|>   ->  /de/[slug]<matched suffix>
```

One entry now serves both, because the suffix group gains an empty final alternative. The group therefore always matches. It captures an empty string for a request that carries no suffix, and the destination copies whatever it captured, so a plain request resolves to the page and a suffixed request resolves to the artifact it asks for. The parameter is matched lazily, so a request for `/de/other.rsc` still prefers the shorter parameter and the `.rsc` suffix over a parameter that swallows the suffix.

The empty alternative is deliberate, and an optional group would not be equivalent. A consumer of these entries can resolve the placeholders in a destination from the match result rather than from the pattern. A group that does not take part in the match is then absent from that result, and the literal text `$rscSuffix` survives into the destination. A group that always takes part avoids depending on how any one consumer treats an absent key, and the cost of getting it wrong is a 404 on every plain navigation to every dynamic route.

One case keeps two entries. A pages router route with `fallback: false` requires the preview cookies on the request for the page, and not on the request for its `.rsc` payload. An entry carries one set of conditions and cannot express that difference, so the merge applies only when both forms agree on their conditions.

Every app that has an app directory therefore halves the entries for its dynamic routes, whether or not it uses Cache Components. We measured the same in-progress feature branch of the v0 chat app as the previous change in this stack, which enumerates precomputed flag, locale and device permutations in `generateStaticParams` for a top-level dynamic segment and so multiplies every route below it. Every dynamic entry on that branch merges. Building it before and after the change removes 48% of the routes that the previous change left, replaces each merged pair with a single entry, and changes nothing else once the build ID is normalized. Across both changes that branch loses 65% of its routes.

This collapse follows `experimental.collapseAdapterRoutes`, which the previous change in this stack added. A build that sets it to `false` emits a separate entry for each form.

**Verified with a [full deploy test run](https://github.com/vercel/next.js/actions/runs/32540912007).**
