### PR TITLE
test: cover metadata across dynamic route params

### DIFF
--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/app/link-accordion.tsx
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/app/link-accordion.tsx
@@ -3,6 +3,8 @@
 import Link, { type LinkProps } from 'next/link'
 import { useState } from 'react'
 
+const productHandles = ['alpha', 'gamma', 'delta', 'epsilon', 'zeta', 'eta']
+
 export function LinkAccordion({
   href,
   children,
@@ -28,6 +30,44 @@ export function LinkAccordion({
       ) : (
         `${children} (link is hidden)`
       )}
+    </>
+  )
+}
+
+export function ProductLinks() {
+  const [areVisible, setAreVisible] = useState(false)
+  const [isBetaVisible, setIsBetaVisible] = useState(false)
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={areVisible}
+        onChange={() => setAreVisible(!areVisible)}
+        data-product-links
+      />
+      <input
+        type="checkbox"
+        checked={isBetaVisible}
+        onChange={() => setIsBetaVisible(!isBetaVisible)}
+        data-beta-link
+      />
+      {areVisible ? (
+        <ul>
+          {productHandles.map((handle) => (
+            <li key={handle}>
+              <Link href={`/products/${handle}`}>{handle}</Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        'product links are hidden'
+      )}
+      {isBetaVisible ? (
+        <Link href="/products/beta" prefetch={false}>
+          beta
+        </Link>
+      ) : null}
     </>
   )
 }

--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/app/page.tsx
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/app/page.tsx
@@ -1,4 +1,4 @@
-import { LinkAccordion } from './link-accordion'
+import { LinkAccordion, ProductLinks } from './link-accordion'
 
 export default function Home() {
   return (
@@ -14,6 +14,7 @@ export default function Home() {
           </LinkAccordion>
         </li>
       </ul>
+      <ProductLinks />
     </main>
   )
 }

--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/app/products/[handle]/client-content.tsx
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/app/products/[handle]/client-content.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { lazy, Suspense, useEffect, useState } from 'react'
+
+const ProductInfo = lazy(() => import('./product-info'))
+
+export function ClientContent({ title }: { title: string }) {
+  const [isMounted, setIsMounted] = useState(false)
+
+  useEffect(() => setIsMounted(true), [])
+
+  return (
+    <Suspense fallback={<p id="client-fallback">Loading client content</p>}>
+      {isMounted ? (
+        <ProductInfo title={title} />
+      ) : (
+        <p id="client-pending">Waiting for hydration</p>
+      )}
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/app/products/[handle]/page.tsx
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/app/products/[handle]/page.tsx
@@ -1,0 +1,61 @@
+import { cacheLife } from 'next/cache'
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+import { ClientContent } from './client-content'
+
+const products: Record<string, { title: string }> = {
+  alpha: { title: 'Alpha Product' },
+  beta: { title: 'Beta Product' },
+  gamma: { title: 'Gamma Product' },
+  delta: { title: 'Delta Product' },
+  epsilon: { title: 'Epsilon Product' },
+  zeta: { title: 'Zeta Product' },
+  eta: { title: 'Eta Product' },
+}
+
+async function getProduct({
+  handle,
+  locale,
+}: {
+  handle: string
+  locale: string
+}) {
+  'use cache'
+  cacheLife('max')
+  return { ...products[handle], locale }
+}
+
+export function generateStaticParams() {
+  return [{ handle: 'alpha' }]
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ handle: string }>
+}): Promise<Metadata> {
+  const { handle } = await params
+  const product = await getProduct({ handle, locale: 'en' })
+  return { title: product.title }
+}
+
+export const instant = false
+
+export default async function ProductPage({
+  params,
+}: {
+  params: Promise<{ handle: string }>
+}) {
+  const { handle } = await params
+  const product = await getProduct({ handle, locale: 'en' })
+
+  return (
+    <main>
+      <Suspense fallback={<p id="product-fallback">Loading product</p>}>
+        <ClientContent title={product.title} />
+      </Suspense>
+      <Link href="/">Home</Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/app/products/[handle]/product-info.tsx
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/app/products/[handle]/product-info.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function ProductInfo({ title }: { title: string }) {
+  return <h1 id="product-title">{title}</h1>
+}

--- a/test/e2e/app-dir/metadata-soft-nav-cache-components/metadata-soft-nav-cache-components.test.ts
+++ b/test/e2e/app-dir/metadata-soft-nav-cache-components/metadata-soft-nav-cache-components.test.ts
@@ -87,4 +87,56 @@ describe('metadata-soft-nav-cache-components', () => {
       )
     })
   })
+
+  it('does not reuse metadata across dynamic params', async () => {
+    let page: Playwright.Page = null as any
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page, { includeAppShellRequests: true })
+
+    // Reveal several links to the same dynamic route in one render. This
+    // populates shared prefetch state for the route, while the final metadata
+    // depends on the concrete `handle` param.
+    await act(async () => {
+      await browser.elementByCss('input[data-product-links]').click()
+    })
+    await act(async () => {
+      await browser.elementByCss('a[href="/products/gamma"]').click()
+    })
+    await retry(async () => {
+      expect(await browser.elementByCss('#product-title').text()).toBe(
+        'Gamma Product'
+      )
+      expect(await browser.eval(() => document.title)).toBe(
+        'Gamma Product | Site'
+      )
+    })
+
+    await browser.elementByCss('a[href="/"]').click()
+    await browser.waitForElementByCss('#home')
+
+    // Beta is intentionally not prefetched. Its full navigation response
+    // contains Beta's metadata and body; neither may be replaced by the
+    // previously visited Gamma route's cached result.
+    await browser.elementByCss('input[data-beta-link]').click()
+    await browser.waitForElementByCss('a[href="/products/beta"]')
+
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/products/beta"]').click()
+      },
+      { includes: 'Beta Product' }
+    )
+    await retry(async () => {
+      expect(await browser.elementByCss('#product-title').text()).toBe(
+        'Beta Product'
+      )
+      expect(await browser.eval(() => document.title)).toBe(
+        'Beta Product | Site'
+      )
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Adds regression coverage for metadata that depends on a dynamic route parameter. The test first populates shared prefetch state for one product route, then navigates to an unprefetched sibling and verifies that both the page body and `document.title` use the new parameter.

The stale-title behavior is reproducible on the 16.3 release line. Canary already handles it correctly after the response transport changes in #96439, but did not have a focused test for this sequence.

## Verification

- `pnpm build-all`
- `HEADLESS=true pnpm test-start-turbo test/e2e/app-dir/metadata-soft-nav-cache-components/metadata-soft-nav-cache-components.test.ts`
- `HEADLESS=true pnpm test-start-webpack test/e2e/app-dir/metadata-soft-nav-cache-components/metadata-soft-nav-cache-components.test.ts`