### PR TITLE
Fix duplicate RSC adapter outputs for App Route Handlers

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -47,6 +47,7 @@ import {
 } from '../../lib/constants'
 
 import { normalizeLocalePath } from '../../shared/lib/i18n/normalize-locale-path'
+import { isAppRouteRoute } from '../../lib/is-app-route-route'
 import { getStaticMetadataPrerenderPathname } from '../../lib/metadata/get-metadata-route'
 import { isStaticMetadataFile } from '../../lib/metadata/is-metadata-route'
 import { addPathPrefix } from '../../shared/lib/router/utils/add-path-prefix'
@@ -659,6 +660,11 @@ export async function handleBuildComplete({
       prerenders: [],
       staticFiles: [],
     }
+    const appRoutePathnames = new Set(
+      (appPageKeys ?? [])
+        .filter(isAppRouteRoute)
+        .map((appPath) => normalizeAppPath(appPath))
+    )
 
     if (config.output === 'export') {
       // collect export assets and provide as static files
@@ -1212,11 +1218,6 @@ export async function handleBuildComplete({
             outputs.appPages.push(output)
           } else {
             outputs.appRoutes.push(output)
-            outputs.appRoutes.push({
-              ...output,
-              pathname: normalizePagePath(output.pathname) + '.rsc',
-              id: normalizePagePath(output.pathname) + '.rsc',
-            })
           }
         }
       }
@@ -2075,11 +2076,31 @@ export async function handleBuildComplete({
       }
     }
 
+    const appRouteRscAliases = outputs.appRoutes
+      .filter((output) => !isDynamicRoute(output.pathname))
+      .map((output) => ({
+        output,
+        source: normalizePagePath(output.pathname),
+      }))
+
     normalizePathnames(config, outputs)
 
     const dynamicRoutes: DynamicRouteItem[] = []
     const dynamicDataRoutes: DynamicRouteItem[] = []
     const dynamicSegmentRoutes: DynamicRouteItem[] = []
+    const appRouteRscRoutes: DynamicRouteItem[] = appRouteRscAliases.map(
+      ({ output, source }) => {
+        const pathname = addPathPrefix(source, config.basePath)
+
+        return {
+          source: source + '.rsc',
+          sourceRegex: `^${escapeStringRegexp(pathname)}(?:\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$`,
+          destination: output.pathname,
+          has: undefined,
+          missing: undefined,
+        }
+      }
+    )
 
     const getDestinationQuery = (routeKeys: Record<string, string>) => {
       const items = Object.entries(routeKeys ?? {})
@@ -2123,13 +2144,20 @@ export async function handleBuildComplete({
         ) + getDestinationQuery(route.routeKeys)
 
       if (appPageKeys && appPageKeys.length > 0) {
+        const isAppRoute = appRoutePathnames.has(route.page)
+
         dynamicRoutes.push({
           source: route.page + '.rsc',
           sourceRegex: sourceRegex.replace(
             new RegExp(escapeStringRegexp('(?:/)?$')),
             '(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$'
           ),
-          destination: destination?.replace(/($|\?)/, '$rscSuffix$1'),
+          // Route Handlers return ordinary responses, but RSC requests are
+          // rewritten to an .rsc pathname before filesystem routing. Point
+          // those aliases back to the one ordinary Route Handler output.
+          destination: isAppRoute
+            ? destination
+            : destination?.replace(/($|\?)/, '$rscSuffix$1'),
           has:
             isFallbackFalse && !pageKeys.includes(route.page)
               ? fallbackFalseHasCondition
@@ -2268,6 +2296,7 @@ export async function handleBuildComplete({
       const combinedDynamicRoutes = [
         ...dynamicDataRoutes,
         ...dynamicSegmentRoutes,
+        ...appRouteRscRoutes,
         ...dynamicRoutes,
       ] satisfies Route[]
 

--- a/test/production/adapter-config/adapter-config.test.ts
+++ b/test/production/adapter-config/adapter-config.test.ts
@@ -91,6 +91,45 @@ describe('adapter-config', () => {
     expect(staticOutputs.length).toBeGreaterThan(0)
     expect(prerenderOutputs.length).toBeGreaterThan(0)
 
+    expect(
+      outputs.appRoutes
+        .map((output) => output.pathname)
+        .filter((pathname) => pathname.endsWith('.rsc'))
+    ).toEqual([])
+
+    // Route Handlers need RSC pathname aliases because App Router
+    // navigations are rewritten to .rsc before filesystem routing. The aliases
+    // must point back to the one ordinary Route Handler output.
+    expect(routing.dynamicRoutes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: '/node-route.rsc',
+          destination: '/docs/node-route',
+        }),
+        expect.objectContaining({
+          source: '/edge-route.rsc',
+          destination: '/docs/edge-route',
+        }),
+        expect.objectContaining({
+          source: '/isr-route/[slug].rsc',
+          destination: '/docs/isr-route/[slug]?nxtPslug=$nxtPslug',
+        }),
+      ])
+    )
+
+    const dynamicRscRouteSources = routing.dynamicRoutes
+      .map((route) => route.source)
+      .filter((source) => source.endsWith('.rsc') && source.includes('['))
+      .sort()
+    expect(dynamicRscRouteSources).toEqual([
+      '/isr-app/[slug].rsc',
+      '/isr-pages-fallback-false/[slug].rsc',
+      '/isr-pages-fallback-true/[slug].rsc',
+      '/isr-pages/[slug].rsc',
+      '/isr-route/[slug].rsc',
+      '/node-app/[slug].rsc',
+    ])
+
     const expectedRouteConfigs = [
       {
         pathname: '/docs/node-app',
@@ -474,5 +513,39 @@ describe('adapter-config', () => {
     expect(preferredRegionRoute).toBeDefined()
     expect(preferredRegionRoute?.runtime).toBe('edge')
     expect(preferredRegionRoute?.config.preferredRegion).toEqual(['cdg1'])
+  })
+})
+
+describe('adapter-config root Route Handler', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  it('aliases root RSC requests to one Route Handler output', async () => {
+    await next.remove('app/page.tsx')
+    await next.patchFile(
+      'app/route.ts',
+      `export function GET() {
+        return new Response('root')
+      }`
+    )
+    await next.build()
+
+    const { outputs, routing }: Parameters<NextAdapter['onBuildComplete']>[0] =
+      await next.readJSON('build-complete.json')
+
+    expect(
+      outputs.appRoutes.filter((output) => output.pathname === '/docs')
+    ).toHaveLength(1)
+    expect(routing.dynamicRoutes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: '/index.rsc',
+          sourceRegex: expect.stringMatching(/^\^\/docs\/index/),
+          destination: '/docs',
+        }),
+      ])
+    )
   })
 })

--- a/test/production/deterministic-build/deployment-id.test.ts
+++ b/test/production/deterministic-build/deployment-id.test.ts
@@ -266,7 +266,6 @@ async function runTest(
               '.vercel/output/functions/app-page.func/.vc-config.json',
               '.vercel/output/functions/app-page.rsc.func/.vc-config.json',
               '.vercel/output/functions/app-route.func/.vc-config.json',
-              '.vercel/output/functions/app-route.rsc.func/.vc-config.json',
               '.vercel/output/functions/pages-dynamic.func/.vc-config.json',
               '.vercel/output/functions/pages-static-gsp.func/.vc-config.json',
             ])


