### PR TITLE
Show the errors of an AggregateError behind a cause

### DIFF
--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -579,6 +579,25 @@ function sourceMapError(
   return newError
 }
 
+/**
+ * Node.js passes the remaining depth in `depth`. An `AggregateError` keeps its
+ * errors in an array. Node.js spends one level of the depth on that array, and
+ * one more level on each error in the array. A `cause` costs one level only.
+ * This function adds the missing level back, so an `AggregateError` prints its
+ * errors at the same nesting as a `cause`. Without it, a `fetch` failure logs
+ * `[errors]: [ [Error], [Error] ]` and hides the address and the port of every
+ * refused connection.
+ *
+ * A `depth` of `null` means unlimited, so this function returns it unchanged.
+ */
+function getInspectDepth(error: Error, depth: number | null): number | null {
+  if (depth === null || !(error instanceof AggregateError)) {
+    return depth
+  }
+
+  return depth + 1
+}
+
 export function patchErrorInspectNodeJS(
   errorConstructor: ErrorConstructor
 ): void {
@@ -588,7 +607,7 @@ export function patchErrorInspectNodeJS(
 
   // @ts-expect-error -- TODO upstream types
   errorConstructor.prototype[inspectSymbol] = function (
-    depth: number,
+    depth: number | null,
     inspectOptions: util.InspectOptions,
     inspect: typeof util.inspect
   ): string {
@@ -607,7 +626,7 @@ export function patchErrorInspectNodeJS(
       try {
         return inspect(newError, {
           ...inspectOptions,
-          depth,
+          depth: getInspectDepth(newError, depth),
         })
       } finally {
         ;(newError as any)[inspectSymbol] = originalCustomInspect

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/rsc-error-log-aggregate-nested/page.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/rsc-error-log-aggregate-nested/page.js
@@ -1,0 +1,14 @@
+/* global AggregateError */
+function logError() {
+  const error1 = Object.assign(new Error('Error 1'), { code: 'ERR_ONE' })
+  const error2 = Object.assign(new TypeError('Error 2'), { code: 'ERR_TWO' })
+  const aggregateError = new AggregateError([error1, error2], 'Aggregate')
+  console.error(
+    new Error('rsc-error-log-aggregate-nested', { cause: aggregateError })
+  )
+}
+
+export default function Page() {
+  logError()
+  return null
+}

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -269,6 +269,61 @@ describe('app-dir - server source maps', () => {
     }
   })
 
+  it('logs an AggregateError behind a `cause`', async () => {
+    if (isNextDev) {
+      const outputIndex = next.cliOutput.length
+      await next.render('/rsc-error-log-aggregate-nested')
+
+      await retry(() => {
+        expect(next.cliOutput.slice(outputIndex)).toContain(
+          'Error: rsc-error-log-aggregate-nested'
+        )
+      })
+      expect(normalizeCliOutput(next.cliOutput.slice(outputIndex))).toContain(
+        'Error: rsc-error-log-aggregate-nested' +
+          '\n    at logError (app/rsc-error-log-aggregate-nested/page.js:7:5)' +
+          '\n    at Page (app/rsc-error-log-aggregate-nested/page.js:12:3)' +
+          "\n   5 |   const aggregateError = new AggregateError([error1, error2], 'Aggregate')" +
+          '\n   6 |   console.error(' +
+          "\n>  7 |     new Error('rsc-error-log-aggregate-nested', { cause: aggregateError })" +
+          '\n     |     ^' +
+          '\n   8 |   )' +
+          '\n   9 | }' +
+          '\n  10 | {' +
+          '\n  [cause]: AggregateError: Aggregate' +
+          '\n      at logError (app/rsc-error-log-aggregate-nested/page.js:5:26)' +
+          '\n      at Page (app/rsc-error-log-aggregate-nested/page.js:12:3)' +
+          "\n    3 |   const error1 = Object.assign(new Error('Error 1'), { code: 'ERR_ONE' })" +
+          "\n    4 |   const error2 = Object.assign(new TypeError('Error 2'), { code: 'ERR_TWO' })" +
+          "\n  > 5 |   const aggregateError = new AggregateError([error1, error2], 'Aggregate')" +
+          '\n      |                          ^' +
+          '\n    6 |   console.error(' +
+          "\n    7 |     new Error('rsc-error-log-aggregate-nested', { cause: aggregateError })" +
+          '\n    8 |   ) {' +
+          // TODO(veil): Node.js spends one level of the inspect depth on the
+          // array of errors, and one more level on each error in the array. The
+          // errors of an AggregateError behind a `cause` therefore fall outside
+          // the default depth.
+          '\n    [errors]: [ [Error], [Error] ]' +
+          '\n  }' +
+          '\n}'
+      )
+    } else {
+      if (isTurbopack) {
+        // TODO(veil): Sourcemap names
+        //
+        // TODO(veil): relative paths in production
+        expect(normalizeCliOutput(next.cliOutput)).toContain(
+          '(app/rsc-error-log-aggregate-nested/page.js:7:5)'
+        )
+        expect(normalizeCliOutput(next.cliOutput)).toContain('[cause]:')
+        expect(normalizeCliOutput(next.cliOutput)).toContain('[errors]:')
+      } else {
+        // TODO(veil): line/column numbers are flaky in Webpack
+      }
+    }
+  })
+
   it('logged errors in client components during ssr have a sourcemapped stack with a codeframe', async () => {
     if (isNextDev) {
       const outputIndex = next.cliOutput.length

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -269,7 +269,7 @@ describe('app-dir - server source maps', () => {
     }
   })
 
-  it('logs an AggregateError behind a `cause`', async () => {
+  it('prints the errors of an AggregateError behind a `cause`', async () => {
     if (isNextDev) {
       const outputIndex = next.cliOutput.length
       await next.render('/rsc-error-log-aggregate-nested')
@@ -300,14 +300,40 @@ describe('app-dir - server source maps', () => {
           '\n    6 |   console.error(' +
           "\n    7 |     new Error('rsc-error-log-aggregate-nested', { cause: aggregateError })" +
           '\n    8 |   ) {' +
-          // TODO(veil): Node.js spends one level of the inspect depth on the
-          // array of errors, and one more level on each error in the array. The
-          // errors of an AggregateError behind a `cause` therefore fall outside
-          // the default depth.
-          '\n    [errors]: [ [Error], [Error] ]' +
+          '\n    [errors]: [' +
+          '\n      Error: Error 1' +
+          '\n          at logError (app/rsc-error-log-aggregate-nested/page.js:3:32)' +
+          '\n          at Page (app/rsc-error-log-aggregate-nested/page.js:12:3)' +
+          '\n        1 | /* global AggregateError */' +
+          '\n        2 | function logError() {' +
+          "\n      > 3 |   const error1 = Object.assign(new Error('Error 1'), { code: 'ERR_ONE' })" +
+          '\n          |                                ^' +
+          "\n        4 |   const error2 = Object.assign(new TypeError('Error 2'), { code: 'ERR_TWO' })" +
+          "\n        5 |   const aggregateError = new AggregateError([error1, error2], 'Aggregate')" +
+          '\n        6 |   console.error( {' +
+          "\n        code: 'ERR_ONE'" +
+          '\n      },' +
+          '\n      TypeError: Error 2' +
+          '\n          at logError (app/rsc-error-log-aggregate-nested/page.js:4:32)' +
+          '\n          at Page (app/rsc-error-log-aggregate-nested/page.js:12:3)' +
+          '\n        2 | function logError() {' +
+          "\n        3 |   const error1 = Object.assign(new Error('Error 1'), { code: 'ERR_ONE' })" +
+          "\n      > 4 |   const error2 = Object.assign(new TypeError('Error 2'), { code: 'ERR_TWO' })" +
+          '\n          |                                ^' +
+          "\n        5 |   const aggregateError = new AggregateError([error1, error2], 'Aggregate')" +
+          '\n        6 |   console.error(' +
+          "\n        7 |     new Error('rsc-error-log-aggregate-nested', { cause: aggregateError }) {" +
+          "\n        code: 'ERR_TWO'" +
+          '\n      }' +
+          '\n    ]' +
           '\n  }' +
           '\n}'
       )
+      // The errors of the AggregateError carry own properties, so Node.js
+      // applies its depth limit to them. They must not collapse to `[Error]`.
+      expect(
+        normalizeCliOutput(next.cliOutput.slice(outputIndex))
+      ).not.toContain('[Error]')
     } else {
       if (isTurbopack) {
         // TODO(veil): Sourcemap names
@@ -318,6 +344,8 @@ describe('app-dir - server source maps', () => {
         )
         expect(normalizeCliOutput(next.cliOutput)).toContain('[cause]:')
         expect(normalizeCliOutput(next.cliOutput)).toContain('[errors]:')
+        expect(normalizeCliOutput(next.cliOutput)).toContain("code: 'ERR_ONE'")
+        expect(normalizeCliOutput(next.cliOutput)).toContain("code: 'ERR_TWO'")
       } else {
         // TODO(veil): line/column numbers are flaky in Webpack
       }


### PR DESCRIPTION
A failed `fetch` hid the reason of the failure. Node.js reports every refused connection attempt in the `errors` of an `AggregateError`, and the terminal logged `[errors]: [ [Error], [Error] ]` without the address or the port of a single attempt.

An `AggregateError` keeps its errors in an array. Node.js spends one level of the inspect depth on that array, and one more level on each error in the array, while a `cause` costs one level only. The errors of an `AggregateError` behind a cause therefore fell outside the default depth of two. Node.js also returns an error early when it carries no own properties, before it applies the depth, so the collapse hit only the errors that carry diagnostics.

Next.js now adds the missing level back for an `AggregateError`, so its errors print at the same nesting as a cause. A depth of `null` means unlimited and stays unchanged, because `null + 1` would reduce it to one level.
