### PR TITLE
fix(wasm): don't enable SWC's plugin host for wasm targets

### DIFF
--- a/crates/next-napi-bindings/Cargo.toml
+++ b/crates/next-napi-bindings/Cargo.toml
@@ -81,13 +81,21 @@ swc_core = { workspace = true, features = [
     "ecma_transforms_typescript",
     "ecma_utils",
     "ecma_visit",
+] }
+
+# Dependencies for the native, non-wasm32 build.
+#
+# SWC's plugin host is native-only: `__plugin_transform_host` turns on `swc/plugin`, which pulls in
+# the plugin runner and compiles SWC's `target_arch = "wasm32"` plugin path, and SWC does not support
+# running wasm plugins from inside wasm (https://github.com/swc-project/swc/issues/3934).
+# `plugin_transform_host_native_filesystem_cache` is a native filesystem cache and cannot apply there
+# either.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+swc_core = { workspace = true, features = [
     "__plugin_transform_host",
     "__plugin_transform_host_schema_v1",
     "plugin_transform_host_native_filesystem_cache",
 ] }
-
-# Dependencies for the native, non-wasm32 build.
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 swc_ecma_react_compiler = { workspace = true }
 turbopack-lightningcss-napi = { workspace = true }
 lightningcss = { workspace = true }

--- a/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
@@ -38,15 +38,22 @@ swc_core = { workspace = true, features = [
   "ecma_ast",
   "ecma_visit",
   "common",
-  "__plugin_transform_host",
-  "__plugin_transform_host_schema_v1",
 ] }
 swc_emotion = { workspace = true }
 swc_relay = { workspace = true }
 
-# wasmtime cannot be hosted inside wasm (no JIT, and `wasi-common` needs native filesystem APIs),
-# so the SWC wasm-plugin backend is native-only. SWC's own wasm32 path skips plugin transforms too,
-# see https://github.com/swc-project/swc/issues/3934.
+# SWC's plugin host is native-only, so its features must not be enabled for wasm.
+#
+# `swc_core/__plugin_transform_host` turns on `swc/plugin`, which pulls in the plugin runner and
+# `tokio`'s multi-thread runtime, and compiles SWC's `target_arch = "wasm32"` plugin path. SWC does
+# not support executing wasm plugins from inside wasm (see
+# https://github.com/swc-project/swc/issues/3934), and hosting them needs the wasmtime backend gated
+# out below, so enabling these for wasm builds code that can never run.
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
+swc_core = { workspace = true, features = [
+  "__plugin_transform_host",
+  "__plugin_transform_host_schema_v1",
+] }
+# wasmtime cannot be hosted inside wasm (no JIT, and `wasi-common` needs native filesystem APIs).
 swc_plugin_backend_wasmtime = { workspace = true }
 


### PR DESCRIPTION
> Replaces #97788, which was **not merged**. Reordering this stack briefly left that PR
> pointing at a base branch that had come to contain its own head commit, so GitHub closed it
> as merged and deleted its branch. Nothing from it reached `canary`. It had been approved;
> this PR is the same commit (`142f8882a2`), restored, and needs review again. Sorry for the churn.

### What?

Stop enabling SWC's plugin-host Cargo features when building for wasm.

### Why?

`turbopack-ecmascript-plugins` and `next-napi-bindings` both requested `swc_core`'s
`__plugin_transform_host` unconditionally, and that feature includes **`swc/plugin`** directly. So
every wasm build pulled in SWC's plugin runner and compiled SWC's `target_arch = "wasm32"` plugin
path — code that cannot run there.

SWC does not support executing wasm plugins from inside wasm (see
swc-project/swc#3934; its own wasm binding stubs the equivalent feature out to `[]`), and hosting them
needs the wasmtime backend, which was already gated to non-wasm. The plugin rule on the Next.js side
is native-only too. Only the Cargo features were never gated to match the code boundary that already
existed.

This is what lets the rest of the stack build for wasm **without patching SWC**: the wasm32 plugin arm
that does not compile is simply never built.

It also removes a portability hazard beyond that compile error — `swc/plugin` brings in tokio's
multi-thread runtime, which wasi accepts only on the threaded target; plain `wasm32-wasip1` rejects
those tokio features outright.

`plugin_transform_host_native_filesystem_cache` moves with them: it is a *native* filesystem cache and
cannot apply on wasm.

### How?

Both crates keep their shared AST/transform features and move the plugin-host features into their
existing non-wasm dependency blocks.

Verified on the resolved feature graph rather than by reading manifests, because feature unification
can make a manifest look right while the graph is wrong:

- `cargo tree -p next-napi-bindings --target wasm32-wasip1-threads -e features` — no
  `swc feature "plugin"`, no `swc_core feature "__plugin_transform_host"`;
- the same query for the host target lists all six plugin-related features, byte-identical to before.


<!-- fleet b6d0486f-97c7-42a7-bdaf-3490774cdec3 -->
