### PR TITLE
Serve a run of fallback shells from one route entry

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -56,6 +56,7 @@ import { escapeStringRegexp } from '../../shared/lib/escape-regexp'
 import { sortSortableRoutes } from '../../shared/lib/router/utils/sortable-routes'
 import { defaultOverrides } from '../../server/require-hook'
 import { generateRoutesManifest } from '../generate-routes-manifest'
+import { collectFallbackShellRuns } from './fallback-shell-runs'
 import { Bundler } from '../../lib/bundler'
 import { resolveCacheHandlerPathToFilesystem } from '../../lib/format-dynamic-import-path'
 import { InvariantError } from '../../shared/lib/invariant-error'
@@ -2100,7 +2101,24 @@ export async function handleBuildComplete({
       },
     ]
 
+    // Without this collapse the loop below emits one entry per shell.
+    const fallbackShellRuns = config.experimental.collapseAdapterRoutes
+      ? collectFallbackShellRuns(
+          routesManifest.dynamicRoutes,
+          (page) => prerenderManifest.dynamicRoutes[page]?.fallback === false
+        )
+      : undefined
+
     for (const route of routesManifest.dynamicRoutes) {
+      // An earlier entry in this loop serves this shell.
+      if (fallbackShellRuns?.replacedPages.has(route.page)) {
+        continue
+      }
+
+      const fallbackShellRun = fallbackShellRuns?.byRepresentativePage.get(
+        route.page
+      )
+
       const shouldLocalize = Boolean(config.i18n)
 
       const routeRegex = getNamedRouteRegex(route.page, {
@@ -2110,7 +2128,29 @@ export async function handleBuildComplete({
       const isFallbackFalse =
         prerenderManifest.dynamicRoutes[route.page]?.fallback === false
 
-      const sourceRegex = routeRegex.namedRegex.replace(
+      // An entry for a whole run of shells matches every prefix in that run.
+      // The destination copies the prefix that matched.
+      //
+      // This replacement runs on the pattern for the page, and `sourceRegex`
+      // below prefixes the result with the base path and the locale group. That
+      // order is deliberate. The search text anchors at `^`, and here that
+      // anchor is the start of the page path. On `sourceRegex` the same anchor
+      // is the start of the base path. A replacement there would match a base
+      // path such as `/de/x`, and it would rewrite that base path instead of
+      // the page path.
+      const pagePattern = fallbackShellRun
+        ? routeRegex.namedRegex.replace(
+            `^/${escapeStringRegexp(fallbackShellRun.prefixes[0])}/`,
+            `^/(?<shellPrefix>${fallbackShellRun.prefixes
+              .map((prefix) => escapeStringRegexp(prefix))
+              .join('|')})/`
+          )
+        : routeRegex.namedRegex
+      const pagePath = fallbackShellRun
+        ? path.posix.join('/', '$shellPrefix', fallbackShellRun.tail)
+        : route.page
+
+      const sourceRegex = pagePattern.replace(
         '^',
         `^${config.basePath && config.basePath !== '/' ? path.posix.join('/', config.basePath || '') : ''}[/]?${shouldLocalize ? '(?<nextLocale>[^/]{1,})' : ''}`
       )
@@ -2119,7 +2159,7 @@ export async function handleBuildComplete({
           '/',
           config.basePath,
           shouldLocalize ? '/$nextLocale' : '',
-          route.page
+          pagePath
         ) + getDestinationQuery(route.routeKeys)
 
       const hasAppPages = Boolean(appPageKeys && appPageKeys.length > 0)
@@ -2157,7 +2197,7 @@ export async function handleBuildComplete({
         // not match is then absent from that result, and the literal text
         // `$rscSuffix` stays in the destination.
         dynamicRoutes.push({
-          source: route.page,
+          source: pagePath,
           sourceRegex: sourceRegex.replace(
             new RegExp(escapeStringRegexp('(?:/)?$')),
             '(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$'
@@ -2173,7 +2213,7 @@ export async function handleBuildComplete({
         // suffix, so each request resolves to the artifact that it asks for.
         if (hasAppPages) {
           dynamicRoutes.push({
-            source: route.page + '.rsc',
+            source: pagePath + '.rsc',
             sourceRegex: sourceRegex.replace(
               new RegExp(escapeStringRegexp('(?:/)?$')),
               '(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$'
@@ -2186,7 +2226,7 @@ export async function handleBuildComplete({
 
         // needs basePath and locale handling if pages router
         dynamicRoutes.push({
-          source: route.page,
+          source: pagePath,
           sourceRegex,
           destination,
           has: plainHas,

--- a/packages/next/src/build/adapter/fallback-shell-runs.test.ts
+++ b/packages/next/src/build/adapter/fallback-shell-runs.test.ts
@@ -1,0 +1,104 @@
+import { pageToRoute } from '../utils'
+import { collectFallbackShellRuns } from './fallback-shell-runs'
+import type { RoutesManifest } from '..'
+
+// The suites in `test/production/app-dir/adapter-dynamic-routes` cover the
+// shapes that a build produces, and they pin the entries that come out of them.
+// Most cases below cover something those suites cannot: inputs that make this
+// function decline. A build does not produce those inputs, and a guard that
+// stopped declining would collapse shells that are not safe to collapse, which
+// no snapshot would catch.
+//
+// The first case is a successful collapse, so that the file also shows the
+// shape of a result.
+
+/**
+ * A fallback shell, which the build derives from a source page.
+ */
+function shell(page: string, sourcePage: string) {
+  return pageToRoute(page, sourcePage)
+}
+
+/**
+ * Any other dynamic route, which carries no source page.
+ */
+function plain(page: string) {
+  return pageToRoute(page, undefined)
+}
+
+function collect(
+  routes: ReturnType<typeof plain>[],
+  fallbackFalsePages: string[] = []
+) {
+  const result = collectFallbackShellRuns(
+    routes as RoutesManifest['dynamicRoutes'],
+    (page) => fallbackFalsePages.includes(page)
+  )
+
+  return {
+    runs: Object.fromEntries(result.byRepresentativePage),
+    replaced: [...result.replacedPages],
+  }
+}
+
+describe('collectFallbackShellRuns', () => {
+  it('collapses a run of shells that share a source page', () => {
+    expect(
+      collect([
+        shell('/de/posts/[id]', '/[lang]/posts/[id]'),
+        shell('/en/posts/[id]', '/[lang]/posts/[id]'),
+        plain('/[lang]/posts/[id]'),
+      ])
+    ).toEqual({
+      runs: {
+        '/de/posts/[id]': { prefixes: ['de', 'en'], tail: 'posts/[id]' },
+      },
+      replaced: ['/en/posts/[id]'],
+    })
+  })
+
+  it('keeps shells that another route separates', () => {
+    // The entry would take the position of the first shell, so it would move
+    // ahead of the route between the two.
+    expect(
+      collect([
+        shell('/de/posts/[id]', '/[lang]/posts/[id]'),
+        plain('/other/[id]'),
+        shell('/en/posts/[id]', '/[lang]/posts/[id]'),
+      ])
+    ).toEqual({ runs: {}, replaced: [] })
+  })
+
+  it('keeps shells that disagree on `fallback: false`', () => {
+    // One entry carries one set of conditions, so it cannot serve both.
+    expect(
+      collect(
+        [
+          shell('/de/posts/[id]', '/[lang]/posts/[id]'),
+          shell('/en/posts/[id]', '/[lang]/posts/[id]'),
+        ],
+        ['/en/posts/[id]']
+      )
+    ).toEqual({ runs: {}, replaced: [] })
+  })
+
+  it('keeps shells whose resolved segment is not the first one', () => {
+    // The prefix of a shell starts at the first segment, so `/docs` in front of
+    // the resolved segment puts these outside what the caller can rewrite.
+    expect(
+      collect([
+        shell('/docs/de/posts/[id]', '/docs/[lang]/posts/[id]'),
+        shell('/docs/en/posts/[id]', '/docs/[lang]/posts/[id]'),
+      ])
+    ).toEqual({ runs: {}, replaced: [] })
+  })
+
+  it('keeps shells that resolve every segment', () => {
+    // The pattern for `/de` ends after the prefix, so it has no slash for the
+    // caller to replace. A build cannot produce this shape, because it derives
+    // a fallback shell only from a prerender that leaves a param unresolved.
+    expect(collect([shell('/de', '/[lang]'), shell('/en', '/[lang]')])).toEqual(
+      { runs: {}, replaced: [] }
+    )
+  })
+})

--- a/packages/next/src/build/adapter/fallback-shell-runs.ts
+++ b/packages/next/src/build/adapter/fallback-shell-runs.ts
@@ -1,0 +1,263 @@
+/**
+ * One entry in the route table that a build passes to an adapter can serve
+ * several fallback shells.
+ *
+ * A fallback shell repeats the whole path of its source page, and it resolves
+ * the leading params of that page to concrete values. Those values form the
+ * prefix of the shell path, so the shells of one source page differ only in
+ * that prefix. A pattern can list several prefixes as alternatives, which lets
+ * one entry match them all.
+ *
+ * The shells that one entry serves are a run: a stretch of neighbours in the
+ * manifest. Adjacency is what makes a run safe to serve from one entry. That
+ * entry takes the position of the first shell of the run, which this file
+ * calls the representative, so every shell that the entry replaces keeps its
+ * place relative to the routes around it.
+ */
+
+import type { RoutesManifest } from '..'
+import { getNamedRouteRegex } from '../../shared/lib/router/utils/route-regex'
+import { escapeStringRegexp } from '../../shared/lib/escape-regexp'
+
+export type FallbackShellRun = {
+  /**
+   * The prefix of each shell of the run, in the order that the manifest lists
+   * them. The pattern of the entry holds these as alternatives, and the first
+   * one belongs to the representative.
+   */
+  prefixes: readonly string[]
+  /**
+   * The path that follows the prefix, without a leading slash. Every shell of
+   * the run shares it.
+   */
+  tail: string
+}
+
+export type FallbackShellRuns = {
+  /**
+   * The runs, keyed by the page of the representative of each.
+   */
+  byRepresentativePage: Map<string, FallbackShellRun>
+  /**
+   * The pages of the shells that a run serves, apart from the representative
+   * that keys it. The caller emits no entry of its own for these.
+   */
+  replacedPages: Set<string>
+}
+
+/**
+ * A run while this file still collects it. The exported shape holds only what
+ * the caller needs in order to emit the entry.
+ */
+type PendingRun = {
+  /**
+   * The source page that every shell of the run repeats.
+   */
+  sourcePage: string
+  /**
+   * The path that every shell of the run has after its prefix.
+   */
+  tail: string
+  /**
+   * Whether the shells have `fallback: false`. Every shell of the run agrees on
+   * this value.
+   */
+  isFallbackFalse: boolean
+  /**
+   * The shells of the run, in the order that the manifest lists them.
+   */
+  shells: Array<{
+    /**
+     * The page of the shell.
+     */
+    page: string
+    /**
+     * The leading part of that page, which holds the values that the shell
+     * resolves for the params of the source page.
+     */
+    prefix: string
+  }>
+}
+
+/**
+ * Splits the page of a fallback shell into the prefix that holds its resolved
+ * param values, and the path that follows.
+ *
+ * Returns undefined when the page resolves nothing, or when the resolved
+ * segments are not consecutive from the first segment onwards.
+ */
+function splitShellPage(
+  page: string,
+  sourcePage: string
+): { prefix: string; tail: string } | undefined {
+  const pageSegments = page.split('/')
+  const sourceSegments = sourcePage.split('/')
+  if (pageSegments.length !== sourceSegments.length) {
+    return undefined
+  }
+
+  const resolved: number[] = []
+  for (let index = 0; index < pageSegments.length; index++) {
+    if (pageSegments[index] !== sourceSegments[index]) {
+      resolved.push(index)
+    }
+  }
+  if (resolved.length === 0) {
+    return undefined
+  }
+
+  // A shell resolves the leading params of its source page, so the resolved
+  // segments are consecutive and the first of them is the first segment of the
+  // path. `split` returns an empty string at index 0, so they start at index 1.
+  for (let position = 0; position < resolved.length; position++) {
+    if (resolved[position] !== position + 1) {
+      return undefined
+    }
+  }
+
+  // The source page declares a param at each resolved position, and the shell
+  // holds a value there. Anything else means the two pages differ for another
+  // reason, and the leading segments are not a prefix of resolved values.
+  for (const index of resolved) {
+    if (
+      !sourceSegments[index].startsWith('[') ||
+      pageSegments[index].startsWith('[')
+    ) {
+      return undefined
+    }
+  }
+
+  const tailStart = resolved.length + 1
+  return {
+    prefix: pageSegments.slice(1, tailStart).join('/'),
+    tail: pageSegments.slice(tailStart).join('/'),
+  }
+}
+
+/**
+ * Collects the runs of fallback shells that one entry can serve.
+ *
+ * The shells of a run are neighbours in the manifest that agree on:
+ *
+ * - The source page.
+ * - The path that follows the prefix.
+ * - The value of `fallback: false`.
+ *
+ * They have to be neighbours because the entry takes the position of the first
+ * shell of the run. Every shell that the entry replaces then keeps its place
+ * relative to the routes around it. Any other route between two shells ends the
+ * run, because an entry that reached across it would move ahead of a route that
+ * a request matches first.
+ *
+ * They have to agree on `fallback: false` because an entry carries one set of
+ * conditions.
+ *
+ * The caller builds one pattern for a run, and it lists the prefixes of the run
+ * as complete alternatives. For a source page `/[team]/[locale]/posts/[id]`
+ * with shells for `acme/en`, `acme/de` and `globex/en`, that pattern holds:
+ *
+ * ```
+ * (?<shellPrefix>acme/en|acme/de|globex/en)
+ * ```
+ *
+ * A pattern that offered a choice per param instead, such as
+ * `(acme|globex)/(en|de)`, would also match `globex/de`. The build never
+ * prerendered that pair, so a request for it would resolve to an output that
+ * does not exist, and it would then fall through to whichever route claims the
+ * rewritten path.
+ *
+ * A shell can belong to no run, and one source page can hold several runs. That
+ * happens when the build resolves a different number of params for neighbouring
+ * shells, because their prefixes then have different lengths and the paths that
+ * follow them differ.
+ *
+ * A run of only one shell has a single prefix, so an entry for it would match
+ * what the entry for that shell already matches. This function leaves such a
+ * shell out of the result.
+ */
+export function collectFallbackShellRuns(
+  dynamicRoutes: RoutesManifest['dynamicRoutes'],
+  hasFallbackFalse: (page: string) => boolean
+): FallbackShellRuns {
+  const runs: PendingRun[] = []
+  let current: PendingRun | undefined
+
+  for (const route of dynamicRoutes) {
+    // `pageToRoute` sets `sourcePage` only when the build passes it a source
+    // page, and the build does that for a fallback shell. The field therefore
+    // names the page whose path this shell repeats, and it is absent on every
+    // other route.
+    const { sourcePage } = route
+    const split =
+      sourcePage && sourcePage !== route.page
+        ? splitShellPage(route.page, sourcePage)
+        : undefined
+
+    // This route is not a shell that a run can hold, so it ends the run in
+    // progress.
+    if (!sourcePage || !split) {
+      current = undefined
+      continue
+    }
+
+    const isFallbackFalse = hasFallbackFalse(route.page)
+
+    if (
+      current &&
+      (current.sourcePage !== sourcePage ||
+        current.tail !== split.tail ||
+        current.isFallbackFalse !== isFallbackFalse)
+    ) {
+      current = undefined
+    }
+
+    if (!current) {
+      current = {
+        sourcePage,
+        tail: split.tail,
+        isFallbackFalse,
+        shells: [],
+      }
+      runs.push(current)
+    }
+
+    current.shells.push({ page: route.page, prefix: split.prefix })
+  }
+
+  const byRepresentativePage = new Map<string, FallbackShellRun>()
+  const replacedPages = new Set<string>()
+
+  for (const run of runs) {
+    if (run.shells.length < 2) {
+      continue
+    }
+
+    // The caller replaces the escaped prefix at the start of the pattern for
+    // the representative, so this function keeps the run only when that pattern
+    // starts with the prefix.
+    //
+    // Two things make that true today. `getNamedRouteRegex` escapes each
+    // segment the same way, and a fallback shell keeps at least one param
+    // unresolved, so a slash always follows its prefix. This check holds the
+    // run back if either stops being true.
+    const [representative, ...replaced] = run.shells
+    const { namedRegex } = getNamedRouteRegex(representative.page, {
+      prefixRouteKeys: true,
+    })
+    if (
+      !namedRegex.startsWith(`^/${escapeStringRegexp(representative.prefix)}/`)
+    ) {
+      continue
+    }
+
+    byRepresentativePage.set(representative.page, {
+      prefixes: run.shells.map((shell) => shell.prefix),
+      tail: run.tail,
+    })
+    for (const shell of replaced) {
+      replacedPages.add(shell.page)
+    }
+  }
+
+  return { byRepresentativePage, replacedPages }
+}

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-base-path.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-base-path.test.ts
@@ -30,7 +30,7 @@ describe(`adapter dynamic routes (cache components, base path ${basePath})`, () 
     const routing: AdapterRouting = await next.readJSON('build-complete.json')
 
     // A base path prefixes the entries. It does not add or remove any.
-    expect(routing.dynamicRoutes).toHaveLength(9)
+    expect(routing.dynamicRoutes).toHaveLength(7)
 
     for (const route of routing.dynamicRoutes) {
       expect(route.sourceRegex.startsWith(`^${basePath}`)).toBe(true)

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-cache-components.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-cache-components.test.ts
@@ -41,19 +41,15 @@ describe('adapter dynamic routes (cache components)', () => {
 
     expect(serializeDynamicRoutes(routing.dynamicRoutes))
       .toMatchInlineSnapshot(`
-     "9 entries
+     "7 entries
 
      /[lang]
        ^[/]?/(?<nxtPlang>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
        -> /[lang]$rscSuffix?nxtPlang=$nxtPlang
 
-     /de/fallback-shell/[slug]
-       ^[/]?/de/fallback\\-shell/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
-       -> /de/fallback-shell/[slug]$rscSuffix?nxtPslug=$nxtPslug
-
-     /en/fallback-shell/[slug]
-       ^[/]?/en/fallback\\-shell/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
-       -> /en/fallback-shell/[slug]$rscSuffix?nxtPslug=$nxtPslug
+     /$shellPrefix/fallback-shell/[slug]
+       ^[/]?/(?<shellPrefix>de|en)/fallback\\-shell/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /$shellPrefix/fallback-shell/[slug]$rscSuffix?nxtPslug=$nxtPslug
 
      /[lang]/fallback-shell/[slug]
        ^[/]?/(?<nxtPlang>[^/]+?)/fallback\\-shell/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
@@ -67,13 +63,9 @@ describe('adapter dynamic routes (cache components)', () => {
        ^[/]?/(?<nxtPlang>[^/]+?)/static(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
        -> /[lang]/static$rscSuffix?nxtPlang=$nxtPlang
 
-     /de/[slug]
-       ^[/]?/de/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
-       -> /de/[slug]$rscSuffix?nxtPslug=$nxtPslug
-
-     /en/[slug]
-       ^[/]?/en/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
-       -> /en/[slug]$rscSuffix?nxtPslug=$nxtPslug
+     /$shellPrefix/[slug]
+       ^[/]?/(?<shellPrefix>de|en)/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /$shellPrefix/[slug]$rscSuffix?nxtPslug=$nxtPslug
 
      /[lang]/[slug]
        ^[/]?/(?<nxtPlang>[^/]+?)/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-no-root-params.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-no-root-params.test.ts
@@ -15,16 +15,19 @@ import {
 // - An entry that resolves both params, such as `/sparse/en/posts/[id]`.
 // - An entry that resolves only `team`, such as `/sparse/[locale]/posts/[id]`.
 //
-// The two shapes have different paths after the resolved segments, so the
-// entries stay as they are. One entry serves one shape of path, and an
-// alternation cannot hold both shapes at once.
+// The two shapes alternate, so only neighbours of one shape collapse into a
+// single entry. The two entries for the `acme.one-two,three` team that resolve
+// both params are such a pair. The entry for the `sparse` team that resolves
+// both params has an entry of the other shape on each side, so it stays as it
+// is.
 //
 // The order of the entries carries the behavior. An entry that resolves both
 // params comes before an entry that resolves one, so a request for
 // `/sparse/en/posts/1` reaches the output for `/sparse/en/posts/[id]` and not
-// the one for `/sparse/[locale]/posts/[id]`. A collapse that grouped the second
-// shape across teams would move it ahead of the first shape and change which
-// output a request reaches.
+// the one for `/sparse/[locale]/posts/[id]`. A collapsed entry takes the
+// position of the first entry that it replaces, and a run of neighbours stops
+// at any route of another shape, so every replaced entry keeps its place
+// relative to the routes around it.
 describe('adapter dynamic routes (no root params)', () => {
   const { next } = nextTestSetup({
     files: path.join(__dirname, 'no-root-params'),
@@ -39,15 +42,11 @@ describe('adapter dynamic routes (no root params)', () => {
 
     expect(serializeDynamicRoutes(routing.dynamicRoutes))
       .toMatchInlineSnapshot(`
-     "6 entries
+     "5 entries
 
-     /acme.one-two,three/de/posts/[id]
-       ^[/]?/acme\\.one\\-two,three/de/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
-       -> /acme.one-two,three/de/posts/[id]$rscSuffix?nxtPid=$nxtPid
-
-     /acme.one-two,three/en/posts/[id]
-       ^[/]?/acme\\.one\\-two,three/en/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
-       -> /acme.one-two,three/en/posts/[id]$rscSuffix?nxtPid=$nxtPid
+     /$shellPrefix/posts/[id]
+       ^[/]?/(?<shellPrefix>acme\\.one\\-two,three/de|acme\\.one\\-two,three/en)/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /$shellPrefix/posts/[id]$rscSuffix?nxtPid=$nxtPid
 
      /acme.one-two,three/[locale]/posts/[id]
        ^[/]?/acme\\.one\\-two,three/(?<nxtPlocale>[^/]+?)/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$

--- a/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-shell-prefixes.test.ts
+++ b/test/production/app-dir/adapter-dynamic-routes/dynamic-routes-shell-prefixes.test.ts
@@ -29,19 +29,11 @@ describe('adapter dynamic routes (shell prefixes)', () => {
 
     expect(serializeDynamicRoutes(routing.dynamicRoutes))
       .toMatchInlineSnapshot(`
-     "4 entries
+     "2 entries
 
-     /acme.one-two,three/de/posts/[id]
-       ^[/]?/acme\\.one\\-two,three/de/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
-       -> /acme.one-two,three/de/posts/[id]$rscSuffix?nxtPid=$nxtPid
-
-     /acme.one-two,three/en/posts/[id]
-       ^[/]?/acme\\.one\\-two,three/en/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
-       -> /acme.one-two,three/en/posts/[id]$rscSuffix?nxtPid=$nxtPid
-
-     /sparse/en/posts/[id]
-       ^[/]?/sparse/en/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
-       -> /sparse/en/posts/[id]$rscSuffix?nxtPid=$nxtPid
+     /$shellPrefix/posts/[id]
+       ^[/]?/(?<shellPrefix>acme\\.one\\-two,three/de|acme\\.one\\-two,three/en|sparse/en)/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+       -> /$shellPrefix/posts/[id]$rscSuffix?nxtPid=$nxtPid
 
      /[team]/[locale]/posts/[id]
        ^[/]?/(?<nxtPteam>[^/]+?)/(?<nxtPlocale>[^/]+?)/posts/(?<nxtPid>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$


### PR DESCRIPTION
A fallback shell repeats the whole path of its source page and resolves the leading params to concrete values. Take `/[team]/[locale]/[slug]`, where the build prerenders three combinations of the two leading params. It emits one entry per combination, and the entries differ only in that leading part of the path:

```diff
- /acme/en/<slug><suffix>    ->  /acme/en/[slug]<matched suffix>
- /acme/de/<slug><suffix>    ->  /acme/de/[slug]<matched suffix>
- /globex/en/<slug><suffix>  ->  /globex/en/[slug]<matched suffix>
+ /(?<shellPrefix>acme/en|acme/de|globex/en)/<slug><suffix>  ->  /$shellPrefix/[slug]<matched suffix>
```

One entry now serves them all. Its pattern lists the leading part of each shell path as an alternative, and its destination copies whichever one matched.

Those alternatives are complete, and that matters. A pattern that offered a choice per param instead, `(acme|globex)/(en|de)`, would also match `globex/de`. The build never prerendered that combination, so a request for it would resolve to an output that does not exist, and it would then fall through to whichever route claims the rewritten path.

An entry serves neighbours in the manifest, and only those. It takes the position of the first shell that it replaces, so every replaced shell keeps its place relative to the routes around it. Any other route between two shells ends the run, because an entry that reached across it would move ahead of a route that a request matches first. The shells of a run also have to agree on `fallback: false`, because an entry carries one set of conditions.

A source page can therefore hold several runs, and a shell can belong to none. That happens when the build resolves a different number of params for neighbouring shells, which leaves them with different paths after the resolved part.

This removes the multiplier that the number of prerendered combinations applies to every route below the resolved params. We measured the same in-progress feature branch of the v0 chat app as the previous changes in this stack. Building it before and after this change removes 87% of the routes that those changes left. Across the stack that branch loses 95% of its routes.

This collapse follows `experimental.collapseAdapterRoutes`, which an earlier change in this stack added. A build that sets it to `false` emits one entry per shell.

**Verified with a [full deploy test run](https://github.com/vercel/next.js/actions/runs/32577936779).**