### PR TITLE
fix(turbopack-trace-utils): skip the ctrl-c handler on wasm

### DIFF
--- a/turbopack/crates/turbopack-trace-utils/src/exit.rs
+++ b/turbopack/crates/turbopack-trace-utils/src/exit.rs
@@ -19,8 +19,12 @@ impl<T> Drop for ExitGuard<T> {
 
 impl<T: Send + 'static> ExitGuard<T> {
     /// Drop a guard when Ctrl-C is pressed or the [ExitGuard] is dropped.
+    ///
+    /// On wasm targets there is no Ctrl-C to listen for (`tokio::signal` does not exist on wasi),
+    /// so the guard is only dropped when the [ExitGuard] itself is dropped.
     pub fn new(guard: T) -> Result<Self> {
         let guard = Arc::new(Mutex::new(Some(guard)));
+        #[cfg(not(target_family = "wasm"))]
         {
             let guard = guard.clone();
             tokio::spawn(async move {
@@ -58,11 +62,16 @@ impl ExitHandler {
     /// [`ExitHandler::new_receiver`] instead.
     ///
     /// This may listen for other signals, like `SIGTERM` or `SIGPIPE` in the future.
+    ///
+    /// On wasm targets there are no process signals, so nothing is ever run: the returned handler
+    /// only fires through [`ExitReceiver::run_exit_handler`], which this function has no way to
+    /// reach. wasm callers should use [`ExitHandler::new_receiver`].
     pub fn listen() -> &'static Arc<ExitHandler> {
         let (handler, receiver) = Self::new_receiver();
         if GLOBAL_EXIT_HANDLER.set(handler).is_err() {
             panic!("ExitHandler::listen must only be called once");
         }
+        #[cfg(not(target_family = "wasm"))]
         tokio::spawn(async move {
             tokio::signal::ctrl_c()
                 .await
@@ -70,6 +79,8 @@ impl ExitHandler {
             receiver.run_exit_handler().await;
             std::process::exit(0);
         });
+        #[cfg(target_family = "wasm")]
+        drop(receiver);
         GLOBAL_EXIT_HANDLER.get().expect("value is set")
     }
 


### PR DESCRIPTION
> Replaces #97582, which was **not merged**. Reordering this stack briefly left that PR
> pointing at a base branch that had come to contain its own head commit, so GitHub closed it
> as merged and deleted its branch. Nothing from it reached `canary`. It had been approved;
> this PR is the same commit (`8f8bc4d0b0`), restored, and needs review again. Sorry for the churn.

### What?

`turbopack-trace-utils` no longer registers a Ctrl-C handler on wasm targets.

### Why?

`tokio::signal` does not exist on wasi, so `exit.rs` failed to compile. There is also no SIGINT to
wait for inside a wasm instance, so there is nothing to handle.

### How?

The `tokio::spawn` calls in `ExitGuard::new` and `ExitHandler::listen` are gated to non-wasm. On
wasm, `ExitGuard` fires only when the guard is dropped, and `ExitHandler::listen` registers no
handler — the doc comments now say so, and point wasm callers at `ExitHandler::new_receiver`.

<!-- NEXT_JS_LLM -->



<!-- fleet b6d0486f-97c7-42a7-bdaf-3490774cdec3 -->