### PR TITLE
Turbopack: pass comments to SWC plugins when a file has any comments

### DIFF
--- a/test/e2e/app-dir/swc-plugins-comments/app/layout.tsx
+++ b/test/e2e/app-dir/swc-plugins-comments/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/swc-plugins-comments/app/page.tsx
+++ b/test/e2e/app-dir/swc-plugins-comments/app/page.tsx
@@ -1,0 +1,34 @@
+import { leadingOnly } from '../lib/leading-only'
+import { withTrailing } from '../lib/with-trailing'
+
+const FILES = ['lib/leading-only.js', 'lib/with-trailing.js']
+
+// The plugin stores each file's coverage map on `globalThis.__coverage__`
+// (keyed by path, relative or absolute depending on the bundler). `fnMap` is
+// empty when the ignore hint was honored.
+function getInstrumentedFunctions(file: string): string[] {
+  const coverage: Record<string, any> = (globalThis as any).__coverage__ ?? {}
+  const key = Object.keys(coverage).find((path) => path.endsWith(file))
+  if (!key) return ['<coverage map not found>']
+  return Object.values(coverage[key].fnMap ?? {}).map((fn: any) => fn.name)
+}
+
+export default function Page() {
+  return (
+    <main>
+      <ul>
+        {FILES.map((file) => {
+          const instrumented = getInstrumentedFunctions(file)
+          return (
+            <li key={file} id={file.replace(/[^a-z-]/g, '-')}>
+              {instrumented.length === 0 ? 'honored' : instrumented.join(', ')}
+            </li>
+          )
+        })}
+      </ul>
+      <p hidden>
+        {leadingOnly()} {withTrailing()}
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/swc-plugins-comments/lib/leading-only.js
+++ b/test/e2e/app-dir/swc-plugins-comments/lib/leading-only.js
@@ -1,0 +1,6 @@
+// This file only has leading comments.
+
+/* istanbul ignore next */
+export function leadingOnly() {
+  return 'leading-only'
+}

--- a/test/e2e/app-dir/swc-plugins-comments/lib/with-trailing.js
+++ b/test/e2e/app-dir/swc-plugins-comments/lib/with-trailing.js
@@ -1,0 +1,8 @@
+// Same as leading-only.js plus one trailing comment.
+
+/* istanbul ignore next */
+export function withTrailing() {
+  return 'with-trailing'
+}
+
+export const unrelated = 1 // one trailing comment

--- a/test/e2e/app-dir/swc-plugins-comments/next.config.js
+++ b/test/e2e/app-dir/swc-plugins-comments/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    // Reads `/* istanbul ignore next */` comments.
+    swcPlugins: [['swc-plugin-coverage-instrument', {}]],
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/swc-plugins-comments/swc-plugins-comments.test.ts
+++ b/test/e2e/app-dir/swc-plugins-comments/swc-plugins-comments.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// Regression test for https://github.com/vercel/next.js/issues/97866:
+// Turbopack only passed comments to SWC plugins when a file had both leading
+// and trailing comments.
+describe('swc-plugins-comments', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    dependencies: {
+      'swc-plugin-coverage-instrument': '0.0.32',
+    },
+  })
+  if (skipped) return
+
+  it('passes comments to plugins for a file with only leading comments', async () => {
+    const $ = await next.render$('/')
+    expect($('#lib-leading-only-js').text()).toBe('honored')
+  })
+
+  it('passes comments to plugins for a file with leading and trailing comments', async () => {
+    const $ = await next.render$('/')
+    expect($('#lib-with-trailing-js').text()).toBe('honored')
+  })
+})

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -133,12 +133,13 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
             .try_join()
             .await?;
 
+        // Expose comments to plugins whenever the source has any. swc/core enables
+        // the proxy whenever a comments store exists at all; only skip it here when
+        // there is nothing to expose, so a file with only leading comments (the
+        // common case: JSDoc and full-line `//` comments) still gets its comments.
         let should_enable_comments_proxy =
-            !ctx.comments.leading.is_empty() && !ctx.comments.trailing.is_empty();
+            !ctx.comments.leading.is_empty() || !ctx.comments.trailing.is_empty();
 
-        //[TODO]: as same as swc/core does, we should set should_enable_comments_proxy
-        // depends on the src's comments availability. For now, check naively if leading
-        // / trailing comments are empty.
         let comments = if should_enable_comments_proxy {
             Some(turbopack_ecmascript::swc_comments_to_single_threaded(
                 ctx.comments,


### PR DESCRIPTION
### What?

Allow SWC plugins to receive comments when the file has _any_ by updating `should_enable_comments_proxy` check in  [`swc_ecma_transform_plugins.rs` lines 136–141 on canary](https://github.com/vercel/next.js/blob/canary/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs) to use `||` instead of `&&` 

Also cleaned up the `TODO`

### Why?

Turbopack only exposed comments to SWC plugins when a file had _both_ leading AND trailing comments. Comment driven plugins which worked under Webpack, failed silently when using Turbopack (i.e. acted as if the comment was not there).

This was initially discovered with a proprietary plugin but was reproduced with the [swc-plugin-coverage-instrument](https://www.npmjs.com/package/swc-plugin-coverage-instrument) which failed silently (i.e. comment hint ignored) in an identical way to the proprietary one

### How?

Swapped the `&&` to an `||` instead of removing the check altogether which maintains the gate for files which have no comments

Tests added using the [swc-plugin-coverage-instrument](https://www.npmjs.com/package/swc-plugin-coverage-instrument) plugin which fail on unpatched Turbopack but pass with the fix.

Fixes #97866
