### PR TITLE
docs: await params in JS Server/Client Components examples

### DIFF
--- a/docs/01-app/01-getting-started/05-server-and-client-components.mdx
+++ b/docs/01-app/01-getting-started/05-server-and-client-components.mdx
@@ -59,12 +59,13 @@ export default async function Page({
 }
 ```
 
-```jsx filename="app/[id]/page.js" highlight={1,12} switcher
+```jsx filename="app/[id]/page.js" highlight={1,13} switcher
 import LikeButton from '@/app/ui/like-button'
 import { getPost } from '@/lib/data'
 
 export default async function Page({ params }) {
-  const post = await getPost(params.id)
+  const { id } = await params
+  const post = await getPost(id)
 
   return (
     <div>
@@ -264,12 +265,13 @@ export default async function Page({
 }
 ```
 
-```jsx filename="app/[id]/page.js" highlight={1,7} switcher
+```jsx filename="app/[id]/page.js" highlight={1,8} switcher
 import LikeButton from '@/app/ui/like-button'
 import { getPost } from '@/lib/data'
 
 export default async function Page({ params }) {
-  const post = await getPost(params.id)
+  const { id } = await params
+  const post = await getPost(id)
 
   return <LikeButton likes={post.likes} />
 }


### PR DESCRIPTION
## For Contributors

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### What?

In `docs/01-app/01-getting-started/05-server-and-client-components.mdx`, the TypeScript `page.tsx` examples already await async `params`, but the paired JavaScript `page.js` switcher examples still read `params.id` synchronously.

### Why?

Since Next.js 15, `params` is a Promise for App Router pages in both JavaScript and TypeScript. Leaving the JS examples on the old pattern is inconsistent with the TS examples on the same page and with the async params API.

### How?

Updated both `page.js` examples to:

```js
const { id } = await params
const post = await getPost(id)
```

Also adjusted the `highlight` line numbers to match the added line.

<!-- NEXT_JS_LLM -->

Made with [Cursor](https://cursor.com)