### PR TITLE
Support custom pageExtensions in @next/next/no-html-link-for-pages

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -107,8 +107,20 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const nextSettings: { pageExtensions?: string[] } =
+      context.settings?.next || {}
+    const pageExtensions = nextSettings.pageExtensions
+
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,28 +5,49 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
+const defaultPageExtensions = ['jsx', 'js', 'tsx', 'ts']
+
+function buildPageExtensionRegex(pageExtensions: string[] = defaultPageExtensions) {
+  const exts = pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')
+  return new RegExp(`\\.(${exts})$`)
+}
+
+function buildExactPageExtensionRegex(name: string, pageExtensions: string[] = defaultPageExtensions) {
+  const exts = pageExtensions.map((ext) => ext.replace(/^\./, '')).join('|')
+  return new RegExp(`^${name}\\.(${exts})$`)
+}
+
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = defaultPageExtensions
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const pageExtRegex = buildPageExtensionRegex(pageExtensions)
+  const indexExtRegex = buildExactPageExtensionRegex('index', pageExtensions)
+
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    if (pageExtRegex.test(dirent.name)) {
+      if (indexExtRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(indexExtRegex, '')}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(pageExtRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -36,24 +57,36 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = defaultPageExtensions
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const pageExtRegex = buildPageExtensionRegex(pageExtensions)
+  const pageFileRegex = buildExactPageExtensionRegex('page', pageExtensions)
+  const layoutFileRegex = buildExactPageExtensionRegex('layout', pageExtensions)
+
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (pageExtRegex.test(dirent.name)) {
+      if (pageFileRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageFileRegex, '')}`)
+      } else if (!layoutFileRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageExtRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -136,13 +169,16 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions?: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +192,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions?: string[]
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -495,4 +495,34 @@ describe('no-html-link-for-pages', function () {
       'Do not use an `<a>` element to navigate to `/photo/1/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
     )
   })
+  it('invalid custom pageExtension route with pageExtensions in settings', function () {
+    const linterConfigWithPageExtensions = {
+      ...linterConfigWithCustomDirectory,
+      settings: {
+        next: {
+          pageExtensions: ['page.js', 'page.tsx', 'js', 'jsx'],
+        },
+      },
+    }
+    const invalidCustomExtCode = `
+      import Link from 'next/link';
+      export default function Test() {
+        return (
+          <div>
+            <a href='/custom-ext'>Custom Ext Page</a>
+          </div>
+        );
+      }
+    `
+    const [report] = linters.withCustomPages.verify(
+      invalidCustomExtCode,
+      linterConfigWithPageExtensions,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/custom-ext/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
 })

--- a/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/custom-ext.page.js
+++ b/test/unit/eslint-plugin-next/with-custom-pages-dir/custom-pages/custom-ext.page.js
@@ -1,0 +1,1 @@
+export default () => {}


### PR DESCRIPTION
Closes #53473

### What?
Allows the `@next/next/no-html-link-for-pages` ESLint rule to respect custom `pageExtensions` configured under `settings.next.pageExtensions` (e.g. `['page.js', 'page.tsx', 'js', 'jsx']` or `['page.tsx', 'page.ts']`).

### Why?
Previously, `parseUrlForPages` and `parseUrlForAppDir` in `packages/eslint-plugin-next/src/utils/url.ts` only hardcoded regex matches for standard `.(j|t)sx?` files (`/(\.(j|t)sx?)$/`). Projects that define custom `pageExtensions` (like `*.page.jsx` or custom suffixes) were ignored by the rule, causing `<a>` tags targeting those pages not to be flagged.

### How?
- Updated `getUrlFromPagesDirectories`, `getUrlFromAppDirectory`, `parseUrlForPages`, and `parseUrlForAppDir` in `packages/eslint-plugin-next/src/utils/url.ts` to accept an optional `pageExtensions` array and dynamically construct exact and suffix regular expressions matching configured extensions.
- Extracted `context.settings.next.pageExtensions` in `packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts` and passed it down to the URL discovery generators.
- Added unit tests in `test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts` verifying detection of routes with custom extensions configured via ESLint settings.