### PR TITLE
Fix standalone output absolute symlink targets

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1293,8 +1293,39 @@ export async function copyTracedFiles(
           const symlink = await fs.readlink(tracedFilePath).catch(() => null)
 
           if (symlink) {
+            let symlinkTarget = symlink
+            let junctionTarget = symlink
+
+            if (path.isAbsolute(symlink)) {
+              // Junction targets can use the Windows namespaced path format.
+              const relativeTarget = path.relative(
+                path.toNamespacedPath(tracingRoot),
+                path.toNamespacedPath(symlink)
+              )
+              const isTargetInsideTracingRoot =
+                relativeTarget === '' ||
+                (relativeTarget !== '..' &&
+                  !relativeTarget.startsWith(`..${path.sep}`) &&
+                  !path.isAbsolute(relativeTarget))
+
+              if (isTargetInsideTracingRoot) {
+                junctionTarget = path.join(outputPath, relativeTarget)
+                symlinkTarget =
+                  path.relative(path.dirname(fileOutputPath), junctionTarget) ||
+                  '.'
+              }
+            }
+
+            // The target might not exist in the output yet. Read its type from
+            // the source so that Windows can create the correct link.
+            const targetStat = await fs.stat(tracedFilePath).catch(() => null)
+
             try {
-              await fs.symlink(symlink, fileOutputPath)
+              await fs.symlink(
+                symlinkTarget,
+                fileOutputPath,
+                targetStat?.isDirectory() ? 'dir' : 'file'
+              )
             } catch (err: any) {
               // Windows doesn't support creating symlinks without elevated privileges, unless
               // "Developer Mode" is turned on. If we failed to create a symlink due to EPERM, try
@@ -1307,10 +1338,10 @@ export async function copyTracedFiles(
               if (
                 process.platform === 'win32' &&
                 err.code === 'EPERM' &&
-                path.isAbsolute(symlink)
+                path.isAbsolute(junctionTarget)
               ) {
                 try {
-                  await fs.symlink(symlink, fileOutputPath, 'junction')
+                  await fs.symlink(junctionTarget, fileOutputPath, 'junction')
                 } catch (junctionErr: any) {
                   if (junctionErr.code !== 'EEXIST') {
                     throw junctionErr

--- a/test/unit/copy-traced-files.test.ts
+++ b/test/unit/copy-traced-files.test.ts
@@ -1,0 +1,216 @@
+/* eslint-env jest */
+
+import fs from 'fs-extra'
+import os from 'node:os'
+import path from 'node:path'
+import { copyTracedFiles } from 'next/dist/build/utils'
+
+function isPathInside(parent: string, child: string) {
+  const relative = path.relative(parent, child)
+  return (
+    relative === '' ||
+    (relative !== '..' &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  )
+}
+
+async function copyTrace(projectDir: string, files: string[]) {
+  const distDir = path.join(projectDir, '.next')
+
+  await fs.outputJson(path.join(projectDir, 'package.json'), { name: 'app' })
+  await fs.outputJson(path.join(distDir, 'next-server.js.nft.json'), {
+    version: 1,
+    files,
+  })
+
+  await copyTracedFiles(
+    projectDir,
+    distDir,
+    [],
+    undefined,
+    projectDir,
+    {} as any,
+    {
+      version: 3,
+      middleware: {},
+      functions: {},
+      sortedMiddleware: [],
+    } as any,
+    false,
+    false,
+    new Set()
+  )
+
+  return path.join(distDir, 'standalone')
+}
+
+describe('copyTracedFiles', () => {
+  let testDir: string
+
+  beforeEach(async () => {
+    testDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'next-copy-traced-files-'))
+    )
+  })
+
+  afterEach(async () => {
+    await fs.remove(testDir)
+  })
+
+  it('remaps absolute directory links into the standalone output', async () => {
+    const projectDir = path.join(testDir, 'project')
+    const packageTarget = path.join(
+      projectDir,
+      'node_modules/.pnpm/my-pkg@1.0.0/node_modules/my-pkg'
+    )
+    const packageLink = path.join(projectDir, 'node_modules/my-pkg')
+
+    await fs.outputFile(
+      path.join(packageTarget, 'index.js'),
+      'module.exports = 1'
+    )
+    await fs.ensureDir(path.dirname(packageLink))
+    await fs.symlink(
+      packageTarget,
+      packageLink,
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    const standaloneDir = await copyTrace(projectDir, [
+      '../node_modules/my-pkg',
+      '../node_modules/.pnpm/my-pkg@1.0.0/node_modules/my-pkg/index.js',
+    ])
+
+    const copiedLink = path.join(standaloneDir, 'node_modules/my-pkg')
+    const copiedTarget = await fs.readlink(copiedLink)
+    const resolvedTarget = path.resolve(path.dirname(copiedLink), copiedTarget)
+
+    expect(isPathInside(standaloneDir, resolvedTarget)).toBe(true)
+    expect(await fs.readFile(path.join(copiedLink, 'index.js'), 'utf8')).toBe(
+      'module.exports = 1'
+    )
+
+    // POSIX supports relative directory links without special privileges, so
+    // the standalone output should remain valid after being relocated.
+    if (process.platform !== 'win32') {
+      expect(path.isAbsolute(copiedTarget)).toBe(false)
+
+      const movedStandaloneDir = path.join(testDir, 'moved-standalone')
+      await fs.move(standaloneDir, movedStandaloneDir)
+      await fs.remove(projectDir)
+
+      expect(
+        await fs.readFile(
+          path.join(movedStandaloneDir, 'node_modules/my-pkg/index.js'),
+          'utf8'
+        )
+      ).toBe('module.exports = 1')
+    }
+  })
+
+  it('uses dot for an absolute link to its own parent', async () => {
+    const projectDir = path.join(testDir, 'project')
+    const packageTarget = path.join(projectDir, 'node_modules/my-pkg')
+    const packageLink = path.join(packageTarget, 'self')
+
+    await fs.ensureDir(packageTarget)
+    await fs.symlink(
+      packageTarget,
+      packageLink,
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+
+    const standaloneDir = await copyTrace(projectDir, [
+      '../node_modules/my-pkg/self',
+    ])
+    const copiedPackageDir = path.join(standaloneDir, 'node_modules/my-pkg')
+    const copiedLink = path.join(copiedPackageDir, 'self')
+
+    expect(await fs.realpath(copiedLink)).toBe(
+      await fs.realpath(copiedPackageDir)
+    )
+  })
+
+  it('preserves absolute directory links outside the tracing root', async () => {
+    const projectDir = path.join(testDir, 'project')
+    const packageTarget = path.join(testDir, 'external-package')
+    const packageLink = path.join(projectDir, 'node_modules/external-package')
+
+    await fs.outputFile(
+      path.join(packageTarget, 'index.js'),
+      'module.exports = 1'
+    )
+    await fs.ensureDir(path.dirname(packageLink))
+    await fs.symlink(
+      packageTarget,
+      packageLink,
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    const sourceTarget = await fs.readlink(packageLink)
+
+    const standaloneDir = await copyTrace(projectDir, [
+      '../node_modules/external-package',
+    ])
+    const copiedLink = path.join(standaloneDir, 'node_modules/external-package')
+    const copiedTarget = await fs.readlink(copiedLink)
+    const resolvedTarget = await fs.realpath(copiedLink)
+
+    expect(path.isAbsolute(copiedTarget)).toBe(true)
+    expect(path.resolve(copiedTarget)).toBe(path.resolve(sourceTarget))
+    expect(resolvedTarget).toBe(await fs.realpath(packageTarget))
+    expect(isPathInside(standaloneDir, resolvedTarget)).toBe(false)
+  })
+
+  if (process.platform !== 'win32') {
+    it('preserves existing relative directory links', async () => {
+      const projectDir = path.join(testDir, 'project')
+      const packageTarget = path.join(
+        projectDir,
+        'node_modules/.pnpm/my-pkg@1.0.0/node_modules/my-pkg'
+      )
+      const packageLink = path.join(projectDir, 'node_modules/my-pkg')
+      const relativeTarget = '.pnpm/my-pkg@1.0.0/node_modules/my-pkg'
+
+      await fs.outputFile(
+        path.join(packageTarget, 'index.js'),
+        'module.exports = 1'
+      )
+      await fs.ensureDir(path.dirname(packageLink))
+      await fs.symlink(relativeTarget, packageLink, 'dir')
+
+      const standaloneDir = await copyTrace(projectDir, [
+        '../node_modules/my-pkg',
+        '../node_modules/.pnpm/my-pkg@1.0.0/node_modules/my-pkg/index.js',
+      ])
+      const copiedLink = path.join(standaloneDir, 'node_modules/my-pkg')
+
+      expect(await fs.readlink(copiedLink)).toBe(relativeTarget)
+      expect(await fs.readFile(path.join(copiedLink, 'index.js'), 'utf8')).toBe(
+        'module.exports = 1'
+      )
+    })
+
+    it('remaps absolute file links into the standalone output', async () => {
+      const projectDir = path.join(testDir, 'project')
+      const fileTarget = path.join(projectDir, 'files/target.js')
+      const fileLink = path.join(projectDir, 'files/link.js')
+
+      await fs.outputFile(fileTarget, 'module.exports = 1')
+      await fs.symlink(fileTarget, fileLink, 'file')
+
+      const standaloneDir = await copyTrace(projectDir, [
+        '../files/link.js',
+        '../files/target.js',
+      ])
+      const copiedLink = path.join(standaloneDir, 'files/link.js')
+      const copiedTarget = await fs.readlink(copiedLink)
+
+      expect(path.isAbsolute(copiedTarget)).toBe(false)
+      expect(isPathInside(standaloneDir, await fs.realpath(copiedLink))).toBe(
+        true
+      )
+      expect(await fs.readFile(copiedLink, 'utf8')).toBe('module.exports = 1')
+    })
+  }
+})


### PR DESCRIPTION
## Summary

- remap absolute traced symlink and junction targets inside outputFileTracingRoot to the corresponding standalone output path
- prefer relative symlink targets so standalone artifacts remain portable, while retaining an absolute in-output target for the Windows junction fallback
- preserve relative links and absolute links outside the tracing root, with cross-platform regression coverage

Closes #95450.

This also keeps the generated standalone tree relocatable on platforms that support relative directory symlinks, rather than binding copied links to the original output directory.

## Verification

- `pnpm jest test/unit/copy-traced-files.test.ts --runInBand`
- `pnpm test-start-turbo test/production/pnpm-support/index.test.ts`
- `pnpm test-start-webpack test/production/pnpm-support/index.test.ts`
- reporter reproduction at commit 4041811b65f031f80a5931872bf91caa254e2eab with an absolute pnpm directory link: `pnpm build && pnpm test` resolves `next` inside standalone; the moved artifact remains readable after source `node_modules` is removed
- `pnpm --filter=next build`
- `pnpm --filter=next types`
- Not run: `pnpm build-all` (the checked-in DevBox image does not include Cargo/Rust; the JavaScript package build passed)

<!-- NEXT_JS_LLM -->