### PR TITLE
[test] Deflake the page config test for a string config value

### DIFF
--- a/test/production/page-config/page-config.test.ts
+++ b/test/production/page-config/page-config.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Page Config', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
@@ -18,9 +18,32 @@ describe('Page Config', () => {
 
     try {
       const { cliOutput } = await next.build()
-      expect(cliOutput).toContain(
-        "Next.js can't recognize the exported `config`"
-      )
+
+      // The two bundlers reject this config in different places, so each one
+      // reports a different error.
+      if (isTurbopack) {
+        // Turbopack rejects the config in its own transform, and the build
+        // stops there. It never reads the value with the segment config schema.
+        expect(cliOutput).toContain(
+          "Next.js can't recognize the exported `config` field"
+        )
+      } else {
+        // Webpack reads the value with the segment config schema, and the
+        // schema rejects the string. The build stops with that error.
+        //
+        // `getPageStaticInfo` also warns that it cannot recognize the field.
+        // Only the server compilation logs that warning, and the build can stop
+        // before the server compilation reaches this page. The warning
+        // therefore does not always reach the output, and this test does not
+        // assert it. The tests below do, because the build does not stop for
+        // the configs they use.
+        expect(cliOutput).toContain(
+          'Invalid segment configuration options detected for "/invalid/string-config"'
+        )
+        expect(cliOutput).toContain(
+          'Expected object, received string at "config"'
+        )
+      }
     } finally {
       await next.patchFile('pages/invalid/string-config.js', origContent)
     }


### PR DESCRIPTION
[Flakiness metrics](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.name%3A%22Page%20Config%20shows%20valid%20error%20when%20page%20config%20is%20a%20string%22%20%40test.type%3A%22nextjs%22%20%40test.status%3A%22fail%22&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=timestamp%2Casc&fromUser=false&index=citest&start=1787041882706&end=1787646682706&paused=false)

The test asserted a warning that the build does not always print. Webpack logs it from the server compilation only, and the build stops when the segment config schema rejects the string value. The build can stop before the server compilation reaches the page, and the warning is then missing.

Each bundler now gets the error that it always prints. Webpack reports that the segment config schema rejected the value. Turbopack rejects the config in its own transform, before it reads the value with that schema, so it keeps reporting that it cannot recognize the field. The four tests below still assert the warning, because their configs do not stop the build.