### PR TITLE
perf: split cold TurboMalloc accounting paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10326,6 +10326,7 @@ dependencies = [
 name = "turbo-tasks-malloc"
 version = "0.1.0"
 dependencies = [
+ "codspeed-criterion-compat",
  "libc",
  "libmimalloc-sys",
  "mimalloc",

--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -9,7 +9,14 @@ autobenches = false
 [lib]
 bench = false
 
+[[bench]]
+name = "allocation"
+harness = false
+
 [dependencies]
+
+[dev-dependencies]
+criterion = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 libmimalloc-sys = { version = "0.1.44", features = [

--- a/turbopack/crates/turbo-tasks-malloc/benches/allocation.rs
+++ b/turbopack/crates/turbo-tasks-malloc/benches/allocation.rs
@@ -1,0 +1,57 @@
+//! Measures the cost of the raw allocation paths through [`TurboMalloc`], including its
+//! thread-local allocation accounting. Useful when changing the allocator's instrumentation, since
+//! that code runs on every allocation and deallocation in Turbopack.
+
+use std::alloc::{Layout, alloc, dealloc, realloc};
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+#[global_allocator]
+static ALLOC: turbo_tasks_malloc::TurboMalloc = turbo_tasks_malloc::TurboMalloc;
+
+const ALIGN: usize = 8;
+const SIZE: usize = 64;
+const LARGER_SIZE: usize = 128;
+
+fn make_layout(size: usize) -> Layout {
+    Layout::from_size_align(size, ALIGN).expect("valid layout")
+}
+
+fn benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("turbo_malloc");
+
+    group.bench_function("alloc_dealloc", |b| {
+        b.iter(|| {
+            // `black_box` the size so the allocation can't be optimized away or folded.
+            let layout = make_layout(black_box(SIZE));
+            // SAFETY: the layout has a non-zero size, and the pointer is freed with the same
+            // layout it was allocated with.
+            unsafe {
+                let ptr = alloc(layout);
+                assert!(!ptr.is_null(), "allocation failed");
+                dealloc(black_box(ptr), layout);
+            }
+        });
+    });
+
+    group.bench_function("alloc_realloc_dealloc", |b| {
+        b.iter(|| {
+            let layout = make_layout(black_box(SIZE));
+            let new_size = black_box(LARGER_SIZE);
+            // SAFETY: `ptr` is allocated with `layout`, reallocated to `new_size` with the same
+            // alignment, and finally freed with the layout it then has.
+            unsafe {
+                let ptr = alloc(layout);
+                assert!(!ptr.is_null(), "allocation failed");
+                let ptr = realloc(ptr, layout, new_size);
+                assert!(!ptr.is_null(), "reallocation failed");
+                dealloc(black_box(ptr), make_layout(new_size));
+            }
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/turbopack/crates/turbo-tasks-malloc/src/counter.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/counter.rs
@@ -36,29 +36,28 @@ impl ThreadLocalCounter {
             allocation_counters: AllocationCounters::new(),
         }
     }
+    #[inline(always)]
     fn add(&mut self, size: usize) {
         self.allocation_counters.allocations += size;
         self.allocation_counters.allocation_count += 1;
         if self.buffer >= size {
             self.buffer -= size;
         } else {
-            let offset = size - self.buffer + TARGET_BUFFER;
-            self.buffer = TARGET_BUFFER;
-            ALLOCATED.fetch_add(offset, Ordering::Relaxed);
+            add_slow(self, size);
         }
     }
 
+    #[inline(always)]
     fn remove(&mut self, size: usize) {
         self.allocation_counters.deallocations += size;
         self.allocation_counters.deallocation_count += 1;
         self.buffer += size;
         if self.buffer > MAX_BUFFER {
-            let offset = self.buffer - TARGET_BUFFER;
-            self.buffer = TARGET_BUFFER;
-            ALLOCATED.fetch_sub(offset, Ordering::Relaxed);
+            remove_slow(self);
         }
     }
 
+    #[inline(always)]
     fn update(&mut self, old_size: usize, new_size: usize) {
         self.allocation_counters.deallocations += old_size;
         self.allocation_counters.deallocation_count += 1;
@@ -71,18 +70,14 @@ impl ThreadLocalCounter {
                 if self.buffer >= size {
                     self.buffer -= size;
                 } else {
-                    let offset = size - self.buffer + TARGET_BUFFER;
-                    self.buffer = TARGET_BUFFER;
-                    ALLOCATED.fetch_add(offset, Ordering::Relaxed);
+                    add_slow(self, size);
                 }
             }
             std::cmp::Ordering::Greater => {
                 let size = old_size - new_size;
                 self.buffer += size;
                 if self.buffer > MAX_BUFFER {
-                    let offset = self.buffer - TARGET_BUFFER;
-                    self.buffer = TARGET_BUFFER;
-                    ALLOCATED.fetch_sub(offset, Ordering::Relaxed);
+                    remove_slow(self);
                 }
             }
         }
@@ -95,6 +90,25 @@ impl ThreadLocalCounter {
         }
         self.allocation_counters = AllocationCounters::default();
     }
+}
+
+// Keep the uncommon atomic updates out of the allocator's inlined hot path.
+#[cold]
+#[inline(never)]
+fn add_slow(local: &mut ThreadLocalCounter, size: usize) {
+    debug_assert!(local.buffer < size);
+    let offset = size - local.buffer + TARGET_BUFFER;
+    local.buffer = TARGET_BUFFER;
+    ALLOCATED.fetch_add(offset, Ordering::Relaxed);
+}
+
+#[cold]
+#[inline(never)]
+fn remove_slow(local: &mut ThreadLocalCounter) {
+    debug_assert!(local.buffer > MAX_BUFFER);
+    let offset = local.buffer - TARGET_BUFFER;
+    local.buffer = TARGET_BUFFER;
+    ALLOCATED.fetch_sub(offset, Ordering::Relaxed);
 }
 
 thread_local! {
@@ -113,6 +127,7 @@ pub fn reset_allocation_counters(start: AllocationCounters) {
     with_local_counter(|local| local.allocation_counters = start);
 }
 
+#[inline(always)]
 fn with_local_counter<T>(f: impl FnOnce(&mut ThreadLocalCounter) -> T) -> T {
     LOCAL_COUNTER.with(|local| {
         let ptr = local.get();
@@ -123,16 +138,19 @@ fn with_local_counter<T>(f: impl FnOnce(&mut ThreadLocalCounter) -> T) -> T {
 }
 
 /// Adds some `size` to the global counter in a thread-local buffered way.
+#[inline(always)]
 pub fn add(size: usize) {
     with_local_counter(|local| local.add(size));
 }
 
 /// Removes some `size` to the global counter in a thread-local buffered way.
+#[inline(always)]
 pub fn remove(size: usize) {
     with_local_counter(|local| local.remove(size));
 }
 
-/// Adds some `size` to the global counter in a thread-local buffered way.
+/// Updates the global counter for a reallocation in a thread-local buffered way.
+#[inline(always)]
 pub fn update(old_size: usize, new_size: usize) {
     with_local_counter(|local| local.update(old_size, new_size));
 }
@@ -171,6 +189,19 @@ mod tests {
         // but it will be reduce to TARGET_BUFFER
         // this means the global counter should reduce by 100 + MAX_BUFFER
         expected -= MAX_BUFFER + 100;
+        assert_eq!(get(), expected);
+
+        update(100, 200);
+        // Small reallocations should use the buffer.
+        assert_eq!(get(), expected);
+        update(0, MAX_BUFFER);
+        // Growing beyond the buffer should require more buffer space. The prior small growth
+        // consumed another 100 bytes from the buffer.
+        expected += MAX_BUFFER + 100;
+        assert_eq!(get(), expected);
+        update(MAX_BUFFER + 1, 0);
+        // Shrinking beyond MAX_BUFFER should flush the excess.
+        expected -= MAX_BUFFER + 1;
         assert_eq!(get(), expected);
     }
 }


### PR DESCRIPTION
### What?

Reduce the binary-size cost of TurboMalloc's allocation instrumentation while preserving its hot-path performance and accounting semantics.

This adds a focused Criterion benchmark for TurboMalloc's raw allocation paths and moves only the uncommon global counter refill/spill operations behind cold, non-inlined helpers. Thread-local allocation counters, buffer checks, and common buffer adjustments remain inline at allocation sites.

### Why?

Rust gives global allocator methods special inlining treatment. TurboMalloc's thread-local accounting was consequently duplicated across allocation and deallocation call sites in `next-swc`, contributing several megabytes of machine code.

Moving the whole accounting path out of line recovered most of that space but made small allocations slower. Splitting only the rare atomic paths provides a smaller size reduction without that hot-path cost.

### How?

The common path remains explicitly inlineable through `add`, `remove`, `update`, and the thread-local access helper. When the local buffer must be refilled or spilled, it calls a `#[cold] #[inline(never)]` helper that performs the global relaxed atomic update.

The arithmetic, thresholds, target buffer values, counter increments, and atomic ordering are unchanged. The counter test now also covers realloc growth/spill and shrink/flush behavior.

### Benchmark results

Linux x86_64 Intel Xeon, Rust 1.99.0-nightly / LLVM 22.1.8. Native artifacts used the repository's production release command. Direct application measurements used clean `bench/heavy-npm-deps` `next build --turbopack` runs, with 8 samples per arm and rotated/interleaved ordering.

#### Binary size

| alternative | raw artifact delta | `.text` delta |
|---|---:|---:|
| No instrumentation | −6,260,168 B (−4.23%) | −5,466,304 B (−7.69%) |
| `inline(never)` on `add` / `remove` / `update` | −4,338,856 B (−2.93%) | −4,342,464 B (−6.11%) |
| `inline(never)` on whole `GlobalAlloc` methods | −4,153,792 B (−2.80%) | −3,714,688 B (−5.23%) |
| **Cold atomic refill/spill helpers (this PR)** | **−502,864 B (−0.34%)** | **−732,736 B (−1.03%)** |

The current artifact was approximately 148.1 MB raw with 71.1 MB of `.text`. The retained split recovers 8% of the raw and 13% of the `.text` saving from removing instrumentation entirely.

#### Direct `next build --turbopack`

| alternative | mean effect vs current | bootstrap 95% CI | permutation p |
|---|---:|---:|---:|
| No instrumentation | −0.70% | [−2.32%, +1.12%] | 0.466 |
| `inline(never)` on `add` / `remove` / `update` | **+3.53%** | **[+0.65%, +6.43%]** | 0.0448 |
| `inline(never)` on whole `GlobalAlloc` methods | +1.02% | [−2.03%, +4.44%] | 0.586 |
| **Cold atomic refill/spill helpers (this PR)** | **−0.18%** | **[−3.44%, +3.61%]** | **0.929** |

No application-level difference was detected for the retained split or the whole-method placement. The helper-level noinline placement showed evidence of a modest regression.

#### Focused allocator Criterion benchmark

Percent changes are lower-is-better. Where two figures are shown, they are independent runs in reversed order.

| alternative | alloc + dealloc | alloc + realloc + dealloc |
|---|---:|---:|
| No instrumentation | −43.4% | −36.1% |
| `inline(never)` on `add` / `remove` / `update` | +5.5% / +7.5% | +3.0% / −8.1% (inconclusive) |
| `inline(never)` on whole `GlobalAlloc` methods | **+19.4% / +21.4%** | **+2.9% / +6.4%** |
| **Cold atomic refill/spill helpers (this PR)** | **−4.0% / −3.0%** | **−2.8% / −5.4%** |

The full 28-cell turbo-tasks overhead suite was also run twice in reversed order. Large process-level effects changed magnitude or sign between runs, so no conclusion is drawn from that suite.

### Verification

- `cargo fmt -- --check`
- `cargo clippy -p turbo-tasks-malloc --all-targets -- -D warnings -A deprecated`
- `cargo test -p turbo-tasks-malloc`
- `cargo check -p turbo-tasks-malloc --all-targets`
- `cargo bench -p turbo-tasks-malloc --bench allocation -- --test`
- Release `next-swc` builds and Node smoke-loads for every measured arm

<!-- NEXT_JS_LLM -->
