### PR TITLE
Fix metadata prefetch cache key for search params

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -3209,10 +3209,16 @@ function writeServerResponseIntoCache(
         ? now + getStaleTimeMs(navigationSeed.headStaleTimeSeconds)
         : staleAt
 
+    // A head has no loading boundary. Match pingRuntimeHead, which spawns
+    // LoadingBoundary head entries using the concrete Full strategy.
+    const headFetchStrategy =
+      fetchStrategy === FetchStrategy.LoadingBoundary
+        ? FetchStrategy.Full
+        : fetchStrategy
     const writtenHeadEntry = writeSegmentDataIntoCache(
       now,
       map,
-      fetchStrategy,
+      headFetchStrategy,
       head,
       // The decode already resolved the head's partiality from the wire
       // form and the response-level value — see the head read in

--- a/test/e2e/app-dir/segment-cache/metadata-search-params/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata-search-params/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/metadata-search-params/app/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata-search-params/app/link-accordion.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+}: {
+  href: string
+  children: React.ReactNode
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href}>{children}</Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/metadata-search-params/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata-search-params/app/page.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+export default function Home() {
+  const [linksAreVisible, setLinksAreVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={linksAreVisible}
+        onChange={() => setLinksAreVisible(!linksAreVisible)}
+        data-prefetch-links
+      />
+      {linksAreVisible ? (
+        <ul>
+          <li>
+            <Link href="/search?q=alpha">alpha</Link>
+          </li>
+          <li>
+            <Link href="/search?q=beta">beta</Link>
+          </li>
+        </ul>
+      ) : null}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/metadata-search-params/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata-search-params/app/page.tsx
@@ -1,28 +1,14 @@
-'use client'
-
-import Link from 'next/link'
-import { useState } from 'react'
+import { LinkAccordion } from './link-accordion'
 
 export default function Home() {
-  const [linksAreVisible, setLinksAreVisible] = useState(false)
   return (
-    <>
-      <input
-        type="checkbox"
-        checked={linksAreVisible}
-        onChange={() => setLinksAreVisible(!linksAreVisible)}
-        data-prefetch-links
-      />
-      {linksAreVisible ? (
-        <ul>
-          <li>
-            <Link href="/search?q=alpha">alpha</Link>
-          </li>
-          <li>
-            <Link href="/search?q=beta">beta</Link>
-          </li>
-        </ul>
-      ) : null}
-    </>
+    <ul>
+      <li>
+        <LinkAccordion href="/search?q=alpha">alpha</LinkAccordion>
+      </li>
+      <li>
+        <LinkAccordion href="/search?q=beta">beta</LinkAccordion>
+      </li>
+    </ul>
   )
 }

--- a/test/e2e/app-dir/segment-cache/metadata-search-params/app/search/page.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata-search-params/app/search/page.tsx
@@ -21,7 +21,9 @@ export default async function SearchPage({
       <nav>
         <Link href="/search?q=alpha">alpha</Link>{' '}
         <Link href="/search?q=beta">beta</Link>{' '}
-        <Link href="/search?q=gamma">gamma</Link>
+        <Link href="/search?q=gamma" prefetch={false}>
+          gamma
+        </Link>
       </nav>
     </main>
   )

--- a/test/e2e/app-dir/segment-cache/metadata-search-params/app/search/page.tsx
+++ b/test/e2e/app-dir/segment-cache/metadata-search-params/app/search/page.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  const { q } = await searchParams
+  return { title: `Results for ${q}` }
+}
+
+export default async function SearchPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  const { q } = await searchParams
+  return (
+    <main>
+      <h1>Results for {q}</h1>
+      <nav>
+        <Link href="/search?q=alpha">alpha</Link>{' '}
+        <Link href="/search?q=beta">beta</Link>{' '}
+        <Link href="/search?q=gamma">gamma</Link>
+      </nav>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/metadata-search-params/metadata-search-params.test.ts
+++ b/test/e2e/app-dir/segment-cache/metadata-search-params/metadata-search-params.test.ts
@@ -1,0 +1,47 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { retry } from 'next-test-utils'
+import { createRouterAct } from 'router-act'
+
+describe('segment cache (metadata search params)', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    test('prefetching is disabled in development', () => {})
+    return
+  }
+
+  it('does not reuse metadata across search params after a static prefetch attempt', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page: Playwright.Page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Start two prefetches for the same route with different search params in
+    // the same render, then wait for both to settle. Neither result may replace
+    // the other under a shared key.
+    await act(async () => {
+      const toggle = await browser.elementByCss('input[data-prefetch-links]')
+      await toggle.click()
+    })
+
+    await browser.elementByCss('a[href="/search?q=alpha"]').click()
+    await browser.waitForElementByCss('h1')
+    expect(await browser.elementByCss('h1').text()).toBe('Results for alpha')
+    await retry(async () => {
+      expect(await browser.eval(() => document.title)).toBe('Results for alpha')
+    })
+
+    // A search-only navigation that was not prefetched must also replace the
+    // head, rather than leaving whichever prefetch settled last in place.
+    await browser.elementByCss('a[href="/search?q=gamma"]').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('h1').text()).toBe('Results for gamma')
+      expect(await browser.eval(() => document.title)).toBe('Results for gamma')
+    })
+  })
+})

