### PR TITLE
docs: document preloading with Cache Components

### DIFF
--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -545,23 +545,27 @@ export default async function Page({ params }) {
 
 ### Reusing data with `React.cache`
 
-Wrap a data-fetching function in [`React.cache`](https://react.dev/reference/react/cache) so multiple components in the same request share one result instead of refetching:
+For data access that does not use `fetch`, such as an ORM or database query, wrap the function in [`React.cache`](https://react.dev/reference/react/cache). Multiple components can then call the function within the same request while sharing one result:
 
 ```ts filename="app/lib/user.ts" switcher
 import { cache } from 'react'
+import { db, eq, users } from '@/lib/db'
 
-export const getUser = cache(async () => {
-  const res = await fetch('https://api.example.com/user')
-  return res.json()
+export const getUser = cache(async (id: string) => {
+  return db.query.users.findFirst({
+    where: eq(users.id, id),
+  })
 })
 ```
 
 ```js filename="app/lib/user.js" switcher
 import { cache } from 'react'
+import { db, eq, users } from '@/lib/db'
 
-export const getUser = cache(async () => {
-  const res = await fetch('https://api.example.com/user')
-  return res.json()
+export const getUser = cache(async (id) => {
+  return db.query.users.findFirst({
+    where: eq(users.id, id),
+  })
 })
 ```
 
@@ -571,7 +575,12 @@ Server Components can call `getUser()` directly:
 import { getUser } from '../lib/user'
 
 export default async function DashboardPage() {
-  const user = await getUser() // Cached - same request, no duplicate fetch
+  const user = await getUser('1')
+
+  if (!user) {
+    return null
+  }
+
   return <h1>Dashboard for {user.name}</h1>
 }
 ```
@@ -580,20 +589,29 @@ export default async function DashboardPage() {
 import { getUser } from '../lib/user'
 
 export default async function DashboardPage() {
-  const user = await getUser() // Cached - same request, no duplicate fetch
+  const user = await getUser('1')
+
+  if (!user) {
+    return null
+  }
+
   return <h1>Dashboard for {user.name}</h1>
 }
 ```
 
-Since `getUser` is wrapped with `React.cache`, multiple calls within the same request return the same memoized result, whether called directly in Server Components or resolved via context in Client Components.
+Since `getUser` is wrapped with `React.cache`, calls with the same `id` within one request return the same memoized result.
 
-> **Good to know**: [`React.cache`](https://react.dev/reference/react/cache#caveats) is scoped to the current request only. Each request gets its own memoization scope with no sharing between requests.
+> **Good to know:** [`React.cache`](https://react.dev/reference/react/cache#caveats) is scoped to the current request only. Each request gets its own memoization scope with no sharing between requests.
 
 ### Preloading data
 
-Once matching calls can reuse one request, you can start that request before the component that needs it renders. Call the data-fetching function without `await` above blocking work, then call the same function when you render the component.
+Preloading starts a data request before the component that consumes the result renders. Call the data-fetching function without `await` before blocking work, then call the same function in the component.
 
-The example below uses `fetch`, which deduplicates identical requests. For other data access, use `React.cache` as shown above. With Cache Components, add [`'use cache'`](/docs/app/api-reference/directives/use-cache) to the data-fetching function instead of wrapping it in `React.cache`. For request-specific data that reads `cookies()` or `headers()`, use [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private#deduplicating-calls-within-a-request).
+The data-fetching function must deduplicate matching calls so the component can reuse the request started during preloading. Choose the approach that matches your data source:
+
+- For `fetch`, [identical requests are memoized automatically](/docs/app/api-reference/functions/fetch#memoization).
+- For an ORM or database, use `React.cache` as shown above.
+- With Cache Components, add [`'use cache'`](/docs/app/api-reference/directives/use-cache) to the data-fetching function. If the function reads request APIs such as `cookies()` or `headers()`, use [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private). In production, calls to the same private Cache Function with the same arguments reuse the result within one server request. Next.js discards the result when the request finishes.
 
 Keep the preload function next to the component that consumes the data. This makes the dependency easier to find if you move or remove the component:
 

--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -615,7 +615,7 @@ The data-fetching function must deduplicate matching calls so the component can 
 - For an ORM or database, wrap the data-fetching function in [`React.cache`](#reusing-data-with-reactcache).
 - With Cache Components, add [`'use cache'`](/docs/app/api-reference/directives/use-cache) to the data-fetching function. If the function reads request APIs such as `cookies()` or `headers()`, use [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private).
 
-In production, calls to the same private Cache Function with the same arguments reuse a result within one server request. This request-scoped deduplication lets the component reuse a request started during preloading without sharing the result across requests.
+In production, matching calls to a private Cache Function can reuse the same result within one request. This lets a component reuse a request started during preloading without storing the result in a server cache across requests.
 
 Keep the preload function next to the component that consumes the data. This makes the dependency easier to find if you move or remove the component:
 

--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -543,6 +543,82 @@ export default async function Page({ params }) {
 
 > **Good to know:** If one request fails when using `Promise.all`, the entire operation will fail. To handle this, you can use the [`Promise.allSettled`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) method instead.
 
+### Preloading data
+
+Preloading starts a data request before the component that needs it renders. Call the data-fetching function without `await` above blocking work, then call the same function when you render the component.
+
+Keep the preload function next to the component that consumes the data. This makes the dependency easier to find if you move or remove the component:
+
+```tsx filename="app/item/[id]/item.tsx" switcher
+async function getItem(id: string) {
+  const res = await fetch(`https://api.example.com/items/${id}`)
+  return res.json()
+}
+
+export const preload = (id: string) => {
+  void getItem(id)
+}
+
+export default async function Item({ id }: { id: string }) {
+  const item = await getItem(id)
+  return <div>{item.name}</div>
+}
+```
+
+```jsx filename="app/item/[id]/item.js" switcher
+async function getItem(id) {
+  const res = await fetch(`https://api.example.com/items/${id}`)
+  return res.json()
+}
+
+export const preload = (id) => {
+  void getItem(id)
+}
+
+export default async function Item({ id }) {
+  const item = await getItem(id)
+  return <div>{item.name}</div>
+}
+```
+
+Call `preload()` before another blocking request to start loading the item earlier:
+
+```tsx filename="app/item/[id]/page.tsx" switcher
+import Item, { preload } from './item'
+import { checkIsAvailable } from '@/app/lib/data'
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+
+  preload(id)
+  const isAvailable = await checkIsAvailable(id)
+
+  return isAvailable ? <Item id={id} /> : null
+}
+```
+
+```jsx filename="app/item/[id]/page.js" switcher
+import Item, { preload } from './item'
+import { checkIsAvailable } from '@/app/lib/data'
+
+export default async function Page({ params }) {
+  const { id } = await params
+
+  preload(id)
+  const isAvailable = await checkIsAvailable(id)
+
+  return isAvailable ? <Item id={id} /> : null
+}
+```
+
+The item request continues while `checkIsAvailable()` runs. If the page renders `<Item>`, the identical `fetch` call reuses the request that `preload()` started.
+
+For data access that is not based on `fetch` or a Cache Function, wrap the data-fetching function in [`React.cache`](#reusing-data-with-reactcache). With Cache Components, add [`'use cache'`](/docs/app/api-reference/directives/use-cache) to the data-fetching function instead of wrapping it in `React.cache`. Call the same Cache Function from the preload function and the component so matching calls reuse the result. For request-specific data that reads `cookies()` or `headers()`, [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private#deduplicating-calls-within-a-request) deduplicates matching calls within a server request without sharing the result across production requests.
+
 ### Reusing data with `React.cache`
 
 Wrap a data-fetching function in [`React.cache`](https://react.dev/reference/react/cache) so multiple components in the same request share one result instead of refetching:

--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -543,9 +543,55 @@ export default async function Page({ params }) {
 
 > **Good to know:** If one request fails when using `Promise.all`, the entire operation will fail. To handle this, you can use the [`Promise.allSettled`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) method instead.
 
+### Reusing data with `React.cache`
+
+Wrap a data-fetching function in [`React.cache`](https://react.dev/reference/react/cache) so multiple components in the same request share one result instead of refetching:
+
+```ts filename="app/lib/user.ts" switcher
+import { cache } from 'react'
+
+export const getUser = cache(async () => {
+  const res = await fetch('https://api.example.com/user')
+  return res.json()
+})
+```
+
+```js filename="app/lib/user.js" switcher
+import { cache } from 'react'
+
+export const getUser = cache(async () => {
+  const res = await fetch('https://api.example.com/user')
+  return res.json()
+})
+```
+
+Server Components can call `getUser()` directly:
+
+```tsx filename="app/dashboard/page.tsx" switcher
+import { getUser } from '../lib/user'
+
+export default async function DashboardPage() {
+  const user = await getUser() // Cached - same request, no duplicate fetch
+  return <h1>Dashboard for {user.name}</h1>
+}
+```
+
+```jsx filename="app/dashboard/page.js" switcher
+import { getUser } from '../lib/user'
+
+export default async function DashboardPage() {
+  const user = await getUser() // Cached - same request, no duplicate fetch
+  return <h1>Dashboard for {user.name}</h1>
+}
+```
+
+Since `getUser` is wrapped with `React.cache`, multiple calls within the same request return the same memoized result, whether called directly in Server Components or resolved via context in Client Components.
+
+> **Good to know**: `React.cache` is scoped to the current request only. Each request gets its own memoization scope with no sharing between requests.
+
 ### Preloading data
 
-Preloading starts a data request before the component that needs it renders. Call the data-fetching function without `await` above blocking work, then call the same function when you render the component.
+Once a data-fetching function deduplicates matching calls, you can use it to preload data before the component that needs it renders. Call the function without `await` above blocking work, then call the same function when you render the component.
 
 Keep the preload function next to the component that consumes the data. This makes the dependency easier to find if you move or remove the component:
 
@@ -617,50 +663,4 @@ export default async function Page({ params }) {
 
 The item request continues while `checkIsAvailable()` runs. If the page renders `<Item>`, the identical `fetch` call reuses the request that `preload()` started.
 
-For data access that is not based on `fetch` or a Cache Function, wrap the data-fetching function in [`React.cache`](#reusing-data-with-reactcache). With Cache Components, add [`'use cache'`](/docs/app/api-reference/directives/use-cache) to the data-fetching function instead of wrapping it in `React.cache`. Call the same Cache Function from the preload function and the component so matching calls reuse the result. For request-specific data that reads `cookies()` or `headers()`, [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private#deduplicating-calls-within-a-request) deduplicates matching calls within a server request without sharing the result across production requests.
-
-### Reusing data with `React.cache`
-
-Wrap a data-fetching function in [`React.cache`](https://react.dev/reference/react/cache) so multiple components in the same request share one result instead of refetching:
-
-```ts filename="app/lib/user.ts" switcher
-import { cache } from 'react'
-
-export const getUser = cache(async () => {
-  const res = await fetch('https://api.example.com/user')
-  return res.json()
-})
-```
-
-```js filename="app/lib/user.js" switcher
-import { cache } from 'react'
-
-export const getUser = cache(async () => {
-  const res = await fetch('https://api.example.com/user')
-  return res.json()
-})
-```
-
-Server Components can call `getUser()` directly:
-
-```tsx filename="app/dashboard/page.tsx" switcher
-import { getUser } from '../lib/user'
-
-export default async function DashboardPage() {
-  const user = await getUser() // Cached - same request, no duplicate fetch
-  return <h1>Dashboard for {user.name}</h1>
-}
-```
-
-```jsx filename="app/dashboard/page.js" switcher
-import { getUser } from '../lib/user'
-
-export default async function DashboardPage() {
-  const user = await getUser() // Cached - same request, no duplicate fetch
-  return <h1>Dashboard for {user.name}</h1>
-}
-```
-
-Since `getUser` is wrapped with `React.cache`, multiple calls within the same request return the same memoized result, whether called directly in Server Components or resolved via context in Client Components.
-
-> **Good to know**: `React.cache` is scoped to the current request only. Each request gets its own memoization scope with no sharing between requests.
+For data access that is not based on `fetch` or a Cache Function, wrap the data-fetching function in `React.cache`. With Cache Components, add [`'use cache'`](/docs/app/api-reference/directives/use-cache) to the data-fetching function instead of wrapping it in `React.cache`. Call the same Cache Function from the preload function and the component so matching calls reuse the result. For request-specific data that reads `cookies()` or `headers()`, [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private#deduplicating-calls-within-a-request) deduplicates matching calls within a server request without sharing the result across production requests.

--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -587,7 +587,7 @@ export default async function DashboardPage() {
 
 Since `getUser` is wrapped with `React.cache`, multiple calls within the same request return the same memoized result, whether called directly in Server Components or resolved via context in Client Components.
 
-> **Good to know**: `React.cache` is scoped to the current request only. Each request gets its own memoization scope with no sharing between requests.
+> **Good to know**: [`React.cache`](https://react.dev/reference/react/cache#caveats) is scoped to the current request only. Each request gets its own memoization scope with no sharing between requests.
 
 ### Preloading data
 

--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -605,7 +605,9 @@ Since `getUser` is wrapped with `React.cache`, calls with the same `id` within o
 
 ### Preloading data
 
-Preloading starts a data request before the component that consumes the result renders. Call the data-fetching function without `await` before blocking work, then call the same function in the component.
+When a component renders after other blocking work, its data request starts late even if the request inputs are already available. Preloading starts the request earlier so it can run in parallel with that work and avoid a request waterfall.
+
+To preload data, call the data-fetching function without `await` before blocking work, then call the same function in the component that consumes the result.
 
 The data-fetching function must deduplicate matching calls so the component can reuse the request started during preloading. Use one of the following approaches:
 

--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -591,7 +591,9 @@ Since `getUser` is wrapped with `React.cache`, multiple calls within the same re
 
 ### Preloading data
 
-Once a data-fetching function deduplicates matching calls, you can use it to preload data before the component that needs it renders. Call the function without `await` above blocking work, then call the same function when you render the component.
+Once matching calls can reuse one request, you can start that request before the component that needs it renders. Call the data-fetching function without `await` above blocking work, then call the same function when you render the component.
+
+The example below uses `fetch`, which deduplicates identical requests. For other data access, use `React.cache` as shown above. With Cache Components, add [`'use cache'`](/docs/app/api-reference/directives/use-cache) to the data-fetching function instead of wrapping it in `React.cache`. For request-specific data that reads `cookies()` or `headers()`, use [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private#deduplicating-calls-within-a-request).
 
 Keep the preload function next to the component that consumes the data. This makes the dependency easier to find if you move or remove the component:
 
@@ -662,5 +664,3 @@ export default async function Page({ params }) {
 ```
 
 The item request continues while `checkIsAvailable()` runs. If the page renders `<Item>`, the identical `fetch` call reuses the request that `preload()` started.
-
-For data access that is not based on `fetch` or a Cache Function, wrap the data-fetching function in `React.cache`. With Cache Components, add [`'use cache'`](/docs/app/api-reference/directives/use-cache) to the data-fetching function instead of wrapping it in `React.cache`. Call the same Cache Function from the preload function and the component so matching calls reuse the result. For request-specific data that reads `cookies()` or `headers()`, [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private#deduplicating-calls-within-a-request) deduplicates matching calls within a server request without sharing the result across production requests.

--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -610,7 +610,7 @@ Preloading starts a data request before the component that consumes the result r
 The data-fetching function must deduplicate matching calls so the component can reuse the request started during preloading. Choose the approach that matches your data source:
 
 - For `fetch`, [identical requests are memoized automatically](/docs/app/api-reference/functions/fetch#memoization).
-- For an ORM or database, use `React.cache` as shown above.
+- For an ORM or database, wrap the data-fetching function in [`React.cache`](#reusing-data-with-reactcache).
 - With Cache Components, add [`'use cache'`](/docs/app/api-reference/directives/use-cache) to the data-fetching function. If the function reads request APIs such as `cookies()` or `headers()`, use [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private). In production, calls to the same private Cache Function with the same arguments reuse the result within one server request. Next.js discards the result when the request finishes.
 
 Keep the preload function next to the component that consumes the data. This makes the dependency easier to find if you move or remove the component:

--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -607,13 +607,13 @@ Since `getUser` is wrapped with `React.cache`, calls with the same `id` within o
 
 Preloading starts a data request before the component that consumes the result renders. Call the data-fetching function without `await` before blocking work, then call the same function in the component.
 
-The data-fetching function must deduplicate matching calls so the component can reuse the request started during preloading. Choose the approach that matches your data source:
+The data-fetching function must deduplicate matching calls so the component can reuse the request started during preloading. Use one of the following approaches:
 
 - For `fetch`, [identical requests are memoized automatically](/docs/app/api-reference/functions/fetch#memoization).
 - For an ORM or database, wrap the data-fetching function in [`React.cache`](#reusing-data-with-reactcache).
 - With Cache Components, add [`'use cache'`](/docs/app/api-reference/directives/use-cache) to the data-fetching function. If the function reads request APIs such as `cookies()` or `headers()`, use [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private).
 
-In production, calls to the same private Cache Function with the same arguments reuse a result within one server request. This lets the component reuse a request started during preloading without sharing the result across requests.
+In production, calls to the same private Cache Function with the same arguments reuse a result within one server request. This request-scoped deduplication lets the component reuse a request started during preloading without sharing the result across requests.
 
 Keep the preload function next to the component that consumes the data. This makes the dependency easier to find if you move or remove the component:
 

--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -611,7 +611,9 @@ The data-fetching function must deduplicate matching calls so the component can 
 
 - For `fetch`, [identical requests are memoized automatically](/docs/app/api-reference/functions/fetch#memoization).
 - For an ORM or database, wrap the data-fetching function in [`React.cache`](#reusing-data-with-reactcache).
-- With Cache Components, add [`'use cache'`](/docs/app/api-reference/directives/use-cache) to the data-fetching function. If the function reads request APIs such as `cookies()` or `headers()`, use [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private). In production, calls to the same private Cache Function with the same arguments reuse the result within one server request. Next.js discards the result when the request finishes.
+- With Cache Components, add [`'use cache'`](/docs/app/api-reference/directives/use-cache) to the data-fetching function. If the function reads request APIs such as `cookies()` or `headers()`, use [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private).
+
+In production, calls to the same private Cache Function with the same arguments reuse a result within one server request. This lets the component reuse a request started during preloading without sharing the result across requests.
 
 Keep the preload function next to the component that consumes the data. This makes the dependency easier to find if you move or remove the component:
 

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -441,9 +441,9 @@ Like the `fetch` Data Cache, `unstable_cache` persists cached values across depl
 
 **Usually no change.** `React.cache` continues to deduplicate matching calls within a React render.
 
-With Cache Components, each Cache Function runs in its own React render scope. If the same `React.cache` helper is called from separate Cache Functions—for example, when one starts the work during preloading and another consumes it—those calls do not share the React memoization scope.
+However, each Cache Function has an isolated React cache scope. Calls from separate Cache Functions do not share a `React.cache` result, such as when one Cache Function preloads data and another consumes it.
 
-When a helper reads request data and matching calls need to share work across Cache Function scopes, replace the React wrapper with [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private). If the function only needs request-scoped deduplication, use `cacheLife({ stale: Infinity })` so it does not lower the route's stale time. Private Cache Function results are not stored on the server across production requests.
+When a helper reads request data and matching calls need to share work across Cache Function scopes, replace the React wrapper with [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private). If the function only needs request-scoped deduplication, use `cacheLife({ stale: Infinity })` so it does not lower the route's stale time. Private Cache Function results are not stored in a server cache across production requests.
 
 ## On-demand revalidation (`revalidateTag`, `revalidatePath`, `updateTag`)
 

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -437,6 +437,14 @@ export async function getUser(id) {
 
 Like the `fetch` Data Cache, `unstable_cache` persists cached values across deployments and serverless instances, while `use cache` does not. See [`fetch` cache options](#fetch-cache-options) above for the storage details.
 
+## `React.cache`
+
+**Usually no change.** `React.cache` continues to deduplicate matching calls within a React render.
+
+With Cache Components, each Cache Function runs in its own React render scope. If the same `React.cache` helper is called from separate Cache Functions—for example, when one starts the work during preloading and another consumes it—those calls do not share the React memoization scope.
+
+When a helper reads request data and matching calls need to share work across Cache Function scopes, replace the React wrapper with [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private). If the function only needs request-scoped deduplication, use `cacheLife({ stale: Infinity })` so it does not lower the route's stale time. Private Cache Function results are not stored on the server across production requests.
+
 ## On-demand revalidation (`revalidateTag`, `revalidatePath`, `updateTag`)
 
 On-demand invalidation still works by tagging cached data and expiring it after an event. Tag data with [`cacheTag`](/docs/app/api-reference/functions/cacheTag) inside a `use cache` function instead of the `fetch` `next.tags` option, then choose the invalidation API by the behavior you want:

--- a/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
@@ -11,14 +11,18 @@ related:
     - app/api-reference/functions/cacheTag
 ---
 
-The `'use cache: private'` directive allows functions to access runtime request APIs like `cookies()`, `headers()`, and `searchParams` within a cached scope. In production, Next.js keeps each result on the server for the current request so matching calls can reuse it, then discards it when the request finishes. The client router can keep the rendered output in browser memory according to its `stale` time, but this cache does not persist across page reloads.
+The `'use cache: private'` directive allows functions to access runtime request APIs like `cookies()`, `headers()`, and `searchParams` within a cached scope. In production, Next.js keeps a result on the server for the current request. Calls to the same private Cache Function with the same arguments can reuse the result. Next.js discards the result when the request finishes.
+
+The client router can keep the rendered output in browser memory according to its `stale` time. This client-side cache does not persist across page reloads.
 
 Reach for `'use cache: private'` when:
 
 - You want to cache a function that already accesses runtime data, and refactoring to [move the runtime access outside and pass values as arguments](/docs/app/getting-started/caching#working-with-runtime-apis) is not practical.
-- Compliance requirements prevent storing certain data in a server cache across requests
+- You need request-specific data to be excluded from server caches that persist across production requests.
 
-Because this directive accesses runtime data, the function runs at request time and is excluded from [static shell](/docs/app/getting-started/caching#prerendering) generation. Matching calls during that request share the same result.
+Private Cache Functions run at request time and are excluded from [static shell](/docs/app/getting-started/caching#prerendering) generation. Matching calls during the request share the same result.
+
+To start a private Cache Function before the component that uses it renders, see [Preloading data](/docs/app/getting-started/fetching-data#preloading-data).
 
 It is **not** possible to configure custom cache handlers for `'use cache: private'`.
 
@@ -150,12 +154,6 @@ async function getRecommendations(productId) {
 ```
 
 > **Good to know**: The `stale` time must be at least 30 seconds for per-link prefetching to work, and at least 5 minutes for the content to be included in the route's [App Shell](/docs/app/glossary#app-shell). See [`cacheLife` prerendering behavior](/docs/app/api-reference/functions/cacheLife#prerendering-behavior) for details.
-
-## Deduplicating calls within a request
-
-In production, matching calls to a private Cache Function share the same result within one server request. Next.js retains the result for that request, then discards it instead of reusing it across requests.
-
-This request-level deduplication is useful when multiple Server Components or Cache Functions need the same request-specific data. You can use the [preload pattern](/docs/app/getting-started/fetching-data#preloading-data) to call a private Cache Function before the component that needs its result renders. Call the same private Cache Function with the same arguments from both places.
 
 ## Request APIs allowed in private caches
 

--- a/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
@@ -13,14 +13,14 @@ related:
 
 The `'use cache: private'` directive allows functions to access runtime request APIs like `cookies()`, `headers()`, and `searchParams` within a cached scope. In production, Next.js keeps a result on the server for the current request. Calls to the same private Cache Function with the same arguments can reuse the result. Next.js discards the result when the request finishes.
 
-The client router can keep the rendered output in browser memory according to its `stale` time. This client-side cache does not persist across page reloads.
+The client router can keep the rendered output in browser memory for the [`stale` time](/docs/app/api-reference/functions/cacheLife#client-cache-behavior) configured with `cacheLife`. This client-side cache does not persist across page reloads.
 
 Reach for `'use cache: private'` when:
 
 - You want to cache a function that already accesses runtime data, and refactoring to [move the runtime access outside and pass values as arguments](/docs/app/getting-started/caching#working-with-runtime-apis) is not practical.
 - You need request-specific data to be excluded from server caches that persist across production requests.
 
-Private Cache Functions run at request time and are excluded from [static shell](/docs/app/getting-started/caching#prerendering) generation. To start a private Cache Function before the component that uses it renders, see [Preloading data](/docs/app/getting-started/fetching-data#preloading-data).
+Private Cache Functions run at request time and are excluded from [static shell](/docs/app/getting-started/caching#prerendering) generation. To start a private Cache Function before a component needs its result, see [Preloading data](/docs/app/getting-started/fetching-data#preloading-data).
 
 It is **not** possible to configure custom cache handlers for `'use cache: private'`.
 

--- a/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
@@ -151,7 +151,13 @@ async function getRecommendations(productId) {
 }
 ```
 
-> **Good to know**: The `stale` time must be at least 30 seconds for per-link prefetching to work, and at least 5 minutes for the content to be included in the route's [App Shell](/docs/app/glossary#app-shell). See [`cacheLife` prerendering behavior](/docs/app/api-reference/functions/cacheLife#prerendering-behavior) for details.
+> **Good to know:** The `stale` time must be at least 30 seconds for per-link prefetching to work, and at least 5 minutes for the content to be included in the route's [App Shell](/docs/app/glossary#app-shell). See [`cacheLife` prerendering behavior](/docs/app/api-reference/functions/cacheLife#prerendering-behavior) for details.
+
+### Configuring the client stale time
+
+Private Cache Functions contribute their `stale` time to the route's [Client Cache](/docs/app/glossary#client-cache). If a function only needs request-scoped deduplication, use `cacheLife({ stale: Infinity })` to keep it from lowering the route's stale time.
+
+Next.js uses the shortest stale time from the route's cache entries, so another cache or route setting can still set a finite value. Setting `stale` to `Infinity` does not store the private result on the server across production requests. Use a finite value when the client router should revalidate personalized output after a known interval.
 
 ## Request APIs allowed in private caches
 

--- a/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
@@ -11,7 +11,7 @@ related:
     - app/api-reference/functions/cacheTag
 ---
 
-The `'use cache: private'` directive allows functions to access runtime request APIs like `cookies()`, `headers()`, and `searchParams` within a cached scope. In production, Next.js keeps a result on the server for the current request. Calls to the same private Cache Function with the same arguments can reuse the result. Next.js discards the result when the request finishes.
+The `'use cache: private'` directive allows functions to access runtime request APIs like `cookies()`, `headers()`, and `searchParams` within a cached scope. In production, matching calls within one request can reuse the same result, but Next.js does not store it in a server cache across requests.
 
 The client router can keep the rendered output in browser memory for the [`stale` time](/docs/app/api-reference/functions/cacheLife#client-cache-behavior) configured with `cacheLife`. This client-side cache does not persist across page reloads.
 

--- a/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
@@ -11,14 +11,14 @@ related:
     - app/api-reference/functions/cacheTag
 ---
 
-The `'use cache: private'` directive allows functions to access runtime request APIs like `cookies()`, `headers()`, and `searchParams` within a cached scope. However, results are **never stored on the server**, they're cached only in the browser's memory and do not persist across page reloads.
+The `'use cache: private'` directive allows functions to access runtime request APIs like `cookies()`, `headers()`, and `searchParams` within a cached scope. In production, Next.js keeps each result on the server for the current request so matching calls can reuse it, then discards it when the request finishes. The client router can keep the rendered output in browser memory according to its `stale` time, but this cache does not persist across page reloads.
 
 Reach for `'use cache: private'` when:
 
 - You want to cache a function that already accesses runtime data, and refactoring to [move the runtime access outside and pass values as arguments](/docs/app/getting-started/caching#working-with-runtime-apis) is not practical.
-- Compliance requirements prevent storing certain data on the server, even temporarily
+- Compliance requirements prevent storing certain data in a server cache across requests
 
-Because this directive accesses runtime data, the function executes on every server render and is excluded from running during [static shell](/docs/app/getting-started/caching#prerendering) generation.
+Because this directive accesses runtime data, the function runs at request time and is excluded from [static shell](/docs/app/getting-started/caching#prerendering) generation. Matching calls during that request share the same result.
 
 It is **not** possible to configure custom cache handlers for `'use cache: private'`.
 
@@ -150,6 +150,12 @@ async function getRecommendations(productId) {
 ```
 
 > **Good to know**: The `stale` time must be at least 30 seconds for per-link prefetching to work, and at least 5 minutes for the content to be included in the route's [App Shell](/docs/app/glossary#app-shell). See [`cacheLife` prerendering behavior](/docs/app/api-reference/functions/cacheLife#prerendering-behavior) for details.
+
+## Deduplicating calls within a request
+
+In production, matching calls to a private Cache Function share the same result within one server request. Next.js retains the result for that request, then discards it instead of reusing it across requests.
+
+This request-level deduplication is useful when multiple Server Components or Cache Functions need the same request-specific data. You can use the [preload pattern](/docs/app/getting-started/fetching-data#preloading-data) to call a private Cache Function before the component that needs its result renders. Call the same private Cache Function with the same arguments from both places.
 
 ## Request APIs allowed in private caches
 

--- a/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
@@ -20,9 +20,7 @@ Reach for `'use cache: private'` when:
 - You want to cache a function that already accesses runtime data, and refactoring to [move the runtime access outside and pass values as arguments](/docs/app/getting-started/caching#working-with-runtime-apis) is not practical.
 - You need request-specific data to be excluded from server caches that persist across production requests.
 
-Private Cache Functions run at request time and are excluded from [static shell](/docs/app/getting-started/caching#prerendering) generation. Matching calls during the request share the same result.
-
-To start a private Cache Function before the component that uses it renders, see [Preloading data](/docs/app/getting-started/fetching-data#preloading-data).
+Private Cache Functions run at request time and are excluded from [static shell](/docs/app/getting-started/caching#prerendering) generation. To start a private Cache Function before the component that uses it renders, see [Preloading data](/docs/app/getting-started/fetching-data#preloading-data).
 
 It is **not** possible to configure custom cache handlers for `'use cache: private'`.
 


### PR DESCRIPTION
## Summary

- add the preload pattern to the current App Router data fetching guide
- distinguish automatic fetch memoization, React cache for non-fetch data, and Cache Functions
- clarify request-scoped private caching and when stale: Infinity should not constrain the route stale time

The previous-model caching guide remains unchanged.

## Verification

- Prettier on both edited docs
- alex on both edited docs
- git diff --check
- Not run: full framework build because this is a documentation-only change

<!-- NEXT_JS_LLM -->