### PR TITLE
[turbopack] defer NFT module content hashes

### DIFF
--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -208,7 +208,6 @@ impl Asset for ServerNftJsonAsset {
             self.entries(),
             Some(self.ignores()),
             None,
-            hash_salt,
         )
         .await?
         .iter()

--- a/crates/next-api/src/nft.rs
+++ b/crates/next-api/src/nft.rs
@@ -89,7 +89,6 @@ pub async fn trace_endpoint(
                 .await?
                 .map(|v| *v),
             Some(next_config.config_file_path(project_path.clone())),
-            hash_salt,
         )
         .await?;
 
@@ -284,12 +283,11 @@ pub async fn traced_modules_for_entries(
     traced_entries: Vc<Modules>,
     exclude_glob: Option<Vc<Glob>>,
     forbidden_path: Option<Vc<FileSystemPath>>,
-    hash_salt: Vc<RcStr>,
 ) -> Result<Vc<Modules>> {
     let exclude_glob_and_module_idents = if let Some(exclude_glob) = exclude_glob {
         let exclude_glob = exclude_glob.await?;
-        let data = traced_module_data_for_graph(module_graph, traced_entries, hash_salt).await?;
-        Some((exclude_glob, data.idents.await?))
+        let idents = traced_module_idents_for_graph(module_graph, traced_entries).await?;
+        Some((exclude_glob, idents))
     } else {
         None
     };
@@ -388,13 +386,12 @@ pub struct TracedModuleData {
     pub hashes: ResolvedVc<TracedModuleDataHashes>,
 }
 
-/// This caches the paths for all modules in the graph so that we don't have to do it once per page.
+/// This caches the paths for all modules in the graph without eagerly hashing their contents.
 #[turbo_tasks::function]
-pub async fn traced_module_data_for_graph(
+async fn traced_module_idents_for_graph(
     module_graph: Vc<ModuleGraph>,
     traced_entries: Vc<Modules>,
-    hash_salt: Vc<RcStr>,
-) -> Result<Vc<TracedModuleData>> {
+) -> Result<Vc<TracedModuleDataIdents>> {
     // This function is very similar to traced_modules_for_entries, but doesn't apply the glob and
     // is executed only once for the whole graph.
     let module_graph = module_graph.await?;
@@ -423,30 +420,51 @@ pub async fn traced_module_data_for_graph(
         true,
     )?;
 
-    let (idents, hashes): (FxHashMap<_, _>, FxHashMap<_, _>) = traced_modules
-        .into_iter()
+    Ok(Vc::cell(
+        traced_modules
+            .into_iter()
+            .map(async |module| Ok((module, module.ident().await?)))
+            .try_join()
+            .await?
+            .into_iter()
+            .collect(),
+    ))
+}
+
+/// This caches the paths and content hashes for all modules in the graph so that we don't have to
+/// compute them once per page.
+#[turbo_tasks::function]
+pub async fn traced_module_data_for_graph(
+    module_graph: Vc<ModuleGraph>,
+    traced_entries: Vc<Modules>,
+    hash_salt: Vc<RcStr>,
+) -> Result<Vc<TracedModuleData>> {
+    let idents = traced_module_idents_for_graph(module_graph, traced_entries)
+        .to_resolved()
+        .await?;
+    let hashes = idents
+        .await?
+        .keys()
+        .copied()
         .map(async |module| {
             Ok((
-                (module, module.ident().await?),
-                (
-                    module,
-                    module
-                        .source()
-                        .await?
-                        .context("NFT module has no content")?
-                        .content()
-                        .hash(hash_salt, HashAlgorithm::Xxh3Hash128Hex)
-                        .await?,
-                ),
+                module,
+                module
+                    .source()
+                    .await?
+                    .context("NFT module has no content")?
+                    .content()
+                    .hash(hash_salt, HashAlgorithm::Xxh3Hash128Hex)
+                    .await?,
             ))
         })
         .try_join()
         .await?
         .into_iter()
-        .unzip();
+        .collect();
 
     Ok(TracedModuleData {
-        idents: ResolvedVc::cell(idents),
+        idents,
         hashes: ResolvedVc::cell(hashes),
     }
     .cell())


### PR DESCRIPTION
### What?

Separate trace-graph module path collection from module content hashing. Exclusion filtering now requests only cached module identifiers, while full NFT data still layers content hashes on top when they are required.

### Why?

Applying output-file-tracing exclusion globs needs module paths but not content hashes. Keeping these computations separate avoids requesting full-graph hashes solely to decide which modules should be skipped.

This is an inspection experiment, not a demonstrated performance improvement. A seven-sample release A/B left the median compilation phase unchanged at 2700 ms.

### How?

A private identifier-only graph task owns the existing DFS traversal. `traced_module_data_for_graph` reuses those identifiers and computes hashes for its full result. `traced_modules_for_entries` drops the unused hash-salt input and consumes only identifiers for glob matching.

### Verification

- `cargo fmt -- --check`
- `cargo check -p next-api`
- `next-server.js.nft.json`: byte-identical SHA-256 `da4c5a494efbbb38eb966066115de96adb5d0ec693fba17bbed669c99cafae43`
- `next-minimal-server.js.nft.json`: byte-identical SHA-256 `7c58d40dc2ecbe6ddd26dd0c602467d80f1a8ea3320e2c6e8e5f4d6be14156cd`
- Not run: clippy, Rust test suite, or integration tests (inspection experiment)

<!-- NEXT_JS_LLM -->
