### PR TITLE
Expose tags on set() context for APP_PAGE/APP_ROUTE

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/incrementalCacheHandlerPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/incrementalCacheHandlerPath.mdx
@@ -42,6 +42,8 @@ Returns the cached value or `null` if not found.
 
 The `data` object contains a `kind` property that indicates the type of cache entry. For image optimization, `kind` will be `'IMAGE'` and the data will include properties like `buffer`, `etag`, `extension`, and `revalidate`.
 
+For `'APP_PAGE'` and `'APP_ROUTE'` entries, `ctx.tags` includes both the explicit tags used during rendering (for example from `fetch` calls with `next: { tags: [...] }`) and the implicit path tags (prefixed with `_N_T_`) that `revalidatePath` relies on. You can use these to maintain a tag-to-key index so that `revalidateTag` can invalidate the matching entries.
+
 Returns `Promise<void>`.
 
 ### `revalidateTag()`

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -785,6 +785,23 @@ export class IncrementalCache implements IncrementalCacheType {
         this.cacheControls.set(toRoute(pathname), ctx.cacheControl)
       }
 
+      // Page and route entries carry their tags (explicit fetch tags and
+      // implicit path tags) in the cached value's headers. Expose them on the
+      // context as well so that custom cache handlers can maintain a
+      // tag → key index without parsing the header themselves.
+      if (
+        !ctx.fetchCache &&
+        ctx.tags === undefined &&
+        (data?.kind === CachedRouteKind.APP_PAGE ||
+          data?.kind === CachedRouteKind.APP_ROUTE)
+      ) {
+        const tagsHeader = data.headers?.[NEXT_CACHE_TAGS_HEADER]
+
+        if (typeof tagsHeader === 'string' && tagsHeader.length > 0) {
+          ctx = { ...ctx, tags: tagsHeader.split(',') }
+        }
+      }
+
       await this.cacheHandler?.set(pathname, data, ctx)
     } catch (error) {
       console.warn('Failed to update prerender cache for', pathname, error)

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -254,6 +254,13 @@ export interface SetIncrementalResponseCacheContext {
    * True if this is a fallback request.
    */
   isFallback?: boolean
+
+  /**
+   * The cache tags associated with the entry, including implicit path tags.
+   * Provided so that cache handlers can maintain a tag → key index for
+   * `revalidateTag`/`revalidatePath`.
+   */
+  tags?: string[]
 }
 
 export interface IncrementalResponseCache {

--- a/test/production/app-dir/cache-handler-set-tags/app/layout.tsx
+++ b/test/production/app-dir/cache-handler-set-tags/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/cache-handler-set-tags/app/page.tsx
+++ b/test/production/app-dir/cache-handler-set-tags/app/page.tsx
@@ -1,0 +1,13 @@
+export default async function Page() {
+  const data = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random?page',
+    { next: { tags: ['explicit-tag'] } }
+  ).then((res) => res.text())
+
+  return (
+    <>
+      <p id="page-data">{data}</p>
+      <p id="now">{Date.now()}</p>
+    </>
+  )
+}

--- a/test/production/app-dir/cache-handler-set-tags/app/revalidate-path/route.ts
+++ b/test/production/app-dir/cache-handler-set-tags/app/revalidate-path/route.ts
@@ -1,0 +1,8 @@
+import { revalidatePath } from 'next/cache'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  revalidatePath('/')
+  return Response.json({ revalidated: true })
+}

--- a/test/production/app-dir/cache-handler-set-tags/cache-handler-set-tags.test.ts
+++ b/test/production/app-dir/cache-handler-set-tags/cache-handler-set-tags.test.ts
@@ -1,0 +1,62 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+function getPageSetEntries(cliOutput: string) {
+  return cliOutput
+    .split('\n')
+    .filter((line) => line.includes('test-cache-handler set '))
+    .map((line) => JSON.parse(line.slice(line.indexOf('{'))))
+    .filter((entry) => entry.kind === 'APP_PAGE')
+}
+
+describe('cache-handler-set-tags', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should pass tags to set for APP_PAGE entries, including implicit path tags', async () => {
+    await next.render$('/')
+
+    await retry(async () => {
+      const pageSets = getPageSetEntries(next.cliOutput)
+      expect(pageSets.length).toBeGreaterThan(0)
+
+      const pageSet = pageSets[pageSets.length - 1]
+      expect(pageSet.tags).toEqual(
+        expect.arrayContaining([
+          'explicit-tag',
+          '_N_T_/layout',
+          '_N_T_/page',
+          '_N_T_/',
+        ])
+      )
+    })
+  })
+
+  it('should serve fresh content after revalidatePath invalidates via the tag index', async () => {
+    let initialNow: string
+
+    await retry(async () => {
+      const $ = await next.render$('/')
+      initialNow = $('#now').text()
+      expect(initialNow).not.toBe('')
+
+      // Confirm the page is served from the custom cache handler.
+      const $cached = await next.render$('/')
+      expect($cached('#now').text()).toBe(initialNow)
+    })
+
+    const res = await next.fetch('/revalidate-path')
+    expect((await res.json()).revalidated).toBe(true)
+
+    await retry(async () => {
+      const $fresh = await next.render$('/')
+      expect($fresh('#now').text()).not.toBe(initialNow)
+    })
+  })
+})

--- a/test/production/app-dir/cache-handler-set-tags/cache-handler.js
+++ b/test/production/app-dir/cache-handler-set-tags/cache-handler.js
@@ -1,0 +1,36 @@
+const cache = new Map()
+const tagIndex = new Map()
+
+module.exports = class CacheHandler {
+  async get(key) {
+    return cache.get(key) ?? null
+  }
+
+  async set(key, data, ctx) {
+    console.log(
+      'test-cache-handler set ' +
+        JSON.stringify({ key, kind: data?.kind, tags: ctx.tags ?? null })
+    )
+
+    cache.set(key, { value: data, lastModified: Date.now() })
+
+    for (const tag of ctx.tags ?? []) {
+      if (!tagIndex.has(tag)) {
+        tagIndex.set(tag, new Set())
+      }
+      tagIndex.get(tag).add(key)
+    }
+  }
+
+  async revalidateTag(tags) {
+    tags = [tags].flat()
+    console.log('test-cache-handler revalidateTag ' + JSON.stringify(tags))
+
+    for (const tag of tags) {
+      for (const key of tagIndex.get(tag) ?? []) {
+        cache.delete(key)
+      }
+      tagIndex.delete(tag)
+    }
+  }
+}

--- a/test/production/app-dir/cache-handler-set-tags/next.config.js
+++ b/test/production/app-dir/cache-handler-set-tags/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheHandler: require.resolve('./cache-handler.js'),
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
### What?

Page and route entries now expose their cache tags on `ctx.tags` when a custom cache handler's `set()` is called, in addition to fetch-cache entries.

### Why?

Custom cache handlers need a tag → key index to invalidate entries on revalidateTag/revalidatePath, but ctx.tags was only populated for fetch-cache entries.

Page and route tags (explicit fetch tags plus implicit path tags) already exist in the cached value's headers, so surface them on ctx as well instead of making every handler parse the tags header itself.

### How?

For `APP_PAGE`/`APP_ROUTE` entries, the tags are already serialized into the cached value's `x-next-cache-tags` header at render time. `IncrementalCache.set()` now reads that header and, when `ctx.tags` isn't already set (i.e. this isn't a fetch-cache entry), splits it into `ctx.tags` before calling `cacheHandler.set()`. This avoids requiring every custom handler to parse the header itself.

Fixes #78864
