### PR TITLE
Release extra-chunks abort listeners when instant validation bails out

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -339,6 +339,7 @@ import type {
   PrefetchedSegmentStage,
   SegmentStage,
   StageEndTimes,
+  ValidationPayloadResult,
 } from './instant-validation/instant-validation'
 
 export type GetDynamicParamFromSegment = (
@@ -7494,20 +7495,29 @@ async function validateInstantConfigs(
         ? extraChunksController.signal
         : AbortSignal.any([extraChunksController.signal, validationAbortSignal])
 
-    const payloadResult = await createCombinedPayloadAtDepth(
-      prefetchKind,
-      initialRscPayload,
-      cache,
-      loaderTree,
-      ctx.getDynamicParamFromSegment,
-      ctx.query,
-      depth,
-      groupDepthForValidation,
-      extraChunksSignal,
-      boundaryState,
-      clientReferenceManifest,
-      overrideStageForPartialSegments
-    )
+    let payloadResult: ValidationPayloadResult | null = null
+    try {
+      payloadResult = await createCombinedPayloadAtDepth(
+        prefetchKind,
+        initialRscPayload,
+        cache,
+        loaderTree,
+        ctx.getDynamicParamFromSegment,
+        ctx.query,
+        depth,
+        groupDepthForValidation,
+        extraChunksSignal,
+        boundaryState,
+        clientReferenceManifest,
+        overrideStageForPartialSegments
+      )
+    } finally {
+      // `createCombinedPayloadStream` releases this on the path that continues.
+      if (payloadResult === null) {
+        // Release React's listener from the composite signal.
+        extraChunksController.abort()
+      }
+    }
 
     if (payloadResult === null) {
       return null


### PR DESCRIPTION
Follow-up to #97476. That PR fixed composite abort signal retention in `use-cache-wrapper`, and #97776 mentions in passing that `app-render.tsx` still has the same problem with `extraChunksController` and that nobody had picked it up. So here it is.

Worth saying up front: this only affects `next dev`. Build validation calls `validateInstantConfigs` without a `validationAbortSignal`, so there's no composite there to retain. Only `runDevValidationInBackground` passes one.

### What's going on

`validateOrRetryAtDepth` makes a controller per attempt and composes it with the dev validation signal:

```ts
const extraChunksController = new AbortController()
const extraChunksSignal =
  validationAbortSignal === undefined
    ? extraChunksController.signal
    : AbortSignal.any([extraChunksController.signal, validationAbortSignal])
```

That signal goes down as `releaseSignal`. Any partial segment `deserializeFromChunks` handles ends up in `createNodeStreamWithLateRelease`, which adds an abort listener to it, and that listener closes over the chunk arrays and the Readable.

On the path that continues, `createCombinedPayloadStream` aborts the controller, the composite fires, and the listeners go away. But `createCombinedPayloadAtDepth` returns `null` when the route doesn't need instant UI, and we return before we ever get there. Same story if it throws.

Node holds onto non-empty composite signals while they still have abort listeners and haven't aborted, and nothing here can release it:

- The composite never aborts. `extraChunksController` isn't aborted on this path, and the generation's controller isn't either — `DevValidationGeneration.finish()` only deletes the scheduler's map entry, so a generation that settles normally drops its controller without ever aborting it.
- The listener count never reaches zero.
- The source set never empties either, because `extraChunksController.signal` is still reachable through the composite itself.

So every attempt that bails leaves behind a pinned composite holding that attempt's chunks, and they pile up for as long as the dev server runs.

### The fix

Abort `extraChunksController` when we don't make it to `createCombinedPayloadStream`. Aborting a source triggers the composite and the listeners get dropped, same as #97476.

I put it in a `finally` so the throw case is covered too. This is the release the signal is named for, and it's what `createCombinedPayloadStream` already does one branch over. Nothing reads the payload past this point either way, so the listeners just flush their leftover chunks into Readables that are already unreachable and close them. And if `validationAbortSignal` is undefined the signal isn't a composite at all, so the abort only ends those discarded streams.

### How I checked it

- `pnpm build` passes and the abort shows up in the built `dist/server/app-render/app-render.js`.
- Type check, prettier and eslint clean.
- Wrote a small GC probe on Node 24.19.0 that reproduces the retention on its own (long-lived signal, per-iteration controller, one listener closing over a buffer). Without the release, 200/200 buffers are still reachable after `global.gc()`, for both the `null` return and the throw. With it, 0/200 for both.
- `test/e2e/app-dir/instant-validation/client.test.ts` in dev/webpack: 13 pass, 11 fail. The 11 are inline snapshots that contain paths, and I'm on Windows, so they come out as `app\foo\layout.tsx` instead of `app/foo/layout.tsx`. I reverted the change, rebuilt and reran to be sure — baseline gives the identical 11 failures, so it isn't coming from this.

One gap: I couldn't run the Turbopack arm of those suites, since they skip under webpack in start mode and I don't have a Rust toolchain here to build a matching `next-swc`. Would appreciate CI covering that.
