### PR TITLE
[test] Capture the route table for apps with several param shapes

### DIFF
--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-cache-components.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-cache-components.test.ts
@@ -5,9 +5,9 @@ import {
   type AdapterRouting,
 } from './dynamic-routes-snapshot'
 
-// This suite pins the dynamic routes that a build passes to an adapter for
-// a Cache Components app. The root layout of the fixture returns two root
-// params.
+// This suite pins the dynamic routes that a build passes to an adapter for a
+// Cache Components app. The root layout of the fixture takes one root param and
+// returns two values for it.
 //
 // Each entry in the snapshot becomes one route in the routes document of a
 // deployment. The snapshot covers the routes that this app shape contributes.
@@ -18,13 +18,14 @@ import {
 // route matches an output during the filesystem check, so it needs no
 // rewrite.
 //
-// The fixture holds the shape that grows with the number of root param
-// combinations. `generateStaticParams` on the root layout produces one
-// fallback shell for each combination. Each manifest entry then produces
-// two adapter entries:
+// The fixture holds the shape that grows with the number of root param values.
+// `generateStaticParams` on the root layout produces one fallback shell for
+// each value. Each shell contributes one entry, and that entry serves three
+// kinds of request:
 //
-// - An `.rsc` route.
-// - A plain route.
+// - A request for the page.
+// - A request for its `.rsc` payload.
+// - A per-segment prefetch.
 describe('adapter dynamic routes (cache components)', () => {
   const { next } = nextTestSetup({
     files: path.join(__dirname, 'cache-components'),

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-no-root-params.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-no-root-params.test.ts
@@ -1,0 +1,69 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  serializeDynamicRoutes,
+  type AdapterRouting,
+} from './dynamic-routes-snapshot'
+
+// This suite pins the dynamic routes for an app that has no root params. The
+// root layout sits above the dynamic segments, so `team` and `locale` are
+// ordinary dynamic params, and `generateStaticParams` on a nested layout
+// enumerates them.
+//
+// The build produces two shapes of entry for one source page here:
+//
+// - An entry that resolves both params, such as `/sparse/en/posts/[id]`.
+// - An entry that resolves only `team`, such as `/sparse/[locale]/posts/[id]`.
+//
+// The two shapes have different paths after the resolved segments, so the
+// entries stay as they are. One entry serves one shape of path, and an
+// alternation cannot hold both shapes at once.
+//
+// The order of the entries carries the behavior. An entry that resolves both
+// params comes before an entry that resolves one, so a request for
+// `/sparse/en/posts/1` reaches the output for `/sparse/en/posts/[id]` and not
+// the one for `/sparse/[locale]/posts/[id]`. A collapse that grouped the second
+// shape across teams would move it ahead of the first shape and change which
+// output a request reaches.
+describe('adapter dynamic routes (no root params)', () => {
+  const { next } = nextTestSetup({
+    files: path.join(__dirname, 'no-root-params'),
+    // The fixture sets `generateBuildId`, and this option lets that value take
+    // effect. The harness otherwise assigns a new build ID for each run. A
+    // build ID that reaches an entry then changes the assertions on every run.
+    disableAutoSkewProtection: true,
+  })
+
+  it('emits the expected dynamic routes', async () => {
+    const routing: AdapterRouting = await next.readJSON('build-complete.json')
+
+    expect(serializeDynamicRoutes(routing.dynamicRoutes))
+      .toMatchInlineSnapshot(`
+     "6 entries
+
+     /acme.one-two,three/de/posts/[id]
+       ^[/]?/acme\\.one\\-two,three/de/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /acme.one-two,three/de/posts/[id]$rscSuffix?nxtPid=$nxtPid
+
+     /acme.one-two,three/en/posts/[id]
+       ^[/]?/acme\\.one\\-two,three/en/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /acme.one-two,three/en/posts/[id]$rscSuffix?nxtPid=$nxtPid
+
+     /acme.one-two,three/[locale]/posts/[id]
+       ^[/]?/acme\\.one\\-two,three/(?<nxtPlocale>[^/]+?)/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /acme.one-two,three/[locale]/posts/[id]$rscSuffix?nxtPlocale=$nxtPlocale&nxtPid=$nxtPid
+
+     /sparse/en/posts/[id]
+       ^[/]?/sparse/en/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /sparse/en/posts/[id]$rscSuffix?nxtPid=$nxtPid
+
+     /sparse/[locale]/posts/[id]
+       ^[/]?/sparse/(?<nxtPlocale>[^/]+?)/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /sparse/[locale]/posts/[id]$rscSuffix?nxtPlocale=$nxtPlocale&nxtPid=$nxtPid
+
+     /[team]/[locale]/posts/[id]
+       ^[/]?/(?<nxtPteam>[^/]+?)/(?<nxtPlocale>[^/]+?)/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /[team]/[locale]/posts/[id]$rscSuffix?nxtPteam=$nxtPteam&nxtPlocale=$nxtPlocale&nxtPid=$nxtPid"
+    `)
+  })
+})

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-shell-prefixes-single.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-shell-prefixes-single.test.ts
@@ -1,0 +1,40 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  serializeDynamicRoutes,
+  type AdapterRouting,
+} from './dynamic-routes-snapshot'
+
+// This suite builds the shell prefixes fixture with one combination of root
+// param values, so each source page has one fallback shell.
+//
+// An alternation of one combination saves no entry, and it would replace a
+// literal path with a capture group for no gain. The entry for the shell
+// therefore keeps the combination as it is.
+describe('adapter dynamic routes (shell prefixes, one combination)', () => {
+  const { next } = nextTestSetup({
+    files: path.join(__dirname, 'shell-prefixes'),
+    env: { SINGLE_COMBINATION: '1' },
+    // The fixture sets `generateBuildId`, and this option lets that value take
+    // effect. The harness otherwise assigns a new build ID for each run. A
+    // build ID that reaches an entry then changes the assertions on every run.
+    disableAutoSkewProtection: true,
+  })
+
+  it('keeps the combination in the entry for a lone shell', async () => {
+    const routing: AdapterRouting = await next.readJSON('build-complete.json')
+
+    expect(serializeDynamicRoutes(routing.dynamicRoutes))
+      .toMatchInlineSnapshot(`
+     "2 entries
+
+     /acme.one-two,three/en/posts/[id]
+       ^[/]?/acme\\.one\\-two,three/en/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /acme.one-two,three/en/posts/[id]$rscSuffix?nxtPid=$nxtPid
+
+     /[team]/[locale]/posts/[id]
+       ^[/]?/(?<nxtPteam>[^/]+?)/(?<nxtPlocale>[^/]+?)/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /[team]/[locale]/posts/[id]$rscSuffix?nxtPteam=$nxtPteam&nxtPlocale=$nxtPlocale&nxtPid=$nxtPid"
+    `)
+  })
+})

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-shell-prefixes.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-shell-prefixes.test.ts
@@ -1,0 +1,51 @@
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import {
+  serializeDynamicRoutes,
+  type AdapterRouting,
+} from './dynamic-routes-snapshot'
+
+// This suite pins the dynamic routes for an app whose root layout takes two
+// root params.
+//
+// The fixture returns three combinations of the two root params, and not the
+// full product of four. The build produces one fallback shell for each of the
+// three, and each shell contributes one entry. No entry matches the fourth
+// combination, `sparse/de`, because the build produces no output for it.
+//
+// One combination contains `.`, `-` and `,`. A regex treats those characters as
+// special, and the patterns below escape them.
+describe('adapter dynamic routes (shell prefixes)', () => {
+  const { next } = nextTestSetup({
+    files: path.join(__dirname, 'shell-prefixes'),
+    // The fixture sets `generateBuildId`, and this option lets that value take
+    // effect. The harness otherwise assigns a new build ID for each run. A
+    // build ID that reaches an entry then changes the assertions on every run.
+    disableAutoSkewProtection: true,
+  })
+
+  it('emits the expected dynamic routes', async () => {
+    const routing: AdapterRouting = await next.readJSON('build-complete.json')
+
+    expect(serializeDynamicRoutes(routing.dynamicRoutes))
+      .toMatchInlineSnapshot(`
+     "4 entries
+
+     /acme.one-two,three/de/posts/[id]
+       ^[/]?/acme\\.one\\-two,three/de/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /acme.one-two,three/de/posts/[id]$rscSuffix?nxtPid=$nxtPid
+
+     /acme.one-two,three/en/posts/[id]
+       ^[/]?/acme\\.one\\-two,three/en/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /acme.one-two,three/en/posts/[id]$rscSuffix?nxtPid=$nxtPid
+
+     /sparse/en/posts/[id]
+       ^[/]?/sparse/en/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /sparse/en/posts/[id]$rscSuffix?nxtPid=$nxtPid
+
+     /[team]/[locale]/posts/[id]
+       ^[/]?/(?<nxtPteam>[^/]+?)/(?<nxtPlocale>[^/]+?)/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /[team]/[locale]/posts/[id]$rscSuffix?nxtPteam=$nxtPteam&nxtPlocale=$nxtPlocale&nxtPid=$nxtPid"
+    `)
+  })
+})

--- a/test/production/app-dir/adapter-dynamic-routes/no-root-params/app/[team]/[locale]/layout.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/no-root-params/app/[team]/[locale]/layout.tsx
@@ -1,0 +1,18 @@
+// This layout is not the root layout, so `team` and `locale` are ordinary
+// dynamic params rather than root params. It returns three combinations of
+// them, and not the full product of four.
+export function generateStaticParams() {
+  return [
+    { team: 'acme.one-two,three', locale: 'en' },
+    { team: 'acme.one-two,three', locale: 'de' },
+    { team: 'sparse', locale: 'en' },
+  ]
+}
+
+export default function TeamLocaleLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <>{children}</>
+}

--- a/test/production/app-dir/adapter-dynamic-routes/no-root-params/app/[team]/[locale]/posts/[id]/page.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/no-root-params/app/[team]/[locale]/posts/[id]/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+
+// This page does not resolve `id`. The build therefore produces one fallback
+// shell for each root param combination.
+export default function Page({ params }: { params: Promise<{ id: string }> }) {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      {params.then(({ id }) => (
+        <p>{id}</p>
+      ))}
+    </Suspense>
+  )
+}

--- a/test/production/app-dir/adapter-dynamic-routes/no-root-params/app/layout.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/no-root-params/app/layout.tsx
@@ -1,0 +1,9 @@
+// The root layout is not inside a dynamic segment, so `team` and `locale` are
+// ordinary dynamic params and not root params.
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/adapter-dynamic-routes/no-root-params/my-adapter.mjs
+++ b/test/production/app-dir/adapter-dynamic-routes/no-root-params/my-adapter.mjs
@@ -1,0 +1,14 @@
+import fs from 'fs/promises'
+
+/**
+ * @type {import('next').NextAdapter}
+ */
+export default {
+  name: 'route-table-probe',
+  async onBuildComplete(ctx) {
+    await fs.writeFile(
+      'build-complete.json',
+      JSON.stringify(ctx.routing, null, 2)
+    )
+  },
+}

--- a/test/production/app-dir/adapter-dynamic-routes/no-root-params/next.config.js
+++ b/test/production/app-dir/adapter-dynamic-routes/no-root-params/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  // A build ID that reaches an entry changes the snapshot on every run. A fixed
+  // build ID keeps the snapshot independent of the run.
+  generateBuildId: () => 'test-build-id',
+  adapterPath: require.resolve('./my-adapter.mjs'),
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/adapter-dynamic-routes/shell-prefixes/app/[team]/[locale]/layout.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/shell-prefixes/app/[team]/[locale]/layout.tsx
@@ -1,0 +1,34 @@
+import { locale, team } from 'next/root-params'
+
+// This layout takes two root params. `generateStaticParams` returns three
+// combinations of them, and not the full product of four. The build therefore
+// produces no output for the `sparse` team with the `de` locale.
+//
+// One team value contains `.`, `-` and `,`. A regex treats those characters as
+// special.
+//
+// `SINGLE_COMBINATION` reduces the list to one combination. A suite sets it to
+// build the same app with one fallback shell per source page.
+export function generateStaticParams() {
+  if (process.env.SINGLE_COMBINATION) {
+    return [{ team: 'acme.one-two,three', locale: 'en' }]
+  }
+
+  return [
+    { team: 'acme.one-two,three', locale: 'en' },
+    { team: 'acme.one-two,three', locale: 'de' },
+    { team: 'sparse', locale: 'en' },
+  ]
+}
+
+export default async function Root({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang={await locale()} data-team={await team()}>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/adapter-dynamic-routes/shell-prefixes/app/[team]/[locale]/posts/[id]/page.tsx
+++ b/test/production/app-dir/adapter-dynamic-routes/shell-prefixes/app/[team]/[locale]/posts/[id]/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+
+// This page does not resolve `id`. The build therefore produces one fallback
+// shell for each root param combination.
+export default function Page({ params }: { params: Promise<{ id: string }> }) {
+  return (
+    <Suspense fallback={<p>loading</p>}>
+      {params.then(({ id }) => (
+        <p>{id}</p>
+      ))}
+    </Suspense>
+  )
+}

--- a/test/production/app-dir/adapter-dynamic-routes/shell-prefixes/my-adapter.mjs
+++ b/test/production/app-dir/adapter-dynamic-routes/shell-prefixes/my-adapter.mjs
@@ -1,0 +1,14 @@
+import fs from 'fs/promises'
+
+/**
+ * @type {import('next').NextAdapter}
+ */
+export default {
+  name: 'route-table-probe',
+  async onBuildComplete(ctx) {
+    await fs.writeFile(
+      'build-complete.json',
+      JSON.stringify(ctx.routing, null, 2)
+    )
+  },
+}

--- a/test/production/app-dir/adapter-dynamic-routes/shell-prefixes/next.config.js
+++ b/test/production/app-dir/adapter-dynamic-routes/shell-prefixes/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  // A build ID that reaches an entry changes the snapshot on every run. A fixed
+  // build ID keeps the snapshot independent of the run.
+  generateBuildId: () => 'test-build-id',
+  adapterPath: require.resolve('./my-adapter.mjs'),
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
The existing fixtures take a single root param, so they do not cover the shapes that the fallback shell entries can take. This adds fixtures and suites for three more shapes, and pins the entries that each one produces.

The first has a root layout that takes two root params, and returns three combinations of them rather than the full product of four. An entry that held each root param position separately would also match `sparse/de`, a combination the build never prerendered, and a request for it would resolve to an output that does not exist. One combination is `acme.one-two,three`, which carries the characters a regex treats as special, and the snapshot shows the build escaping them.

The second builds that same app with a single combination, so each source page has one fallback shell.

The third has no root params at all. Its root layout sits above the dynamic segments, so `team` and `locale` are ordinary dynamic params that `generateStaticParams` enumerates on a nested layout. The build then produces two shapes of entry for one source page: entries that resolve both params, such as `/sparse/en/posts/[id]`, and entries that resolve only the first, such as `/sparse/[locale]/posts/[id]`. The order of those entries carries the behavior, because a request for `/sparse/en/posts/1` has to reach the output that resolves both params rather than the one that resolves only the first. The snapshot pins that order.

Two comments on the Cache Components suite were wrong, and this corrects them. That fixture takes one root param with two values, and not two root params. Its entries also no longer come in pairs, because one entry serves the request for the page, the request for its `.rsc` payload, and a per-segment prefetch.
