### PR TITLE
fix(turbo-rcstr): allow the napi feature on wasm targets

### DIFF
--- a/turbopack/crates/turbo-rcstr/Cargo.toml
+++ b/turbopack/crates/turbo-rcstr/Cargo.toml
@@ -23,8 +23,9 @@ turbo-bincode = { workspace = true }
 turbo-rcstr-macros = { path = "../turbo-rcstr-macros" }
 unty = { workspace = true }
 
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
 napi = { workspace = true, optional = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 scattered-collect = { workspace = true }
 
 [dev-dependencies]

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -602,10 +602,7 @@ impl ShrinkToFit for RcStr {
     fn shrink_to_fit(&mut self) {}
 }
 
-#[cfg(all(feature = "napi", target_family = "wasm"))]
-compile_error!("The napi feature cannot be enabled for wasm targets");
-
-#[cfg(all(feature = "napi", not(target_family = "wasm")))]
+#[cfg(feature = "napi")]
 mod napi_impl {
     use napi::{
         bindgen_prelude::{FromNapiValue, ToNapiValue, TypeName, ValidateNapiValue},


### PR DESCRIPTION
> Replaces #97578, which was **not merged**. Reordering this stack briefly left that PR
> pointing at a base branch that had come to contain its own head commit, so GitHub closed it
> as merged and deleted its branch. Nothing from it reached `canary`. It had been approved;
> this PR is the same commit (`0b53306e79`), restored, and needs review again. Sorry for the churn.

### What?

Removes `turbo-rcstr`'s hard stop against combining the `napi` feature with wasm targets, and moves
the `napi` dependency out of the non-wasm dependency table.

### Why?

The crate contained:

```rust
#[cfg(all(feature = "napi", target_family = "wasm"))]
compile_error!("The napi feature cannot be enabled for wasm targets");
```

This predates napi v3, which supports `wasm32-wasip1-threads`. With the assertion removed,
`turbo-rcstr/napi` and everything built on it — `turbopack-node/worker_pool`,
`next-api/worker_pool`, `next-napi-bindings` — compiles for wasm.

### How?

Delete the `compile_error!`, drop the now-redundant `cfg` on the `napi_impl` module, and declare
`napi` as a normal optional dependency rather than a non-wasm-only one.

<!-- NEXT_JS_LLM -->



<!-- fleet b6d0486f-97c7-42a7-bdaf-3490774cdec3 -->