### PR TITLE
Fix no-JavaScript Server Actions on partial pages

### DIFF
--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -319,8 +319,9 @@ export function createAppPageEntrypoint({
      */
     const couldSupportPPR: boolean = Boolean(nextConfig.cacheComponents)
 
-    // Stash postponed state for server actions when in minimal mode.
-    // We extract it here so the RDC is available for the re-render after the action completes.
+    // Split postponed state from Server Action bodies in minimal mode. Fetch
+    // actions resume with that state, while MPA actions only reuse the extracted
+    // action body because their response must include the complete page.
     const resumeStateLengthHeader = req.headers[NEXT_RESUME_STATE_LENGTH_HEADER]
     if (
       !getRequestMeta(req, 'postponed') &&
@@ -371,10 +372,12 @@ export function createAppPageEntrypoint({
 
         if (fullBody.length >= stateLength) {
           // Extract postponed state from the beginning
-          const postponedState = fullBody
-            .subarray(0, stateLength)
-            .toString('utf8')
-          addRequestMeta(req, 'postponed', postponedState)
+          if (isFetchAction) {
+            const postponedState = fullBody
+              .subarray(0, stateLength)
+              .toString('utf8')
+            addRequestMeta(req, 'postponed', postponedState)
+          }
 
           // Store the remaining action body for the action handler
           const actionBody = fullBody.subarray(stateLength)

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -1,6 +1,7 @@
 import type { LoaderTree } from '../../server/lib/app-dir-module'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { FallbackRouteParam } from '../static-paths/types'
+import type { AppPageRenderOperation } from '../../server/app-render/types'
 
 import {
   AppPageRouteModule,
@@ -89,8 +90,6 @@ import { RedirectStatusCode } from '../../client/components/redirect-status-code
 import { InvariantError } from '../../shared/lib/invariant-error' with { 'turbopack-transition': 'next-server-utility' }
 import { scheduleOnNextTick } from '../../lib/scheduler' with { 'turbopack-transition': 'next-server-utility' }
 import { getSegmentParam } from '../../shared/lib/router/utils/get-segment-param' with { 'turbopack-transition': 'next-server-utility' }
-
-type AppPageRenderOperation = 'render' | 'prerender'
 
 /**
  * Builds the cache key for the most complete prerenderable shell we can derive
@@ -861,10 +860,11 @@ export function createAppPageEntrypoint({
             routeModule,
             page: srcPage,
             postponed,
+            renderOperation,
             allowEmptyStaticShell,
             serveStreamingMetadata,
             supportsDynamicResponse:
-              renderOperation === 'render' &&
+              renderOperation !== 'prerender' &&
               (typeof postponed === 'string' || supportsDynamicResponse),
             buildManifest,
             nextFontManifest,
@@ -1567,12 +1567,25 @@ export function createAppPageEntrypoint({
             !isDebugPrerender &&
             (supportsDynamicResponse || isPossibleServerAction)
 
+          const isResumeRender =
+            !forceStaticRender &&
+            !isDebugPrerender &&
+            typeof postponed === 'string' &&
+            hasPostponedState &&
+            !isPossibleServerAction
+
+          const renderOperation: AppPageRenderOperation = isResumeRender
+            ? 'resume'
+            : isRequestSpecificRender
+              ? 'render'
+              : 'prerender'
+
           // Perform the render.
           return doRender({
             span,
             postponed,
             fallbackRouteParams,
-            renderOperation: isRequestSpecificRender ? 'render' : 'prerender',
+            renderOperation,
             allowEmptyStaticShell: isInstantNavigationTest || undefined,
           })
         } catch (err) {
@@ -2109,7 +2122,7 @@ export function createAppPageEntrypoint({
           // This is a resume render, not a fallback render. Fallback params
           // (for cacheComponents routes) are plumbed via request meta above.
           fallbackRouteParams: null,
-          renderOperation: 'render',
+          renderOperation: 'resume',
         })
           .then(async (result) => {
             if (!result) {

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -41,7 +41,7 @@ import {
 import { setManifestsSingleton } from '../../server/app-render/manifests-singleton' with { 'turbopack-transition': 'next-server-utility' }
 import { shouldServeStreamingMetadata } from '../../server/lib/streaming-metadata' with { 'turbopack-transition': 'next-server-utility' }
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths' with { 'turbopack-transition': 'next-server-utility' }
-import { getServerActionRequestMetadata } from '../../server/lib/server-action-request-meta' with { 'turbopack-transition': 'next-server-utility' }
+import { getIsPossibleServerAction } from '../../server/lib/server-action-request-meta' with { 'turbopack-transition': 'next-server-utility' }
 import {
   RSC_HEADER,
   NEXT_ROUTER_PREFETCH_HEADER,
@@ -291,8 +291,7 @@ export function createAppPageEntrypoint({
       getRequestMeta(req, 'isRSCRequest') ??
       isRSCRequestHeader(req.headers[RSC_HEADER])
 
-    const { isFetchAction, isPossibleServerAction } =
-      getServerActionRequestMetadata(req)
+    const isPossibleServerAction = getIsPossibleServerAction(req)
 
     // For subresource requests (e.g. images or fonts), return plain text 404
     // instead of rendering the not-found route.
@@ -319,9 +318,8 @@ export function createAppPageEntrypoint({
      */
     const couldSupportPPR: boolean = Boolean(nextConfig.cacheComponents)
 
-    // Split postponed state from Server Action bodies in minimal mode. Fetch
-    // actions resume with that state, while MPA actions only reuse the extracted
-    // action body because their response must include the complete page.
+    // Stash postponed state for server actions when in minimal mode.
+    // We extract it here so the RDC is available for the re-render after the action completes.
     const resumeStateLengthHeader = req.headers[NEXT_RESUME_STATE_LENGTH_HEADER]
     if (
       !getRequestMeta(req, 'postponed') &&
@@ -372,12 +370,10 @@ export function createAppPageEntrypoint({
 
         if (fullBody.length >= stateLength) {
           // Extract postponed state from the beginning
-          if (isFetchAction) {
-            const postponedState = fullBody
-              .subarray(0, stateLength)
-              .toString('utf8')
-            addRequestMeta(req, 'postponed', postponedState)
-          }
+          const postponedState = fullBody
+            .subarray(0, stateLength)
+            .toString('utf8')
+          addRequestMeta(req, 'postponed', postponedState)
 
           // Store the remaining action body for the action handler
           const actionBody = fullBody.subarray(stateLength)
@@ -1352,16 +1348,19 @@ export function createAppPageEntrypoint({
               : undefined
 
           if (
-            // Dynamic RSC requests and fetch actions should use the postponed data
-            // from the static render (if available). This keeps the resume data
-            // cache consistent between the static and dynamic renders. MPA actions
-            // need a complete HTML document, so they must not resume here.
+            // If this is a dynamic RSC request or a server action request, we should
+            // use the postponed data from the static render (if available). This
+            // ensures that we can utilize the resume data cache (RDC) from the static
+            // render to ensure that the data is consistent between the static and
+            // dynamic renders (for navigations) or when re-rendering after a server
+            // action.
             // Only enable RDC for Navigations if the feature is enabled.
             supportsRDCForNavigations &&
             process.env.NEXT_RUNTIME !== 'edge' &&
             !isMinimalMode &&
             incrementalCache &&
-            (isDynamicRSCRequest || isFetchAction) &&
+            // Include both dynamic RSC requests (navigations) and server actions
+            (isDynamicRSCRequest || isPossibleServerAction) &&
             // We don't typically trigger an on-demand revalidation for dynamic RSC
             // requests, as we're typically revalidating the page in the background
             // instead. However, if the cache entry is stale, we should trigger a

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -41,7 +41,7 @@ import {
 import { setManifestsSingleton } from '../../server/app-render/manifests-singleton' with { 'turbopack-transition': 'next-server-utility' }
 import { shouldServeStreamingMetadata } from '../../server/lib/streaming-metadata' with { 'turbopack-transition': 'next-server-utility' }
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths' with { 'turbopack-transition': 'next-server-utility' }
-import { getIsPossibleServerAction } from '../../server/lib/server-action-request-meta' with { 'turbopack-transition': 'next-server-utility' }
+import { getServerActionRequestMetadata } from '../../server/lib/server-action-request-meta' with { 'turbopack-transition': 'next-server-utility' }
 import {
   RSC_HEADER,
   NEXT_ROUTER_PREFETCH_HEADER,
@@ -291,7 +291,8 @@ export function createAppPageEntrypoint({
       getRequestMeta(req, 'isRSCRequest') ??
       isRSCRequestHeader(req.headers[RSC_HEADER])
 
-    const isPossibleServerAction = getIsPossibleServerAction(req)
+    const { isFetchAction, isPossibleServerAction } =
+      getServerActionRequestMetadata(req)
 
     // For subresource requests (e.g. images or fonts), return plain text 404
     // instead of rendering the not-found route.
@@ -1348,19 +1349,16 @@ export function createAppPageEntrypoint({
               : undefined
 
           if (
-            // If this is a dynamic RSC request or a server action request, we should
-            // use the postponed data from the static render (if available). This
-            // ensures that we can utilize the resume data cache (RDC) from the static
-            // render to ensure that the data is consistent between the static and
-            // dynamic renders (for navigations) or when re-rendering after a server
-            // action.
+            // Dynamic RSC requests and fetch actions should use the postponed data
+            // from the static render (if available). This keeps the resume data
+            // cache consistent between the static and dynamic renders. MPA actions
+            // need a complete HTML document, so they must not resume here.
             // Only enable RDC for Navigations if the feature is enabled.
             supportsRDCForNavigations &&
             process.env.NEXT_RUNTIME !== 'edge' &&
             !isMinimalMode &&
             incrementalCache &&
-            // Include both dynamic RSC requests (navigations) and server actions
-            (isDynamicRSCRequest || isPossibleServerAction) &&
+            (isDynamicRSCRequest || isFetchAction) &&
             // We don't typically trigger an on-demand revalidation for dynamic RSC
             // requests, as we're typically revalidating the page in the background
             // instead. However, if the cache entry is stale, we should trigger a

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -131,6 +131,7 @@ async function requestHandler(
       params,
       page: srcPage,
       postponed: undefined,
+      renderOperation: 'render',
       serveStreamingMetadata: true,
       supportsDynamicResponse: true,
       buildManifest,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3324,11 +3324,10 @@ function prepareAppPage(
   )
 
   // If provided, parse the postponed state so its RDC is available to the
-  // render. Keep the React state only for requests that can resume it.
+  // render.
   let postponedState: PostponedState | null = null
   if (typeof renderOpts.postponed === 'string') {
-    const { isFetchAction, isPossibleMPAAction } =
-      getServerActionRequestMetadata(req)
+    const { isFetchAction } = getServerActionRequestMetadata(req)
 
     if (fallbackRouteParams) {
       if (!isFetchAction) {
@@ -3340,18 +3339,6 @@ function prepareAppPage(
       // A fetch action with fallback params cannot render this page, so its
       // React postponed state cannot be resumed. The RDC is still useful while
       // executing cached functions in the action.
-      postponedState = {
-        type: DynamicState.DATA,
-        renderResumeDataCache: parseResumeDataCacheFromPostponedState(
-          renderOpts.postponed,
-          renderOpts.experimental.maxPostponedStateSizeBytes,
-          renderOpts.experimental.disableResumeDataCacheCompression
-        ),
-      }
-    } else if (isPossibleMPAAction) {
-      // An MPA action needs a complete HTML document, so it cannot resume the
-      // React render. Its RDC is still needed to keep cached values consistent
-      // with the static shell when the action did not invalidate them.
       postponedState = {
         type: DynamicState.DATA,
         renderResumeDataCache: parseResumeDataCacheFromPostponedState(
@@ -3548,8 +3535,6 @@ async function renderToStream(
 ): Promise<AnyStream> {
   /* eslint-disable @next/internal/no-ambiguous-jsx -- React Client */
   // MARK: renderToStream setup
-  const { isPossibleMPAAction } = getServerActionRequestMetadata(req)
-
   const {
     assetPrefix,
     htmlRequestId,
@@ -3559,10 +3544,9 @@ async function renderToStream(
     requestId,
     workStore,
   } = ctx
-  // MPA actions reuse the RDC from the postponed state, but their response
-  // must come from a complete server render rather than a postponed response.
   const shouldUsePostponedResponse =
-    typeof renderOpts.postponed === 'string' && !isPossibleMPAAction
+    typeof renderOpts.postponed === 'string' &&
+    renderOpts.renderOperation === 'resume'
 
   const {
     basePath,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -170,7 +170,10 @@ import {
   getPostponedFromState,
 } from './postponed-state'
 import { isDynamicServerError } from '../../client/components/hooks-server-context'
-import { getServerActionRequestMetadata } from '../lib/server-action-request-meta'
+import {
+  getIsPossibleServerAction,
+  getServerActionRequestMetadata,
+} from '../lib/server-action-request-meta'
 import { getFlightStream } from './use-flight-response'
 import {
   StaticGenBailoutError,
@@ -221,7 +224,6 @@ import {
 import AppRouter from '../../client/components/app-router'
 import type { ServerComponentsHmrCache } from '../response-cache'
 import type { RequestErrorContext } from '../instrumentation/types'
-import { getIsPossibleServerAction } from '../lib/server-action-request-meta'
 import { createInitialRouterState } from '../../client/components/router-reducer/create-initial-router-state'
 import { createMutableActionQueue } from '../../client/components/app-router-instance'
 import { getRevalidateReason } from '../instrumentation/utils'
@@ -3321,12 +3323,15 @@ function prepareAppPage(
     fallbackRouteParams
   )
 
-  // If provided, the postpone state should be parsed so it can be provided to
-  // React.
+  // If provided, parse the postponed state so its RDC is available to the
+  // render. Keep the React state only for requests that can resume it.
   let postponedState: PostponedState | null = null
   if (typeof renderOpts.postponed === 'string') {
+    const { isFetchAction, isPossibleMPAAction } =
+      getServerActionRequestMetadata(req)
+
     if (fallbackRouteParams) {
-      if (!getServerActionRequestMetadata(req).isFetchAction) {
+      if (!isFetchAction) {
         throw new InvariantError(
           'postponed state should not be provided when fallback params are provided'
         )
@@ -3335,6 +3340,18 @@ function prepareAppPage(
       // A fetch action with fallback params cannot render this page, so its
       // React postponed state cannot be resumed. The RDC is still useful while
       // executing cached functions in the action.
+      postponedState = {
+        type: DynamicState.DATA,
+        renderResumeDataCache: parseResumeDataCacheFromPostponedState(
+          renderOpts.postponed,
+          renderOpts.experimental.maxPostponedStateSizeBytes,
+          renderOpts.experimental.disableResumeDataCacheCompression
+        ),
+      }
+    } else if (isPossibleMPAAction) {
+      // An MPA action needs a complete HTML document, so it cannot resume the
+      // React render. Its RDC is still needed to keep cached values consistent
+      // with the static shell when the action did not invalidate them.
       postponedState = {
         type: DynamicState.DATA,
         renderResumeDataCache: parseResumeDataCacheFromPostponedState(
@@ -3531,6 +3548,8 @@ async function renderToStream(
 ): Promise<AnyStream> {
   /* eslint-disable @next/internal/no-ambiguous-jsx -- React Client */
   // MARK: renderToStream setup
+  const { isPossibleMPAAction } = getServerActionRequestMetadata(req)
+
   const {
     assetPrefix,
     htmlRequestId,
@@ -3540,6 +3559,10 @@ async function renderToStream(
     requestId,
     workStore,
   } = ctx
+  // MPA actions reuse the RDC from the postponed state, but their response
+  // must come from a complete server render rather than a postponed response.
+  const shouldUsePostponedResponse =
+    typeof renderOpts.postponed === 'string' && !isPossibleMPAAction
 
   const {
     basePath,
@@ -4068,7 +4091,7 @@ async function renderToStream(
       if (process.env.__NEXT_USE_NODE_STREAMS) {
         // If provided, the postpone state should be parsed as JSON so it can be
         // provided to React.
-        if (typeof renderOpts.postponed === 'string') {
+        if (shouldUsePostponedResponse) {
           if (postponedState?.type === DynamicState.DATA) {
             // We have a complete HTML Document in the prerender but we need to
             // still include the new server component render because it was not included
@@ -4209,7 +4232,7 @@ async function renderToStream(
         // MARK: webStreams HTML
         // If provided, the postpone state should be parsed as JSON so it can be
         // provided to React.
-        if (typeof renderOpts.postponed === 'string') {
+        if (shouldUsePostponedResponse) {
           if (postponedState?.type === DynamicState.DATA) {
             // We have a complete HTML Document in the prerender but we need to
             // still include the new server component render because it was not included

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -91,6 +91,8 @@ export type ServerOnInstrumentationRequestError = (
   silenceLog: boolean
 ) => void | Promise<void>
 
+export type AppPageRenderOperation = 'render' | 'prerender' | 'resume'
+
 export interface RenderOptsPartial {
   dir?: string
   previewProps: __ApiPreviewProps | undefined
@@ -102,6 +104,12 @@ export interface RenderOptsPartial {
   trailingSlash: boolean
   images: ImageConfigComplete
   supportsDynamicResponse: boolean
+  /**
+   * Describes how the outer runtime will compose this render's HTML. A resume
+   * render is appended to an existing shell; render and prerender operations
+   * must produce standalone output.
+   */
+  renderOperation?: AppPageRenderOperation
   runtime?: ServerRuntime
   serverComponents?: boolean
   enableTainting?: boolean

--- a/packages/next/src/server/lib/server-action-request-meta.ts
+++ b/packages/next/src/server/lib/server-action-request-meta.ts
@@ -10,7 +10,6 @@ export function getServerActionRequestMetadata(
   isURLEncodedAction: boolean
   isMultipartAction: boolean
   isFetchAction: boolean
-  isPossibleMPAAction: boolean
   isPossibleServerAction: boolean
 } {
   let actionId: string | null
@@ -38,17 +37,16 @@ export function getServerActionRequestMetadata(
       typeof actionId === 'string' &&
       req.method === 'POST'
   )
-  const isPossibleMPAAction =
-    !isFetchAction && (isURLEncodedAction || isMultipartAction)
 
-  const isPossibleServerAction = Boolean(isFetchAction || isPossibleMPAAction)
+  const isPossibleServerAction = Boolean(
+    isFetchAction || isURLEncodedAction || isMultipartAction
+  )
 
   return {
     actionId,
     isURLEncodedAction,
     isMultipartAction,
     isFetchAction,
-    isPossibleMPAAction,
     isPossibleServerAction,
   }
 }

--- a/packages/next/src/server/lib/server-action-request-meta.ts
+++ b/packages/next/src/server/lib/server-action-request-meta.ts
@@ -10,6 +10,7 @@ export function getServerActionRequestMetadata(
   isURLEncodedAction: boolean
   isMultipartAction: boolean
   isFetchAction: boolean
+  isPossibleMPAAction: boolean
   isPossibleServerAction: boolean
 } {
   let actionId: string | null
@@ -37,16 +38,17 @@ export function getServerActionRequestMetadata(
       typeof actionId === 'string' &&
       req.method === 'POST'
   )
+  const isPossibleMPAAction =
+    !isFetchAction && (isURLEncodedAction || isMultipartAction)
 
-  const isPossibleServerAction = Boolean(
-    isFetchAction || isURLEncodedAction || isMultipartAction
-  )
+  const isPossibleServerAction = Boolean(isFetchAction || isPossibleMPAAction)
 
   return {
     actionId,
     isURLEncodedAction,
     isMultipartAction,
     isFetchAction,
+    isPossibleMPAAction,
     isPossibleServerAction,
   }
 }

--- a/packages/next/src/server/route-modules/app-page/module.ts
+++ b/packages/next/src/server/route-modules/app-page/module.ts
@@ -1,6 +1,6 @@
 import type { AppPageRouteDefinition } from '../../route-definitions/app-page-route-definition'
 import type RenderResult from '../../render-result'
-import type { RenderOpts } from '../../app-render/types'
+import type { AppPageRenderOperation, RenderOpts } from '../../app-render/types'
 import { addRequestMeta, type NextParsedUrlQuery } from '../../request-meta'
 import type { LoaderTree } from '../../lib/app-dir-module'
 import type { PrerenderManifest } from '../../../build'
@@ -75,7 +75,7 @@ export interface AppPageRouteHandlerContext extends RouteModuleHandleContext {
   page: string
   query: NextParsedUrlQuery
   fallbackRouteParams: OpaqueFallbackRouteParams | null
-  renderOpts: RenderOpts
+  renderOpts: RenderOpts & { renderOperation: AppPageRenderOperation }
   serverComponentsHmrCache?: ServerComponentsHmrCache
   sharedContext: AppSharedContext
 }

--- a/test/e2e/app-dir/cache-components/app/server-action-mpa-partial/action.ts
+++ b/test/e2e/app-dir/cache-components/app/server-action-mpa-partial/action.ts
@@ -1,0 +1,5 @@
+'use server'
+
+export async function action() {
+  return 'result'
+}

--- a/test/e2e/app-dir/cache-components/app/server-action-mpa-partial/action.ts
+++ b/test/e2e/app-dir/cache-components/app/server-action-mpa-partial/action.ts
@@ -1,5 +1,12 @@
 'use server'
 
+import { revalidatePath } from 'next/cache'
+
 export async function action() {
   return 'result'
+}
+
+export async function revalidatingAction() {
+  revalidatePath('/server-action-mpa-partial')
+  return 'revalidated'
 }

--- a/test/e2e/app-dir/cache-components/app/server-action-mpa-partial/form.tsx
+++ b/test/e2e/app-dir/cache-components/app/server-action-mpa-partial/form.tsx
@@ -1,15 +1,25 @@
 'use client'
 
 import { useActionState } from 'react'
-import { action } from './action'
+import { action, revalidatingAction } from './action'
 
 export function ActionForm() {
   const [result, formAction] = useActionState(action, 'initial')
+  const [revalidationResult, revalidationFormAction] = useActionState(
+    revalidatingAction,
+    'initial'
+  )
 
   return (
-    <form action={formAction}>
-      <button>Submit</button>
-      <p id="action-state">{result}</p>
-    </form>
+    <>
+      <form action={formAction}>
+        <button id="submit-button">Submit</button>
+        <p id="action-state">{result}</p>
+      </form>
+      <form action={revalidationFormAction}>
+        <button id="revalidate-button">Revalidate</button>
+        <p id="revalidation-state">{revalidationResult}</p>
+      </form>
+    </>
   )
 }

--- a/test/e2e/app-dir/cache-components/app/server-action-mpa-partial/form.tsx
+++ b/test/e2e/app-dir/cache-components/app/server-action-mpa-partial/form.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useActionState } from 'react'
+import { action } from './action'
+
+export function ActionForm() {
+  const [result, formAction] = useActionState(action, 'initial')
+
+  return (
+    <form action={formAction}>
+      <button>Submit</button>
+      <p id="action-state">{result}</p>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/cache-components/app/server-action-mpa-partial/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/server-action-mpa-partial/page.tsx
@@ -1,0 +1,20 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+import { ActionForm } from './form'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Server Action on a partial page</h1>
+      <ActionForm />
+      <Suspense fallback={<p>Loading request data</p>}>
+        <RequestData />
+      </Suspense>
+    </main>
+  )
+}
+
+async function RequestData() {
+  await connection()
+  return <p>Request data ready</p>
+}

--- a/test/e2e/app-dir/cache-components/app/server-action-mpa-partial/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/server-action-mpa-partial/page.tsx
@@ -2,16 +2,25 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 import { ActionForm } from './form'
 
-export default function Page() {
+export default async function Page() {
+  const cachedTimestamp = await getCachedTimestamp()
+
   return (
     <main>
       <h1>Server Action on a partial page</h1>
+      <p id="cached-timestamp">{cachedTimestamp}</p>
       <ActionForm />
       <Suspense fallback={<p>Loading request data</p>}>
         <RequestData />
       </Suspense>
     </main>
   )
+}
+
+async function getCachedTimestamp() {
+  'use cache'
+
+  return Date.now()
 }
 
 async function RequestData() {

--- a/test/e2e/app-dir/cache-components/cache-components.server-action.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.server-action.test.ts
@@ -22,10 +22,36 @@ describe('cache-components', () => {
     })
 
     expect(await browser.elementByCss('#action-state').text()).toBe('initial')
-    await browser.elementByCss('button').click()
+    const cachedTimestamp = await browser
+      .elementByCss('#cached-timestamp')
+      .text()
+    await browser.elementByCss('#submit-button').click()
 
     await retry(async () => {
       expect(await browser.elementByCss('#action-state').text()).toBe('result')
+      expect(await browser.elementByCss('#cached-timestamp').text()).toBe(
+        cachedTimestamp
+      )
+    })
+  })
+
+  it('should revalidate cached data in a complete MPA response', async () => {
+    const browser = await next.browser('/server-action-mpa-partial', {
+      disableJavaScript: true,
+    })
+
+    const cachedTimestamp = await browser
+      .elementByCss('#cached-timestamp')
+      .text()
+    await browser.elementByCss('#revalidate-button').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#revalidation-state').text()).toBe(
+        'revalidated'
+      )
+      expect(await browser.elementByCss('#cached-timestamp').text()).not.toBe(
+        cachedTimestamp
+      )
     })
   })
 

--- a/test/e2e/app-dir/cache-components/cache-components.server-action.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.server-action.test.ts
@@ -16,6 +16,19 @@ describe('cache-components', () => {
     })
   })
 
+  it('should return a complete MPA response after a server action', async () => {
+    const browser = await next.browser('/server-action-mpa-partial', {
+      disableJavaScript: true,
+    })
+
+    expect(await browser.elementByCss('#action-state').text()).toBe('initial')
+    await browser.elementByCss('button').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#action-state').text()).toBe('result')
+    })
+  })
+
   it('should not have cache components errors when encoding bound args for inline server actions', async () => {
     const browser = await next.browser('/server-action-inline')
     expect(await browser.elementByCss('p').text()).toBe('initial')

--- a/test/e2e/app-dir/cache-components/cache-components.server-action.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.server-action.test.ts
@@ -55,6 +55,22 @@ describe('cache-components', () => {
     })
   })
 
+  it('should return complete HTML for an unrelated urlencoded POST', async () => {
+    const response = await next.fetch('/server-action-mpa-partial', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: 'foo=bar',
+    })
+    const html = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(html).toStartWith('<!DOCTYPE html>')
+    expect(html).toContain('id="cached-timestamp"')
+    expect(html).toEndWith('</body></html>')
+  })
+
   it('should not have cache components errors when encoding bound args for inline server actions', async () => {
     const browser = await next.browser('/server-action-inline')
     expect(await browser.elementByCss('p').text()).toBe('initial')


### PR DESCRIPTION
## What?

Keep the static part of a partial page when a Server Action form is submitted without JavaScript. Add regression coverage for a Cache Components page that submits before hydration.

## Why?

Next currently loads cached postponed state for every request that could be a Server Action. That works for JavaScript fetch actions because the client can merge the returned data into the current page. A native form submission replaces the page instead. Its response contains the action result but omits the static page content, so the form disappears.

## How?

Read the full Server Action request metadata and only load persisted postponed state for JavaScript fetch actions. RSC navigations and fetch actions keep the existing optimized path. Native form submissions use the normal page render.

## Verification

- `pnpm test-start-turbo test/e2e/app-dir/cache-components/cache-components.server-action.test.ts`
- `pnpm test-start-webpack test/e2e/app-dir/cache-components/cache-components.server-action.test.ts`
- `pnpm test-dev-turbo test/e2e/app-dir/cache-components/cache-components.server-action.test.ts`
- `pnpm test-dev-webpack test/e2e/app-dir/cache-components/cache-components.server-action.test.ts`