### PR DESCRIPTION
## What

- Emit one `APP_ROUTE` adapter output per App Route Handler instead of materializing a second `.rsc` function from the same entrypoint.
- Preserve RSC-header and segment-prefetch navigation by adding lightweight route aliases that point to the ordinary handler output.
- For dynamic handlers, strip the synthetic RSC suffix before forwarding parameters to the handler.
- Keep the existing App Page and hybrid Pages Router RSC behavior unchanged.

## Why

The Vercel adapter rewrites App Router requests carrying the `rsc: 1` header to an `.rsc` pathname before filesystem routing. Route Handlers therefore still need an RSC-shaped route, even though they return ordinary responses rather than an RSC artifact.

The legacy builder satisfied that invariant by creating a second function with an `.rsc` pathname. The Build Output API port retained the same behavior, but adapter consumers such as `@vercel/next` materialize both outputs, so one handler becomes two deployed functions.

This change preserves the routing invariant while routing both pathname forms to one function. Static aliases are ordered before catch-all App Page routes, and dynamic aliases keep route parameters separate from the synthetic `.rsc` or `.segments/...segment.rsc` suffix.

## Verification

- `pnpm build`
- `pnpm test-start test/production/adapter-config/adapter-config.test.ts`
- `pnpm test-start-turbo test/production/adapter-config/adapter-config.test.ts`
- focused Prettier, ESLint, and `git diff --check`
- real `@vercel/next` issue reproduction: 6 Route Handlers produce 6 functions, including dynamic Node, Edge, nested, and route-group handlers
- static navigation reproduction with a catch-all App Page: `/logout.rsc` and segment-prefetch paths resolve to `/logout`
- dynamic route-table probes: `/api/acme.rsc` and segment-prefetch paths capture `tenantId = acme`, not `acme.rsc`
- isolated root-handler regression: under `basePath: /docs`, `/index.rsc` aliases to the single `/docs` output for both Webpack and Turbopack
- shared export-mode adapter fixture under both Webpack and Turbopack

Fixes #97564
