### PR TITLE
fix: avoid duplicate close listeners in proxy requests

### DIFF
--- a/packages/next/src/server/lib/router-utils/proxy-request.test.ts
+++ b/packages/next/src/server/lib/router-utils/proxy-request.test.ts
@@ -1,0 +1,152 @@
+/* eslint-env jest */
+import type { AddressInfo } from 'node:net'
+import type { NextUrlWithParsedQuery } from '../../request-meta'
+
+import http from 'node:http'
+
+import { proxyRequest } from './proxy-request'
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: unknown) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve']
+  let reject!: Deferred<T>['reject']
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+async function listen(server: http.Server): Promise<string> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address() as AddressInfo
+  return `http://127.0.0.1:${port}`
+}
+
+async function closeServer(server: http.Server | undefined) {
+  if (!server?.listening) return
+  server.closeAllConnections()
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()))
+  })
+}
+
+function toParsedUrl(target: string): NextUrlWithParsedQuery {
+  const parsed = new URL(target)
+  return {
+    auth: null,
+    hash: parsed.hash || null,
+    hostname: parsed.hostname,
+    href: parsed.href,
+    pathname: parsed.pathname,
+    port: parsed.port || null,
+    protocol: parsed.protocol,
+    query: Object.fromEntries(parsed.searchParams),
+    search: parsed.search || null,
+    slashes: true,
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>): Promise<T> {
+  let timer: NodeJS.Timeout
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error('Timed out')), 5_000)
+      timer.unref()
+    }),
+  ]).finally(() => clearTimeout(timer))
+}
+
+describe('proxyRequest', () => {
+  let targetServer: http.Server | undefined
+  let proxyServer: http.Server | undefined
+
+  afterEach(async () => {
+    await closeServer(proxyServer)
+    await closeServer(targetServer)
+    proxyServer = undefined
+    targetServer = undefined
+  })
+
+  it('does not add redundant close listeners to the response', async () => {
+    targetServer = http.createServer((_req, res) => res.end('proxied'))
+    const targetUrl = await listen(targetServer)
+    const closeListenerCount = deferred<number>()
+    const proxyError = deferred<never>()
+
+    proxyServer = http.createServer((req, res) => {
+      const initialCount = res.listenerCount('close')
+      res.once('finish', () => {
+        closeListenerCount.resolve(res.listenerCount('close') - initialCount)
+      })
+      proxyRequest(req, res, toParsedUrl(targetUrl)).catch(proxyError.reject)
+    })
+    const proxyUrl = await listen(proxyServer)
+
+    const response = await fetch(proxyUrl)
+    expect(await response.text()).toBe('proxied')
+    expect(
+      await Promise.race([closeListenerCount.promise, proxyError.promise])
+    ).toBeLessThanOrEqual(5)
+  })
+
+  it('aborts the upstream request when the client disconnects before a response', async () => {
+    const targetReceived = deferred<void>()
+    const targetClosed = deferred<void>()
+
+    targetServer = http.createServer((_req, res) => {
+      targetReceived.resolve()
+      res.once('close', () => targetClosed.resolve())
+    })
+    const targetUrl = await listen(targetServer)
+
+    proxyServer = http.createServer((req, res) => {
+      proxyRequest(req, res, toParsedUrl(targetUrl)).catch(() => {})
+    })
+    const proxyUrl = await listen(proxyServer)
+
+    const clientRequest = http.request(proxyUrl)
+    clientRequest.on('error', () => {})
+    clientRequest.end()
+
+    await withTimeout(targetReceived.promise)
+    clientRequest.destroy()
+    await withTimeout(targetClosed.promise)
+  })
+
+  it('aborts the upstream response when the client disconnects while streaming', async () => {
+    const targetStarted = deferred<void>()
+    const targetClosed = deferred<void>()
+
+    targetServer = http.createServer((_req, res) => {
+      res.once('close', () => targetClosed.resolve())
+      res.write('first chunk')
+      targetStarted.resolve()
+    })
+    const targetUrl = await listen(targetServer)
+
+    proxyServer = http.createServer((req, res) => {
+      proxyRequest(req, res, toParsedUrl(targetUrl)).catch(() => {})
+    })
+    const proxyUrl = await listen(proxyServer)
+
+    const clientClosed = deferred<void>()
+    const clientRequest = http.get(proxyUrl, (res) => {
+      res.once('data', () => {
+        res.destroy()
+        clientClosed.resolve()
+      })
+    })
+    clientRequest.on('error', () => {})
+
+    await withTimeout(targetStarted.promise)
+    await withTimeout(clientClosed.promise)
+    await withTimeout(targetClosed.promise)
+  })
+})

--- a/packages/next/src/server/lib/router-utils/proxy-request.ts
+++ b/packages/next/src/server/lib/router-utils/proxy-request.ts
@@ -42,22 +42,12 @@ export async function proxyRequest(
 
   let finished = false
 
-  // httpxy does not properly detect a client disconnect in newer
-  // versions of Node.js. This is caused because it only listens for the
-  // `aborted` event on the our request object, but it also fully reads
-  // and closes the request object. Node **will not** fire `aborted` when
-  // the request is already closed. Listening for `close` on our response
-  // object will detect the disconnect, and we can abort the proxy's
-  // connection.
-  proxy.on('proxyReq', (proxyReq) => {
-    res.on('close', () => proxyReq.destroy())
-  })
-
+  // httpxy destroys the proxy request and response when the client
+  // disconnects. The disconnect can happen before the proxy response is
+  // emitted, so handle that race before httpxy attaches its close listener.
   proxy.on('proxyRes', (proxyRes) => {
     if (res.destroyed) {
       proxyRes.destroy()
-    } else {
-      res.on('close', () => proxyRes.destroy())
     }
   })
 


### PR DESCRIPTION
### What?

Remove the two `ServerResponse` close listeners that Next.js retained from its former `http-proxy` integration. Keep the immediate `res.destroyed` check, which covers a response that closed before `httpxy` emits `proxyRes`.

Add focused tests for:

- the number of close listeners added during a normal proxy request
- a client disconnect before the upstream responds
- a client disconnect while the upstream response is streaming

### Why?

`httpxy` v0.5.5 already destroys both the upstream request and response when the downstream client disconnects. When #96060 replaced `http-proxy` with `httpxy`, Next.js kept its older disconnect workaround as well. Those two duplicate listeners raise the per-response listener count from 9 to 11 in the issue reproduction and trigger Node.js's `MaxListenersExceededWarning`.

This keeps the `httpxy` migration and removes only the redundant ownership.

### How?

Validated with the issue reproduction in development, production, and standalone modes. Each mode completed 5 sequential and 30 concurrent external rewrites with 9 close listeners per response and no max-listener warning.

Also ran:

- `pnpm testonly packages/next/src/server/lib/router-utils/proxy-request.test.ts --runInBand`
- `pnpm testonly-dev test/e2e/rewrites-hostname/rewrites-hostname.test.ts --runInBand`
- `pnpm testonly-start test/e2e/rewrites-hostname/rewrites-hostname.test.ts --runInBand`
- `pnpm --filter=next typescript`
- targeted ESLint
- `pnpm build --filter=next`

Fixes #97757
