### PR TITLE
Test Turbopack dev with zero output retention

### DIFF
--- a/test/e2e/app-dir/app/next.config.js
+++ b/test/e2e/app-dir/app/next.config.js
@@ -9,6 +9,7 @@ module.exports = {
     clientRouterFilterRedirects: true,
     parallelServerCompiles: true,
     parallelServerBuildTraces: true,
+    turbopackStaleOutputMaxAge: 0,
     webpackBuildWorker: true,
   },
   // output: 'standalone',


### PR DESCRIPTION
## Summary

Set `experimental.turbopackStaleOutputMaxAge` to `0` in the broad app-dir development fixture to exercise the complete Turbopack-owned output sweep on every startup.

Depends on #97833.

## Verification

- `pnpm test-dev-turbo test/e2e/app-dir/app/index.test.ts` (111 passed, 8 skipped)

<!-- NEXT_JS_LLM -->