### PR TITLE
Turn off the adapter route collapses by default

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -507,7 +507,9 @@ export interface ExperimentalConfig {
    * A collapsed entry resolves each request to the same output as the entries
    * that it replaces.
    *
-   * @default true
+   * The default is `false`, so a build keeps one entry per route.
+   *
+   * @default false
    */
   collapseAdapterRoutes?: boolean
   useSkewCookie?: boolean
@@ -2241,7 +2243,7 @@ export const defaultConfig = Object.freeze({
   adapterPath: process.env.NEXT_ADAPTER_PATH || undefined,
   experimental: {
     coldCacheBadge: false,
-    collapseAdapterRoutes: true,
+    collapseAdapterRoutes: false,
     devValidationWorker: true,
     useSkewCookie: false,
     cssChunking: true,

--- a/test/production/app-dir/adapter-dynamic-routes/cache-components/next.config.js
+++ b/test/production/app-dir/adapter-dynamic-routes/cache-components/next.config.js
@@ -3,6 +3,9 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  // The option is off by default. These snapshots pin the collapsed route
+  // table, so the fixture enables it.
+  experimental: { collapseAdapterRoutes: true },
   // A build ID that reaches an entry changes the snapshot on every run. A
   // fixed build ID keeps the snapshot independent of the run.
   generateBuildId: () => 'test-build-id',

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/next.config.js
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/next.config.js
@@ -7,6 +7,9 @@ const nextConfig = {
   // that variable overrides a config that omits the field. An omitted field
   // would let that matrix turn Cache Components on for this fixture.
   cacheComponents: false,
+  // The option is off by default. These snapshots pin the collapsed route
+  // table, so the fixture enables it.
+  experimental: { collapseAdapterRoutes: true },
   // The source regex of a pages router data route holds the build ID. A fixed
   // build ID keeps the snapshot independent of the run.
   generateBuildId: () => 'test-build-id',

--- a/test/production/app-dir/adapter-dynamic-routes/no-root-params/next.config.js
+++ b/test/production/app-dir/adapter-dynamic-routes/no-root-params/next.config.js
@@ -3,6 +3,9 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  // The option is off by default. These snapshots pin the collapsed route
+  // table, so the fixture enables it.
+  experimental: { collapseAdapterRoutes: true },
   // A build ID that reaches an entry changes the snapshot on every run. A fixed
   // build ID keeps the snapshot independent of the run.
   generateBuildId: () => 'test-build-id',

--- a/test/production/app-dir/adapter-dynamic-routes/shell-prefixes/next.config.js
+++ b/test/production/app-dir/adapter-dynamic-routes/shell-prefixes/next.config.js
@@ -3,6 +3,9 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  // The option is off by default. These snapshots pin the collapsed route
+  // table, so the fixture enables it.
+  experimental: { collapseAdapterRoutes: true },
   // A build ID that reaches an entry changes the snapshot on every run. A fixed
   // build ID keeps the snapshot independent of the run.
   generateBuildId: () => 'test-build-id',


### PR DESCRIPTION
`experimental.collapseAdapterRoutes` now defaults to `false`, so a build keeps one entry per route unless the project opts in. The changes below it in this stack stay as they are, and a project that sets the option to `true` gets the route table that they produce.

The default starts off so that we can dogfood the behavior on selected apps before every build gets it. The default moves back to `true` once enough apps have run with it.

The four fixtures under `test/production/app-dir/adapter-dynamic-routes` set the option, because their snapshots pin the collapsed table. A build of the Cache Components fixture without the option emits the 27 entries that the first commit in this stack recorded, which is what the option now turns off.