### PR TITLE
[turbopack] defer free variable member resolution

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -450,7 +450,7 @@ struct AnalysisState<'a> {
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     origin_path: FileSystemPath,
     compile_time_info: ResolvedVc<CompileTimeInfo>,
-    free_var_references_members: ResolvedVc<FreeVarReferencesMembers>,
+    free_var_references_members: Vc<FreeVarReferencesMembers>,
     compile_time_info_ref: ReadRef<CompileTimeInfo>,
     arena: &'a ThreadLocal<Bump>,
     var_graph: VarGraph<'a>,
@@ -848,11 +848,7 @@ async fn analyze_ecmascript_module_internal(
             origin,
             origin_path: origin_path.clone(),
             compile_time_info,
-            free_var_references_members: compile_time_info_ref
-                .free_var_references
-                .members()
-                .to_resolved()
-                .await?,
+            free_var_references_members: compile_time_info_ref.free_var_references.members(),
             compile_time_info_ref,
             var_graph,
             allow_project_root_tracing: !source.ident().await?.path.is_in_node_modules(),


### PR DESCRIPTION
### What?

Keep the compile-time free-variable member set as a lazy `Vc` in ECMAScript analysis state instead of resolving it while every module's analysis state is constructed.

### Why?

Only two assignment-analysis paths query this member set. Deferring resolution avoids an eager task wait for modules that never reach either path while preserving the same cached member-set computation.

This is an inspection experiment, not a demonstrated performance improvement. The observed benchmark difference was neutral and was measured with a debug native binding, so it is not valid evidence for a micro-optimization.

### How?

`AnalysisState` stores `Vc<FreeVarReferencesMembers>`. Both existing consumers continue to await the generated `contains_key` task when they actually need the set.

### Verification

- `cargo fmt -- --check`
- `cargo check -p turbopack-ecmascript`
- Not run: clippy, Rust test suite, or integration tests (inspection experiment)

<!-- NEXT_JS_LLM -->
