### PR TITLE
docs: fix inconsistent British spelling in turbopackChunking.mdx

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackChunking.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackChunking.mdx
@@ -10,7 +10,7 @@ version: experimental
 
 `experimental.turbopackChunking` lets you configure Turbopack's production JavaScript
 chunker. These options allow you to change the assumptions the chunker makes about user
-behaviour, tweak the raw size thresholds it uses, and enable the experimental component
+behavior, tweak the raw size thresholds it uses, and enable the experimental component
 chunks feature.
 
 </AppOnly>
@@ -19,7 +19,7 @@ chunks feature.
 
 `experimental.turbopackChunking` lets you configure Turbopack's production JavaScript
 chunker. These options allow you to change the assumptions the chunker makes about user
-behaviour and tweak the raw size thresholds it uses.
+behavior and tweak the raw size thresholds it uses.
 
 </PagesOnly>
 


### PR DESCRIPTION
Small doc consistency fix — this file uses "behaviour" (British spelling) where the rest of the docs consistently use "behavior" (115 occurrences elsewhere in `docs/` vs. 1 in this file).