### PR TITLE
Add experimental.agentHmrBatching: hold HMR during an agent's multi-step edit

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/agentHmrBatching.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/agentHmrBatching.mdx
@@ -1,0 +1,70 @@
+---
+title: agentHmrBatching
+description: Let an AI coding agent group a multi-step edit into a single HMR update, and receive compile errors itself instead of showing them in the browser.
+version: experimental
+---
+
+An AI coding agent edits a project in many small steps: rename a component, then
+update its call sites, then add the prop it now needs. Each write is a file
+change, so the dev server compiles it and pushes an HMR update, and the preview
+in the browser walks through every intermediate state — including the ones that
+only make sense half-finished. Meanwhile the compile errors from those states
+land in the browser's error overlay, in front of a person, rather than going back
+to the agent that can still fix them.
+
+`experimental.agentHmrBatching` lets the agent group those steps into one update.
+
+```js filename="next.config.js"
+module.exports = {
+  experimental: {
+    // Batches are opened and closed through MCP tools, so the MCP server has to
+    // be enabled too (it is, by default).
+    mcpServer: true,
+    agentHmrBatching: true,
+  },
+}
+```
+
+## How it works
+
+The agent wraps a multi-step edit in a batch:
+
+1. `begin_hmr_batch` — from here on, every HMR message that would change what the
+   browser is rendering is held back instead of delivered, so the preview keeps
+   showing the last output that compiled.
+2. The agent writes as many files as the change needs. The dev server compiles
+   each write as usual; only the delivery to the browser waits.
+3. `end_hmr_batch` — waits for the compilation to settle, then either:
+   - **`status: "flushed"`** — the code compiles. The held messages are delivered
+     as one coalesced update, so the preview goes straight from the last good
+     state to the new one without rendering anything in between.
+   - **`status: "withheld"`** — the code does not compile. Nothing is delivered,
+     the preview stays on the last good state, and the errors are returned in the
+     tool result. They are the agent's to fix; the held updates stay queued and
+     are delivered once the code compiles again.
+
+`get_hmr_batch_status` reports whether a batch is open, how much it is holding,
+and the errors from the most recent compilation.
+
+With no batch open, HMR behaves exactly as it does with this option off.
+
+## Reading an `end_hmr_batch` result
+
+| Field              | Meaning                                                                                                                                        |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `status`           | `flushed`, `withheld`, or `no-batch`.                                                                                                          |
+| `compiled`         | Whether a compile result was observed at all. When `false`, an empty `errors` means the edit never reached the bundler — not that it is valid. |
+| `errors`           | Compilation errors as of the end of the batch.                                                                                                 |
+| `heldMessageCount` | How many HMR messages the batch was holding when it closed.                                                                                    |
+| `previewPreserved` | `false` if the batch held so many messages that they had to be released early, so the preview did briefly move.                                |
+| `timedOut`         | The batch was closed by the dev server because it stayed open past its timeout, not by the agent.                                              |
+
+## Good to know
+
+- A batch has a timeout (30 seconds by default, set per batch with `timeoutMs`).
+  An agent that exits without closing its batch does not leave the preview frozen:
+  the dev server closes it and releases the held updates.
+- Batches do not nest. Opening one while another is open returns the open batch.
+- Batching holds back HMR pushes to already-connected clients. It does not freeze
+  the server: a reload or a new navigation during a batch renders the current
+  state of the code, half-finished or not.

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -311,6 +311,7 @@ export const experimentalSchema = {
   proxyTimeout: z.number().gte(0).optional(),
   rootParams: z.boolean().optional(),
   mcpServer: z.boolean().optional(),
+  agentHmrBatching: z.boolean().optional(),
   removeUncaughtErrorAndRejectionListeners: z.boolean().optional(),
   validateRSCRequestHeaders: z.boolean().optional(),
   scrollRestoration: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1464,6 +1464,24 @@ export interface ExperimentalConfig {
   mcpServer?: boolean
 
   /**
+   * Let an AI coding agent group a multi-step edit into a single HMR update.
+   *
+   * While a batch is open, the dev server holds back every HMR message that
+   * would change what the browser is rendering, so the preview keeps showing
+   * the last output that compiled instead of walking through each half-finished
+   * intermediate step. Closing the batch either delivers the held messages as
+   * one update, or — if the code does not compile — leaves the preview alone
+   * and hands the errors back to the agent.
+   *
+   * Batches are opened and closed through the `begin_hmr_batch` /
+   * `end_hmr_batch` MCP tools, so this also requires `mcpServer`. With no batch
+   * open, HMR behaves exactly as it does with this option off.
+   *
+   * @default false
+   */
+  agentHmrBatching?: boolean
+
+  /**
    * Acquires a lockfile at `<distDir>/lock` when starting `next dev` or `next
    * build`. Failing to acquire the lock causes the process to exit with an
    * error message.
@@ -2336,6 +2354,7 @@ export const defaultConfig = Object.freeze({
     proxyClientMaxBodySize: 10_485_760, // 10MB
     hideLogsAfterAbort: false,
     mcpServer: true,
+    agentHmrBatching: false,
     turbopackFileSystemCacheForDev: true,
     turbopackFileSystemCacheForBuild: true,
     turbopackInferModuleSideEffects: true,

--- a/packages/next/src/server/dev/agent-hmr-batch.test.ts
+++ b/packages/next/src/server/dev/agent-hmr-batch.test.ts
@@ -1,0 +1,536 @@
+import type { HmrMessageSentToBrowser } from './hot-reloader-types'
+import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
+import {
+  AgentHmrBatchController,
+  MAX_QUEUED_MESSAGES,
+  getBatchDisposition,
+} from './agent-hmr-batch'
+
+const built = (
+  errors: Array<{ message: string }> = [],
+  warnings: Array<{ message: string }> = []
+): HmrMessageSentToBrowser => ({
+  type: HMR_MESSAGE_SENT_TO_BROWSER.BUILT,
+  hash: 'hash',
+  errors,
+  warnings,
+})
+
+const building = (): HmrMessageSentToBrowser => ({
+  type: HMR_MESSAGE_SENT_TO_BROWSER.BUILDING,
+})
+
+const serverComponentChanges = (): HmrMessageSentToBrowser => ({
+  type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+})
+
+const turbopackUpdate = (): HmrMessageSentToBrowser => ({
+  type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_MESSAGE,
+  data: [],
+})
+
+const reloadPage = (): HmrMessageSentToBrowser => ({
+  type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
+  data: '/',
+})
+
+const turbopackConnected = (): HmrMessageSentToBrowser => ({
+  type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_CONNECTED,
+  data: { sessionId: 1 },
+})
+
+const serverError = (message: string): HmrMessageSentToBrowser => ({
+  type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_ERROR,
+  errorJSON: JSON.stringify({ message, stack: `${message}\n  at <anonymous>` }),
+})
+
+/**
+ * A controller with fully controlled time and timers, plus a recording
+ * "browser" so tests can assert on exactly what was delivered and when.
+ */
+function setup({ enabled = true }: { enabled?: boolean } = {}) {
+  let currentTime = 1_000
+  const timers = new Map<number, { fn: () => void; at: number }>()
+  let nextTimerId = 1
+  const delivered: string[] = []
+  const warnings: string[] = []
+  let compiling = false
+
+  const controller = new AgentHmrBatchController({
+    now: () => currentTime,
+    isCompiling: () => compiling,
+    logger: {
+      warn: (message: string) => {
+        warnings.push(message)
+      },
+    },
+    setTimer: (fn, ms) => {
+      const id = nextTimerId++
+      timers.set(id, { fn, at: currentTime + ms })
+      return id
+    },
+    clearTimer: (handle) => {
+      timers.delete(handle as number)
+    },
+  })
+
+  controller.configure({ enabled })
+
+  /**
+   * Pushes a message through the gate the way a hot reloader does: deliver it
+   * unless the controller took it over.
+   */
+  function send(message: HmrMessageSentToBrowser, label: string) {
+    const held = controller.intercept(message, () => {
+      delivered.push(label)
+    })
+    if (!held) {
+      delivered.push(label)
+    }
+    return held
+  }
+
+  function advance(ms: number) {
+    currentTime += ms
+    for (const [id, timer] of [...timers]) {
+      if (timer.at <= currentTime) {
+        timers.delete(id)
+        timer.fn()
+      }
+    }
+  }
+
+  // Every unit test drives compilation explicitly, so settling has nothing to
+  // wait for. The settle path has its own test below.
+  const end = () => controller.end({ settle: false })
+
+  return {
+    controller,
+    send,
+    end,
+    advance,
+    delivered,
+    warnings,
+    setCompiling: (value: boolean) => {
+      compiling = value
+    },
+  }
+}
+
+describe('getBatchDisposition', () => {
+  it('holds messages that change what the browser renders', () => {
+    expect(
+      getBatchDisposition(HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_MESSAGE)
+    ).toBe('hold')
+    expect(getBatchDisposition(HMR_MESSAGE_SENT_TO_BROWSER.BUILT)).toBe('hold')
+    expect(getBatchDisposition(HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE)).toBe(
+      'hold'
+    )
+    expect(
+      getBatchDisposition(HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES)
+    ).toBe('hold')
+    expect(getBatchDisposition(HMR_MESSAGE_SENT_TO_BROWSER.SERVER_ERROR)).toBe(
+      'hold'
+    )
+  })
+
+  it('drops the transient compiling indicator', () => {
+    expect(getBatchDisposition(HMR_MESSAGE_SENT_TO_BROWSER.BUILDING)).toBe(
+      'drop'
+    )
+  })
+
+  it('passes messages unrelated to the rendered output', () => {
+    expect(
+      getBatchDisposition(HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_CONNECTED)
+    ).toBe('pass')
+    expect(
+      getBatchDisposition(HMR_MESSAGE_SENT_TO_BROWSER.CACHE_INDICATOR)
+    ).toBe('pass')
+    expect(
+      getBatchDisposition(HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_PAGE_METADATA)
+    ).toBe('pass')
+  })
+})
+
+describe('AgentHmrBatchController', () => {
+  it('is inert when no batch is open', () => {
+    const { send, delivered } = setup()
+
+    send(turbopackUpdate(), 'update')
+    send(built(), 'built')
+
+    expect(delivered).toEqual(['update', 'built'])
+  })
+
+  it('refuses to open a batch unless the feature is enabled', () => {
+    const { controller, send, delivered } = setup({ enabled: false })
+
+    expect(controller.begin()).toMatchObject({
+      status: 'disabled',
+      batchId: null,
+    })
+    expect(controller.isHolding()).toBe(false)
+
+    send(turbopackUpdate(), 'update')
+    expect(delivered).toEqual(['update'])
+  })
+
+  it('holds browser-visible updates while a batch is open', () => {
+    const { controller, send, delivered } = setup()
+
+    expect(controller.begin()).toMatchObject({ status: 'opened' })
+
+    expect(send(turbopackUpdate(), 'update-1')).toBe(true)
+    expect(send(built(), 'built')).toBe(true)
+    expect(delivered).toEqual([])
+    expect(controller.isHolding()).toBe(true)
+  })
+
+  it('lets through messages that do not affect the rendered output', () => {
+    const { controller, send, delivered } = setup()
+    controller.begin()
+
+    expect(send(turbopackConnected(), 'connected')).toBe(false)
+    expect(delivered).toEqual(['connected'])
+  })
+
+  it('never replays the transient compiling indicator', async () => {
+    const { controller, send, end, delivered } = setup()
+    controller.begin()
+
+    send(building(), 'building')
+    send(built(), 'built')
+
+    const result = await end()
+
+    expect(result.droppedMessageCount).toBe(1)
+    expect(delivered).toEqual(['built'])
+  })
+
+  it('flushes a clean batch as one coalesced burst', async () => {
+    const { controller, send, end, delivered } = setup()
+    controller.begin()
+
+    // Three edit/compile cycles, the shape of a multi-step agent edit.
+    for (let step = 1; step <= 3; step++) {
+      send(building(), `building-${step}`)
+      send(turbopackUpdate(), `update-${step}`)
+      send(serverComponentChanges(), `rsc-${step}`)
+      send(built(), `built-${step}`)
+    }
+
+    expect(delivered).toEqual([])
+
+    const result = await end()
+
+    expect(result.status).toBe('flushed')
+    expect(result.compiled).toBe(true)
+    expect(result.errors).toEqual([])
+    expect(result.previewPreserved).toBe(true)
+
+    // Every module update is applied, in order, because they are incremental
+    // patches. The "refetch" and "compiled" signals collapse to one each, the
+    // last payload wins, and coalescing moves them behind the updates they
+    // now describe.
+    expect(delivered).toEqual([
+      'update-1',
+      'update-2',
+      'update-3',
+      'rsc-3',
+      'built-3',
+    ])
+  })
+
+  it('withholds the flush and returns the errors when the batch ends broken', async () => {
+    const { controller, send, end, delivered } = setup()
+    controller.begin()
+
+    send(turbopackUpdate(), 'update')
+    send(built([{ message: 'Module not found: ./missing' }]), 'built-broken')
+
+    const result = await end()
+
+    expect(result.status).toBe('withheld')
+    expect(result.compiled).toBe(true)
+    expect(result.errors).toEqual([{ message: 'Module not found: ./missing' }])
+    // The browser is still on the last state that compiled.
+    expect(delivered).toEqual([])
+  })
+
+  it('releases a withheld queue on the next clean compile', async () => {
+    const { controller, send, end, delivered } = setup()
+    controller.begin()
+    send(turbopackUpdate(), 'update-1')
+    send(built([{ message: 'Unexpected token' }]), 'built-broken')
+
+    expect((await end()).status).toBe('withheld')
+    expect(delivered).toEqual([])
+
+    // The agent fixes the syntax error outside of a batch.
+    send(built(), 'built-fixed')
+
+    expect(delivered).toEqual(['update-1', 'built-fixed'])
+  })
+
+  it('keeps withholding while the compilation is still broken', async () => {
+    const { controller, send, end, delivered } = setup()
+    controller.begin()
+    send(turbopackUpdate(), 'update-1')
+    send(built([{ message: 'Unexpected token' }]), 'built-broken')
+    await end()
+
+    // A second, still-failing compile must not push the intermediate update.
+    send(built([{ message: 'Unexpected token' }]), 'built-still-broken')
+
+    expect(delivered).toEqual(['built-still-broken'])
+
+    send(built(), 'built-fixed')
+    expect(delivered).toEqual(['built-still-broken', 'update-1', 'built-fixed'])
+  })
+
+  it('reports HMR server errors to the agent instead of the overlay', async () => {
+    const { controller, send, end, delivered } = setup()
+    controller.begin()
+
+    send(serverError('boom'), 'server-error')
+
+    const result = await end()
+
+    expect(result.status).toBe('withheld')
+    expect(result.errors).toEqual([
+      { message: 'boom', stack: expect.stringContaining('boom') },
+    ])
+    expect(delivered).toEqual([])
+  })
+
+  it('reports an unparseable server error payload verbatim', async () => {
+    const { controller, end } = setup()
+    controller.begin()
+
+    controller.intercept(
+      {
+        type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_ERROR,
+        errorJSON: 'not json',
+      },
+      () => {}
+    )
+
+    expect((await end()).errors).toEqual([{ message: 'not json' }])
+  })
+
+  it('distinguishes "compiled cleanly" from "never compiled"', async () => {
+    const { controller, end } = setup()
+    controller.begin()
+
+    const result = await end()
+
+    expect(result.status).toBe('flushed')
+    expect(result.errors).toEqual([])
+    // No compile result was observed, so the empty error list is the absence of
+    // evidence rather than a clean build.
+    expect(result.compiled).toBe(false)
+  })
+
+  it('does not nest batches', async () => {
+    const { controller, send, end, delivered } = setup()
+
+    const first = controller.begin()
+    send(turbopackUpdate(), 'update-1')
+
+    const second = controller.begin()
+    expect(second).toMatchObject({
+      status: 'already-open',
+      batchId: first.batchId,
+    })
+
+    // The outer batch's queue survives the redundant `begin`.
+    send(built(), 'built')
+    expect(delivered).toEqual([])
+
+    await end()
+    expect(delivered).toEqual(['update-1', 'built'])
+  })
+
+  it('drains host-owned queues before its own on flush', async () => {
+    const { controller, send, end, delivered } = setup()
+    controller.onResume(() => {
+      delivered.push('host-queue')
+    })
+    controller.begin()
+
+    send(built(), 'built')
+    await end()
+
+    // Module updates queued by the bundler have to land before the `BUILT`
+    // that reports the compilation as finished.
+    expect(delivered).toEqual(['host-queue', 'built'])
+  })
+
+  it('releases held updates when an abandoned batch times out', () => {
+    const { controller, send, advance, delivered, warnings } = setup()
+    controller.begin({ timeoutMs: 5_000 })
+
+    send(turbopackUpdate(), 'update')
+    expect(delivered).toEqual([])
+
+    advance(5_000)
+
+    expect(controller.isHolding()).toBe(false)
+    expect(delivered).toEqual(['update'])
+    expect(warnings.join('\n')).toContain('was not closed within 5000ms')
+  })
+
+  it('reports a timed-out batch to a late end() call', async () => {
+    const { controller, advance, end } = setup()
+    controller.begin({ timeoutMs: 5_000 })
+    advance(5_000)
+
+    const result = await end()
+
+    expect(result.timedOut).toBe(true)
+    expect(result.status).toBe('flushed')
+  })
+
+  it('clamps the batch timeout to a sane range', () => {
+    const { controller } = setup()
+
+    expect(controller.begin({ timeoutMs: 1 }).timeoutMs).toBe(1_000)
+    controller.resetForTesting()
+    expect(controller.begin({ timeoutMs: 10 ** 9 }).timeoutMs).toBe(300_000)
+  })
+
+  it('bounds the queue rather than growing without limit', async () => {
+    const { controller, send, end, delivered, warnings } = setup()
+    controller.begin()
+
+    // Turbopack updates are not coalesced, so they are what can actually pile
+    // up during a runaway recompile loop.
+    for (let i = 0; i <= MAX_QUEUED_MESSAGES; i++) {
+      send(turbopackUpdate(), `update-${i}`)
+    }
+
+    expect(delivered).toHaveLength(MAX_QUEUED_MESSAGES + 1)
+    expect(warnings.join('\n')).toContain('flushing early to bound memory')
+
+    const result = await end()
+    // The preview did briefly move off the last good state, and the batch says
+    // so rather than claiming a guarantee it did not keep.
+    expect(result.previewPreserved).toBe(false)
+  })
+
+  it('reports what it held', async () => {
+    const { controller, send, end } = setup()
+    controller.begin()
+
+    send(turbopackUpdate(), 'update-1')
+    send(turbopackUpdate(), 'update-2')
+    send(reloadPage(), 'reload')
+    send(building(), 'building')
+
+    const result = await end()
+
+    expect(result.heldMessageCount).toBe(3)
+    expect(result.droppedMessageCount).toBe(1)
+    expect(
+      result.heldMessageTypes[HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_MESSAGE]
+    ).toBe(2)
+    expect(
+      result.heldMessageTypes[HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE]
+    ).toBe(1)
+  })
+
+  it('reports status while a batch is open', () => {
+    const { controller, send } = setup()
+    controller.begin()
+    send(turbopackUpdate(), 'update')
+
+    expect(controller.status()).toMatchObject({
+      enabled: true,
+      open: true,
+      heldMessageCount: 1,
+      pendingFromPreviousBatch: 0,
+    })
+  })
+
+  it('accepts a compile result from a host with a better error source', async () => {
+    const { controller, end } = setup()
+    controller.begin()
+
+    controller.recordCompileResult([{ message: 'from the bundler' }])
+
+    const result = await end()
+    expect(result.status).toBe('withheld')
+    expect(result.compiled).toBe(true)
+    expect(result.errors).toEqual([{ message: 'from the bundler' }])
+  })
+})
+
+describe('AgentHmrBatchController settling', () => {
+  it('waits for an in-flight compilation before reporting errors', async () => {
+    // Real timers here: this is the one behaviour that is about waiting.
+    let compiling = false
+    const controller = new AgentHmrBatchController({
+      isCompiling: () => compiling,
+      logger: { warn: () => {} },
+    })
+    controller.configure({ enabled: true })
+    controller.begin()
+
+    // The agent's write has not reached the bundler yet when it closes the
+    // batch, so a naive end() would report a clean build.
+    compiling = true
+    const ending = controller.end({
+      settle: { quietMs: 10, graceMs: 50, maxWaitMs: 5_000, pollMs: 5 },
+    })
+
+    controller.intercept(
+      { type: HMR_MESSAGE_SENT_TO_BROWSER.BUILDING },
+      () => {}
+    )
+    controller.intercept(built([{ message: 'late error' }]), () => {})
+    compiling = false
+
+    const result = await ending
+
+    expect(result.compiled).toBe(true)
+    expect(result.errors).toEqual([{ message: 'late error' }])
+    expect(result.status).toBe('withheld')
+  })
+
+  it('returns promptly when the edits triggered no recompile', async () => {
+    const controller = new AgentHmrBatchController({
+      isCompiling: () => false,
+      logger: { warn: () => {} },
+    })
+    controller.configure({ enabled: true })
+    controller.begin()
+
+    const startedAt = Date.now()
+    const result = await controller.end({
+      settle: { quietMs: 5, graceMs: 40, maxWaitMs: 5_000, pollMs: 5 },
+    })
+
+    expect(result.status).toBe('flushed')
+    expect(result.compiled).toBe(false)
+    // It waits out the grace period once, and does not sit until maxWaitMs.
+    expect(Date.now() - startedAt).toBeLessThan(2_000)
+  })
+})
+
+describe('end() outside a batch', () => {
+  it('reports that there is nothing to end', async () => {
+    const { controller } = setup()
+    expect(await controller.end({ settle: false })).toMatchObject({
+      status: 'no-batch',
+      batchId: null,
+    })
+  })
+
+  it('reports the feature as disabled', async () => {
+    const { controller } = setup({ enabled: false })
+    expect(await controller.end({ settle: false })).toMatchObject({
+      status: 'disabled',
+    })
+  })
+})

--- a/packages/next/src/server/dev/agent-hmr-batch.ts
+++ b/packages/next/src/server/dev/agent-hmr-batch.ts
@@ -1,0 +1,785 @@
+/**
+ * Agent-scoped HMR batching (experimental).
+ *
+ * An AI coding agent edits a project in many small steps: rename a component,
+ * then update its three call sites, then add the prop it now needs. Every one
+ * of those writes is a file change, so the dev server compiles it and pushes an
+ * HMR update. The preview in the browser therefore walks through every
+ * intermediate state the agent passed through — including the ones that only
+ * make sense half-finished — and the human watching it sees a flicker of
+ * broken renders and error overlays that nobody asked to look at. Meanwhile the
+ * agent, which is the party that could actually act on a compile error, only
+ * learns about it if it thinks to go read the error state.
+ *
+ * A batch inverts that. The agent opens one around a multi-step edit, and for
+ * as long as it is open every message that would change what the browser is
+ * showing is held back instead of delivered, so the preview keeps rendering
+ * the last output that compiled. When the agent closes the batch:
+ *
+ * - if the code compiles, the held messages are flushed as one coalesced burst,
+ *   so the preview goes straight from the last good state to the new good state
+ *   and never renders anything in between;
+ * - if it does not compile, nothing is flushed — the preview stays on the last
+ *   good state — and the errors are returned to the agent as the result of
+ *   closing the batch, which is the moment it can still do something about
+ *   them.
+ *
+ * Held messages are never dropped. A batch that ends on a compile error keeps
+ * its queue, and the next clean compile drains it, so the browser always
+ * catches up rather than being left permanently stale.
+ *
+ * This is deliberately inert unless a batch is open: with no batch, every
+ * message takes exactly the path it took before. The only entry point is the
+ * MCP tooling in `../mcp/tools/hmr-batch.ts`, which is registered only when
+ * `experimental.agentHmrBatching` is set.
+ */
+
+import type {
+  BuiltMessage,
+  CompilationError,
+  HmrMessageSentToBrowser,
+  ServerErrorMessage,
+  SyncMessage,
+} from './hot-reloader-types'
+import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
+
+/**
+ * What an open batch does with a message.
+ *
+ * - `hold`: applying it changes what the browser renders, so it waits for the
+ *   batch to end.
+ * - `drop`: a transient signal that the flush at the end of the batch
+ *   supersedes, so replaying it would only produce a stale flash.
+ * - `pass`: unrelated to the rendered output (per-request plumbing, devtools
+ *   state), so batching it would break features for no benefit.
+ */
+export type BatchDisposition = 'hold' | 'drop' | 'pass'
+
+/**
+ * Every message type, classified. A `Record` over the full union rather than a
+ * `switch` with a default, so that adding an HMR message type does not silently
+ * inherit `pass`: TypeScript reports the missing key and whoever adds it has to
+ * decide whether it moves the preview.
+ */
+const BATCH_DISPOSITIONS: Record<
+  HmrMessageSentToBrowser['type'],
+  BatchDisposition
+> = {
+  // Applying new code, refetching, or reloading: all of these visibly move the
+  // preview off the last good state.
+  [HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_MESSAGE]: 'hold',
+  [HMR_MESSAGE_SENT_TO_BROWSER.BUILT]: 'hold',
+  [HMR_MESSAGE_SENT_TO_BROWSER.SYNC]: 'hold',
+  [HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE]: 'hold',
+  [HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES]: 'hold',
+  [HMR_MESSAGE_SENT_TO_BROWSER.STATIC_PARAMS_CHANGED]: 'hold',
+  [HMR_MESSAGE_SENT_TO_BROWSER.MIDDLEWARE_CHANGES]: 'hold',
+  [HMR_MESSAGE_SENT_TO_BROWSER.CLIENT_CHANGES]: 'hold',
+  [HMR_MESSAGE_SENT_TO_BROWSER.SERVER_ONLY_CHANGES]: 'hold',
+  [HMR_MESSAGE_SENT_TO_BROWSER.ADDED_PAGE]: 'hold',
+  [HMR_MESSAGE_SENT_TO_BROWSER.REMOVED_PAGE]: 'hold',
+  [HMR_MESSAGE_SENT_TO_BROWSER.DEV_PAGES_MANIFEST_UPDATE]: 'hold',
+  // Raises the error overlay over the preview. Held so the agent, not the human
+  // watching the preview, is the one who gets told.
+  [HMR_MESSAGE_SENT_TO_BROWSER.SERVER_ERROR]: 'hold',
+
+  // "Compiling…" for work the agent is driving. The flush at the end of the
+  // batch reports the outcome, so replaying this would only flash an indicator
+  // for a build that already finished.
+  [HMR_MESSAGE_SENT_TO_BROWSER.BUILDING]: 'drop',
+
+  // Per-request plumbing, devtools state, and indicators. None of them change
+  // what the page renders, and holding them would break those features during
+  // a batch for no benefit.
+  [HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_CONNECTED]: 'pass',
+  [HMR_MESSAGE_SENT_TO_BROWSER.ISR_MANIFEST]: 'pass',
+  [HMR_MESSAGE_SENT_TO_BROWSER.CACHE_INDICATOR]: 'pass',
+  [HMR_MESSAGE_SENT_TO_BROWSER.DEVTOOLS_CONFIG]: 'pass',
+  [HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_CURRENT_ERROR_STATE]: 'pass',
+  [HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_PAGE_METADATA]: 'pass',
+  [HMR_MESSAGE_SENT_TO_BROWSER.REQUEST_INSIGHTS_UPDATE]: 'pass',
+  [HMR_MESSAGE_SENT_TO_BROWSER.REACT_DEBUG_CHUNK]: 'pass',
+  [HMR_MESSAGE_SENT_TO_BROWSER.ERRORS_TO_SHOW_IN_BROWSER]: 'pass',
+}
+
+export function getBatchDisposition(
+  type: HmrMessageSentToBrowser['type']
+): BatchDisposition {
+  // A message type the dev server sends but this table has not seen (only
+  // reachable if the two get out of sync) is treated as unrelated to the
+  // preview, which is the behaviour it had before batching existed.
+  return BATCH_DISPOSITIONS[type] ?? 'pass'
+}
+
+/**
+ * Message types that carry the whole current state, so that only the last one
+ * matters and earlier copies can be dropped. Everything else is queued without
+ * coalescing, because dropping an earlier copy would lose information:
+ * Turbopack updates are incremental module patches that all have to be applied,
+ * and `SERVER_ONLY_CHANGES` / `ADDED_PAGE` / `REMOVED_PAGE` each name a
+ * different page.
+ */
+const COALESCING_MESSAGE_TYPES: ReadonlySet<HmrMessageSentToBrowser['type']> =
+  new Set([
+    HMR_MESSAGE_SENT_TO_BROWSER.BUILT,
+    HMR_MESSAGE_SENT_TO_BROWSER.SYNC,
+    HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
+    HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+    HMR_MESSAGE_SENT_TO_BROWSER.STATIC_PARAMS_CHANGED,
+    HMR_MESSAGE_SENT_TO_BROWSER.MIDDLEWARE_CHANGES,
+    HMR_MESSAGE_SENT_TO_BROWSER.CLIENT_CHANGES,
+    HMR_MESSAGE_SENT_TO_BROWSER.DEV_PAGES_MANIFEST_UPDATE,
+  ])
+
+function getCoalesceKey(message: HmrMessageSentToBrowser): string | null {
+  return COALESCING_MESSAGE_TYPES.has(message.type)
+    ? String(message.type)
+    : null
+}
+
+export interface AgentHmrBatchSettleOptions {
+  /**
+   * How long the compilation has to be quiet before the batch is considered
+   * settled. The agent's last write and the recompile it triggers are not
+   * synchronous with the call that closes the batch, so closing without
+   * waiting would report "no errors" for a build that had not started.
+   */
+  quietMs?: number
+  /**
+   * How long to wait for a recompile to start at all. Some batches genuinely
+   * change nothing the bundler cares about; those pay this once and return.
+   */
+  graceMs?: number
+  /** Upper bound on the total settle wait. */
+  maxWaitMs?: number
+  /** Poll interval while waiting. */
+  pollMs?: number
+}
+
+const DEFAULT_SETTLE: Required<AgentHmrBatchSettleOptions> = {
+  quietMs: 300,
+  graceMs: 2_000,
+  maxWaitMs: 30_000,
+  pollMs: 25,
+}
+
+/** Default lifetime of a batch before the watchdog closes it. */
+export const DEFAULT_BATCH_TIMEOUT_MS = 30_000
+export const MIN_BATCH_TIMEOUT_MS = 1_000
+export const MAX_BATCH_TIMEOUT_MS = 300_000
+
+/**
+ * Cap on how many messages a single batch holds. A batch is a bounded editing
+ * window, so hitting this means something is wrong (a runaway watcher loop, an
+ * agent that never closes its batch and left the watchdog to do it). Growing
+ * without bound would be worse than a flash of an intermediate state, so the
+ * queue is flushed and the batch reports that it happened.
+ */
+export const MAX_QUEUED_MESSAGES = 512
+
+export type AgentHmrBatchStatus =
+  /** Held messages were delivered: the preview is on the new state. */
+  | 'flushed'
+  /** The batch ended on a compile error: the preview is on the last good state. */
+  | 'withheld'
+  /** Nothing to end. */
+  | 'no-batch'
+  /** `experimental.agentHmrBatching` is not enabled. */
+  | 'disabled'
+
+export interface AgentHmrBatchResult {
+  status: AgentHmrBatchStatus
+  batchId: string | null
+  durationMs: number
+  /** The watchdog closed this batch because the agent never did. */
+  timedOut: boolean
+  /**
+   * Whether a compile result was observed while the batch was open. `false`
+   * means the edits did not reach the bundler, so an empty `errors` is the
+   * absence of evidence rather than a clean build.
+   */
+  compiled: boolean
+  errors: CompilationError[]
+  warnings: CompilationError[]
+  heldMessageCount: number
+  /** Counts per HMR message type, for debugging what a batch actually held. */
+  heldMessageTypes: Record<string, number>
+  droppedMessageCount: number
+  /**
+   * Whether the browser was kept on a single state for the whole batch. False
+   * if the queue cap forced an early flush mid-batch.
+   */
+  previewPreserved: boolean
+}
+
+export interface AgentHmrBatchBeginResult {
+  status: 'opened' | 'already-open' | 'disabled'
+  batchId: string | null
+  timeoutMs: number
+}
+
+export interface AgentHmrBatchStatusResult {
+  enabled: boolean
+  open: boolean
+  batchId: string | null
+  openedForMs: number | null
+  heldMessageCount: number
+  heldMessageTypes: Record<string, number>
+  /** Messages held from a previous batch that ended on a compile error. */
+  pendingFromPreviousBatch: number
+  errors: CompilationError[]
+  warnings: CompilationError[]
+}
+
+interface QueuedMessage {
+  coalesceKey: string | null
+  type: HmrMessageSentToBrowser['type']
+  deliver: () => void
+}
+
+export interface AgentHmrBatchDeps {
+  now?: () => number
+  /**
+   * Whether the bundler currently has a compilation in flight. Used to settle
+   * a batch before reporting its errors; without it, settling falls back to
+   * the quiet period alone.
+   */
+  isCompiling?: () => boolean
+  logger?: Pick<Console, 'warn'>
+  setTimer?: (fn: () => void, ms: number) => unknown
+  clearTimer?: (handle: unknown) => void
+}
+
+function hasErrorsField(
+  message: HmrMessageSentToBrowser
+): message is BuiltMessage | SyncMessage {
+  return (
+    message.type === HMR_MESSAGE_SENT_TO_BROWSER.BUILT ||
+    message.type === HMR_MESSAGE_SENT_TO_BROWSER.SYNC
+  )
+}
+
+function describeServerError(message: ServerErrorMessage): CompilationError {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(message.errorJSON)
+  } catch {
+    // The payload is opaque to us; report it verbatim rather than losing it.
+    return { message: message.errorJSON }
+  }
+
+  const error = parsed as { message?: unknown; stack?: unknown }
+  return {
+    message:
+      typeof error?.message === 'string' ? error.message : message.errorJSON,
+    stack: typeof error?.stack === 'string' ? error.stack : undefined,
+  }
+}
+
+export class AgentHmrBatchController {
+  private enabled = false
+  private batchId: string | null = null
+  private openedAt = 0
+  private batchCounter = 0
+
+  /**
+   * Held messages in delivery order. Keyed so a coalescing message can replace
+   * its predecessor; entries that must not coalesce get a synthetic key. A
+   * `Map` iterates in insertion order, and re-inserting moves an entry to the
+   * end, which is what coalescing should do: the surviving copy is the newest,
+   * so it belongs after everything queued since the copy it replaces.
+   */
+  private queue = new Map<string, QueuedMessage>()
+  private queueSequence = 0
+  private heldMessageTypes = new Map<HmrMessageSentToBrowser['type'], number>()
+  private droppedMessageCount = 0
+  private forcedFlush = false
+
+  /**
+   * Latest compile result seen while the batch was open. `SERVER_ERROR`
+   * messages are appended to `errors` because they are also something the
+   * agent needs to hear about, and they are cleared with the rest on the next
+   * compile result.
+   */
+  private errors: CompilationError[] = []
+  private warnings: CompilationError[] = []
+  private serverErrors: CompilationError[] = []
+  private sawCompileResult = false
+
+  /** Bumped by any message crossing the gate; used to detect a quiet period. */
+  private activityCount = 0
+  private lastActivityAt = 0
+  private activityCountAtOpen = 0
+
+  private resumeCallbacks = new Set<() => void>()
+  private watchdog: unknown = null
+  /**
+   * Result of a batch the watchdog closed, held until an `end` call collects
+   * it. Without this, an agent that closed its batch late would be told there
+   * was no batch, and never learn that its edits were released without it.
+   */
+  private pendingTimeoutResult: AgentHmrBatchResult | null = null
+
+  private readonly now: () => number
+  private readonly logger: Pick<Console, 'warn'>
+  private readonly setTimer: (fn: () => void, ms: number) => unknown
+  private readonly clearTimer: (handle: unknown) => void
+  private isCompiling: (() => boolean) | undefined
+
+  constructor(deps: AgentHmrBatchDeps = {}) {
+    this.now = deps.now ?? Date.now
+    this.logger = deps.logger ?? console
+    this.isCompiling = deps.isCompiling
+    this.setTimer =
+      deps.setTimer ??
+      ((fn, ms) => {
+        const handle = setTimeout(fn, ms)
+        // A dev-server watchdog must not be a reason for the process to stay
+        // alive.
+        handle.unref?.()
+        return handle
+      })
+    this.clearTimer =
+      deps.clearTimer ?? ((handle) => clearTimeout(handle as any))
+  }
+
+  /**
+   * Wired from the hot reloader once the bundler exists. `enabled` mirrors
+   * `experimental.agentHmrBatching`.
+   */
+  configure({
+    enabled,
+    isCompiling,
+  }: {
+    enabled?: boolean
+    isCompiling?: () => boolean
+  }): void {
+    if (enabled !== undefined) {
+      this.enabled = enabled
+    }
+    if (isCompiling !== undefined) {
+      this.isCompiling = isCompiling
+    }
+  }
+
+  /**
+   * True while a batch is holding browser-visible updates. Callers that
+   * maintain their own outbound queue (the Turbopack hot reloader keeps
+   * per-client message and update queues) check this and skip their flush,
+   * leaving the messages where they already are, and register an `onResume`
+   * callback so the batch can drive that flush when it ends.
+   */
+  isHolding(): boolean {
+    return this.batchId !== null
+  }
+
+  /**
+   * Registers a flush for a queue this controller does not own. Called on
+   * every batch flush, before the controller's own queue is drained, so that
+   * bundler-level updates land ahead of the `BUILT` that concludes them —
+   * the order they arrive in outside a batch.
+   */
+  onResume(callback: () => void): () => void {
+    this.resumeCallbacks.add(callback)
+    return () => {
+      this.resumeCallbacks.delete(callback)
+    }
+  }
+
+  /**
+   * The gate every HMR delivery point calls.
+   *
+   * Returns `true` when an open batch has taken the message over and the
+   * caller must not deliver it; `false` when the caller should deliver it now.
+   * `deliver` is invoked later, on flush, so it should read whatever state it
+   * needs at call time rather than closing over a stale snapshot.
+   *
+   * @param coalesceKey Overrides the default coalescing. Pass a stable key for
+   * a delivery step that fans out to several clients so it collapses as one
+   * unit; pass `null` to queue every occurrence.
+   */
+  intercept(
+    message: HmrMessageSentToBrowser,
+    deliver: () => void,
+    { coalesceKey }: { coalesceKey?: string | null } = {}
+  ): boolean {
+    const disposition = getBatchDisposition(message.type)
+
+    if (disposition === 'pass') {
+      // Per-request plumbing and devtools state stream continuously and say
+      // nothing about the compilation, so they are neither recorded as
+      // activity nor allowed to influence a batch.
+      return false
+    }
+
+    this.recordFromMessage(message)
+
+    const key =
+      coalesceKey !== undefined ? coalesceKey : getCoalesceKey(message)
+
+    if (this.batchId === null) {
+      if (key !== null) {
+        // This message is about to be delivered, and it carries the whole
+        // current state for its key. A copy still queued behind a batch that
+        // ended on a compile error is therefore stale — replaying it would
+        // flash the superseded state (an error overlay for an error the agent
+        // has already fixed) before this message corrects it.
+        this.queue.delete(key)
+      }
+      // Anything else still queued catches up first, so the browser sees the
+      // module updates it missed before the message that concludes them.
+      this.drainIfClean()
+      return false
+    }
+
+    if (disposition === 'drop') {
+      this.droppedMessageCount++
+      return true
+    }
+
+    this.enqueue({ coalesceKey: key, type: message.type, deliver })
+    return true
+  }
+
+  /**
+   * Records compilation state without gating anything. For hosts that have a
+   * better error source than the messages crossing the gate.
+   */
+  recordCompileResult(
+    errors: readonly CompilationError[],
+    warnings: readonly CompilationError[] = []
+  ): void {
+    this.sawCompileResult = true
+    this.errors = [...errors]
+    this.warnings = [...warnings]
+    // A fresh compile result supersedes the errors from the previous one.
+    this.serverErrors = []
+  }
+
+  begin({ timeoutMs }: { timeoutMs?: number } = {}): AgentHmrBatchBeginResult {
+    if (!this.enabled) {
+      return { status: 'disabled', batchId: null, timeoutMs: 0 }
+    }
+
+    const clampedTimeout = Math.min(
+      MAX_BATCH_TIMEOUT_MS,
+      Math.max(MIN_BATCH_TIMEOUT_MS, timeoutMs ?? DEFAULT_BATCH_TIMEOUT_MS)
+    )
+
+    if (this.batchId !== null) {
+      // Batches do not nest: a second `begin` from an agent that lost track of
+      // its own state should not silently discard the outer batch's queue.
+      return {
+        status: 'already-open',
+        batchId: this.batchId,
+        timeoutMs: clampedTimeout,
+      }
+    }
+
+    this.batchId = `hmr-batch-${++this.batchCounter}`
+    this.openedAt = this.now()
+    this.activityCountAtOpen = this.activityCount
+    // Anchor the quiet period to the batch opening, so that settling cannot
+    // read a long-idle dev server as "this edit already finished compiling".
+    this.lastActivityAt = this.openedAt
+    this.heldMessageTypes.clear()
+    this.droppedMessageCount = 0
+    this.forcedFlush = false
+    this.sawCompileResult = false
+
+    this.watchdog = this.setTimer(() => {
+      this.watchdog = null
+      if (this.batchId === null) {
+        return
+      }
+      this.logger.warn(
+        `[agent-hmr-batch] batch ${this.batchId} was not closed within ${clampedTimeout}ms; ` +
+          `releasing held HMR updates. The agent that opened it may have exited without calling end_hmr_batch.`
+      )
+      this.close({ timedOut: true })
+    }, clampedTimeout)
+
+    return {
+      status: 'opened',
+      batchId: this.batchId,
+      timeoutMs: clampedTimeout,
+    }
+  }
+
+  /**
+   * Closes the batch, waiting for the compilation triggered by the agent's
+   * edits to settle first so the reported errors describe the code the agent
+   * just wrote.
+   */
+  async end({
+    settle,
+  }: {
+    settle?: AgentHmrBatchSettleOptions | false
+  } = {}): Promise<AgentHmrBatchResult> {
+    if (this.batchId === null) {
+      return (
+        this.consumePendingTimeoutResult() ??
+        this.emptyResult(this.enabled ? 'no-batch' : 'disabled')
+      )
+    }
+
+    if (settle !== false) {
+      await this.waitForSettle({ ...DEFAULT_SETTLE, ...settle })
+    }
+
+    if (this.batchId === null) {
+      // The watchdog fired while we were settling. It already closed the batch
+      // and produced a result; report that rather than a second, emptier one.
+      return this.consumePendingTimeoutResult() ?? this.emptyResult('no-batch')
+    }
+
+    return this.close({ timedOut: false })
+  }
+
+  status(): AgentHmrBatchStatusResult {
+    const open = this.batchId !== null
+    return {
+      enabled: this.enabled,
+      open,
+      batchId: this.batchId,
+      openedForMs: open ? this.now() - this.openedAt : null,
+      heldMessageCount: open ? this.queue.size : 0,
+      heldMessageTypes: open ? this.heldMessageTypesAsRecord() : {},
+      pendingFromPreviousBatch: open ? 0 : this.queue.size,
+      errors: this.currentErrors(),
+      warnings: [...this.warnings],
+    }
+  }
+
+  /** Test seam: drops all state without delivering anything. */
+  resetForTesting(): void {
+    if (this.watchdog !== null) {
+      this.clearTimer(this.watchdog)
+      this.watchdog = null
+    }
+    this.batchId = null
+    this.queue.clear()
+    this.heldMessageTypes.clear()
+    this.droppedMessageCount = 0
+    this.forcedFlush = false
+    this.errors = []
+    this.warnings = []
+    this.serverErrors = []
+    this.sawCompileResult = false
+    this.resumeCallbacks.clear()
+    this.pendingTimeoutResult = null
+  }
+
+  private consumePendingTimeoutResult(): AgentHmrBatchResult | null {
+    const result = this.pendingTimeoutResult
+    this.pendingTimeoutResult = null
+    return result
+  }
+
+  private emptyResult(status: AgentHmrBatchStatus): AgentHmrBatchResult {
+    return {
+      status,
+      batchId: null,
+      durationMs: 0,
+      timedOut: false,
+      compiled: false,
+      errors: [],
+      warnings: [],
+      heldMessageCount: 0,
+      heldMessageTypes: {},
+      droppedMessageCount: 0,
+      previewPreserved: true,
+    }
+  }
+
+  private currentErrors(): CompilationError[] {
+    return [...this.errors, ...this.serverErrors]
+  }
+
+  private heldMessageTypesAsRecord(): Record<string, number> {
+    const record: Record<string, number> = {}
+    for (const [type, count] of this.heldMessageTypes) {
+      record[String(type)] = count
+    }
+    return record
+  }
+
+  private recordFromMessage(message: HmrMessageSentToBrowser): void {
+    this.activityCount++
+    this.lastActivityAt = this.now()
+
+    if (hasErrorsField(message)) {
+      this.recordCompileResult(message.errors, message.warnings)
+    } else if (message.type === HMR_MESSAGE_SENT_TO_BROWSER.SERVER_ERROR) {
+      this.serverErrors = [...this.serverErrors, describeServerError(message)]
+    }
+  }
+
+  private enqueue(entry: QueuedMessage): void {
+    this.heldMessageTypes.set(
+      entry.type,
+      (this.heldMessageTypes.get(entry.type) ?? 0) + 1
+    )
+
+    const key = entry.coalesceKey ?? `#uncoalesced:${this.queueSequence++}`
+
+    // Re-insert rather than overwrite in place, so the surviving copy is
+    // ordered by when it was last produced.
+    this.queue.delete(key)
+    this.queue.set(key, entry)
+
+    if (this.queue.size > MAX_QUEUED_MESSAGES) {
+      this.logger.warn(
+        `[agent-hmr-batch] batch ${this.batchId} held more than ${MAX_QUEUED_MESSAGES} HMR messages; ` +
+          `flushing early to bound memory. The preview may briefly show an intermediate state.`
+      )
+      this.forcedFlush = true
+      this.flushQueue()
+    }
+  }
+
+  /**
+   * Delivers everything queued. Bundler-owned queues go first so their module
+   * updates precede the `BUILT` that reports the compilation as finished.
+   */
+  private flushQueue(): void {
+    for (const resume of this.resumeCallbacks) {
+      try {
+        resume()
+      } catch (error) {
+        this.logger.warn(
+          `[agent-hmr-batch] a resume callback threw while flushing: ${error}`
+        )
+      }
+    }
+
+    const queued = [...this.queue.values()]
+    this.queue.clear()
+
+    for (const entry of queued) {
+      try {
+        entry.deliver()
+      } catch (error) {
+        this.logger.warn(
+          `[agent-hmr-batch] failed to deliver a held HMR message: ${error}`
+        )
+      }
+    }
+  }
+
+  /**
+   * Lets a queue withheld by a failed batch catch up once the code compiles
+   * again. Without this, a batch that ended on an error would leave the
+   * browser permanently behind.
+   */
+  private drainIfClean(): void {
+    if (this.queue.size === 0) {
+      // Nothing of ours to release. A host-owned queue drains on its own
+      // schedule; it has its own error gate.
+      return
+    }
+    if (this.currentErrors().length > 0) {
+      return
+    }
+    this.flushQueue()
+  }
+
+  private close({ timedOut }: { timedOut: boolean }): AgentHmrBatchResult {
+    const batchId = this.batchId!
+    const durationMs = this.now() - this.openedAt
+    const heldMessageTypes = this.heldMessageTypesAsRecord()
+    const heldMessageCount = this.queue.size
+    const droppedMessageCount = this.droppedMessageCount
+    const errors = this.currentErrors()
+    const warnings = [...this.warnings]
+    const previewPreserved = !this.forcedFlush
+
+    if (this.watchdog !== null) {
+      this.clearTimer(this.watchdog)
+      this.watchdog = null
+    }
+
+    // Closing before flushing: the flush must run outside the batch so that
+    // any message it produces takes the normal path.
+    this.batchId = null
+
+    let status: AgentHmrBatchStatus
+    if (errors.length > 0) {
+      // Hold the line. The preview stays on the last state that compiled, and
+      // the queue survives for the next clean compile to release.
+      status = 'withheld'
+    } else {
+      status = 'flushed'
+      this.flushQueue()
+    }
+
+    const result: AgentHmrBatchResult = {
+      status,
+      batchId,
+      durationMs,
+      timedOut,
+      compiled: this.sawCompileResult,
+      errors,
+      warnings,
+      heldMessageCount,
+      heldMessageTypes,
+      droppedMessageCount,
+      previewPreserved,
+    }
+
+    if (timedOut) {
+      this.pendingTimeoutResult = result
+    }
+
+    return result
+  }
+
+  private async waitForSettle(
+    settle: Required<AgentHmrBatchSettleOptions>
+  ): Promise<void> {
+    const { quietMs, graceMs, maxWaitMs, pollMs } = settle
+    const start = this.now()
+    const deadline = start + maxWaitMs
+
+    // The write that triggers the recompile races the call that closes the
+    // batch, so give the watcher a moment to notice it. Once anything has
+    // crossed the gate there is real activity to wait on instead.
+    const graceDeadline = Math.min(start + graceMs, deadline)
+    while (
+      this.activityCount === this.activityCountAtOpen &&
+      this.now() < graceDeadline &&
+      this.batchId !== null
+    ) {
+      await sleep(pollMs)
+    }
+
+    while (this.now() < deadline && this.batchId !== null) {
+      const compiling = this.isCompiling?.() ?? false
+      if (!compiling && this.now() - this.lastActivityAt >= quietMs) {
+        return
+      }
+      await sleep(pollMs)
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const handle = setTimeout(resolve, ms)
+    handle.unref?.()
+  })
+}
+
+let controller: AgentHmrBatchController | undefined
+
+/**
+ * Process-wide controller. The dev server runs one bundler per process, and
+ * the MCP tools that open and close batches live in that same process, so a
+ * singleton is the whole scope of a batch.
+ */
+export function getAgentHmrBatchController(): AgentHmrBatchController {
+  if (!controller) {
+    controller = new AgentHmrBatchController()
+  }
+  return controller
+}

--- a/packages/next/src/server/dev/hot-middleware.ts
+++ b/packages/next/src/server/dev/hot-middleware.ts
@@ -30,6 +30,7 @@ import type { HmrMessageSentToBrowser } from './hot-reloader-types'
 import { HMR_MESSAGE_SENT_TO_BROWSER } from './hot-reloader-types'
 import { devIndicatorServerState } from './dev-indicator-server-state'
 import { createBinaryHmrMessageData } from './messages'
+import { getAgentHmrBatchController } from './agent-hmr-batch'
 import type { NextConfigComplete } from '../config-shared'
 import {
   getRequestInsightsSnapshot,
@@ -82,6 +83,13 @@ export class WebpackHotMiddleware {
   private middlewareLatestStats: { ts: number; stats: webpack.Stats } | null =
     null
   private serverLatestStats: { ts: number; stats: webpack.Stats } | null = null
+  /**
+   * Agent-scoped HMR batching. Inert unless an agent has opened a batch; see
+   * `./agent-hmr-batch.ts`.
+   */
+  private agentHmrBatch = getAgentHmrBatchController()
+  /** Compilers whose invalidation has not finished compiling yet. */
+  private invalidatedCompilers = new Set<number>()
 
   constructor(
     compilers: webpack.Compiler[],
@@ -90,6 +98,22 @@ export class WebpackHotMiddleware {
     private config: NextConfigComplete,
     private devToolsConfig: DevToolsConfig
   ) {
+    this.agentHmrBatch.configure({
+      enabled: config.experimental.agentHmrBatching === true,
+      isCompiling: () => this.invalidatedCompilers.size > 0,
+    })
+
+    // Separate taps, so that tracking "is a compilation in flight" cannot
+    // change the early-return conditions the publishing handlers below rely on.
+    compilers.forEach((compiler, index) => {
+      compiler.hooks.invalid.tap('agent-hmr-batch', () => {
+        this.invalidatedCompilers.add(index)
+      })
+      compiler.hooks.done.tap('agent-hmr-batch', () => {
+        this.invalidatedCompilers.delete(index)
+      })
+    })
+
     compilers[0].hooks.invalid.tap(
       'webpack-hot-middleware',
       this.onClientInvalid
@@ -258,12 +282,20 @@ export class WebpackHotMiddleware {
       return
     }
 
-    for (const wsClient of [
-      ...this.clientsWithoutHtmlRequestId,
-      ...this.clientsByHtmlRequestId.values(),
-    ]) {
-      this.publishToClient(wsClient, message)
+    const deliver = () => {
+      for (const wsClient of [
+        ...this.clientsWithoutHtmlRequestId,
+        ...this.clientsByHtmlRequestId.values(),
+      ]) {
+        this.publishToClient(wsClient, message)
+      }
     }
+
+    if (this.agentHmrBatch.intercept(message, deliver)) {
+      return
+    }
+
+    deliver()
   }
 
   publishToLegacyClients = (message: HmrMessageSentToBrowser) => {

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -137,6 +137,7 @@ import {
 } from '../lib/trace/request-insights'
 import { resolvePathToRoute } from '../mcp/tools/utils/resolve-path-to-route'
 import { handleErrorStateResponse } from '../mcp/tools/get-errors'
+import { getAgentHmrBatchController } from './agent-hmr-batch'
 import { handlePageMetadataResponse } from '../mcp/tools/get-page-metadata'
 import { setStackFrameResolver } from '../mcp/tools/utils/format-errors'
 import { recordMcpTelemetry } from '../mcp/mcp-telemetry-tracker'
@@ -823,6 +824,21 @@ export async function createHotReloaderTurbopack(
   let updateInProgress = false
   let pendingServerComponentChanges = false
 
+  // Agent-scoped HMR batching. Inert unless an agent has opened a batch
+  // through the MCP tools, which are only registered when the experimental
+  // flag is set. See `./agent-hmr-batch.ts`.
+  const agentHmrBatch = getAgentHmrBatchController()
+  agentHmrBatch.configure({
+    enabled: nextConfig.experimental.agentHmrBatching === true,
+    isCompiling: () => updateInProgress,
+  })
+  // The per-client message and update queues below already hold everything a
+  // compilation produced, so a batch flush re-drives that flush rather than
+  // duplicating the queue.
+  const disposeAgentHmrBatchResume = agentHmrBatch.onResume(() => {
+    sendEnqueuedMessages()
+  })
+
   function sendServerComponentChanges() {
     sendHmr('server-component-changes', {
       type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
@@ -854,6 +870,13 @@ export async function createHotReloaderTurbopack(
   function sendEnqueuedMessages() {
     if (hasCompilationErrors()) {
       // During compilation errors we want to delay the HMR events until errors are fixed
+      return
+    }
+
+    if (agentHmrBatch.isHolding()) {
+      // An agent is mid-edit. Leave the messages queued so the browser keeps
+      // rendering the last output that compiled; closing the batch calls back
+      // into here to deliver them.
       return
     }
 
@@ -1613,14 +1636,22 @@ export async function createHotReloaderTurbopack(
     },
 
     send(action) {
-      const payload = JSON.stringify(action)
+      const deliver = () => {
+        const payload = JSON.stringify(action)
 
-      for (const client of [
-        ...clientsWithoutHtmlRequestId,
-        ...clientsByHtmlRequestId.values(),
-      ]) {
-        client.send(payload)
+        for (const client of [
+          ...clientsWithoutHtmlRequestId,
+          ...clientsByHtmlRequestId.values(),
+        ]) {
+          client.send(payload)
+        }
       }
+
+      if (agentHmrBatch.intercept(action, deliver)) {
+        return
+      }
+
+      deliver()
     },
 
     getServerComponentsHmrRefreshHash() {
@@ -1970,6 +2001,8 @@ export async function createHotReloaderTurbopack(
       // Report MCP telemetry if MCP server is enabled
       recordMcpTelemetry(opts.telemetry)
 
+      disposeAgentHmrBatchResume()
+
       for (const wsClient of [
         ...clientsWithoutHtmlRequestId,
         ...clientsByHtmlRequestId.values(),
@@ -2054,27 +2087,52 @@ export async function createHotReloaderTurbopack(
           addToErrorsMap(errors, currentTopLevelIssues)
           addErrors(errors, currentEntryIssues)
 
-          for (const client of [
-            ...clientsWithoutHtmlRequestId,
-            ...clientsByHtmlRequestId.values(),
-          ]) {
-            const state = clientStates.get(client)
-            if (!state) {
-              continue
+          // Report the current version without advancing it: a completed
+          // compilation is not itself an edit, and this hash is not consumed by
+          // the Turbopack client. Read here rather than inside the send below,
+          // so that a send an agent batch defers still reports the hash of the
+          // compilation it belongs to.
+          const hash = String(hmrHash)
+
+          const sendBuiltToClients = () => {
+            for (const client of [
+              ...clientsWithoutHtmlRequestId,
+              ...clientsByHtmlRequestId.values(),
+            ]) {
+              const state = clientStates.get(client)
+              if (!state) {
+                continue
+              }
+
+              const clientErrors = new Map(errors)
+              addErrors(clientErrors, state.clientIssues)
+
+              sendToClient(client, {
+                type: HMR_MESSAGE_SENT_TO_BROWSER.BUILT,
+                hash,
+                errors: [...clientErrors.values()],
+                warnings: [],
+              })
             }
+          }
 
-            const clientErrors = new Map(errors)
-            addErrors(clientErrors, state.clientIssues)
-
-            sendToClient(client, {
-              type: HMR_MESSAGE_SENT_TO_BROWSER.BUILT,
-              // Report the current version without advancing it: a completed
-              // compilation is not itself an edit, and this hash is not
-              // consumed by the Turbopack client.
-              hash: String(hmrHash),
-              errors: [...clientErrors.values()],
-              warnings: [],
-            })
+          // The whole fan-out is one unit as far as a batch is concerned: it
+          // is one compilation's result, and the errors on it are what the
+          // batch hands back to the agent that caused them. Client-specific
+          // issues are left out of that summary; they are added per client
+          // when the message is actually delivered.
+          if (
+            !agentHmrBatch.intercept(
+              {
+                type: HMR_MESSAGE_SENT_TO_BROWSER.BUILT,
+                hash,
+                errors: [...errors.values()],
+                warnings: [],
+              },
+              sendBuiltToClients
+            )
+          ) {
+            sendBuiltToClients()
           }
 
           if (hmrEventHappened) {

--- a/packages/next/src/server/mcp/get-or-create-mcp-server.ts
+++ b/packages/next/src/server/mcp/get-or-create-mcp-server.ts
@@ -8,6 +8,8 @@ import { registerGetRoutesTool } from './tools/get-routes'
 import { registerGetCompilationIssuesTool } from './tools/get-compilation-issues'
 import { registerCompileRouteTool } from './tools/compile-route'
 import { registerGetRequestInsightsTool } from './tools/get-request-insights'
+import { registerHmrBatchTools } from './tools/hmr-batch'
+import { getAgentHmrBatchController } from '../dev/agent-hmr-batch'
 import type { HmrMessageSentToBrowser } from '../dev/hot-reloader-types'
 import type { NextConfigComplete } from '../config-shared'
 import type { Project } from '../../build/swc/types'
@@ -65,6 +67,10 @@ export const getOrCreateMcpServer = (options: McpServerOptions) => {
     appDir: options.appDir,
   })
   registerGetRequestInsightsTool(mcpServer)
+
+  if (options.nextConfig.experimental.agentHmrBatching) {
+    registerHmrBatchTools(mcpServer, getAgentHmrBatchController)
+  }
 
   if (options.getTurbopackProject) {
     registerGetCompilationIssuesTool(mcpServer, options.getTurbopackProject)

--- a/packages/next/src/server/mcp/tools/hmr-batch.ts
+++ b/packages/next/src/server/mcp/tools/hmr-batch.ts
@@ -1,0 +1,125 @@
+/**
+ * MCP tools for agent-scoped HMR batching.
+ *
+ * These are the only way to open and close a batch, and they are registered
+ * only when `experimental.agentHmrBatching` is set. See
+ * `../../dev/agent-hmr-batch.ts` for what a batch actually does.
+ *
+ * The intended shape of an agent's turn is:
+ *
+ *   begin_hmr_batch  →  write files  →  end_hmr_batch
+ *
+ * with `end_hmr_batch` being the thing that reports whether the edit compiles.
+ * That is the point of the batch: the errors go to the agent that can still
+ * fix them, while the human watching the preview never sees the intermediate
+ * states.
+ */
+import type { McpServer } from 'next/dist/compiled/@modelcontextprotocol/sdk/server/mcp'
+import z from 'next/dist/compiled/zod'
+import { mcpTelemetryTracker } from '../mcp-telemetry-tracker'
+import {
+  type AgentHmrBatchController,
+  DEFAULT_BATCH_TIMEOUT_MS,
+  MAX_BATCH_TIMEOUT_MS,
+  MIN_BATCH_TIMEOUT_MS,
+} from '../../dev/agent-hmr-batch'
+
+function json(value: unknown, isError?: boolean) {
+  return {
+    ...(isError ? { isError: true } : null),
+    content: [{ type: 'text' as const, text: JSON.stringify(value) }],
+  }
+}
+
+export function registerHmrBatchTools(
+  server: McpServer,
+  getController: () => AgentHmrBatchController
+) {
+  server.registerTool(
+    'begin_hmr_batch',
+    {
+      description:
+        'Open an HMR batch before making a multi-step edit. While the batch is open the dev server ' +
+        'holds back every HMR update, so the browser preview keeps rendering the last output that ' +
+        'compiled instead of flickering through each intermediate step. Always close it with ' +
+        'end_hmr_batch, which reports whether the finished edit compiles. ' +
+        'Batches do not nest: if one is already open this returns that batch instead of opening another.',
+      inputSchema: {
+        timeoutMs: z
+          .number()
+          .int()
+          .describe(
+            'How long the batch may stay open before the dev server closes it on its own, in ' +
+              `milliseconds (default ${DEFAULT_BATCH_TIMEOUT_MS}, clamped to ` +
+              `${MIN_BATCH_TIMEOUT_MS}–${MAX_BATCH_TIMEOUT_MS}). This is a safety net for an agent ` +
+              'that exits without closing its batch; it is not a deadline to plan edits around.'
+          )
+          .optional(),
+      },
+    },
+    async ({ timeoutMs }) => {
+      mcpTelemetryTracker.recordToolCall('mcp/begin_hmr_batch')
+
+      const result = getController().begin({ timeoutMs })
+
+      if (result.status === 'disabled') {
+        return json(
+          {
+            error:
+              'Agent HMR batching is not enabled. Set `experimental.agentHmrBatching: true` in next.config.js.',
+          },
+          true
+        )
+      }
+
+      return json(result)
+    }
+  )
+
+  server.registerTool(
+    'end_hmr_batch',
+    {
+      description:
+        'Close the HMR batch opened by begin_hmr_batch. Waits for the compilation triggered by the ' +
+        'edit to settle, then either delivers the held updates to the browser as a single update ' +
+        '(status "flushed") or, when the edit does not compile, leaves the preview on the last good ' +
+        'state and returns the errors (status "withheld"). A "withheld" result means the errors are ' +
+        'yours to fix: the held updates are still queued and are delivered once the code compiles ' +
+        'again. `compiled: false` means no compilation was observed at all, so an empty error list ' +
+        'says nothing about whether the code is valid.',
+      inputSchema: {},
+    },
+    async () => {
+      mcpTelemetryTracker.recordToolCall('mcp/end_hmr_batch')
+
+      const result = await getController().end()
+
+      if (result.status === 'disabled') {
+        return json(
+          {
+            error:
+              'Agent HMR batching is not enabled. Set `experimental.agentHmrBatching: true` in next.config.js.',
+          },
+          true
+        )
+      }
+
+      return json(result)
+    }
+  )
+
+  server.registerTool(
+    'get_hmr_batch_status',
+    {
+      description:
+        'Report whether an HMR batch is open, how many HMR messages it is holding back, and the ' +
+        'errors from the most recent compilation. Useful for recovering after losing track of ' +
+        'batch state, and for checking whether updates are still queued behind a failed batch.',
+      inputSchema: {},
+    },
+    async () => {
+      mcpTelemetryTracker.recordToolCall('mcp/get_hmr_batch_status')
+      return json(getController().status())
+    }
+  )
+}

--- a/packages/next/src/telemetry/events/build.ts
+++ b/packages/next/src/telemetry/events/build.ts
@@ -281,6 +281,9 @@ export type McpToolName =
   | 'mcp/get_server_action_by_id'
   | 'mcp/get_compilation_issues'
   | 'mcp/compile_route'
+  | 'mcp/begin_hmr_batch'
+  | 'mcp/end_hmr_batch'
+  | 'mcp/get_hmr_batch_status'
 
 export type EventMcpToolUsage = {
   toolName: McpToolName

--- a/packages/next/src/telemetry/events/mcp-telemetry.test.ts
+++ b/packages/next/src/telemetry/events/mcp-telemetry.test.ts
@@ -82,6 +82,9 @@ describe('MCP Telemetry Events', () => {
       'mcp/get_server_action_by_id',
       'mcp/get_compilation_issues',
       'mcp/compile_route',
+      'mcp/begin_hmr_batch',
+      'mcp/end_hmr_batch',
+      'mcp/get_hmr_batch_status',
     ]
 
     const usages = allTools.map((tool, index) => ({
@@ -91,7 +94,7 @@ describe('MCP Telemetry Events', () => {
 
     const events = eventMcpToolUsage(usages)
 
-    expect(events).toHaveLength(9)
+    expect(events).toHaveLength(allTools.length)
 
     events.forEach((event, index) => {
       expect(event.eventName).toBe(EVENT_MCP_TOOL_USAGE)

--- a/test/development/mcp-server/fixtures/hmr-batch-app/app/layout.tsx
+++ b/test/development/mcp-server/fixtures/hmr-batch-app/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/mcp-server/fixtures/hmr-batch-app/app/message.ts
+++ b/test/development/mcp-server/fixtures/hmr-batch-app/app/message.ts
@@ -1,0 +1,1 @@
+export const message = 'initial'

--- a/test/development/mcp-server/fixtures/hmr-batch-app/app/page.tsx
+++ b/test/development/mcp-server/fixtures/hmr-batch-app/app/page.tsx
@@ -1,0 +1,5 @@
+import { message } from './message'
+
+export default function Page() {
+  return <p id="message">{message}</p>
+}

--- a/test/development/mcp-server/fixtures/hmr-batch-app/next.config.js
+++ b/test/development/mcp-server/fixtures/hmr-batch-app/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  experimental: {
+    mcpServer: true,
+    agentHmrBatching: true,
+  },
+}

--- a/test/development/mcp-server/mcp-server-hmr-batch.test.ts
+++ b/test/development/mcp-server/mcp-server-hmr-batch.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Agent-scoped HMR batching, end to end against a real dev server.
+ *
+ * The reproduction these tests encode: an agent making a multi-step edit
+ * produces one HMR update per step, so the browser preview walks through every
+ * half-finished intermediate state, and compile errors land in the browser's
+ * error overlay rather than in the hands of the agent that caused them.
+ */
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry, waitForNoRedbox } from 'next-test-utils'
+
+describe('mcp-server agent HMR batching', () => {
+  const { next, skipped } = nextTestSetup({
+    files: path.join(__dirname, 'fixtures', 'hmr-batch-app'),
+  })
+
+  if (skipped) {
+    return
+  }
+
+  async function callMcp(method: string, params: object) {
+    const response = await fetch(`${next.url}/_next/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'hmr-batch',
+        method,
+        params,
+      }),
+    })
+
+    const text = await response.text()
+    const match = text.match(/data: ({.*})/s)
+    expect(match).toBeTruthy()
+    return JSON.parse(match![1]).result
+  }
+
+  async function callTool(name: string, args: object = {}) {
+    const result = await callMcp('tools/call', { name, arguments: args })
+    return JSON.parse(result?.content?.[0]?.text)
+  }
+
+  type BatchStatus = {
+    enabled: boolean
+    open: boolean
+    batchId: string | null
+    heldMessageCount: number
+    heldMessageTypes: Record<string, number>
+    pendingFromPreviousBatch: number
+    errors: Array<{ message: string }>
+  }
+
+  const getStatus = (): Promise<BatchStatus> => callTool('get_hmr_batch_status')
+
+  /** How many compilations this batch has held so far. */
+  const builtCount = (status: BatchStatus) => status.heldMessageTypes.built ?? 0
+
+  async function setMessage(value: string) {
+    await next.patchFile(
+      'app/message.ts',
+      `export const message = '${value}'\n`
+    )
+  }
+
+  /**
+   * Writes a file and waits until the dev server has finished compiling it and
+   * the open batch has held the result. Waiting on the batch's own accounting
+   * rather than on a timeout is what makes "the preview did not move" a real
+   * assertion instead of a race.
+   */
+  async function editAndAwaitHeldCompile(write: () => Promise<void>) {
+    const before = builtCount(await getStatus())
+    await write()
+
+    let status: BatchStatus
+    await retry(async () => {
+      status = await getStatus()
+      expect(builtCount(status)).toBeGreaterThan(before)
+    }, 30_000)
+
+    return status!
+  }
+
+  const readMessage = (browser: Awaited<ReturnType<typeof next.browser>>) =>
+    browser.elementByCss('#message').text()
+
+  afterEach(async () => {
+    // Leave no batch open for the next test, whatever happened in this one.
+    const status = await getStatus()
+    if (status.open) {
+      await callTool('end_hmr_batch')
+    }
+  })
+
+  it('exposes the batch tools when experimental.agentHmrBatching is on', async () => {
+    const { tools } = await callMcp('tools/list', {})
+    const names = tools.map((tool: { name: string }) => tool.name)
+
+    expect(names).toContain('begin_hmr_batch')
+    expect(names).toContain('end_hmr_batch')
+    expect(names).toContain('get_hmr_batch_status')
+
+    expect(await getStatus()).toMatchObject({
+      enabled: true,
+      open: false,
+      batchId: null,
+    })
+  })
+
+  it('changes nothing about HMR while no batch is open', async () => {
+    await setMessage('no-batch-before')
+    const browser = await next.browser('/')
+    await retry(async () => {
+      expect(await readMessage(browser)).toBe('no-batch-before')
+    }, 15_000)
+
+    await setMessage('no-batch-after')
+
+    await retry(async () => {
+      expect(await readMessage(browser)).toBe('no-batch-after')
+    }, 15_000)
+  })
+
+  it('keeps the preview on the last good state for the length of a batch', async () => {
+    await setMessage('before-batch')
+    const browser = await next.browser('/')
+    await retry(async () => {
+      expect(await readMessage(browser)).toBe('before-batch')
+    }, 15_000)
+
+    const begun = await callTool('begin_hmr_batch')
+    expect(begun).toMatchObject({ status: 'opened' })
+
+    // A multi-step edit: three separate writes, each compiled by the dev
+    // server, none of them shown.
+    for (const step of ['step-1', 'step-2', 'step-3']) {
+      await editAndAwaitHeldCompile(() => setMessage(step))
+      expect(await readMessage(browser)).toBe('before-batch')
+    }
+
+    const status = await getStatus()
+    expect(status.open).toBe(true)
+    expect(status.batchId).toBe(begun.batchId)
+    expect(status.heldMessageCount).toBeGreaterThan(0)
+
+    const ended = await callTool('end_hmr_batch')
+    expect(ended).toMatchObject({
+      status: 'flushed',
+      batchId: begun.batchId,
+      compiled: true,
+      errors: [],
+      previewPreserved: true,
+    })
+
+    // One jump, from the state before the batch straight to the final one.
+    await retry(async () => {
+      expect(await readMessage(browser)).toBe('step-3')
+    }, 15_000)
+  })
+
+  it('hands compile errors to the agent and leaves the preview alone', async () => {
+    await setMessage('last-good')
+    const browser = await next.browser('/')
+    await retry(async () => {
+      expect(await readMessage(browser)).toBe('last-good')
+    }, 15_000)
+
+    expect(await callTool('begin_hmr_batch')).toMatchObject({
+      status: 'opened',
+    })
+
+    await editAndAwaitHeldCompile(async () => {
+      await next.patchFile(
+        'app/message.ts',
+        `import { missing } from './does-not-exist'\n` +
+          `export const message = missing\n`
+      )
+    })
+
+    const ended = await callTool('end_hmr_batch')
+
+    expect(ended.status).toBe('withheld')
+    expect(ended.compiled).toBe(true)
+    expect(ended.errors.length).toBeGreaterThan(0)
+    expect(
+      ended.errors.map((error: { message: string }) => error.message).join('\n')
+    ).toContain('does-not-exist')
+
+    // The error went to the agent, not to the human watching the preview.
+    expect(await readMessage(browser)).toBe('last-good')
+    await waitForNoRedbox(browser)
+
+    // The held updates were not thrown away: fixing the code releases them.
+    await setMessage('after-fix')
+    await retry(async () => {
+      expect(await readMessage(browser)).toBe('after-fix')
+    }, 15_000)
+  })
+
+  it('does not nest batches', async () => {
+    const first = await callTool('begin_hmr_batch')
+    expect(first.status).toBe('opened')
+
+    const second = await callTool('begin_hmr_batch')
+    expect(second).toMatchObject({
+      status: 'already-open',
+      batchId: first.batchId,
+    })
+
+    const ended = await callTool('end_hmr_batch')
+    expect(ended.batchId).toBe(first.batchId)
+
+    expect(await callTool('end_hmr_batch')).toMatchObject({
+      status: 'no-batch',
+    })
+  })
+})


### PR DESCRIPTION
Adds experimental `agentHmrBatching`, so an AI coding agent can group a multi-step edit into a single HMR update and receive the compile errors itself instead of showing them to whoever is watching the preview. Off by default; inert unless an agent explicitly opens a batch.

Follows the agent-scoped HMR batching discussion in [this Slack thread](https://vercel.slack.com/archives/C06QB6ZPEQ6/p1787527246637289) — proof of concept for the two things it asked for: preserve the last good preview across an agent's intermediate edits, and return compile errors to the agent when the batch completes.

## The problem

An agent edits in many small steps: rename a component, then update its three call sites, then add the prop it now needs. Each write is a file change, so the dev server compiles it and pushes an HMR update, and the preview walks through every intermediate state the agent passed through — including the ones that only make sense half-finished. Meanwhile the errors from those states go to the browser's error overlay, in front of a person, rather than back to the agent that can still fix them.

## What a batch does

```
begin_hmr_batch  →  write files  →  end_hmr_batch
```

While the batch is open, every HMR message that would change what the browser renders is held instead of delivered, so the preview keeps showing the last output that compiled. `end_hmr_batch` waits for the compilation to settle and then either:

- **`status: "flushed"`** — the code compiles. Held messages are delivered as one coalesced burst, so the preview goes straight from the last good state to the new one and never renders anything in between.
- **`status: "withheld"`** — the code does not compile. Nothing is delivered, the preview stays on the last good state, and the errors are returned in the tool result. The queue survives, so the next clean compile releases it; the browser catches up rather than being left stale.

Enable with:

```js
// next.config.js
module.exports = {
  experimental: {
    mcpServer: true, // on by default; the batch tools live on the MCP server
    agentHmrBatching: true,
  },
}
```

## How it works

`packages/next/src/server/dev/agent-hmr-batch.ts` is a small controller that both hot reloaders consult at their delivery boundary. Each HMR message type is classified once, in an exhaustive `Record` over the message union so a new type cannot silently inherit a default:

- **hold** — Turbopack updates, `built`/`sync`, page reloads, RSC/client/middleware change signals, `serverError`. These move the preview.
- **drop** — `building`. The flush reports the outcome, so replaying a spinner for a finished build only causes a flash.
- **pass** — per-request plumbing, devtools state, indicators. Holding these would break those features during a batch for no benefit.

Held messages coalesce by type where a message carries the whole current state (only the last `built` matters), and are queued individually where it does not (Turbopack updates are incremental module patches that all have to be applied). Coalescing moves the survivor to the end of the queue, so module updates still land ahead of the `built` that concludes them.

Wiring, per bundler:

- **Turbopack** — `hotReloader.send` and the per-compilation `built` fan-out go through the gate; `sendEnqueuedMessages` returns early while a batch is holding, leaving messages in the existing per-client queues, and the batch re-drives that flush when it ends. Reuses the queues that are already there rather than adding a second one.
- **webpack/rspack** — `WebpackHotMiddleware.publish` goes through the same gate.

Errors reported to the agent are read off the `built`/`sync` messages the gate already sees, so no separate error-collection path was needed.

Safety properties, since a wedged batch would be worse than the flicker it prevents:

- **Watchdog.** Every batch has a timeout (30s default, `timeoutMs` per batch, clamped to 1s–5min). An agent that exits without closing its batch does not leave the preview frozen — the dev server closes it, releases the held updates, logs a warning, and reports `timedOut: true` to a late `end_hmr_batch`.
- **Bounded queue.** Past 512 held messages the queue flushes early and the result says `previewPreserved: false`, rather than growing without limit.
- **Settling.** The agent's last write and its recompile are not synchronous with `end_hmr_batch`, so it waits for the compilation to go quiet before reporting. When no compilation was observed at all the result says `compiled: false`, so an empty `errors` is never mistaken for a clean build.
- **No nesting.** `begin_hmr_batch` on an open batch returns that batch instead of discarding its queue.

## Tests

- `packages/next/src/server/dev/agent-hmr-batch.test.ts` — 28 unit tests over the controller with injected time and timers: hold/drop/pass classification, coalescing and ordering, flush vs. withhold, releasing a withheld queue on the next clean compile (and *not* on a still-failing one), no stale-error replay, watchdog, queue cap, settling.
- `test/development/mcp-server/mcp-server-hmr-batch.test.ts` — 5 e2e tests against a real dev server and a real browser: a three-step edit inside a batch leaves the preview on its pre-batch state and then jumps straight to the final one; a batch that ends broken returns the errors, leaves the preview alone with no redbox, and releases the held updates once the code is fixed; HMR is unchanged with no batch open.

Rather than sleeping and hoping, the e2e tests wait on the batch's own accounting (`get_hmr_batch_status` reports how many compilations it has held), so "the preview did not move" is asserted after the dev server has provably compiled and held each step.

Verified locally: unit tests pass; the e2e suite passes on both `test-dev-turbo` and `test-dev-webpack`; the full `test/development/mcp-server/` directory passes (48 tests) with no regressions in the existing MCP tools.

## Limitations

- Batching holds back HMR pushes to already-connected clients. It does not freeze the server: a reload or a fresh navigation during a batch renders the current state of the code, half-finished or not.
- Warnings are only as good as what the bundler puts on the HMR message; Turbopack currently sends none, so `warnings` is empty there.
