### PR TITLE
Fix pnpm dev on a fresh clone

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "turbo run build --remote-cache-timeout 60 --summarize true",
     "build-all": "turbo run build build-native-auto --remote-cache-timeout 60 --summarize true",
     "lerna": "lerna",
-    "dev": "turbo run dev --parallel --filter=\"!@next/bundle-analyzer-ui\"",
+    "dev": "turbo run dev:precompile --filter=\"next\" --filter=\"eslint-config-next\" && turbo run dev --concurrency=100 --filter=\"!@next/bundle-analyzer-ui\"",
     "bench:render-pipeline": "tsx bench/render-pipeline/benchmark.ts",
     "bench:render-pipeline:analyze": "tsx bench/render-pipeline/analyze-profiles.ts",
     "bench:render-pipeline:client": "tsx bench/render-pipeline/client-trace.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -8,8 +8,11 @@
       "outputs": ["dist/**"]
     },
     "dev": {
-      "dependsOn": ["^dev"],
-      "outputs": ["dist/**"]
+      "cache": false,
+      "persistent": true
+    },
+    "dev:precompile": {
+      "dependsOn": ["^build"]
     },
     "storybook": {},
     "build-storybook": {


### PR DESCRIPTION
## Summary

- replace the deprecated `--parallel` launch, which discards the package task graph
- add a finite transit-node phase that builds the dependencies required by `next` and `eslint-config-next`
- declare `dev` tasks uncached and persistent, then launch them with high concurrency

On a fresh clone, `next#dev` can otherwise start before the polyfill packages exist, while `eslint-config-next#dev` can start before the ESLint plugin declarations exist. Running `^dev` directly cannot express the ordering because those tasks are long-lived watchers. The transit-node phase preserves dependency ordering without requiring a full build.

The Turbo 2.9.4 upgrade exposed the race more consistently through launch ordering, but exact-version testing also showed that the underlying race existed with Turbo 2.8.11. This fixes the workflow instead of reverting Turbo or documenting a full build as a prerequisite.

Fixes #97506

## Verification

- cold `pnpm dev` on current canary with all generated outputs and local Turbo metadata removed
- cold `pnpm dev` on the exact merge commit from #92425
- warm `pnpm dev` with all six prerequisite builds restored from Turbo cache
- `pnpm exec prettier --check package.json turbo.json`
- `git diff --check`
- `pnpm check-unused-turbo-tasks` *(fails on six pre-existing unrelated Rust items)*

<!-- NEXT_JS_LLM -->