### PR TITLE
Redirects should be respected after cookies.set

### DIFF
--- a/test/e2e/app-dir/server-action-cookie-rewrite/app/actions.ts
+++ b/test/e2e/app-dir/server-action-cookie-rewrite/app/actions.ts
@@ -1,0 +1,8 @@
+'use server'
+
+import { cookies } from 'next/headers'
+
+export async function logIn() {
+  const cookieStore = await cookies()
+  cookieStore.set('isLoggedIn', '1')
+}

--- a/test/e2e/app-dir/server-action-cookie-rewrite/app/authed/page.tsx
+++ b/test/e2e/app-dir/server-action-cookie-rewrite/app/authed/page.tsx
@@ -1,0 +1,3 @@
+export default function AuthedPage() {
+  return <p id="logged-in">You are logged in</p>
+}

--- a/test/e2e/app-dir/server-action-cookie-rewrite/app/layout.tsx
+++ b/test/e2e/app-dir/server-action-cookie-rewrite/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/server-action-cookie-rewrite/app/page.tsx
+++ b/test/e2e/app-dir/server-action-cookie-rewrite/app/page.tsx
@@ -1,0 +1,12 @@
+import { logIn } from './actions'
+
+export default function Page() {
+  return (
+    <main>
+      <p id="logged-out">You are logged out</p>
+      <form action={logIn}>
+        <button id="log-in">Log in</button>
+      </form>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/server-action-cookie-rewrite/next.config.js
+++ b/test/e2e/app-dir/server-action-cookie-rewrite/next.config.js
@@ -1,0 +1,18 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  async rewrites() {
+    return {
+      beforeFiles: [
+        {
+          source: '/',
+          has: [{ type: 'cookie', key: 'isLoggedIn' }],
+          destination: '/authed',
+        },
+      ],
+    }
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/server-action-cookie-rewrite/server-action-cookie-rewrite.test.ts
+++ b/test/e2e/app-dir/server-action-cookie-rewrite/server-action-cookie-rewrite.test.ts
@@ -1,0 +1,28 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('server-action-cookie-rewrite', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should use a cookie set by a Server Action when refreshing the route', async () => {
+    const browser = await next.browser('/')
+
+    expect(await browser.elementById('logged-out').text()).toBe(
+      'You are logged out'
+    )
+
+    await browser.elementById('log-in').click()
+
+    await retry(async () => {
+      expect(await browser.eval('document.cookie')).toContain('isLoggedIn=1')
+    })
+
+    await retry(async () => {
+      expect(await browser.elementByCss('body').text()).toContain(
+        'You are logged in'
+      )
+    })
+  })
+})


### PR DESCRIPTION
A rerender caused by `cookies.set` in a server action bypasses `rewrites()` defined in next.config.js.

Here's a separate repro: [samselikoff/2026-04-10-stale-cookie-during-refresh](https://github.com/samselikoff/2026-04-10-stale-cookie-during-refresh)