### PR TITLE
Preserve generated PPR shells after tag expiration

### DIFF
--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -1122,15 +1122,14 @@ export function createAppPageEntrypoint({
             fallbackMode = FallbackMode.BLOCKING_STATIC_RENDER
           }
 
-          if (previousIncrementalCacheEntry?.isStale === -1) {
-            isOnDemandRevalidate = true
-          }
+          const isBlockingRevalidation =
+            previousIncrementalCacheEntry?.isStale === -1
 
           // TODO: adapt for PPR
-          // only allow on-demand revalidate for fallback: true/blocking
-          // or for prerendered fallback: false paths
+          // Only allow on-demand or expired-entry blocking revalidation for
+          // fallback: true/blocking or prerendered fallback: false paths
           if (
-            isOnDemandRevalidate &&
+            (isOnDemandRevalidate || isBlockingRevalidation) &&
             (fallbackMode !== FallbackMode.NOT_FOUND ||
               previousIncrementalCacheEntry)
           ) {
@@ -1384,9 +1383,12 @@ export function createAppPageEntrypoint({
               incrementalCacheEntry.value &&
               incrementalCacheEntry.value.kind === CachedRouteKind.APP_PAGE
             ) {
-              // CRITICAL: we're assigning the postponed data from the cache entry
-              // here as we're using the RDC to resume the render.
-              postponed = incrementalCacheEntry.value.postponed
+              // Expired entries must not be resumed because their postponed
+              // state can contain data invalidated by the expired tag. Render
+              // the navigation without it so those reads are fresh.
+              if (incrementalCacheEntry.isStale !== -1) {
+                postponed = incrementalCacheEntry.value.postponed
+              }
 
               // If the cache entry is stale, we should trigger a background
               // revalidation so that subsequent requests will get a fresh response.

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -304,15 +304,27 @@ export default class FileSystemCache implements CacheHandler {
       if (typeof tagsHeader === 'string') {
         const cacheTags = tagsHeader.split(',')
 
-        // we trigger a blocking validation if an ISR page
-        // had a tag revalidated, if we want to be a background
-        // revalidation instead we return data.lastModified = -1
         if (
           cacheTags.length > 0 &&
           areTagsExpired(cacheTags, data.lastModified)
         ) {
           if (FileSystemCache.debug) {
             console.log('FileSystemCache: expired tags', cacheTags)
+          }
+
+          // Keep generated PPR route shells long enough for IncrementalCache to
+          // distinguish blocking revalidation from a true cache miss. The
+          // response cache never serves an entry with this sentinel timestamp;
+          // it blocks on a concrete render instead of serving the generic
+          // fallback shell.
+          if (
+            data.value.kind === CachedRouteKind.APP_PAGE &&
+            data.value.postponed !== undefined &&
+            ctx.kind === IncrementalCacheKind.APP_PAGE &&
+            ctx.isRoutePPREnabled &&
+            ctx.isFallback === false
+          ) {
+            return { ...data, lastModified: -1 }
           }
 
           return null

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -693,6 +693,7 @@ export class IncrementalCache implements IncrementalCacheType {
     if (cacheData) {
       entry = {
         isStale,
+        isTagExpired: cacheData.lastModified === -1 || undefined,
         cacheControl,
         revalidateAfter,
         value: cacheData.value,

--- a/packages/next/src/server/response-cache/index.test.ts
+++ b/packages/next/src/server/response-cache/index.test.ts
@@ -1,5 +1,9 @@
 import ResponseCache from './index'
-import { CachedRouteKind, type ResponseCacheEntry } from './types'
+import {
+  CachedRouteKind,
+  type IncrementalResponseCacheEntry,
+  type ResponseCacheEntry,
+} from './types'
 import { RouteKind } from '../route-kind'
 import RenderResult from '../render-result'
 import { HTML_CONTENT_TYPE_HEADER } from '../../lib/constants'
@@ -100,6 +104,39 @@ describe('ResponseCache', () => {
 
       expect(renderCount).toBe(1)
       expect(followUp).not.toBeNull()
+    })
+  })
+
+  describe('failed blocking revalidation', () => {
+    it('does not revive an entry explicitly expired by a tag', async () => {
+      const cache = new ResponseCache(false)
+      const incrementalCache = mockIncrementalCache()
+      const expiredEntry: IncrementalResponseCacheEntry = {
+        value: {
+          kind: CachedRouteKind.APP_PAGE,
+          html: 'expired html',
+          rscData: undefined,
+          postponed: '{}',
+          status: 200,
+          headers: undefined,
+          segmentData: undefined,
+        },
+        cacheControl: { revalidate: 60, expire: undefined },
+        isStale: -1,
+        isTagExpired: true,
+      }
+      incrementalCache.get.mockResolvedValue(expiredEntry)
+
+      const error = new Error('revalidation failed')
+      await expect(
+        cache.get('/test', jest.fn().mockRejectedValue(error), {
+          routeKind: RouteKind.APP_PAGE,
+          incrementalCache,
+          isRoutePPREnabled: true,
+        })
+      ).rejects.toBe(error)
+
+      expect(incrementalCache.set).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/next/src/server/response-cache/index.ts
+++ b/packages/next/src/server/response-cache/index.ts
@@ -505,7 +505,11 @@ export default class ResponseCache implements ResponseCacheBase {
     } catch (err) {
       // When a path is erroring we automatically re-set the existing cache
       // with new revalidate and expire times to prevent non-stop retrying.
-      if (previousIncrementalCacheEntry?.cacheControl) {
+      // Never revive content that was explicitly expired by a tag.
+      if (
+        previousIncrementalCacheEntry?.cacheControl &&
+        !previousIncrementalCacheEntry.isTagExpired
+      ) {
         const revalidate = Math.min(
           Math.max(
             previousIncrementalCacheEntry.cacheControl.revalidate || 3,

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -142,6 +142,11 @@ export interface IncrementalResponseCacheEntry {
    * `-1` here dictates a blocking revalidate should be used
    */
   isStale?: boolean | -1
+  /**
+   * True when a cache handler retained a tag-expired entry so the route can
+   * blocking-revalidate without treating it as a cache miss.
+   */
+  isTagExpired?: boolean
   isMiss?: boolean
   isFallback?: boolean
   value: Exclude<IncrementalCacheValue, CachedFetchValue> | null

--- a/test/e2e/app-dir/ppr-unstable-cache/app/[slug]/page.jsx
+++ b/test/e2e/app-dir/ppr-unstable-cache/app/[slug]/page.jsx
@@ -1,0 +1,46 @@
+import { Suspense } from 'react'
+import { cacheLife, cacheTag } from 'next/cache'
+
+export function generateStaticParams() {
+  return [{ slug: 'known' }]
+}
+
+export default function Page({ params, searchParams }) {
+  return (
+    <Suspense fallback={<p id="route-fallback">route fallback</p>}>
+      <Content params={params} searchParams={searchParams} />
+    </Suspense>
+  )
+}
+
+async function Content({ params, searchParams }) {
+  const { slug } = await params
+  const value = await getValue(slug)
+
+  return (
+    <article>
+      <h1 id="dynamic-ppr-content">{value}</h1>
+      <Suspense fallback={<p id="search-fallback">search fallback</p>}>
+        <SearchParams searchParams={searchParams} />
+      </Suspense>
+    </article>
+  )
+}
+
+async function SearchParams({ searchParams }) {
+  const { query = 'none' } = await searchParams
+  return <p id="search-params">{query}</p>
+}
+
+async function getValue(slug) {
+  'use cache'
+  cacheLife({ stale: 300, revalidate: 3600, expire: 86400 })
+  cacheTag('unstable-cache-fetch')
+
+  const forceCached = await fetch(
+    process.env.TEST_DATA_SERVER + '?cache=ppr-force-cache',
+    { cache: 'force-cache' }
+  ).then((response) => response.text())
+
+  return `${slug}:${forceCached}:${process.pid}:${Date.now()}`
+}

--- a/test/e2e/app-dir/ppr-unstable-cache/ppr-unstable-cache.test.ts
+++ b/test/e2e/app-dir/ppr-unstable-cache/ppr-unstable-cache.test.ts
@@ -26,8 +26,9 @@ describe('ppr-unstable-cache', () => {
     }
   })
 
-  it('should not cache inner fetch calls', async () => {
+  it('should revalidate inner fetches without degrading generated PPR shells', async () => {
     let generations: string[] = []
+    let pprForceCacheGenerations: string[] = []
     server = http.createServer(async (req, res) => {
       try {
         if (!req.url) throw new Error('No URL')
@@ -37,7 +38,11 @@ describe('ppr-unstable-cache', () => {
 
         const random = Math.floor(Math.random() * 1000).toString()
         const data = cache + ':' + random
-        generations.push(data)
+        if (cache === 'ppr-force-cache') {
+          pprForceCacheGenerations.push(data)
+        } else {
+          generations.push(data)
+        }
         res.end(data)
       } catch (err) {
         res.statusCode = 500
@@ -51,6 +56,14 @@ describe('ppr-unstable-cache', () => {
     await next.start()
 
     expect(generations).toHaveLength(2)
+    expect(pprForceCacheGenerations).toHaveLength(1)
+
+    const $dynamicBefore = await next.render$('/known')
+    const dynamicValueBefore = $dynamicBefore('#dynamic-ppr-content').text()
+    expect(dynamicValueBefore).toBeTruthy()
+    expect(
+      $dynamicBefore('#dynamic-ppr-content').closest('[hidden]').length
+    ).toBe(0)
 
     const first = await next
       .render$('/')
@@ -75,6 +88,24 @@ describe('ppr-unstable-cache', () => {
     const revalidate = await next.fetch('/revalidate-tag', { method: 'POST' })
     expect(revalidate.status).toBe(200)
     await revalidate.text()
+
+    const dynamicRscResponse = await next.fetch('/known', {
+      headers: { RSC: '1' },
+    })
+    expect(dynamicRscResponse.status).toBe(200)
+    const dynamicRscAfter = await dynamicRscResponse.text()
+    expect(dynamicRscAfter).toContain('known:')
+    expect(dynamicRscAfter).not.toContain(dynamicValueBefore)
+    expect(pprForceCacheGenerations).toHaveLength(1)
+
+    const $dynamicAfter = await next.render$('/known')
+    const dynamicValueAfter = $dynamicAfter('#dynamic-ppr-content').text()
+    expect(dynamicValueAfter).toBeTruthy()
+    expect(dynamicValueAfter).not.toBe(dynamicValueBefore)
+    expect(pprForceCacheGenerations).toHaveLength(1)
+    expect(
+      $dynamicAfter('#dynamic-ppr-content').closest('[hidden]').length
+    ).toBe(0)
 
     const revalidated = await next
       .render$('/')

--- a/test/unit/incremental-cache/file-system-cache.test.ts
+++ b/test/unit/incremental-cache/file-system-cache.test.ts
@@ -1,7 +1,10 @@
 import { promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import FileSystemCache from 'next/dist/server/lib/incremental-cache/file-system-cache'
 import { nodeFs } from 'next/dist/server/lib/node-fs-methods'
+import { NEXT_CACHE_TAGS_HEADER } from 'next/dist/lib/constants'
 import {
   CachedRouteKind,
   IncrementalCacheKind,
@@ -51,6 +54,95 @@ describe('FileSystemCache', () => {
       status: 200,
       kind: IncrementalCacheKind.APP_ROUTE,
     })
+  })
+
+  it('preserves expired generated PPR shells for blocking revalidation', async () => {
+    const serverDistDir = await fs.mkdtemp(
+      join(tmpdir(), 'next-fs-cache-expired-route-')
+    )
+    const tag = 'expired-route-entry'
+    const fsCache = new FileSystemCache({
+      _requestHeaders: {},
+      flushToDisk: true,
+      fs: nodeFs,
+      serverDistDir,
+      revalidatedTags: [],
+      maxMemoryCacheSize: 0,
+    })
+
+    try {
+      await fsCache.set(
+        'expired-page',
+        {
+          kind: CachedRouteKind.APP_PAGE,
+          html: 'expired page',
+          rscData: undefined,
+          postponed: '{}',
+          headers: { [NEXT_CACHE_TAGS_HEADER]: tag },
+          status: 200,
+          segmentData: undefined,
+        },
+        {
+          isRoutePPREnabled: true,
+          isFallback: false,
+        }
+      )
+
+      const oldDate = new Date(Date.now() - 1000)
+      await fs.utimes(
+        join(serverDistDir, 'app', 'expired-page.html'),
+        oldDate,
+        oldDate
+      )
+      await fsCache.revalidateTag(tag, { expire: 0 })
+
+      const entry = await fsCache.get('expired-page', {
+        kind: IncrementalCacheKind.APP_PAGE,
+        isRoutePPREnabled: true,
+        isFallback: false,
+      })
+
+      expect(entry).toMatchObject({
+        lastModified: -1,
+        value: {
+          kind: CachedRouteKind.APP_PAGE,
+          html: 'expired page',
+        },
+      })
+
+      await fsCache.set(
+        'expired-static-page',
+        {
+          kind: CachedRouteKind.APP_PAGE,
+          html: 'expired static page',
+          rscData: Buffer.from('expired static page RSC'),
+          postponed: undefined,
+          headers: { [NEXT_CACHE_TAGS_HEADER]: tag },
+          status: 200,
+          segmentData: undefined,
+        },
+        {
+          isRoutePPREnabled: false,
+          isFallback: false,
+        }
+      )
+      await fs.utimes(
+        join(serverDistDir, 'app', 'expired-static-page.html'),
+        oldDate,
+        oldDate
+      )
+      await fsCache.revalidateTag(tag, { expire: 0 })
+
+      expect(
+        await fsCache.get('expired-static-page', {
+          kind: IncrementalCacheKind.APP_PAGE,
+          isRoutePPREnabled: false,
+          isFallback: false,
+        })
+      ).toBeNull()
+    } finally {
+      await fs.rm(serverDistDir, { recursive: true, force: true })
+    }
   })
 })
 


### PR DESCRIPTION
Fixes #97457.

## Why

A hard `revalidateTag(..., { expire: 0 })` made the file-system cache return `null` for an already-generated PPR route. That collapsed two different states—an expired concrete route and a true cache miss—so the App Router selected the dynamic route's generic fallback shell.

Restoring the background fallback-shell specialization removed by #79258 would recreate the `next start` / minimal-mode divergence that change addressed. This instead uses the existing blocking-revalidation sentinel while retaining the concrete generated PPR entry.

## What changed

- retain hard tag-expired, non-fallback PPR `APP_PAGE` entries with postponed state as blocking revalidations
- block the concrete request without enabling full on-demand cache bypass
- prevent dynamic RSC requests from resuming expired postponed state
- prevent regeneration failures from reviving explicitly tag-expired HTML through error backoff
- add unit and production E2E regression coverage, including an assertion that unrelated inner fetch-cache data is reused

The guard is intentionally limited to entries with postponed state. Applying it to fully static PPR entries caused an existing supported route with an inner no-store fetch to enter blocking prerendering and fail.

## Tests

- `pnpm build-all`
- `pnpm --filter=next build`
- `pnpm jest test/unit/incremental-cache/file-system-cache.test.ts packages/next/src/server/response-cache/index.test.ts --runInBand`
- `pnpm test-start-turbo test/e2e/app-dir/ppr-unstable-cache/ppr-unstable-cache.test.ts`
- `pnpm test-start-turbo test/production/app-dir/use-cache-expire/use-cache-expire.test.ts`
- targeted ESLint for all changed files
- `git diff --check origin/canary...HEAD`

## Scope

This directly fixes and verifies the open-source `next start` path. Minimal mode skips this incremental-cache read and is fronted by the platform cache/proxy, so the Vercel-hosted behavior may require a matching platform-side change to preserve concrete params or expired-entry state.