### PR TITLE
Expand Turbopack dev cleanup

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1282,7 +1282,7 @@ export default async function build(
           .traceAsyncFn(() =>
             recursiveDeleteSyncWithAsyncRetries(
               distDir,
-              /^(cache|dev|lock|trace)/
+              new Set(['cache', 'dev', 'lock', 'trace'])
             )
           )
       }

--- a/packages/next/src/lib/recursive-delete.ts
+++ b/packages/next/src/lib/recursive-delete.ts
@@ -94,7 +94,7 @@ export async function recursiveDeleteSyncWithAsyncRetries(
   /** Directory to delete the contents of */
   dir: string,
   /** Exclude based on relative file path */
-  exclude?: RegExp,
+  exclude?: ReadonlySet<string>,
   /**
    * Only delete files whose mtime is at least this old. Directories are
    * removed once empty.
@@ -118,7 +118,7 @@ async function deleteContents(
     futureMtimeThreshold,
     previousPath,
   }: {
-    exclude: RegExp | undefined
+    exclude: ReadonlySet<string> | undefined
     staleBefore: number | undefined
     futureMtimeThreshold: number
     /** Relative path to the directory being deleted, used for exclude */
@@ -142,7 +142,7 @@ async function deleteContents(
       const absolutePath = join(dir, part.name)
       const pp = join(previousPath ?? '', part.name)
 
-      if (exclude?.test(pp)) {
+      if (exclude?.has(pp)) {
         keptAnything = true
         return
       }

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -162,15 +162,25 @@ const sessionId = Math.floor(Number.MAX_SAFE_INTEGER * Math.random())
 /** Output directory (relative to `distDir`) of server-HMR-managed chunks. */
 const SERVER_HMR_CHUNKS_DIR = join('server', 'chunks')
 
-const STALE_SWEPT_OUTPUT_DIRS = [
+const TURBOPACK_OUTPUT_DIRS = [
   join('static', 'chunks'),
   join('static', 'media'),
+  join('static', 'service-worker'),
   join('server', 'app'),
   join('server', 'pages'),
   SERVER_HMR_CHUNKS_DIR,
+  join('server', 'assets'),
   join('server', 'edge', 'chunks'),
   join('server', 'edge', 'assets'),
+  join('server', 'middleware'),
+  join('server', 'instrumentation'),
 ]
+
+const RETAINED_OUTPUT_PATHS = new Set([
+  'cache',
+  'lock',
+  ...TURBOPACK_OUTPUT_DIRS,
+])
 
 declare const __next__clear_chunk_cache__: (() => void) | null | undefined
 
@@ -389,6 +399,19 @@ export async function createHotReloaderTurbopack(
 
   const bindings = getBindingsSync()
 
+  // This must finish before Turbopack records any writes. Once turbo-tasks has
+  // recorded a write effect, it dedups by hash without checking the file.
+  await recursiveDeleteSyncWithAsyncRetries(distDir, RETAINED_OUTPUT_PATHS)
+  await Promise.all(
+    TURBOPACK_OUTPUT_DIRS.map((subDir) =>
+      recursiveDeleteSyncWithAsyncRetries(
+        join(distDir, subDir),
+        undefined,
+        nextConfig.experimental.turbopackStaleOutputMaxAge
+      )
+    )
+  )
+
   // Turbopack requires native bindings and cannot run with WASM bindings.
   // Detect this early and give a clear, actionable error message.
   if (bindings.isWasm) {
@@ -456,23 +479,6 @@ export async function createHotReloaderTurbopack(
       distDir,
     })
   }
-
-  // Clean up any old output files from previous runs. This is safe as Turbopack
-  // will restore any missing chunks from persistent cache or recompute them.
-  //
-  // That only holds here, before the project exists: once turbo-tasks has
-  // recorded a write effect for a path, the write dedups on the recorded hash
-  // without checking the file, so a deleted output stays missing for the rest
-  // of the session.
-  await Promise.all(
-    STALE_SWEPT_OUTPUT_DIRS.map((subDir) =>
-      recursiveDeleteSyncWithAsyncRetries(
-        join(distDir, subDir),
-        undefined,
-        nextConfig.experimental.turbopackStaleOutputMaxAge!
-      )
-    )
-  )
 
   const project = await bindings.turbo.createProject(
     {

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -399,6 +399,18 @@ export async function createHotReloaderTurbopack(
 
   const bindings = getBindingsSync()
 
+  // Turbopack requires native bindings and cannot run with WASM bindings.
+  // Detect this early and give a clear, actionable error message.
+  if (bindings.isWasm) {
+    throw new Error(
+      `Turbopack is not supported on this platform (${process.platform}/${process.arch}) because native bindings are not available. ` +
+        `Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings.\n\n` +
+        `To use Next.js on this platform, use Webpack instead:\n` +
+        `  next dev --webpack\n\n` +
+        `For more information, see: https://nextjs.org/docs/app/api-reference/turbopack#supported-platforms`
+    )
+  }
+
   // This must finish before Turbopack records any writes. Once turbo-tasks has
   // recorded a write effect, it dedups by hash without checking the file.
   await recursiveDeleteSyncWithAsyncRetries(distDir, RETAINED_OUTPUT_PATHS)
@@ -411,18 +423,6 @@ export async function createHotReloaderTurbopack(
       )
     )
   )
-
-  // Turbopack requires native bindings and cannot run with WASM bindings.
-  // Detect this early and give a clear, actionable error message.
-  if (bindings.isWasm) {
-    throw new Error(
-      `Turbopack is not supported on this platform (${process.platform}/${process.arch}) because native bindings are not available. ` +
-        `Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings.\n\n` +
-        `To use Next.js on this platform, use Webpack instead:\n` +
-        `  next dev --webpack\n\n` +
-        `For more information, see: https://nextjs.org/docs/app/api-reference/turbopack#supported-platforms`
-    )
-  }
 
   // For the debugging purpose, check if createNext or equivalent next instance setup in test cases
   // works correctly. Normally `run-test` hides output so only will be visible when `--debug` flag is used.

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -687,7 +687,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
       .traceAsyncFn(() =>
         recursiveDeleteSyncWithAsyncRetries(
           join(this.dir, this.config.distDir),
-          /^(cache|lock)/
+          new Set(['cache', 'lock'])
         )
       )
   }

--- a/test/unit/recursive-delete.test.ts
+++ b/test/unit/recursive-delete.test.ts
@@ -38,7 +38,10 @@ describe('recursiveDeleteSyncWithAsyncRetries', () => {
         overwrite: true,
       })
       // preserve cache dir
-      await recursiveDeleteSyncWithAsyncRetries(testpreservefileDir, /^cache/)
+      await recursiveDeleteSyncWithAsyncRetries(
+        testpreservefileDir,
+        new Set(['cache'])
+      )
 
       const result = await recursiveReadDir(testpreservefileDir)
       expect(result.length).toBe(1)

--- a/test/unit/recursive-delete.test.ts
+++ b/test/unit/recursive-delete.test.ts
@@ -37,14 +37,41 @@ describe('recursiveDeleteSyncWithAsyncRetries', () => {
       await recursiveCopy(resolveDataDir, testpreservefileDir, {
         overwrite: true,
       })
-      // preserve cache dir
       await recursiveDeleteSyncWithAsyncRetries(
         testpreservefileDir,
         new Set(['cache'])
       )
 
       const result = await recursiveReadDir(testpreservefileDir)
-      expect(result.length).toBe(1)
+      expect(result).toEqual(['/cache/test.txt'])
+    } finally {
+      // Ensure test cleanup
+      await recursiveDeleteSyncWithAsyncRetries(testpreservefileDir)
+
+      const cleanupResult = await recursiveReadDir(testpreservefileDir)
+      expect(cleanupResult.length).toBe(0)
+    }
+  })
+
+  it('should exclude a nested path', async () => {
+    expect.assertions(4)
+    try {
+      await recursiveCopy(resolveDataDir, testpreservefileDir, {
+        overwrite: true,
+      })
+      await recursiveDeleteSyncWithAsyncRetries(
+        testpreservefileDir,
+        new Set([join('aa', 'cache.js')])
+      )
+
+      const result = await recursiveReadDir(testpreservefileDir)
+      expect(result).toEqual(['/aa/cache.js'])
+      expect(
+        await fs.pathExists(join(testpreservefileDir, 'aa', 'cache.js'))
+      ).toBe(true)
+      expect(
+        await fs.pathExists(join(testpreservefileDir, 'aa', 'index.js'))
+      ).toBe(false)
     } finally {
       // Ensure test cleanup
       await recursiveDeleteSyncWithAsyncRetries(testpreservefileDir)


### PR DESCRIPTION
## Summary

Builds on #97591. Webpack currently removes most of `.next` on devserver startup. We can remove more as well.

This keeps the age-based removal introduced in #97591 and expands it to `traces`, logs, etc. However, for any other directory that is not `cache` or `lock`, completely remove it on startup. This includes types, etc.

Apply age-based deletion to Turbopack-owned output that can be restored from cache or recomputed, including route entries, chunks, assets, service workers, middleware, and instrumentation. Completely remove other dev output so logs, traces, generated types, diagnostics, and future framework-owned output cannot be left as mixed generations.

Use exact-path exclusion sets in `recursiveDeleteSyncWithAsyncRetries`. The complete pass retains `cache`, `lock`, and Turbopack-owned paths; the age-based pass then sweeps those Turbopack paths. Both passes finish before project creation.

## Verification

- `pnpm test-unit test/unit/recursive-delete.test.ts`
- `pnpm --filter=next types`