### PR TITLE
fix: allow literal params for closed static routes

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -429,6 +429,43 @@ declare module 'next/form' {
 `
 }
 
+// A route can safely narrow its param values only when the same module proves
+// that it owns a closed static set. Keep this module-local because layouts and
+// pages can share a pathname while generating different param sets.
+const routeParamsTypeDefinitions = `type ValidStaticParams<
+  Route extends keyof ParamMap,
+  Params,
+> = 0 extends (1 & Params)
+  ? never
+  : [Params] extends [Partial<ParamMap[Route]>]
+    ? Pick<Params, Extract<keyof Params, keyof ParamMap[Route]>>
+    : never
+
+type StaticParamsForRoute<
+  Route extends keyof ParamMap,
+  Entry,
+> = Entry extends {
+  dynamicParams: false
+  generateStaticParams: (...args: any[]) => infer Result
+}
+  ? Awaited<Result> extends readonly (infer Params)[]
+    ? ValidStaticParams<Route, Params>
+    : never
+  : never
+
+type ApplyStaticParams<Base, Static> = Static extends unknown
+  ? Omit<Base, keyof Static> & Static
+  : never
+
+type RouteParams<
+  Route extends keyof ParamMap,
+  Entry,
+> = [StaticParamsForRoute<Route, Entry>] extends [never]
+  ? ParamMap[Route]
+  : ApplyStaticParams<ParamMap[Route], StaticParamsForRoute<Route, Entry>>
+
+`
+
 export function generateValidatorFile(
   routesManifest: RouteTypesManifest
 ): string {
@@ -465,7 +502,7 @@ export function generateValidatorFile(
           (type === 'AppPageConfig' ||
             type === 'LayoutConfig' ||
             type === 'RouteHandlerConfig')
-            ? `${type}<${JSON.stringify(route)}>`
+            ? `${type}<${JSON.stringify(route)}, Specific>`
             : type
 
         // NOTE: we previously used `satisfies` here, but it's not supported by TypeScript 4.8 and below.
@@ -517,16 +554,20 @@ export function generateValidatorFile(
   // Build type definitions based on what's actually used
   let typeDefinitions = ''
 
+  if (appPageValidations || layoutValidations || appRouteHandlerValidations) {
+    typeDefinitions += routeParamsTypeDefinitions
+  }
+
   if (appPageValidations) {
-    typeDefinitions += `type AppPageConfig<Route extends AppRoutes = AppRoutes> = {
-  default: React.ComponentType<{ params: Promise<ParamMap[Route]> } & any> | ((props: { params: Promise<ParamMap[Route]> } & any) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
+    typeDefinitions += `type AppPageConfig<Route extends AppRoutes, Entry> = {
+  default: React.ComponentType<{ params: Promise<RouteParams<Route, Entry>> } & any> | ((props: { params: Promise<RouteParams<Route, Entry>> } & any) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
   generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
   generateMetadata?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
+    props: { params: Promise<RouteParams<Route, Entry>> } & any,
     parent: ResolvingMetadata
   ) => Promise<any> | any
   generateViewport?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
+    props: { params: Promise<RouteParams<Route, Entry>> } & any,
     parent: ResolvingViewport
   ) => Promise<any> | any
   metadata?: any
@@ -558,15 +599,15 @@ export function generateValidatorFile(
   }
 
   if (layoutValidations) {
-    typeDefinitions += `type LayoutConfig<Route extends LayoutRoutes = LayoutRoutes> = {
-  default: React.ComponentType<LayoutProps<Route>> | ((props: LayoutProps<Route>) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
+    typeDefinitions += `type LayoutConfig<Route extends LayoutRoutes, Entry> = {
+  default: React.ComponentType<Omit<LayoutProps<Route>, 'params'> & { params: Promise<RouteParams<Route, Entry>> }> | ((props: Omit<LayoutProps<Route>, 'params'> & { params: Promise<RouteParams<Route, Entry>> }) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
   generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
   generateMetadata?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
+    props: { params: Promise<RouteParams<Route, Entry>> } & any,
     parent: ResolvingMetadata
   ) => Promise<any> | any
   generateViewport?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
+    props: { params: Promise<RouteParams<Route, Entry>> } & any,
     parent: ResolvingViewport
   ) => Promise<any> | any
   metadata?: any
@@ -577,14 +618,14 @@ export function generateValidatorFile(
   }
 
   if (appRouteHandlerValidations) {
-    typeDefinitions += `type RouteHandlerConfig<Route extends AppRouteHandlerRoutes = AppRouteHandlerRoutes> = {
-  GET?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  POST?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  PUT?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  PATCH?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  DELETE?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  HEAD?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  OPTIONS?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
+    typeDefinitions += `type RouteHandlerConfig<Route extends AppRouteHandlerRoutes, Entry> = {
+  GET?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
+  POST?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
+  PUT?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
+  PATCH?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
+  DELETE?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
+  HEAD?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
+  OPTIONS?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
 }
 
 `
@@ -706,7 +747,7 @@ export function generateValidatorFileStrict(
           (type === 'AppPageConfig' ||
             type === 'LayoutConfig' ||
             type === 'RouteHandlerConfig')
-            ? `${type}<${JSON.stringify(route)}>`
+            ? `${type}<${JSON.stringify(route)}, typeof handler>`
             : type
 
         return `// Validate ${filePath}
@@ -752,16 +793,20 @@ export function generateValidatorFileStrict(
   // Build type definitions based on what's actually used
   let typeDefinitions = ''
 
+  if (appPageValidations || layoutValidations || appRouteHandlerValidations) {
+    typeDefinitions += routeParamsTypeDefinitions
+  }
+
   if (appPageValidations) {
-    typeDefinitions += `type AppPageConfig<Route extends AppRoutes = AppRoutes> = {
-  default: React.JSXElementConstructor<PageProps<Route>>
+    typeDefinitions += `type AppPageConfig<Route extends AppRoutes, Entry> = {
+  default: React.JSXElementConstructor<Omit<PageProps<Route>, 'params'> & { params: Promise<RouteParams<Route, Entry>> }>
   generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
   generateMetadata?: (
-    props: PageProps<Route>,
+    props: Omit<PageProps<Route>, 'params'> & { params: Promise<RouteParams<Route, Entry>> },
     parent: ResolvingMetadata
   ) => Promise<any> | any
   generateViewport?: (
-    props: PageProps<Route>,
+    props: Omit<PageProps<Route>, 'params'> & { params: Promise<RouteParams<Route, Entry>> },
     parent: ResolvingViewport
   ) => Promise<any> | any
   metadata?: any
@@ -793,15 +838,15 @@ export function generateValidatorFileStrict(
   }
 
   if (layoutValidations) {
-    typeDefinitions += `type LayoutConfig<Route extends LayoutRoutes = LayoutRoutes> = {
-  default: React.ComponentType<LayoutProps<Route>> | ((props: LayoutProps<Route>) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
+    typeDefinitions += `type LayoutConfig<Route extends LayoutRoutes, Entry> = {
+  default: React.ComponentType<Omit<LayoutProps<Route>, 'params'> & { params: Promise<RouteParams<Route, Entry>> }> | ((props: Omit<LayoutProps<Route>, 'params'> & { params: Promise<RouteParams<Route, Entry>> }) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
   generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
   generateMetadata?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
+    props: { params: Promise<RouteParams<Route, Entry>> } & any,
     parent: ResolvingMetadata
   ) => Promise<any> | any
   generateViewport?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
+    props: { params: Promise<RouteParams<Route, Entry>> } & any,
     parent: ResolvingViewport
   ) => Promise<any> | any
   metadata?: any
@@ -812,14 +857,14 @@ export function generateValidatorFileStrict(
   }
 
   if (appRouteHandlerValidations) {
-    typeDefinitions += `type RouteHandlerConfig<Route extends AppRouteHandlerRoutes = AppRouteHandlerRoutes> = {
-  GET?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  POST?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  PUT?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  PATCH?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  DELETE?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  HEAD?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  OPTIONS?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
+    typeDefinitions += `type RouteHandlerConfig<Route extends AppRouteHandlerRoutes, Entry> = {
+  GET?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
+  POST?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
+  PUT?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
+  PATCH?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
+  DELETE?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
+  HEAD?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
+  OPTIONS?: (request: NextRequest, context: { params: Promise<RouteParams<Route, Entry>> }) => Promise<Response | void> | Response | void
 }
 
 `

--- a/test/e2e/app-dir/typed-routes-validator/app/closed-layout/[locale]/layout.tsx
+++ b/test/e2e/app-dir/typed-routes-validator/app/closed-layout/[locale]/layout.tsx
@@ -1,0 +1,18 @@
+type Locale = 'en' | 'de'
+
+export const dynamicParams = false
+
+export function generateStaticParams(): { locale: Locale }[] {
+  return [{ locale: 'en' }, { locale: 'de' }]
+}
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ locale: Locale }>
+}) {
+  const { locale } = await params
+  return <div data-locale={locale}>{children}</div>
+}

--- a/test/e2e/app-dir/typed-routes-validator/app/closed-layout/[locale]/page.tsx
+++ b/test/e2e/app-dir/typed-routes-validator/app/closed-layout/[locale]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null
+}

--- a/test/e2e/app-dir/typed-routes-validator/app/closed-page/[locale]/page.tsx
+++ b/test/e2e/app-dir/typed-routes-validator/app/closed-page/[locale]/page.tsx
@@ -1,0 +1,34 @@
+type Locale = 'en' | 'de'
+
+export const dynamicParams = false
+
+export async function generateStaticParams(): Promise<{ locale: Locale }[]> {
+  return [{ locale: 'en' }, { locale: 'de' }]
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>
+}) {
+  const { locale } = await params
+  return { title: locale }
+}
+
+export async function generateViewport({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>
+}) {
+  const { locale } = await params
+  return { themeColor: locale === 'en' ? 'black' : 'white' }
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ locale: Locale }>
+}) {
+  const { locale } = await params
+  return locale
+}

--- a/test/e2e/app-dir/typed-routes-validator/app/closed-route/[locale]/route.ts
+++ b/test/e2e/app-dir/typed-routes-validator/app/closed-route/[locale]/route.ts
@@ -1,0 +1,17 @@
+import type { NextRequest } from 'next/server'
+
+type Locale = 'en' | 'de'
+
+export const dynamicParams = false
+
+export function generateStaticParams(): { locale: Locale }[] {
+  return [{ locale: 'en' }, { locale: 'de' }]
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ locale: Locale }> }
+) {
+  const { locale } = await params
+  return Response.json({ locale })
+}

--- a/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
+++ b/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
@@ -271,6 +271,66 @@ describe('typed-routes-validator', () => {
       expect(exitCode).toBe(0)
     })
 
+    it('should accept literal params only for closed static param sets', async () => {
+      const tsconfig = await next.readFile('tsconfig.json')
+      await next.patchFile(
+        'tsconfig.json',
+        tsconfig.replace('"strict": false', '"strict": true')
+      )
+
+      const { exitCode: closedExitCode } = await next.build()
+
+      await next.patchFile(
+        'app/open/[locale]/layout.tsx',
+        `
+    type Locale = 'en' | 'de'
+
+    export const dynamicParams = true
+
+    export function generateStaticParams(): { locale: Locale }[] {
+      return [{ locale: 'en' }, { locale: 'de' }]
+    }
+
+    export default async function Layout({
+      children,
+      params,
+    }: {
+      children: React.ReactNode
+      params: Promise<{ locale: Locale }>
+    }) {
+      const { locale } = await params
+      return <div data-locale={locale}>{children}</div>
+    }
+            `
+      )
+      await next.patchFile(
+        'app/open/[locale]/page.tsx',
+        `
+    export default function Page() {
+      return null
+    }
+            `
+      )
+
+      const { exitCode, cliOutput } = await next.build()
+      // clean up before assertion just in case it fails
+      await next.deleteFile('app/open/[locale]/layout.tsx')
+      await next.deleteFile('app/open/[locale]/page.tsx')
+      await next.patchFile('tsconfig.json', tsconfig)
+
+      expect(closedExitCode).toBe(0)
+      expect(exitCode).toBe(1)
+      if (strictRouteTypes) {
+        expect(cliOutput).toMatch(
+          /Type error: Type 'typeof import\(.*' does not satisfy the expected type 'LayoutConfig</
+        )
+      } else {
+        expect(cliOutput).toMatch(
+          /Type error: Type 'typeof import\(.*' does not satisfy the constraint 'LayoutConfig</
+        )
+      }
+    })
+
     it('should fail type checking with invalid layout exports', async () => {
       await next.patchFile(
         'app/invalid/layout.tsx',


### PR DESCRIPTION
## Summary

Fixes #97523.

When a route module exports `dynamicParams = false`, use its typed `generateStaticParams` return value to validate the module's page, layout, metadata, viewport, and route-handler params against the closed static set. Routes without that module-local proof keep the existing broad `string`/`string[]` param contract, so open routes and rewrite-driven params remain rejected.

The refinement rejects `any`, `unknown`, and return unions containing values incompatible with the route shape. It is generated for both compatibility and strict route validators, with e2e coverage for sync/async static params and an open-route control.

## Verification

- `__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true pnpm test-start-webpack test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts`
- `__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true pnpm test-start-turbo test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts`
- Focused closed/open regression test with compatibility route types
- Type-level soundness checks with TypeScript 6.0 and 4.8
- `pnpm --filter=next types`
- `pnpm --filter=next build`

Compatibility-mode full-suite runs have one unrelated existing failure in `should fail type checking with invalid page props`; the same webpack diagnostic mismatch and Turbopack acceptance reproduce on the untouched canary commit.

<!-- NEXT_JS_LLM -->
