### PR TITLE
typegen: allow narrowed string literal union params in AppPageConfig and LayoutConfig default component signatures

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -519,7 +519,7 @@ export function generateValidatorFile(
 
   if (appPageValidations) {
     typeDefinitions += `type AppPageConfig<Route extends AppRoutes = AppRoutes> = {
-  default: React.ComponentType<{ params: Promise<ParamMap[Route]> } & any> | ((props: { params: Promise<ParamMap[Route]> } & any) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
+  default: React.ComponentType<{ params: Promise<any> } & any> | ((props: { params: Promise<any> } & any) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
   generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
   generateMetadata?: (
     props: { params: Promise<ParamMap[Route]> } & any,
@@ -559,7 +559,7 @@ export function generateValidatorFile(
 
   if (layoutValidations) {
     typeDefinitions += `type LayoutConfig<Route extends LayoutRoutes = LayoutRoutes> = {
-  default: React.ComponentType<LayoutProps<Route>> | ((props: LayoutProps<Route>) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
+  default: React.ComponentType<{ params?: Promise<any>; children?: React.ReactNode } & any> | ((props: { params?: Promise<any>; children?: React.ReactNode } & any) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
   generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
   generateMetadata?: (
     props: { params: Promise<ParamMap[Route]> } & any,


### PR DESCRIPTION
### Motivation
Closes #97523: When page or layout components declare narrowed parameter types (e.g. `params: Promise<{ locale: "en" | "de" }>` alongside `dynamicParams = false`), the route export validator currently enforces exact match against `Promise<ParamMap[Route]>`, producing a type checking failure during `next build`.

### Solution
Allow default component exports in `AppPageConfig` and `LayoutConfig` to accept subtype/narrowed parameter objects (`Promise<any>` in component props), while retaining strict static param and metadata types.

Signed-off-by: sundeep8967 <sundeep8967@gmail.com>