### PR TITLE
docs(readme): use standard relative paths for license, code of conduct, and contributing guidelines

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -9,7 +9,7 @@
 
 <a href="https://vercel.com"><img alt="Vercel logo" src="https://img.shields.io/badge/MADE%20BY%20Vercel-000000.svg?style=for-the-badge&logo=Vercel&labelColor=000"></a>
 <a href="https://www.npmjs.com/package/next"><img alt="NPM version" src="https://img.shields.io/npm/v/next.svg?style=for-the-badge&labelColor=000000"></a>
-<a href="https://github.com/vercel/next.js/blob/canary/license.md"><img alt="License" src="https://img.shields.io/npm/l/next.svg?style=for-the-badge&labelColor=000000"></a>
+<a href="license.md"><img alt="License" src="https://img.shields.io/npm/l/next.svg?style=for-the-badge&labelColor=000000"></a>
 <a href="https://github.com/vercel/next.js/discussions"><img alt="Join the community on GitHub" src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&logo=Next.js&labelColor=000000&logoWidth=20"></a>
 
 </div>
@@ -31,11 +31,11 @@ The Next.js community can be found on [GitHub Discussions](https://github.com/ve
 
 To chat with other community members, you can join the Next.js [Discord](https://nextjs.org/discord) server.
 
-Do note that our [Code of Conduct](https://github.com/vercel/next.js/blob/canary/CODE_OF_CONDUCT.md) applies to all Next.js community channels. Users are **highly encouraged** to read and adhere to it to avoid repercussions.
+Do note that our [Code of Conduct](CODE_OF_CONDUCT.md) applies to all Next.js community channels. Users are **highly encouraged** to read and adhere to it to avoid repercussions.
 
 ## Contributing
 
-Contributions to Next.js are welcome and highly appreciated. However, before you jump right into it, we would like you to review our [Contribution Guidelines](/contributing.md) to make sure you have a smooth experience contributing to Next.js.
+Contributions to Next.js are welcome and highly appreciated. However, before you jump right into it, we would like you to review our [Contribution Guidelines](contributing.md) to make sure you have a smooth experience contributing to Next.js.
 
 ### Good First Issues:
 


### PR DESCRIPTION
## Summary

- Replaces hardcoded branch URLs (`https://github.com/vercel/next.js/blob/canary/...`) in `README.md` with standard relative Markdown links for `license.md` and `CODE_OF_CONDUCT.md`.
- Changes absolute leading path `/contributing.md` to relative `contributing.md`.