### PR TITLE
Move mismatch retry handling into the navigator interface

### DIFF
--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -319,10 +319,15 @@ export const publicAppRouterInstance: AppRouterInstance = {
   back: () => window.history.back(),
   forward: () => window.history.forward(),
   prefetch: prefetchRoute,
-  replace: replace,
-  push: push,
-  refresh: refresh,
-  hmrRefresh: hmrRefresh,
+  // These wrappers must not be simplified to bare references (e.g.
+  // `replace: replace`). This module is part of an import cycle with the
+  // navigator module, so reading one of its exports during module evaluation
+  // can crash, depending on which module in the cycle is evaluated first.
+  // Wrapping defers the reads until the method is called.
+  replace: (href, options) => replace(href, options),
+  push: (href, options) => push(href, options),
+  refresh: () => refresh(),
+  hmrRefresh: () => hmrRefresh(),
   // Default value. Each route segment provides its own value at runtime. Refer
   // to `useRouter()`.
   bfcacheId: '0',

--- a/packages/next/src/client/components/concurrent-router-queue.ts
+++ b/packages/next/src/client/components/concurrent-router-queue.ts
@@ -21,6 +21,10 @@ import type {
 import type { NavigateOptions } from '../../shared/lib/app-router-context.shared-runtime'
 import type { LinkInstance } from './links'
 import type { RouterTransitionPrefetchIntent } from '../router-transition-types'
+import type { FlightRouterState } from '../../shared/lib/app-router-types'
+import type { NavigationSeed } from './segment-cache/decode-server-response'
+import type { FulfilledRouteCacheEntry } from './segment-cache/cache'
+import type { FreshnessPolicy } from './render-tree'
 
 // Keep in sync with the identical message in concurrent-call-server.ts, so
 // all unimplemented behavior shares a single error (and error code).
@@ -81,6 +85,23 @@ export function legacyUrgentBFCacheRestore(
 }
 
 export function refresh(): void {
+  notImplemented()
+}
+
+export function finishMismatchedNavigationRequest(
+  _url: URL,
+  _nextUrl: string | null,
+  _seed: NavigationSeed | null,
+  _baseTree: FlightRouterState,
+  _routeCacheEntry: FulfilledRouteCacheEntry | null,
+  _navigateType: 'push' | 'replace',
+  _hard: boolean,
+  _freshness: FreshnessPolicy.RefreshAll | FreshnessPolicy.HistoryTraversal
+): void {
+  notImplemented()
+}
+
+export function finishNavigationRequest(): void {
   notImplemented()
 }
 

--- a/packages/next/src/client/components/navigator.ts
+++ b/packages/next/src/client/components/navigator.ts
@@ -1,6 +1,10 @@
 // This module is the router's operation interface: one function per
 // user-facing operation, called directly by the corresponding entry points
-// (Link, the public router methods, the history event handlers).
+// (Link, the public router methods, the history event handlers). A few
+// internal operations (currently the completion reports for navigation
+// requests, called from render-tree.ts) also enter through this interface,
+// so shared machinery below the fork reaches the active implementation
+// without importing either one.
 //
 // The navigator owns the startTransition for its operations, along with the
 // centralized safety checks; callers must invoke these functions
@@ -29,5 +33,7 @@ export {
   restore,
   legacyUrgentBFCacheRestore,
   refresh,
+  finishMismatchedNavigationRequest,
+  finishNavigationRequest,
   hmrRefresh,
 } from './sequential-router-queue'

--- a/packages/next/src/client/components/render-tree.ts
+++ b/packages/next/src/client/components/render-tree.ts
@@ -13,13 +13,11 @@ import {
 import { matchSegment } from './match-segments'
 import { createHrefFromUrl } from './router-reducer/create-href-from-url'
 import { fetchServerResponse } from './router-reducer/fetch-server-response'
-import { dispatchAppRouterAction } from './use-action-queue'
 import {
-  ACTION_SERVER_PATCH,
-  type ServerPatchAction,
-} from './router-reducer/router-reducer-types'
+  finishMismatchedNavigationRequest,
+  finishNavigationRequest,
+} from './navigator'
 import { isNavigatingToNewRootLayout } from './router-reducer/is-navigating-to-new-root-layout'
-import { getLastCommittedTree } from './router-reducer/reducers/committed-state'
 import {
   createNavigationSeed,
   type NavigationSeed,
@@ -34,13 +32,10 @@ import {
   convertReusedFlightRouterStateToRouteTree,
   readSegmentCacheEntryForNavigation,
   waitForSegmentCacheEntry,
-  markRouteEntryAsDynamicRewrite,
-  invalidateRouteCacheEntries,
   spawnStaticStageCacheWrite,
   writeRuntimePrefetchStreamIntoCache,
   EntryStatus,
 } from './segment-cache/cache'
-import { discoverKnownRoute } from './segment-cache/optimistic-routes'
 import { urlSearchParamsToParsedUrlQuery } from '../route-params'
 import type { NormalizedSearch } from './segment-cache/cache-key'
 import type { CacheMap } from './segment-cache/cache-map'
@@ -1392,11 +1387,6 @@ function compareSegments(
   return SegmentMatchKind.Change
 }
 
-// Represents whether the previuos navigation resulted in a route tree mismatch.
-// A mismatch results in a refresh of the page. If there are two successive
-// mismatches, we will fall back to an MPA navigation, to prevent a retry loop.
-let previousNavigationDidMismatch = false
-
 // Writes a dynamic server response into the tree created by
 // updateCacheNodeOnNavigation. All pending promises that were spawned by the
 // navigation will be resolved, either with dynamic data from the server, or
@@ -1436,7 +1426,7 @@ export function spawnDynamicRequests(
   const dynamicRequestTree = task.dynamicRequestTree
   if (dynamicRequestTree === null) {
     // This navigation was fully cached. There are no dynamic requests to spawn.
-    previousNavigationDidMismatch = false
+    finishNavigationRequest()
     return
   }
 
@@ -1572,7 +1562,7 @@ async function finishNavigationTask(
     }
     case NavigationTaskExitStatus.Done: {
       // The task has completely finished. There's no missing data. Exit.
-      previousNavigationDidMismatch = false
+      finishNavigationRequest()
       return
     }
     case NavigationTaskExitStatus.SoftRetry: {
@@ -1583,14 +1573,14 @@ async function finishNavigationTask(
       // happen in a row, fall back to a hard retry.
       const isHardRetry = false
       const primaryRequestResult = await primaryRequestPromise
-      dispatchRetryDueToTreeMismatch(
-        isHardRetry,
+      finishMismatchedNavigationRequest(
         primaryRequestResult.url,
         nextUrl,
         primaryRequestResult.seed,
         task.route,
         routeCacheEntry,
         navigateType,
+        isHardRetry,
         FreshnessPolicy.RefreshAll
       )
       return
@@ -1602,14 +1592,14 @@ async function finishNavigationTask(
       // (HistoryTraversal) instead of re-fetching it. See issue #95195.
       const isHardRetry = false
       const primaryRequestResult = await primaryRequestPromise
-      dispatchRetryDueToTreeMismatch(
-        isHardRetry,
+      finishMismatchedNavigationRequest(
         primaryRequestResult.url,
         nextUrl,
         primaryRequestResult.seed,
         task.route,
         routeCacheEntry,
         navigateType,
+        isHardRetry,
         FreshnessPolicy.HistoryTraversal
       )
       return
@@ -1625,14 +1615,14 @@ async function finishNavigationTask(
       // doesn't exist yet.
       const isHardRetry = true
       const primaryRequestResult = await primaryRequestPromise
-      dispatchRetryDueToTreeMismatch(
-        isHardRetry,
+      finishMismatchedNavigationRequest(
         primaryRequestResult.url,
         nextUrl,
         primaryRequestResult.seed,
         task.route,
         routeCacheEntry,
         navigateType,
+        isHardRetry,
         FreshnessPolicy.RefreshAll
       )
       return
@@ -1690,97 +1680,6 @@ function waitForRequestsToFinish(
       )
     }
   })
-}
-
-function dispatchRetryDueToTreeMismatch(
-  isHardRetry: boolean,
-  retryUrl: URL,
-  retryNextUrl: string | null,
-  seed: NavigationSeed | null,
-  baseTree: FlightRouterState,
-  // The route cache entry used for this navigation, if it came from route
-  // prediction. If the navigation results in a mismatch, we mark it as having
-  // a dynamic rewrite so future predictions bail out.
-  routeCacheEntry: FulfilledRouteCacheEntry | null,
-  // The original navigation's push/replace intent.
-  originalNavigateType: 'push' | 'replace',
-  // Freshness policy for the retry navigation. `RefreshAll` re-fetches the
-  // tree's dynamic data (used for genuine tree mismatches). `HistoryTraversal`
-  // reuses the data already in the tree (used when only the URL needs
-  // correcting after a redirect).
-  retryFreshnessPolicy:
-    | FreshnessPolicy.RefreshAll
-    | FreshnessPolicy.HistoryTraversal
-) {
-  // If the navigation used a route prediction, mark it as having a dynamic
-  // rewrite since it resulted in a mismatch.
-  if (routeCacheEntry !== null) {
-    markRouteEntryAsDynamicRewrite(routeCacheEntry)
-  } else if (seed !== null) {
-    // Even without a direct reference to the route cache entry, we can still
-    // mark the route as having a dynamic rewrite by traversing the known route
-    // tree. This handles cases where the navigation didn't originate from a
-    // route prediction, but still needs to mark the pattern.
-    const metadataVaryPath = seed.metadataVaryPath
-    if (metadataVaryPath !== null) {
-      const now = Date.now()
-      discoverKnownRoute(
-        now,
-        retryUrl.pathname,
-        retryUrl.search as NormalizedSearch,
-        retryNextUrl,
-        null,
-        seed.routeTree,
-        metadataVaryPath,
-        false, // couldBeIntercepted - doesn't matter, we're just marking hasDynamicRewrite
-        createHrefFromUrl(retryUrl),
-        false, // supportsPerSegmentPrefetching - doesn't matter, we're just marking hasDynamicRewrite
-        true // hasDynamicRewrite
-      )
-    }
-  }
-
-  // Invalidate all route cache entries. Other entries may have been derived
-  // from the template before we knew it had a dynamic rewrite. This also
-  // triggers re-prefetching of visible links.
-  invalidateRouteCacheEntries(retryNextUrl, baseTree)
-
-  // If this is the second time in a row that a navigation resulted in a
-  // mismatch, fall back to a hard (MPA) refresh.
-  isHardRetry = isHardRetry || previousNavigationDidMismatch
-  previousNavigationDidMismatch = true
-
-  // If the original navigation hasn't committed to the browser history yet
-  // (the transition suspended before React committed), inherit its push/replace
-  // intent. Otherwise, the pushState already ran, so use 'replace' to avoid
-  // creating a duplicate history entry.
-  //
-  // This works because React entangles the retry's state update with the
-  // original pending transition — they commit together as a single batch,
-  // so the navigate type from the retry is what HistoryUpdater ultimately sees.
-  //
-  // TODO: Ideally this check would happen right before we schedule the React
-  // update (i.e., closer to where the action is dispatched into the queue),
-  // not here where the action is constructed. But the current action queue
-  // doesn't provide a natural place for that. Revisit when we refactor the
-  // action queue into a more reactive navigation model.
-  const lastCommitted = getLastCommittedTree()
-  const retryNavigateType: 'push' | 'replace' =
-    lastCommitted !== null && baseTree !== lastCommitted
-      ? originalNavigateType
-      : 'replace'
-
-  const retryAction: ServerPatchAction = {
-    type: ACTION_SERVER_PATCH,
-    previousTree: baseTree,
-    url: retryUrl,
-    nextUrl: retryNextUrl,
-    seed,
-    mpa: isHardRetry,
-    navigateType: retryNavigateType,
-    freshnessPolicy: retryFreshnessPolicy,
-  }
-  dispatchAppRouterAction(retryAction)
 }
 
 async function fetchMissingDynamicData(

--- a/packages/next/src/client/components/sequential-router-queue.ts
+++ b/packages/next/src/client/components/sequential-router-queue.ts
@@ -18,10 +18,12 @@ import {
   ACTION_NAVIGATE,
   ACTION_REFRESH,
   ACTION_RESTORE,
+  ACTION_SERVER_PATCH,
   type AppHistoryState,
   type AppRouterState,
   type NavigateAction,
   ScrollBehavior,
+  type ServerPatchAction,
 } from './router-reducer/router-reducer-types'
 import type { NavigateOptions } from '../../shared/lib/app-router-context.shared-runtime'
 import { dispatchAppRouterAction } from './use-action-queue'
@@ -32,7 +34,21 @@ import { startRouterTransition } from './router-transition'
 import { addBasePath } from '../add-base-path'
 import { isExternalURL } from './app-router-utils'
 import { isJavaScriptURLString } from '../lib/javascript-url'
-import { resetKnownRoutes } from './segment-cache/optimistic-routes'
+import {
+  discoverKnownRoute,
+  resetKnownRoutes,
+} from './segment-cache/optimistic-routes'
+import {
+  markRouteEntryAsDynamicRewrite,
+  invalidateRouteCacheEntries,
+  type FulfilledRouteCacheEntry,
+} from './segment-cache/cache'
+import { getLastCommittedTree } from './router-reducer/reducers/committed-state'
+import { createHrefFromUrl } from './router-reducer/create-href-from-url'
+import type { FlightRouterState } from '../../shared/lib/app-router-types'
+import type { NavigationSeed } from './segment-cache/decode-server-response'
+import type { NormalizedSearch } from './segment-cache/cache-key'
+import type { FreshnessPolicy } from './render-tree'
 
 function getRequiredAppRouterState(): AppRouterState {
   const state = getCurrentAppRouterState()
@@ -182,6 +198,119 @@ export function refresh(): void {
       type: ACTION_REFRESH,
     })
   })
+}
+
+// Represents whether the previous navigation resulted in a route tree mismatch.
+// A mismatch results in a refresh of the page. If there are two successive
+// mismatches, we will fall back to an MPA navigation, to prevent a retry loop.
+//
+// NOTE: This state was originally tracked directly in the render-tree.ts
+// module. In the Concurrent Router implementation, we will likely track this
+// as part of the internal router state machine.
+let previousNavigationDidMismatch = false
+
+/**
+ * Internal operation, not a user-facing one: the back-edge from shared
+ * navigation machinery (render-tree.ts), called when a navigation request's
+ * dynamic server response does not match the client tree. Responds by
+ * dispatching a refresh of the (possibly redirect-corrected) target. There is
+ * no originating event, and deliberately no startTransition here — the
+ * refresh's transition comes from the action queue's internal wrap.
+ *
+ * @param url The (possibly redirect-corrected) target URL.
+ * @param seed Server data to reuse, if any.
+ * @param baseTree The tree the failed navigation was based on.
+ * @param routeCacheEntry The route cache entry used for the navigation, if it
+ * came from route prediction; since the navigation resulted in a mismatch, it
+ * is marked as having a dynamic rewrite so future predictions bail out.
+ * @param navigateType The original navigation's push/replace intent.
+ * @param hard Escalate to an MPA navigation. Raw per-mismatch value; even
+ * when false, the refresh escalates here if the previous navigation
+ * also mismatched.
+ */
+export function finishMismatchedNavigationRequest(
+  url: URL,
+  nextUrl: string | null,
+  seed: NavigationSeed | null,
+  baseTree: FlightRouterState,
+  routeCacheEntry: FulfilledRouteCacheEntry | null,
+  navigateType: 'push' | 'replace',
+  hard: boolean,
+  freshness: FreshnessPolicy.RefreshAll | FreshnessPolicy.HistoryTraversal
+): void {
+  // If the navigation used a route prediction, mark it as having a dynamic
+  // rewrite since it resulted in a mismatch.
+  if (routeCacheEntry !== null) {
+    markRouteEntryAsDynamicRewrite(routeCacheEntry)
+  } else if (seed !== null) {
+    // Even without a direct reference to the route cache entry, we can still
+    // mark the route as having a dynamic rewrite by traversing the known route
+    // tree. This handles cases where the navigation didn't originate from a
+    // route prediction, but still needs to mark the pattern.
+    const metadataVaryPath = seed.metadataVaryPath
+    if (metadataVaryPath !== null) {
+      const now = Date.now()
+      discoverKnownRoute(
+        now,
+        url.pathname,
+        url.search as NormalizedSearch,
+        nextUrl,
+        null,
+        seed.routeTree,
+        metadataVaryPath,
+        false, // couldBeIntercepted - doesn't matter, we're just marking hasDynamicRewrite
+        createHrefFromUrl(url),
+        false, // supportsPerSegmentPrefetching - doesn't matter, we're just marking hasDynamicRewrite
+        true // hasDynamicRewrite
+      )
+    }
+  }
+
+  // Invalidate all route cache entries. Other entries may have been derived
+  // from the template before we knew it had a dynamic rewrite. This also
+  // triggers re-prefetching of visible links.
+  invalidateRouteCacheEntries(nextUrl, baseTree)
+
+  // If this is the second time in a row that a navigation resulted in a
+  // mismatch, fall back to a hard (MPA) refresh.
+  hard = hard || previousNavigationDidMismatch
+  previousNavigationDidMismatch = true
+
+  // If the original navigation hasn't committed to the browser history yet
+  // (the transition suspended before React committed), inherit its push/replace
+  // intent. Otherwise, the pushState already ran, so use 'replace' to avoid
+  // creating a duplicate history entry.
+  //
+  // This works because React entangles the retry's state update with the
+  // original pending transition — they commit together as a single batch,
+  // so the navigate type from the retry is what HistoryUpdater ultimately sees.
+  const lastCommitted = getLastCommittedTree()
+  const retryNavigateType: 'push' | 'replace' =
+    lastCommitted !== null && baseTree !== lastCommitted
+      ? navigateType
+      : 'replace'
+
+  const retryAction: ServerPatchAction = {
+    type: ACTION_SERVER_PATCH,
+    previousTree: baseTree,
+    url,
+    nextUrl,
+    seed,
+    mpa: hard,
+    navigateType: retryNavigateType,
+    freshnessPolicy: freshness,
+  }
+  dispatchAppRouterAction(retryAction)
+}
+
+/**
+ * Internal operation, not a user-facing one: called by shared navigation
+ * machinery (render-tree.ts) when a navigation request completes without a
+ * tree mismatch — either fully cached, or all of its dynamic requests
+ * finished cleanly. Clears the two-strike mismatch-escalation state.
+ */
+export function finishNavigationRequest(): void {
+  previousNavigationDidMismatch = false
 }
 
 // Tracks the newest HMR refresh generation so that a newer refresh can abort


### PR DESCRIPTION
render-tree.ts is shared navigation machinery — it will be used by both the existing router queue and the experimental concurrentRouterQueue implementation — but it dispatched server-patch retries directly into the sequential queue via dispatchAppRouterAction, which shared code can't do once the implementations fork.

Instead, render-tree now reports how a navigation request finished through two new internal navigator operations: finishNavigationRequest (the request completed cleanly) and finishMismatchedNavigationRequest (the dynamic response didn't match the client tree). Since imports of the navigator module are swapped at the bundler level, the calls route to whichever implementation is active. This is the pattern we'll use whenever code needs to fork on the navigator implementation.

No behavior changes.
