### PR TITLE
fix(turbopack-node): make process_pool inert on wasm

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -88,7 +88,7 @@ use turbopack_core::{
         VersionState, VersionedContent,
     },
 };
-#[cfg(feature = "process_pool")]
+#[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
 use turbopack_node::child_process_backend;
 use turbopack_node::execution_context::ExecutionContext;
 #[cfg(feature = "worker_pool")]
@@ -1233,7 +1233,7 @@ impl Project {
         let node_backend = match strategy {
             #[cfg(feature = "worker_pool")]
             TurbopackPluginRuntimeStrategy::WorkerThreads => worker_threads_backend(),
-            #[cfg(feature = "process_pool")]
+            #[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
             TurbopackPluginRuntimeStrategy::ChildProcesses => child_process_backend(),
         };
 

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -923,7 +923,7 @@ pub enum ModuleIds {
 pub enum TurbopackPluginRuntimeStrategy {
     #[cfg(feature = "worker_pool")]
     WorkerThreads,
-    #[cfg(feature = "process_pool")]
+    #[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
     ChildProcesses,
 }
 
@@ -2588,9 +2588,14 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub fn turbopack_plugin_runtime_strategy(&self) -> Vc<TurbopackPluginRuntimeStrategy> {
-        #[cfg(feature = "process_pool")]
+        // Child processes cannot be spawned from inside wasm, so worker threads are the only
+        // available runtime there.
+        #[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
         let default = TurbopackPluginRuntimeStrategy::ChildProcesses;
-        #[cfg(all(feature = "worker_pool", not(feature = "process_pool")))]
+        #[cfg(all(
+            feature = "worker_pool",
+            any(not(feature = "process_pool"), target_family = "wasm")
+        ))]
         let default = TurbopackPluginRuntimeStrategy::WorkerThreads;
 
         self.experimental

--- a/turbopack/crates/turbopack-node/src/backend.rs
+++ b/turbopack/crates/turbopack-node/src/backend.rs
@@ -30,7 +30,7 @@ mod sealed {
 #[turbo_tasks::value_impl]
 impl sealed::Sealed for crate::worker_pool::WorkerThreadsBackend {}
 
-#[cfg(feature = "process_pool")]
+#[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
 #[turbo_tasks::value_impl]
 impl sealed::Sealed for crate::process_pool::ChildProcessesBackend {}
 

--- a/turbopack/crates/turbopack-node/src/lib.rs
+++ b/turbopack/crates/turbopack-node/src/lib.rs
@@ -20,7 +20,9 @@ pub mod evaluate;
 pub mod execution_context;
 mod format;
 mod pool_stats;
-#[cfg(feature = "process_pool")]
+// The child-process pool needs `tokio::process` and a TCP listener, neither of which exists on
+// wasi, so `process_pool` is inert on wasm and `worker_pool` is the only available backend there.
+#[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
 pub mod process_pool;
 pub mod source_map;
 pub mod transforms;
@@ -28,7 +30,7 @@ pub mod transforms;
 pub mod worker_pool;
 
 pub use backend::{CreatePoolFuture, CreatePoolOptions, NodeBackend};
-#[cfg(feature = "process_pool")]
+#[cfg(all(feature = "process_pool", not(target_family = "wasm")))]
 pub fn child_process_backend() -> Vc<Box<dyn NodeBackend>> {
     Vc::upcast(process_pool::ChildProcessesBackend.cell())
 }


### PR DESCRIPTION
> Replaces #97584, which was **not merged**. Reordering this stack briefly left that PR
> pointing at a base branch that had come to contain its own head commit, so GitHub closed it
> as merged and deleted its branch. Nothing from it reached `canary`. It had been approved;
> this PR is the same commit (`fb0b97fd84`), restored, and needs review again. Sorry for the churn.

### What?

`turbopack-node`'s `process_pool` feature is inert on wasm, leaving `worker_pool` as the only Node
backend there.

### Why?

The child-process pool needs `tokio::process` and a TCP listener, neither of which exists on wasi:

```
error[E0432]: unresolved import `tokio::process`   # gated #[cfg(not(target_os = "wasi"))] in tokio
error[E0599]: no `TcpListener::bind` on wasi
  --> turbopack/crates/turbopack-node/src/process_pool/mod.rs:315
```

Turning the feature off from the outside is not possible: `process_pool` is a **default** feature of
both `turbopack-node` *and* `next-core`, so `--no-default-features` at the top level does not
suppress it.

`worker_pool` — Node worker threads over napi — is already a first-class alternative selected by
`TurbopackPluginRuntimeStrategy`, so no new mechanism is needed.

### How?

Gate the seven `process_pool` sites on `not(target_family = "wasm")`: the module, the sealed backend
impl, the constructor, the config enum variant, the default-strategy selection, and the `next-api`
import and match arm. Host feature semantics are unchanged.

<!-- NEXT_JS_LLM -->



<!-- fleet b6d0486f-97c7-42a7-bdaf-3490774cdec3 -->