### PR TITLE
docs: explain origin matching for allowedOrigins and allowedDevOrigins

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/allowedDevOrigins.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/allowedDevOrigins.mdx
@@ -16,3 +16,25 @@ module.exports = {
   allowedDevOrigins: ['local-origin.dev', '*.local-origin.dev'],
 }
 ```
+
+Only the [`hostname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/hostname) of the request's `Origin` header is matched against your entries. For a request from `http://local-origin.dev:3000/dashboard?tab=1`, that is `local-origin.dev`. The scheme, the port, the path, and the query string are ignored. Write your entries that way too, without `https://` and without a port.
+
+A no-cors cross-site request, such as a script tag loading a dev asset, sends no `Origin` header. Those are matched on the `Referer` hostname instead.
+
+Entries can also expand, through two wildcards: a `*` stands in for exactly one label of the hostname, and `**` for one or more. That is why the example above lists two entries, one for the bare hostname and one for its subdomains.
+
+| Entry                 | Matches                                             | Does not match                                 |
+| --------------------- | --------------------------------------------------- | ---------------------------------------------- |
+| `local-origin.dev`    | `local-origin.dev`                                  | `team.local-origin.dev`                        |
+| `*.local-origin.dev`  | `team.local-origin.dev`                             | `local-origin.dev`, `team.eu.local-origin.dev` |
+| `**.local-origin.dev` | `team.local-origin.dev`, `team.eu.local-origin.dev` | `local-origin.dev`                             |
+
+Partial replacement is not supported. Write `*.local-origin.dev`, rather than `team-*.local-origin.dev`. Using `**` is only supported at the start of the pattern.
+
+The dev server already allows `localhost`, its subdomains, and the hostname it was started with. Any other hostname needs an entry, such as a tunnel used for remote development:
+
+```js filename="next.config.js"
+module.exports = {
+  allowedDevOrigins: ['*.tunnel.example.com'],
+}
+```

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
@@ -10,7 +10,7 @@ Options for configuring Server Actions behavior in your Next.js application. For
 
 ## `allowedOrigins`
 
-A list of extra safe origin domains from which Server Actions can be invoked. Next.js compares the origin of a Server Action request with the host domain, ensuring they match to prevent CSRF attacks. If not provided, only the same origin is allowed.
+A list of extra safe hosts from which Server Actions can be invoked. To prevent CSRF attacks, Next.js compares the host in a request's `Origin` header against the app's own host, taken from `x-forwarded-host` or `host`, and rejects the action when the two differ. If not provided, only the same origin is allowed. A request that carries no `Origin` header at all is allowed through with a warning rather than rejected.
 
 ```js filename="next.config.js"
 /** @type {import('next').NextConfig} */
@@ -19,6 +19,38 @@ module.exports = {
   experimental: {
     serverActions: {
       allowedOrigins: ['my-proxy.com', '*.my-proxy.com'],
+    },
+  },
+}
+```
+
+Only the [`host`](https://developer.mozilla.org/en-US/docs/Web/API/URL/host) of the request's `Origin` header is matched against your entries, which is the hostname plus the port when the URL carries one. For a request from `https://my-proxy.com/checkout`, that is `my-proxy.com`. For one from `https://my-proxy.com:8443/checkout`, `my-proxy.com:8443`. Write your entries the same way.
+
+Entries can also expand, through two wildcards: a `*` stands in for exactly one label of the host, and `**` for one or more. That is why the example above lists two entries, one for the bare host and one for its subdomains.
+
+| Entry               | Matches                                   | Does not match                          |
+| ------------------- | ----------------------------------------- | --------------------------------------- |
+| `my-proxy.com`      | `my-proxy.com`                            | `my-proxy.com:8443`, `app.my-proxy.com` |
+| `*.my-proxy.com`    | `app.my-proxy.com`                        | `my-proxy.com`, `app.my-proxy.com:8443` |
+| `**.my-proxy.com`   | `app.my-proxy.com`, `app.eu.my-proxy.com` | `my-proxy.com`                          |
+| `my-proxy.com:8443` | `my-proxy.com:8443`                       | `my-proxy.com`                          |
+
+Partial replacement is not supported. Write `*.my-proxy.com`, rather than `app-*.my-proxy.com`. Using `**` is only supported at the start of the pattern. A port cannot be wildcarded at all, so a host reached on a custom port has to be listed in full.
+
+Behind a reverse proxy, no entry is needed as long as the proxy forwards the public host in `x-forwarded-host`. When it forwards its own host instead, the browser sends `my-proxy.com` while the server reports something like `localhost:3000`, and that mismatch is what this list is for: the host visible in the browser's address bar is the one to add, not the internal one the server reports.
+
+The check runs in production as well as in development, so the list applies to your deployed app and not only to local work.
+
+For example, remote development through a tunnel needs the tunnel hostname in two places: in [`allowedDevOrigins`](/docs/app/api-reference/config/next-config-js/allowedDevOrigins), so the dev server serves its own assets and endpoints, and here, so actions from it are accepted:
+
+```js filename="next.config.js"
+/** @type {import('next').NextConfig} */
+
+module.exports = {
+  allowedDevOrigins: ['*.tunnel.example.com'],
+  experimental: {
+    serverActions: {
+      allowedOrigins: ['*.tunnel.example.com'],
     },
   },
 }

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
@@ -35,7 +35,7 @@ Entries can also expand, through two wildcards: a `*` stands in for exactly one 
 | `**.my-proxy.com`   | `app.my-proxy.com`, `app.eu.my-proxy.com` | `my-proxy.com`                          |
 | `my-proxy.com:8443` | `my-proxy.com:8443`                       | `my-proxy.com`                          |
 
-Partial replacement is not supported. Write `*.my-proxy.com`, rather than `app-*.my-proxy.com`. Using `**` is only supported at the start of the pattern. A port cannot be wildcarded at all, so a host reached on a custom port has to be listed in full.
+Partial replacement is not supported. Write `*.my-proxy.com`, rather than `app-*.my-proxy.com`. Using `**` is only supported at the start of the pattern. A port cannot be wildcarded, so write it out in full: `my-proxy.com:8443`, or `*.my-proxy.com:8443` for its subdomains.
 
 Behind a reverse proxy, no entry is needed as long as the proxy forwards the public host in `x-forwarded-host`. When it forwards its own host instead, the browser sends `my-proxy.com` while the server reports something like `localhost:3000`, and that mismatch is what this list is for: the host visible in the browser's address bar is the one to add, not the internal one the server reports.
 


### PR DESCRIPTION
The `allowedDevOrigins`, and `allowedOrigins` options, behave slightly different to each other, the former drops the PORT, and it is not clear where are these picked up from. This PR improves guidance on how to use these two.
