### PR TITLE
fix: apply CSP nonce to Pages Router streamed Suspense scripts

### DIFF
--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -1377,6 +1377,7 @@ export async function renderToHTMLImpl(
       return await renderToInitialFizzStream({
         ReactDOMServer: ReactDOMServerPages,
         element: content,
+        streamOptions: { nonce },
       })
     }
 

--- a/test/e2e/pages-router-nonce-streaming/middleware.js
+++ b/test/e2e/pages-router-nonce-streaming/middleware.js
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+
+const nonce = 'test-nonce'
+const csp = `default-src 'self'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'unsafe-inline'`
+
+export function middleware(request) {
+  // The renderer reads the nonce off the *request* CSP header, while the browser
+  // needs it on the response, so both are set here.
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('Content-Security-Policy', csp)
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } })
+  response.headers.set('Content-Security-Policy', csp)
+  return response
+}
+
+export const config = {
+  matcher: '/:path*',
+}

--- a/test/e2e/pages-router-nonce-streaming/pages-router-nonce-streaming.test.ts
+++ b/test/e2e/pages-router-nonce-streaming/pages-router-nonce-streaming.test.ts
@@ -1,0 +1,31 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('Pages Router - CSP nonce on streamed Suspense scripts', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('nonces every inline script emitted while streaming', async () => {
+    const $ = await next.render$('/')
+
+    // Guards against the assertion below passing for the wrong reason: if the
+    // page ever stops streaming there are no reveal scripts to nonce at all.
+    const revealScripts = $('script').filter((_, element) => {
+      return /\$R[A-Z]?=/.test($(element).html() || '')
+    })
+    expect(revealScripts.length).toBeGreaterThan(0)
+
+    // Asserted over every inline script rather than a known prefix: React emits
+    // more than one kind (the reveal runtime and a reveal-timing script), and
+    // matching on their contents would silently miss any it renames or adds.
+    const unnoncedInlineScripts = $('script')
+      .filter((_, element) => {
+        const $element = $(element)
+        return !$element.attr('src') && !$element.attr('nonce')
+      })
+      .map((_, element) => ($(element).html() || '').slice(0, 60))
+      .get()
+
+    expect(unnoncedInlineScripts).toEqual([])
+  })
+})

--- a/test/e2e/pages-router-nonce-streaming/pages/index.js
+++ b/test/e2e/pages-router-nonce-streaming/pages/index.js
@@ -1,0 +1,69 @@
+import { Suspense } from 'react'
+
+// Keyed per request so every request suspends, not just the first one to reach
+// the server. React retries a suspended component, so the same promise has to
+// come back on the retry or it would suspend forever.
+const pending = new Map()
+const resolved = new Set()
+
+function suspendOnce(key, durationMs) {
+  if (resolved.has(key)) return
+
+  let promise = pending.get(key)
+  if (!promise) {
+    promise = new Promise((resolve) => {
+      setTimeout(() => {
+        resolved.add(key)
+        resolve()
+      }, durationMs)
+    })
+    pending.set(key, promise)
+  }
+
+  throw promise
+}
+
+// Bulk markup between the boundaries so the shell is large enough to be flushed
+// before the later boundaries resolve — otherwise React inlines the resolved
+// content and never emits the reveal instructions this test is about.
+function Filler() {
+  return (
+    <div>
+      {Array.from({ length: 200 }, (_, i) => (
+        <p key={i}>Static content line {i}</p>
+      ))}
+    </div>
+  )
+}
+
+function Boundary({ requestId, name, children }) {
+  suspendOnce(`${requestId}-${name}`, 700)
+  return <>{children}</>
+}
+
+// Nested boundaries: each only starts rendering — and therefore only starts
+// suspending — once its parent has resolved, so they resolve in sequence well
+// after the shell has gone out.
+export default function Page({ requestId }) {
+  return (
+    <Suspense fallback={<p id="outer-fallback">loading outer</p>}>
+      <Boundary requestId={requestId} name="outer">
+        <Filler />
+        <Suspense fallback={<p id="middle-fallback">loading middle</p>}>
+          <Boundary requestId={requestId} name="middle">
+            <Filler />
+            <Suspense fallback={<p id="inner-fallback">loading inner</p>}>
+              <Boundary requestId={requestId} name="inner">
+                <p id="slow">resolved</p>
+              </Boundary>
+            </Suspense>
+          </Boundary>
+        </Suspense>
+      </Boundary>
+    </Suspense>
+  )
+}
+
+export function getServerSideProps() {
+  return { props: { requestId: `${Date.now()}-${Math.random()}` } }
+}


### PR DESCRIPTION
Hi NextJs team,

### What?

I am working on a large pages-router-based NextJS app and while implementing CSP headers, I have discovered an annoying bug. It seems that nonce is not passed to the suspense boundaries when using Pages Router. The App router seems to be unaffected. The bug was already previously reported in teh past eg [#96443](https://github.com/vercel/next.js/issues/96443)

### Why?

We could see that the Pages router correctly gets the nonce from the header and applies it to the script tags it renders. But it doesn't hand it over to React Fizz renderer. So the scripts in boundaries get blocked when enfiorcing the CSP policy. An example of a blocked script would be the Reacts reveal timing script `requestAnimationFrame(function(){$RT=performance.now()});` that gets inlined by React 19.x.

### How?

We tried different approaches to fix that but we either had to rewrite the script tags in the server or monkey-patch nextJS. Using Claude we could narrow down the problem to **one line** in the `render.tsx` - simply by passing the nonce to the Fizz it would fix the issue.

Tests added that should show how the suspend then works after CSP fix - it fails without a fix, correctly verifying the problem.

Pls let me know if you need any chanegs or additional info.

Fixes #96443