--- a/test/e2e/app-dir/segment-cache/metadata-search-params/metadata-search-params.test.ts
+++ b/test/e2e/app-dir/segment-cache/metadata-search-params/metadata-search-params.test.ts
@@ -4,22 +4,17 @@ import { retry } from 'next-test-utils'
 import { createRouterAct } from 'router-act'
 
 describe('segment cache (metadata search params)', () => {
-  const isCacheComponents = process.env.__NEXT_CACHE_COMPONENTS === 'true'
-  const { next, isNextDev, skipped } = nextTestSetup({
-    files: __dirname,
-    skipDeployment: true,
-    // Cache Components has different partial prerender and prefetch semantics.
-    skipStart: isCacheComponents,
-  })
-  if (skipped) return
-
-  if (isCacheComponents) {
-    test('prefetching is covered by the Cache Components suites', () => {})
+  if (process.env.__NEXT_CACHE_COMPONENTS === 'true') {
+    test.skip('LoadingBoundary prefetching is not used with Cache Components', () => {})
     return
   }
 
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
   if (isNextDev) {
-    test('prefetching is disabled in development', () => {})
+    test.skip('prefetching is disabled in development', () => {})
     return
   }
 
@@ -31,12 +26,18 @@ describe('segment cache (metadata search params)', () => {
       },
     })
 
-    // Start two prefetches for the same route with different search params in
-    // the same render, then wait for both to settle. Neither result may replace
-    // the other under a shared key.
+    // Start two prefetches for the same route with different search params,
+    // then wait for both to settle. Neither result may replace the other under
+    // a shared key.
     await act(async () => {
-      const toggle = await browser.elementByCss('input[data-prefetch-links]')
-      await toggle.click()
+      const alphaToggle = await browser.elementByCss(
+        'input[data-link-accordion="/search?q=alpha"]'
+      )
+      const betaToggle = await browser.elementByCss(
+        'input[data-link-accordion="/search?q=beta"]'
+      )
+      await alphaToggle.click()
+      await betaToggle.click()
     })
 
     await browser.elementByCss('a[href="/search?q=alpha"]').click()
@@ -48,7 +49,9 @@ describe('segment cache (metadata search params)', () => {
 
     // A search-only navigation that was not prefetched must also replace the
     // head, rather than leaving whichever prefetch settled last in place.
-    await browser.elementByCss('a[href="/search?q=gamma"]').click()
+    await act(async () => {
+      await browser.elementByCss('a[href="/search?q=gamma"]').click()
+    })
     await retry(async () => {
       expect(await browser.elementByCss('h1').text()).toBe('Results for gamma')
       expect(await browser.eval(() => document.title)).toBe('Results for gamma')

--- a/test/e2e/app-dir/segment-cache/metadata-search-params/metadata-search-params.test.ts
+++ b/test/e2e/app-dir/segment-cache/metadata-search-params/metadata-search-params.test.ts
@@ -4,9 +4,19 @@ import { retry } from 'next-test-utils'
 import { createRouterAct } from 'router-act'
 
 describe('segment cache (metadata search params)', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const isCacheComponents = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+  const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    skipDeployment: true,
+    // Cache Components has different partial prerender and prefetch semantics.
+    skipStart: isCacheComponents,
   })
+  if (skipped) return
+
+  if (isCacheComponents) {
+    test('prefetching is covered by the Cache Components suites', () => {})
+    return
+  }
 
   if (isNextDev) {
     test('prefetching is disabled in development', () => {})


### PR DESCRIPTION
Adopts #97729. Closes #97729.

### What?

Treat a `LoadingBoundary` response as `Full` when writing the response's head into the segment cache, matching the strategy already used when the scheduler creates that head entry.

Adds a production e2e regression test with two concurrent prefetches for the same pathname and different search params.

### Why?

`pingRuntimeHead` creates loading-boundary head entries with the concrete `Full` strategy because a head has no loading boundary. The canonical re-keying added in #96095 later wrote the fulfilled head with raw `LoadingBoundary` semantics, which drops search params from the metadata cache key. Concurrent query-specific metadata responses could therefore replace each other under one fallback key; whichever response settled last supplied the title for both URLs.

Fixes #97657

### How?

Normalize `LoadingBoundary` to `Full` at the head write boundary only. Page segments retain loading-boundary keying, and shell/PPR responses keep their existing strategies.

The test reveals alpha and beta links in one React render, waits for both prefetches, navigates to alpha, and verifies both body and title. It then performs a search-only navigation to an unprefetched gamma URL and verifies that the head is replaced.

### Testing

- Regression boundary: test passes at `e70495c1ee` and fails at #96095 merge commit `dfa7f4f713` without the fix (`alpha` body, `beta` title).
- Test passes at `dfa7f4f713` with the fix.
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-turbo test/e2e/app-dir/segment-cache/metadata-search-params/metadata-search-params.test.ts` (pass, plus 3 consecutive repeat runs)
- `NEXT_SKIP_ISOLATE=1 pnpm test-start-webpack test/e2e/app-dir/segment-cache/metadata-search-params/metadata-search-params.test.ts` (pass)
- Relevant existing Turbopack suites: 16 tests pass across metadata, static shell, metadata soft navigation, and stale search-param coverage.
- Existing search-param suites: 6 tests pass with webpack. Their Turbopack builds are currently blocked on canary by an unrelated Edge Runtime `process.cwd()` error.
- `pnpm --filter next build`
- Targeted ESLint and Prettier checks
- Structured external review: 0 findings

