### PR TITLE
turbo-persistence: add TURBO_PERSISTENCE_MMAP=0 to disable mmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9988,6 +9988,7 @@ dependencies = [
  "quick_cache",
  "rand 0.10.1",
  "rayon",
+ "rstest",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -44,6 +44,7 @@ zstd = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
+rstest = { workspace = true }
 tempfile = { workspace = true }
 turbo-tasks-malloc = { workspace = true, features = ["custom_allocator"] }
 

--- a/turbopack/crates/turbo-persistence/benches/mod.rs
+++ b/turbopack/crates/turbo-persistence/benches/mod.rs
@@ -624,6 +624,7 @@ fn prefill_multi_value_database(
             kind: FamilyKind::MultiValue,
             compression: Compression::Lz4,
         }],
+        ..TpDbConfig::new()
     };
     let db =
         TurboPersistence::<SerialScheduler, 1>::open_with_config(path.to_path_buf(), db_config)?;
@@ -699,6 +700,7 @@ fn open_multi_value_db(path: &Path) -> TurboPersistence<SerialScheduler, 1> {
             kind: FamilyKind::MultiValue,
             compression: Compression::Lz4,
         }],
+        ..TpDbConfig::new()
     };
     TurboPersistence::<SerialScheduler, 1>::open_with_config(path.to_path_buf(), db_config).unwrap()
 }
@@ -968,6 +970,7 @@ fn bench_write_multi_value(c: &mut Criterion) {
                                 kind: FamilyKind::MultiValue,
                                 compression: Compression::Lz4,
                             }],
+                            ..TpDbConfig::new()
                         };
                         let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
                             tempdir.path().to_path_buf(),
@@ -1217,7 +1220,13 @@ fn bench_static_sorted_file_lookup(c: &mut Criterion) {
                 sequence_number: 1,
                 block_count: meta.block_count,
             };
-            let sst = StaticSortedFile::open(tempdir.path(), sst_meta, Compression::Lz4).unwrap();
+            let sst = StaticSortedFile::open(
+                tempdir.path(),
+                sst_meta,
+                Compression::Lz4,
+                turbo_persistence::AccessMode::Mmap,
+            )
+            .unwrap();
 
             // Create block caches
             let key_block_cache: BlockCache = BlockCache::with(

--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -267,7 +267,7 @@ fn collect_sst_info(db_path: &Path) -> Result<BTreeMap<u32, Vec<SstInfo>>> {
     let mut meta_files: Vec<MetaFile> = meta_seqs
         .iter()
         .map(|&seq| {
-            MetaFile::open(db_path, seq, None)
+            MetaFile::open(db_path, seq, None, turbo_persistence::AccessMode::Mmap)
                 .with_context(|| format!("Failed to open {seq:08}.meta"))
         })
         .collect::<Result<_>>()?;

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -17,6 +17,7 @@ use anyhow::{Context, Result, bail};
 use auto_hash_map::AutoSet;
 use byteorder::{BE, ReadBytesExt, WriteBytesExt};
 use dashmap::DashSet;
+use either::Either;
 use fs_err::{self as fs, File, OpenOptions, ReadDir};
 use jiff::Timestamp;
 use memmap2::Mmap;
@@ -29,10 +30,10 @@ use tracing::span::EnteredSpan;
 
 pub use crate::compaction::selector::CompactConfig;
 use crate::{
-    Compression, DbConfig, FamilyKind, QueryKey,
+    AccessMode, DbConfig, FamilyKind, QueryKey,
     arc_bytes::ArcBytes,
     compaction::selector::{Compactable, get_merge_segments},
-    compression::{checksum_block, decompress_into_arc},
+    compression::{Compression, checksum_block, decompress_into_arc},
     constants::{
         DATA_THRESHOLD_PER_COMPACTED_FILE, KEY_BLOCK_AVG_SIZE, KEY_BLOCK_CACHE_SIZE,
         MAX_ENTRIES_PER_COMPACTED_FILE, VALUE_BLOCK_AVG_SIZE, VALUE_BLOCK_CACHE_SIZE,
@@ -634,7 +635,12 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         let mut meta_files = self
             .parallel_scheduler
             .parallel_map_collect::<_, _, Result<Vec<MetaFile>>>(&meta_files, |&seq| {
-                let meta_file = MetaFile::open(&self.path, seq, Some(&self.config.family_configs))?;
+                let meta_file = MetaFile::open(
+                    &self.path,
+                    seq,
+                    Some(&self.config.family_configs),
+                    self.config.access_mode,
+                )?;
                 Ok(meta_file)
             })?;
 
@@ -656,19 +662,28 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     fn read_blob(&self, seq: u32, compression: Compression) -> Result<ArcBytes> {
         let path = self.path.join(format!("{seq:08}.blob"));
         let file = File::open(&path)?;
-        let mmap = unsafe { Mmap::map(file.file()) }.with_context(|| {
-            format!(
-                "Failed to mmap blob file {} ({} bytes)",
-                path.display(),
-                file.metadata().map(|m| m.len()).unwrap_or(0)
-            )
-        })?;
-        #[cfg(unix)]
-        mmap.advise(memmap2::Advice::Sequential)?;
-        #[cfg(unix)]
-        mmap.advise(memmap2::Advice::WillNeed)?;
-        advise_mmap_for_persistence(&mmap)?;
-        let mut reader = &mmap[..];
+        let data: Either<Mmap, Vec<u8>> = match self.config.access_mode {
+            AccessMode::Mmap => {
+                let mmap = unsafe { Mmap::map(file.file()) }.with_context(|| {
+                    format!(
+                        "Failed to mmap blob file {} ({} bytes)",
+                        path.display(),
+                        file.metadata().map(|m| m.len()).unwrap_or(0)
+                    )
+                })?;
+                #[cfg(unix)]
+                mmap.advise(memmap2::Advice::Sequential)?;
+                #[cfg(unix)]
+                mmap.advise(memmap2::Advice::WillNeed)?;
+                advise_mmap_for_persistence(&mmap)?;
+                Either::Left(mmap)
+            }
+            AccessMode::File => Either::Right(fs::read(&path)?),
+        };
+        let mut reader: &[u8] = match &data {
+            Either::Left(mmap) => mmap,
+            Either::Right(bytes) => bytes,
+        };
         let uncompressed_length = reader
             .read_u32::<BE>()
             .context("Failed to read uncompressed length from blob file")?;
@@ -926,8 +941,12 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             .parallel_map_collect_owned::<_, _, Result<Vec<_>>>(sync_items, |item| match item {
                 SyncItem::Meta(seq, file) => {
                     file.sync_data()?;
-                    let meta_file =
-                        MetaFile::open(&self.path, seq, Some(&self.config.family_configs))?;
+                    let meta_file = MetaFile::open(
+                        &self.path,
+                        seq,
+                        Some(&self.config.family_configs),
+                        self.config.access_mode,
+                    )?;
                     Ok(SyncResult::Meta(meta_file))
                 }
                 SyncItem::Sst(file) => {
@@ -1593,11 +1612,13 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                 .map(|&index| {
                                     let meta_index = ssts_with_ranges[index].meta_index;
                                     let index_in_meta = ssts_with_ranges[index].index_in_meta;
-                                    let entry = meta_files[meta_index].entry(index_in_meta);
+                                    let meta_file = &meta_files[meta_index];
+                                    let entry = meta_file.entry(index_in_meta);
                                     StaticSortedFileIter::open(
                                         path,
                                         entry.sst_metadata(),
-                                        self.config.family_configs[family as usize].compression,
+                                        meta_file.compression(),
+                                        self.config.access_mode,
                                     )
                                 })
                                 .collect::<Result<Vec<_>>>()?;

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![feature(once_cell_try)]
 #![feature(sync_unsafe_cell)]
 
@@ -35,6 +36,15 @@ pub use db::{
     TurboPersistence, read_current_version,
 };
 
+/// Controls how SST and meta files are read from disk.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AccessMode {
+    /// Memory-map the file and access blocks via the mapped region.
+    Mmap,
+    /// Read blocks directly from the file via pread (no mmap).
+    File,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FamilyKind {
     /// Each key maps to a single value (default LSM behavior).
@@ -64,22 +74,49 @@ pub struct FamilyConfig {
 #[derive(Clone, Debug)]
 pub struct DbConfig<const FAMILIES: usize> {
     pub family_configs: [FamilyConfig; FAMILIES],
+    /// How SST and meta files are read from disk.
+    pub access_mode: AccessMode,
 }
 
-impl<const FAMILIES: usize> Default for DbConfig<FAMILIES> {
-    fn default() -> Self {
+/// Reads the `TURBO_PERSISTENCE_MMAP` env var (cached). Returns `AccessMode::File` when the var
+/// is set to `"0"`, `AccessMode::Mmap` otherwise.
+fn access_mode_env_var() -> AccessMode {
+    static ACCESS_MODE_ENV: std::sync::LazyLock<AccessMode> = std::sync::LazyLock::new(|| {
+        if std::env::var("TURBO_PERSISTENCE_MMAP")
+            .ok()
+            .is_some_and(|v| v == "0")
+        {
+            AccessMode::File
+        } else {
+            AccessMode::Mmap
+        }
+    });
+    *ACCESS_MODE_ENV
+}
+
+impl<const FAMILIES: usize> DbConfig<FAMILIES> {
+    /// Returns a config with all defaults, reading the `TURBO_PERSISTENCE_MMAP` env var
+    /// to determine the access mode.
+    pub fn new() -> Self {
         Self {
             family_configs: [FamilyConfig {
                 name: "unknown",
                 kind: FamilyKind::SingleValue,
                 compression: Compression::Lz4,
             }; FAMILIES],
+            access_mode: access_mode_env_var(),
         }
     }
 }
 /// The largest value that [`WriteBatch::delete_value`] can delete, since the tombstone stores
 /// a copy of the value inline.
 pub use constants::MAX_INLINE_VALUE_SIZE;
+
+impl<const FAMILIES: usize> Default for DbConfig<FAMILIES> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 pub use key::{KeyBase, QueryKey, StoreKey, hash_key};
 pub use meta_file::MetaEntryFlags;
 pub use parallel_scheduler::{ParallelScheduler, SerialScheduler};

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::Ordering,
     fmt::Display,
+    ops::Deref,
     path::{Path, PathBuf},
     sync::OnceLock,
 };
@@ -14,7 +15,7 @@ use smallvec::SmallVec;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Ref, big_endian as be};
 
 use crate::{
-    Compression, FamilyConfig, QueryKey,
+    AccessMode, Compression, FamilyConfig, QueryKey,
     lookup_entry::LookupValue,
     mmap_helper::advise_mmap_for_persistence,
     static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile, StaticSortedFileMetaData},
@@ -92,8 +93,8 @@ impl EntryHeader {
 /// # Safety
 ///
 /// `MetaEntry` stores a `FilterRef<'static>` with a transmuted lifetime that actually borrows
-/// from the parent [`MetaFile`]'s mmap. This is safe because entries are only accessed by
-/// reference through `MetaFile` and are never moved out.
+/// from the parent [`MetaFile`]'s stable backing bytes. This is safe because entries are only
+/// accessed by reference through `MetaFile` and are never moved out.
 ///
 /// For this reason this type should not implement Clone or Copy.
 pub struct MetaEntry {
@@ -109,13 +110,13 @@ pub struct MetaEntry {
     size: u64,
     /// The status flags for this entry.
     flags: MetaEntryFlags,
-    /// Byte offset range of the raw AMQF data within the mmap, used for carrying forward
+    /// Byte offset range of the raw AMQF data within the backing, used for carrying forward
     /// serialized bytes during compaction without re-serializing.
     amqf_data_offset: std::ops::Range<u32>,
     /// The AMQF filter for this file, eagerly deserialized as a zero-copy [`qfilter::FilterRef`]
     /// that borrows directly from the parent [`MetaFile`]'s memory-mapped file.
     ///
-    /// The `'static` lifetime is transmuted — the actual borrow is from `MetaFile::mmap`.
+    /// The `'static` lifetime is transmuted — the actual borrow is from `MetaFile::backing`.
     amqf: qfilter::FilterRef<'static>,
     /// Compression recorded in this entry's meta file.
     compression: Compression,
@@ -123,7 +124,7 @@ pub struct MetaEntry {
     sst: OnceLock<StaticSortedFile>,
 }
 
-// Safety: FilterRef is a read-only view into the mmap which is Send+Sync.
+// Safety: FilterRef is a read-only view into stable backing bytes which are Send+Sync.
 unsafe impl Send for MetaEntry {}
 unsafe impl Sync for MetaEntry {}
 
@@ -148,21 +149,25 @@ impl MetaEntry {
         &self.amqf
     }
 
-    /// Returns the raw serialized AMQF bytes from the mmap.
+    /// Returns the raw serialized AMQF bytes from the stable backing.
     pub fn raw_amqf<'l>(&self, amqf_data: &'l [u8]) -> &'l [u8] {
         &amqf_data[self.amqf_data_offset.start as usize..self.amqf_data_offset.end as usize]
     }
 
     fn sst(&self, meta: &MetaFile) -> Result<&StaticSortedFile> {
         self.sst.get_or_try_init(|| {
-            StaticSortedFile::open(&meta.db_path, self.sst_data, self.compression).with_context(
-                || {
-                    format!(
-                        "Unable to open static sorted file referenced from {:08}.meta",
-                        meta.sequence_number()
-                    )
-                },
+            StaticSortedFile::open(
+                &meta.db_path,
+                self.sst_data,
+                self.compression,
+                meta.access_mode,
             )
+            .with_context(|| {
+                format!(
+                    "Unable to open static sorted file referenced from {:08}.meta",
+                    meta.sequence_number()
+                )
+            })
         })
     }
 
@@ -236,11 +241,26 @@ pub struct StaticSortedFileRange {
     pub max_hash: u64,
 }
 
+enum MetaFileBacking {
+    Mmap(Mmap),
+    Bytes(Box<[u8]>),
+}
+
+impl Deref for MetaFileBacking {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            MetaFileBacking::Mmap(mmap) => mmap,
+            MetaFileBacking::Bytes(bytes) => bytes,
+        }
+    }
+}
+
 /// # Safety
 ///
-/// `entries` **must** be declared before `mmap` so that Rust's field drop order (declaration
-/// order) drops all `FilterRef`s before the mmap is unmapped.  Reordering these fields would
-/// be unsound.
+/// `entries` must be declared before `backing` so every borrowed `FilterRef` is dropped before
+/// its stable mmap or heap storage.
 pub struct MetaFile {
     /// The database path
     db_path: PathBuf,
@@ -250,32 +270,32 @@ pub struct MetaFile {
     family: u32,
     /// Compression recorded for this family.
     compression: Compression,
-    /// The entries of the file. Dropped before `mmap` (field declaration order).
+    /// The entries of the file. Dropped before `backing` (field declaration order).
     entries: Vec<MetaEntry>,
     /// The entries that have been marked as obsolete.
     obsolete_entries: Vec<u32>,
     /// The obsolete SST files.
     obsolete_sst_files: Vec<u32>,
-    /// Byte offset within the mmap where the AMQF data region starts (i.e. the header length).
+    /// Byte offset within the backing where the AMQF data region starts.
     /// Entry AMQF offsets and used-keys offsets are relative to this position.
     amqf_data_start: u32,
     /// The offset of the start of the "used keys" AMQF data relative to the AMQF data region.
     start_of_used_keys_amqf_data_offset: u32,
     /// The offset of the end of the "used keys" AMQF data relative to the AMQF data region.
     end_of_used_keys_amqf_data_offset: u32,
-    /// The memory mapped file.
-    /// The entire memory-mapped file. Must be the last field that matters for drop order —
-    /// `entries` contains `FilterRef`s that borrow from this mmap.
-    mmap: Mmap,
+    /// The access mode inherited by referenced SST files.
+    access_mode: AccessMode,
+    /// Stable bytes backing the parsed filters. Must be declared after `entries`.
+    backing: MetaFileBacking,
 }
 
 impl MetaFile {
-    /// Opens a meta file at the given path. Memory maps the entire file and eagerly deserializes
-    /// all AMQF filters as zero-copy [`qfilter::FilterRef`]s that borrow from the mmap.
+    /// Opens a meta file using mmap or stable heap bytes according to `access_mode`.
     pub fn open(
         db_path: &Path,
         sequence_number: u32,
         family_configs: Option<&[FamilyConfig]>,
+        access_mode: AccessMode,
     ) -> Result<Self> {
         let filename = format!("{sequence_number:08}.meta");
         let path = db_path.join(&filename);
@@ -284,6 +304,7 @@ impl MetaFile {
             sequence_number,
             &path,
             family_configs,
+            access_mode,
         )
         .with_context(|| format!("Unable to open meta file {filename}"))
     }
@@ -293,15 +314,23 @@ impl MetaFile {
         sequence_number: u32,
         path: &Path,
         family_configs: Option<&[FamilyConfig]>,
+        access_mode: AccessMode,
     ) -> Result<Self> {
-        let file = File::open(path)?;
-        let mmap = unsafe { MmapOptions::new().map(file.file()) }.context("Failed to mmap")?;
-        #[cfg(unix)]
-        mmap.advise(memmap2::Advice::Random)
-            .context("Failed to advise mmap")?;
-        advise_mmap_for_persistence(&mmap)?;
-        // Parse the header from the mmap via ReadBytesExt on &[u8].
-        let mut reader: &[u8] = &mmap;
+        let backing = match access_mode {
+            AccessMode::Mmap => {
+                let file = File::open(path)?;
+                let mmap = unsafe { MmapOptions::new().map(file.file()) }
+                    .context("Failed to mmap meta file")?;
+                #[cfg(unix)]
+                mmap.advise(memmap2::Advice::Random)
+                    .context("Failed to advise mmap")?;
+                advise_mmap_for_persistence(&mmap)?;
+                MetaFileBacking::Mmap(mmap)
+            }
+            AccessMode::File => MetaFileBacking::Bytes(fs_err::read(path)?.into_boxed_slice()),
+        };
+        // Parse the header from stable backing bytes via ReadBytesExt on &[u8].
+        let mut reader: &[u8] = &backing;
         let magic = reader.read_u32::<BE>()?;
         if magic != META_FILE_MAGIC {
             bail!("Invalid magic number");
@@ -333,10 +362,10 @@ impl MetaFile {
 
         // Compute where the AMQF data region starts so we can deserialize filters inline.
         // Remaining header: count * ENTRY_HEADER_SIZE + used_keys_end_offset.
-        let header_so_far = (mmap.len() - reader.len()) as u32;
+        let header_so_far = (backing.len() - reader.len()) as u32;
         let amqf_data_start =
             header_so_far + count * (size_of::<EntryHeader>() as u32) + size_of::<u32>() as u32;
-        let amqf_data = &mmap[amqf_data_start as usize..];
+        let amqf_data = &backing[amqf_data_start as usize..];
 
         // Parse entries and eagerly deserialize AMQF filters as zero-copy FilterRefs.
         let mut entries = Vec::with_capacity(count as usize);
@@ -359,7 +388,7 @@ impl MetaFile {
             let amqf_bytes = amqf_data
                 .get(start_of_amqf_data_offset as usize..end_of_amqf_data_offset as usize)
                 .expect("AMQF data out of bounds");
-            // Deserialize the filter borrowing from the mmap, then erase the lifetime.
+            // Deserialize the filter borrowing from the stable backing, then erase the lifetime.
             let amqf: qfilter::FilterRef<'_> =
                 postcard::from_bytes(amqf_bytes).with_context(|| {
                     format!(
@@ -367,7 +396,7 @@ impl MetaFile {
                         sequence_number, sst_data.sequence_number
                     )
                 })?;
-            // Safety: the mmap is kept alive by MetaFile and is dropped after entries (field
+            // Safety: the backing is kept alive by MetaFile and is dropped after entries (field
             // declaration order), so the borrow remains valid for the lifetime of the MetaEntry.
             let amqf: qfilter::FilterRef<'static> = unsafe { std::mem::transmute(amqf) };
 
@@ -400,7 +429,8 @@ impl MetaFile {
             amqf_data_start,
             start_of_used_keys_amqf_data_offset,
             end_of_used_keys_amqf_data_offset,
-            mmap,
+            access_mode,
+            backing,
         })
     }
 
@@ -430,7 +460,7 @@ impl MetaFile {
 
     /// The on-disk size of this meta file in bytes (the length of its memory map).
     pub fn byte_size(&self) -> u64 {
-        self.mmap.len() as u64
+        self.backing.len() as u64
     }
 
     pub fn entries(&self) -> &[MetaEntry] {
@@ -443,7 +473,7 @@ impl MetaFile {
     }
 
     pub fn amqf_data(&self) -> &[u8] {
-        &self.mmap[self.amqf_data_start as usize..]
+        &self.backing[self.amqf_data_start as usize..]
     }
 
     pub fn deserialize_used_key_hashes_amqf(&self) -> Result<Option<qfilter::FilterRef<'_>>> {

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -1,6 +1,8 @@
 use std::{
+    borrow::Cow,
     cmp::Ordering,
     hash::BuildHasherDefault,
+    io,
     path::Path,
     rc::Rc,
     sync::{
@@ -17,7 +19,7 @@ use rustc_hash::FxHasher;
 use smallvec::SmallVec;
 
 use crate::{
-    Compression, QueryKey,
+    AccessMode, Compression, QueryKey,
     arc_bytes::ArcBytes,
     be,
     compression::checksum_block,
@@ -188,41 +190,38 @@ pub type BlockCache = quick_cache::sync::Cache<
 >;
 
 /// Trait abstracting value block reading for `handle_key_match_generic`.
-///
-/// Provides cached reads (small value blocks) and uncached reads (medium value
-/// blocks). Generic over the byte type so it works for both the lookup path
-/// (`ArcBytes` with `BlockCache`) and the iteration path (`RcBytes` with a
-/// single-entry `Option` cache).
 trait ValueBlockCache<B: SharedBytes> {
     fn get_or_read(
         self,
-        mmap: &B::MmapHandle,
+        meta: &StaticSortedFileMetaData,
+        block_index: u16,
+        compression: Compression,
+    ) -> Result<B>;
+    fn read_uncached(
+        self,
         meta: &StaticSortedFileMetaData,
         block_index: u16,
         compression: Compression,
     ) -> Result<B>;
 }
 
-/// Bundles the shared block cache with the per-file CRC-verified bitmap,
-/// used on the lookup path.
+/// Bundles the lookup backing with the shared block cache and per-file CRC bitmap.
 #[derive(Clone, Copy)]
 struct ArcBlockCacheReader<'a> {
+    backing: &'a StaticSortedFileBacking,
     cache: &'a BlockCache,
     verified_blocks: &'a [AtomicU64],
 }
 
-/// Lookup-path: concurrent `BlockCache` with uncompressed-bypass and
-/// once-per-block CRC verification via `verified_blocks` bitmap.
 impl ValueBlockCache<ArcBytes> for ArcBlockCacheReader<'_> {
     fn get_or_read(
         self,
-        mmap: &Arc<Mmap>,
         meta: &StaticSortedFileMetaData,
         block_index: u16,
         compression: Compression,
     ) -> Result<ArcBytes> {
         get_or_cache_block(
-            mmap,
+            self.backing,
             meta,
             block_index,
             self.cache,
@@ -230,17 +229,26 @@ impl ValueBlockCache<ArcBytes> for ArcBlockCacheReader<'_> {
             compression,
         )
     }
+
+    fn read_uncached(
+        self,
+        meta: &StaticSortedFileMetaData,
+        block_index: u16,
+        compression: Compression,
+    ) -> Result<ArcBytes> {
+        read_block_lookup(self.backing, meta, block_index, compression)
+    }
 }
 
-/// Iteration-path: lightweight single-entry cache for sequential reads.
+/// Iteration-path reader with a lightweight single-entry cache for sequential reads.
 struct RcBlockCacheReader<'a> {
+    backing: &'a StaticSortedFileIterBacking,
     cache: &'a mut Option<(u16, RcBytes)>,
 }
 
 impl ValueBlockCache<RcBytes> for RcBlockCacheReader<'_> {
     fn get_or_read(
         self,
-        mmap: &Rc<Mmap>,
         meta: &StaticSortedFileMetaData,
         block_index: u16,
         compression: Compression,
@@ -250,9 +258,18 @@ impl ValueBlockCache<RcBytes> for RcBlockCacheReader<'_> {
         {
             return Ok(block.clone());
         }
-        let block: RcBytes = read_block_generic(mmap, meta, block_index, compression)?;
+        let block = read_block_iter(self.backing, meta, block_index, compression)?;
         *self.cache = Some((block_index, block.clone()));
         Ok(block)
+    }
+
+    fn read_uncached(
+        self,
+        meta: &StaticSortedFileMetaData,
+        block_index: u16,
+        compression: Compression,
+    ) -> Result<RcBytes> {
+        read_block_iter(self.backing, meta, block_index, compression)
     }
 }
 
@@ -271,14 +288,20 @@ impl StaticSortedFileMetaData {
     }
 }
 
-/// A memory mapped SST file.
+enum StaticSortedFileBacking {
+    Mmap(Arc<Mmap>),
+    File {
+        file: Arc<File>,
+        file_len: usize,
+        block_offsets: Arc<[u32]>,
+    },
+}
+
+/// An SST file accessed through mmap or positional file reads.
 pub struct StaticSortedFile {
     /// The meta file of this file.
     meta: StaticSortedFileMetaData,
-    /// The memory mapped file.
-    /// We store as an Arc so we can hand out references (via ArcBytes) that can outlive this
-    /// struct (not that we expect them to outlive it by very much)
-    mmap: Arc<Mmap>,
+    backing: StaticSortedFileBacking,
     /// One bit per block, set when that block's CRC has been verified at least once.
     /// Uncompressed (mmap-backed) blocks bypass the `BlockCache`, so without this
     /// bitmap the CRC would be re-computed on every access. `Relaxed` ordering
@@ -288,37 +311,61 @@ pub struct StaticSortedFile {
 }
 
 impl StaticSortedFile {
-    /// Opens an SST file at the given path with the compression algorithm specified by its meta
-    /// file. This memory maps the file, but does not read it yet.
+    /// Opens an SST file using the configured access mode.
     pub fn open(
         db_path: &Path,
         meta: StaticSortedFileMetaData,
         compression: Compression,
+        access_mode: AccessMode,
     ) -> Result<Self> {
         let filename = format!("{:08}.sst", meta.sequence_number);
         let path = db_path.join(&filename);
         let file = File::open(&path)?;
-        let mmap = unsafe { Mmap::map(file.file()) }.with_context(|| {
-            format!(
-                "Failed to mmap SST file {} ({} bytes)",
-                path.display(),
-                file.metadata().map(|m| m.len()).unwrap_or(0)
-            )
-        })?;
-        #[cfg(unix)]
-        {
-            mmap.advise(memmap2::Advice::Random)?;
-            let offset = meta.block_offsets_start(mmap.len());
-            let _ = mmap.advise_range(memmap2::Advice::Sequential, offset, mmap.len() - offset);
-        }
-        advise_mmap_for_persistence(&mmap)?;
+        let backing = match access_mode {
+            AccessMode::Mmap => {
+                let mmap = unsafe { Mmap::map(file.file()) }.with_context(|| {
+                    format!(
+                        "Failed to mmap SST file {} ({} bytes)",
+                        path.display(),
+                        file.metadata().map(|m| m.len()).unwrap_or(0)
+                    )
+                })?;
+                #[cfg(unix)]
+                {
+                    mmap.advise(memmap2::Advice::Random)?;
+                    let offset = meta.block_offsets_start(mmap.len());
+                    let _ =
+                        mmap.advise_range(memmap2::Advice::Sequential, offset, mmap.len() - offset);
+                }
+                advise_mmap_for_persistence(&mmap)?;
+                StaticSortedFileBacking::Mmap(Arc::new(mmap))
+            }
+            AccessMode::File => {
+                let file_len: usize = file.metadata()?.len().try_into()?;
+                let offset = meta.block_offsets_start(file_len);
+                let mut bytes = vec![0; file_len - offset];
+                pread(file.file(), &mut bytes, offset as u64)?;
+                let block_offsets = bytes
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .map(|bytes| be::read_u32(bytes))
+                    .collect::<Vec<_>>()
+                    .into();
+                StaticSortedFileBacking::File {
+                    file: Arc::new(file),
+                    file_len,
+                    block_offsets,
+                }
+            }
+        };
         let bitmap_words = (meta.block_count as usize).div_ceil(u64::BITS as usize);
         let verified_blocks = (0..bitmap_words)
             .map(|_| AtomicU64::new(0))
             .collect::<Box<[_]>>();
         Ok(Self {
             meta,
-            mmap: Arc::new(mmap),
+            backing,
             verified_blocks,
             compression,
         })
@@ -340,7 +387,7 @@ impl StaticSortedFile {
         // Read it first, then dispatch directly to the key block it points to.
         let index_block_index = self.meta.block_count - 1;
         let index_block = get_or_cache_block(
-            &self.mmap,
+            &self.backing,
             &self.meta,
             index_block_index,
             key_block_cache,
@@ -350,7 +397,7 @@ impl StaticSortedFile {
         let key_block_index = self.lookup_index_block(&index_block, key_hash)?;
 
         let key_block_arc = get_or_cache_block(
-            &self.mmap,
+            &self.backing,
             &self.meta,
             key_block_index,
             key_block_cache,
@@ -358,6 +405,7 @@ impl StaticSortedFile {
             self.compression,
         )?;
         let reader = ArcBlockCacheReader {
+            backing: &self.backing,
             cache: value_block_cache,
             verified_blocks: &self.verified_blocks,
         };
@@ -565,15 +613,7 @@ impl StaticSortedFile {
         key_block_arc: &ArcBytes,
         reader: ArcBlockCacheReader<'_>,
     ) -> Result<LookupValue> {
-        handle_key_match_generic(
-            &self.mmap,
-            &self.meta,
-            ty,
-            val,
-            key_block_arc,
-            self.compression,
-            reader,
-        )
+        handle_key_match_generic(&self.meta, ty, val, key_block_arc, self.compression, reader)
     }
 }
 
@@ -586,45 +626,71 @@ impl StaticSortedFile {
 /// `verified_blocks`. Compressed blocks are looked up in `cache`; on a
 /// miss they are decompressed, CRC-verified, and inserted.
 fn get_or_cache_block(
-    mmap: &Arc<Mmap>,
+    backing: &StaticSortedFileBacking,
     meta: &StaticSortedFileMetaData,
     block_index: u16,
     cache: &BlockCache,
     verified_blocks: &[AtomicU64],
     compression: Compression,
 ) -> Result<ArcBytes> {
-    let (uncompressed_length, checksum, block_data) = get_raw_block_slice(mmap, meta, block_index)
-        .with_context(|| {
-            format!(
-                "Failed to read raw block {} from {:08}.sst",
-                block_index, meta.sequence_number
-            )
-        })?;
+    let mmap_block = if let StaticSortedFileBacking::Mmap(mmap) = backing {
+        let (uncompressed_length, checksum, block_data) =
+            get_raw_block_slice(mmap, meta, block_index).with_context(|| {
+                format!(
+                    "Failed to read raw block {} from {:08}.sst",
+                    block_index, meta.sequence_number
+                )
+            })?;
 
-    if uncompressed_length == 0 {
-        // Uncompressed: serve directly from mmap. Verify CRC only once per file open.
-        verify_checksum_once(meta, block_data, checksum, block_index, verified_blocks)?;
-        // SAFETY: block_data points into the mmap backing `mmap`.
-        return Ok(unsafe { ArcBytes::from_mmap(mmap, block_data) });
-    }
+        if uncompressed_length == 0 {
+            // Uncompressed: serve directly from mmap. Verify CRC only once per file open.
+            verify_checksum_once(meta, block_data, checksum, block_index, verified_blocks)?;
+            // SAFETY: block_data points into the mmap backing `mmap`.
+            return Ok(unsafe { ArcBytes::from_mmap(mmap, block_data) });
+        }
+        Some((uncompressed_length, checksum, block_data))
+    } else {
+        None
+    };
 
     // Compressed: check cache; decompress and insert on miss.
+    // File-backed blocks use the same cache, including uncompressed ones.
     Ok(
         match cache.get_value_or_guard(&(meta.sequence_number, block_index), None) {
             GuardResult::Value(block) => block,
             GuardResult::Guard(guard) => {
+                let (uncompressed_length, checksum, block_data) = match mmap_block {
+                    Some((uncompressed_length, checksum, block_data)) => {
+                        (uncompressed_length, checksum, Cow::Borrowed(block_data))
+                    }
+                    None => get_raw_block(backing, meta, block_index)?,
+                };
                 // A cached block may have been evicted, so re-reading still
                 // benefits from the bitmap to skip redundant CRC verification.
-                verify_checksum_once(meta, block_data, checksum, block_index, verified_blocks)?;
-                let block =
-                    ArcBytes::from_decompressed(compression, uncompressed_length, block_data)
+                match backing {
+                    StaticSortedFileBacking::Mmap(_) => verify_checksum_once(
+                        meta,
+                        &block_data,
+                        checksum,
+                        block_index,
+                        verified_blocks,
+                    )?,
+                    StaticSortedFileBacking::File { .. } => {
+                        verify_checksum(meta, &block_data, checksum, block_index)?
+                    }
+                }
+                let block = if uncompressed_length == 0 {
+                    ArcBytes::from(block_data.into_owned().into_boxed_slice())
+                } else {
+                    ArcBytes::from_decompressed(compression, uncompressed_length, &block_data)
                         .with_context(|| {
                             format!(
                                 "Failed to decompress block {} from {:08}.sst ({} bytes \
                                  uncompressed)",
                                 block_index, meta.sequence_number, uncompressed_length
                             )
-                        })?;
+                        })?
+                };
                 let _ = guard.insert(block.clone());
                 block
             }
@@ -693,6 +759,80 @@ fn get_raw_block_slice<'a>(
     Ok((uncompressed_length, checksum, block))
 }
 
+/// Reads a raw block from either backing. Mmap data remains borrowed; file data is owned.
+fn get_raw_block<'a>(
+    backing: &'a StaticSortedFileBacking,
+    meta: &StaticSortedFileMetaData,
+    block_index: u16,
+) -> Result<(u32, u32, Cow<'a, [u8]>)> {
+    match backing {
+        StaticSortedFileBacking::Mmap(mmap) => {
+            let (uncompressed_length, checksum, block) =
+                get_raw_block_slice(mmap, meta, block_index)?;
+            Ok((uncompressed_length, checksum, Cow::Borrowed(block)))
+        }
+        StaticSortedFileBacking::File {
+            file,
+            file_len,
+            block_offsets,
+        } => {
+            let index = block_index as usize;
+            #[cfg(feature = "strict_checks")]
+            ensure!(index < block_offsets.len(), "block index out of bounds");
+            let block_start = if index == 0 {
+                0
+            } else {
+                block_offsets[index - 1] as usize
+            };
+            let block_end = block_offsets[index] as usize;
+            #[cfg(feature = "strict_checks")]
+            ensure!(block_end <= *file_len, "block end out of bounds");
+            let _ = file_len;
+            ensure!(
+                block_start + BLOCK_HEADER_SIZE <= block_end,
+                "block {} header truncated in {:08}.sst",
+                block_index,
+                meta.sequence_number
+            );
+            let mut bytes = vec![0; block_end - block_start];
+            pread(file.file(), &mut bytes, block_start as u64)?;
+            let uncompressed_length = be::read_u32(&bytes);
+            let checksum = be::read_u32(&bytes[4..]);
+            let block = bytes.split_off(BLOCK_HEADER_SIZE);
+            Ok((uncompressed_length, checksum, Cow::Owned(block)))
+        }
+    }
+}
+
+fn pread(file: &std::fs::File, buf: &mut [u8], offset: u64) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileExt;
+        file.read_exact_at(buf, offset)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::FileExt;
+        let mut read = 0;
+        while read < buf.len() {
+            let count = file.seek_read(&mut buf[read..], offset + read as u64)?;
+            if count == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "unexpected EOF",
+                ));
+            }
+            read += count;
+        }
+        Ok(())
+    }
+    #[cfg(target_os = "wasi")]
+    {
+        use std::os::wasi::fs::FileExt;
+        file.read_exact_at(buf, offset)
+    }
+}
+
 /// Verifies the CRC32 checksum of on-disk block data. Returns an error on mismatch.
 fn verify_checksum(
     meta: &StaticSortedFileMetaData,
@@ -737,57 +877,107 @@ fn verify_checksum_once(
     Ok(())
 }
 
-/// Returns `(uncompressed_length, checksum, block)` wrapping the raw on-disk
-/// data as the given byte type. Generic over `ArcBytes`/`RcBytes`.
-fn get_raw_block_generic<B: SharedBytes>(
-    mmap: &B::MmapHandle,
-    meta: &StaticSortedFileMetaData,
-    block_index: u16,
-) -> Result<(u32, u32, B)> {
-    let (uncompressed_length, checksum, block) = get_raw_block_slice(mmap, meta, block_index)?;
-    // SAFETY: block points into mmap which backs the MmapHandle.
-    Ok((uncompressed_length, checksum, unsafe {
-        B::from_mmap(mmap, block)
-    }))
-}
-
-/// Reads a block, decompresses if needed, and verifies its checksum.
-/// Generic over the byte type (`ArcBytes` or `RcBytes`).
-#[tracing::instrument(level = "info", name = "reading database block", skip_all)]
-fn read_block_generic<B: SharedBytes>(
-    mmap: &B::MmapHandle,
+/// Reads a lookup block, decompresses it if needed, and verifies its checksum.
+fn read_block_lookup(
+    backing: &StaticSortedFileBacking,
     meta: &StaticSortedFileMetaData,
     block_index: u16,
     compression: Compression,
-) -> Result<B> {
-    let (uncompressed_length, expected_checksum, block) =
-        get_raw_block_slice(mmap, meta, block_index).with_context(|| {
-            format!(
-                "Failed to read raw block {} from {:08}.sst",
-                block_index, meta.sequence_number
-            )
-        })?;
-
-    verify_checksum(meta, block, expected_checksum, block_index)?;
-
+) -> Result<ArcBytes> {
+    let (uncompressed_length, checksum, block) = get_raw_block(backing, meta, block_index)?;
+    verify_checksum(meta, &block, checksum, block_index)?;
     if uncompressed_length == 0 {
-        // SAFETY: callers guarantee block points into the mmap.
-        return Ok(unsafe { B::from_mmap(mmap, block) });
+        return match (backing, block) {
+            (StaticSortedFileBacking::Mmap(mmap), Cow::Borrowed(block)) => {
+                // SAFETY: block points into mmap.
+                Ok(unsafe { ArcBytes::from_mmap(mmap, block) })
+            }
+            (_, block) => Ok(ArcBytes::from(block.into_owned().into_boxed_slice())),
+        };
     }
+    ArcBytes::from_decompressed(compression, uncompressed_length, &block).with_context(|| {
+        format!(
+            "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
+            block_index, meta.sequence_number, uncompressed_length
+        )
+    })
+}
 
-    let buffer =
-        B::from_decompressed(compression, uncompressed_length, block).with_context(|| {
-            format!(
-                "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
-                block_index, meta.sequence_number, uncompressed_length
-            )
-        })?;
-    Ok(buffer)
+/// Returns `(uncompressed_length, checksum, block)` wrapping the raw on-disk data as
+/// `RcBytes` for the single-threaded iteration path.
+fn get_raw_block_iter(
+    backing: &StaticSortedFileIterBacking,
+    meta: &StaticSortedFileMetaData,
+    block_index: u16,
+) -> Result<(u32, u32, RcBytes)> {
+    match backing {
+        StaticSortedFileIterBacking::Mmap(mmap) => {
+            let (uncompressed_length, checksum, block) =
+                get_raw_block_slice(mmap, meta, block_index)?;
+            // SAFETY: block points into mmap.
+            Ok((uncompressed_length, checksum, unsafe {
+                RcBytes::from_mmap(mmap, block)
+            }))
+        }
+        StaticSortedFileIterBacking::File {
+            file,
+            file_len,
+            block_offsets,
+        } => {
+            let index = block_index as usize;
+            #[cfg(feature = "strict_checks")]
+            ensure!(index < block_offsets.len(), "block index out of bounds");
+            let block_start = if index == 0 {
+                0
+            } else {
+                block_offsets[index - 1] as usize
+            };
+            let block_end = block_offsets[index] as usize;
+            #[cfg(feature = "strict_checks")]
+            ensure!(block_end <= *file_len, "block end out of bounds");
+            let _ = file_len;
+            ensure!(
+                block_start + BLOCK_HEADER_SIZE <= block_end,
+                "block {} header truncated in {:08}.sst",
+                block_index,
+                meta.sequence_number
+            );
+            let mut bytes = vec![0; block_end - block_start];
+            pread(file.file(), &mut bytes, block_start as u64)?;
+            let uncompressed_length = be::read_u32(&bytes);
+            let checksum = be::read_u32(&bytes[4..]);
+            let block = bytes.split_off(BLOCK_HEADER_SIZE);
+            Ok((
+                uncompressed_length,
+                checksum,
+                RcBytes::from(block.into_boxed_slice()),
+            ))
+        }
+    }
+}
+
+/// Reads an iteration block, decompresses it if needed, and verifies its checksum.
+fn read_block_iter(
+    backing: &StaticSortedFileIterBacking,
+    meta: &StaticSortedFileMetaData,
+    block_index: u16,
+    compression: Compression,
+) -> Result<RcBytes> {
+    let (uncompressed_length, checksum, block) = get_raw_block_iter(backing, meta, block_index)?;
+    verify_checksum(meta, &block, checksum, block_index)?;
+    if uncompressed_length == 0 {
+        return Ok(block);
+    }
+    RcBytes::from_decompressed(compression, uncompressed_length, &block).with_context(|| {
+        format!(
+            "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
+            block_index, meta.sequence_number, uncompressed_length
+        )
+    })
 }
 
 /// Handles a key match by resolving the value reference. Generic over byte type.
 fn handle_key_match_generic<B: SharedBytes>(
-    mmap: &B::MmapHandle,
     meta: &StaticSortedFileMetaData,
     ty: u8,
     val: &[u8],
@@ -801,13 +991,13 @@ fn handle_key_match_generic<B: SharedBytes>(
             let size = be::read_u16(&val[2..]) as usize;
             let position = be::read_u32(&val[4..]) as usize;
             let value = reader
-                .get_or_read(mmap, meta, block, compression)?
+                .get_or_read(meta, block, compression)?
                 .slice(position..position + size);
             LookupValue::Slice { value }
         }
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
             let block = be::read_u16(val);
-            let value = read_block_generic(mmap, meta, block, compression)?;
+            let value = reader.read_uncached(meta, block, compression)?;
             LookupValue::Slice { value }
         }
         KEY_BLOCK_ENTRY_TYPE_BLOB => {
@@ -831,11 +1021,18 @@ fn handle_key_match_generic<B: SharedBytes>(
     })
 }
 
+enum StaticSortedFileIterBacking {
+    Mmap(Rc<Mmap>),
+    File {
+        file: Rc<File>,
+        file_len: usize,
+        block_offsets: Rc<[u32]>,
+    },
+}
+
 /// An iterator over all entries in a SST file in sorted order.
 pub struct StaticSortedFileIter {
-    /// The memory-mapped file, wrapped in `Rc` for non-atomic refcounting.
-    /// All `RcBytes` slices produced during iteration share this `Rc`.
-    mmap: Rc<Mmap>,
+    backing: StaticSortedFileIterBacking,
     /// Metadata (sequence number, block count) needed for block access.
     meta: StaticSortedFileMetaData,
 
@@ -919,38 +1116,60 @@ impl Iterator for StaticSortedFileIter {
 }
 
 impl StaticSortedFileIter {
-    /// Opens an SST file for sequential iteration with the compression algorithm specified by its
-    /// meta file. Uses `MADV_SEQUENTIAL` for read-ahead and wraps the mmap in `Rc<Mmap>` directly
-    /// (no `Arc`), eliminating all atomic refcounting during iteration.
+    /// Opens an SST file for sequential iteration.
     pub fn open(
         db_path: &Path,
         meta: StaticSortedFileMetaData,
         compression: Compression,
+        access_mode: AccessMode,
     ) -> Result<Self> {
         let filename = format!("{:08}.sst", meta.sequence_number);
         let path = db_path.join(&filename);
         let file = File::open(&path)?;
-        let mmap = unsafe { Mmap::map(file.file()) }.with_context(|| {
-            format!(
-                "Failed to mmap SST file {} ({} bytes)",
-                path.display(),
-                file.metadata().map(|m| m.len()).unwrap_or(0)
-            )
-        })?;
-        #[cfg(unix)]
-        mmap.advise(memmap2::Advice::Sequential)?;
-        advise_mmap_for_persistence(&mmap)?;
-        Self::new(Rc::new(mmap), meta, compression)
+        let backing = match access_mode {
+            AccessMode::Mmap => {
+                let mmap = unsafe { Mmap::map(file.file()) }.with_context(|| {
+                    format!(
+                        "Failed to mmap SST file {} ({} bytes)",
+                        path.display(),
+                        file.metadata().map(|m| m.len()).unwrap_or(0)
+                    )
+                })?;
+                #[cfg(unix)]
+                mmap.advise(memmap2::Advice::Sequential)?;
+                advise_mmap_for_persistence(&mmap)?;
+                StaticSortedFileIterBacking::Mmap(Rc::new(mmap))
+            }
+            AccessMode::File => {
+                let file_len: usize = file.metadata()?.len().try_into()?;
+                let offset = meta.block_offsets_start(file_len);
+                let mut bytes = vec![0; file_len - offset];
+                pread(file.file(), &mut bytes, offset as u64)?;
+                let block_offsets = bytes
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .map(|bytes| be::read_u32(bytes))
+                    .collect::<Vec<_>>()
+                    .into();
+                StaticSortedFileIterBacking::File {
+                    file: Rc::new(file),
+                    file_len,
+                    block_offsets,
+                }
+            }
+        };
+        Self::new(backing, meta, compression)
             .with_context(|| format!("Unable to open static sorted file {filename}"))
     }
 
     fn new(
-        mmap: Rc<Mmap>,
+        backing: StaticSortedFileIterBacking,
         meta: StaticSortedFileMetaData,
         compression: Compression,
     ) -> Result<Self> {
         let root_block_index = meta.block_count - 1;
-        let block: RcBytes = read_block_generic(&mmap, &meta, root_block_index, compression)?;
+        let block = read_block_iter(&backing, &meta, root_block_index, compression)?;
         let block_type = block[0];
 
         // The builder always writes an index block as the root block.
@@ -969,9 +1188,9 @@ impl StaticSortedFileIter {
             - size_of::<u16>())
             / INDEX_BLOCK_ENTRY_SIZE;
 
-        let current_key_block = Self::parse_key_block(&mmap, &meta, first_child, compression)?;
+        let current_key_block = Self::parse_key_block(&backing, &meta, first_child, compression)?;
         Ok(StaticSortedFileIter {
-            mmap,
+            backing,
             meta,
             index_entries,
             num_index_entries,
@@ -984,12 +1203,12 @@ impl StaticSortedFileIter {
 
     /// Parses a key block at the given index, returning `RcBytes`-backed data.
     fn parse_key_block(
-        mmap: &Rc<Mmap>,
+        backing: &StaticSortedFileIterBacking,
         meta: &StaticSortedFileMetaData,
         block_index: u16,
         compression: Compression,
     ) -> Result<CurrentKeyBlock> {
-        let block: RcBytes = read_block_generic(mmap, meta, block_index, compression)?;
+        let block = read_block_iter(backing, meta, block_index, compression)?;
         let data = &*block;
         ensure!(data.len() >= 4, "key block too short");
         let block_type = data[0];
@@ -1069,7 +1288,7 @@ impl StaticSortedFileIter {
                 let value = if ty == KEY_BLOCK_ENTRY_TYPE_MEDIUM {
                     let block = be::read_u16(val);
                     let (uncompressed_size, checksum, block) =
-                        get_raw_block_generic(&self.mmap, &self.meta, block)?;
+                        get_raw_block_iter(&self.backing, &self.meta, block)?;
                     IterValue::Medium {
                         uncompressed_size,
                         checksum,
@@ -1077,13 +1296,13 @@ impl StaticSortedFileIter {
                     }
                 } else {
                     handle_key_match_generic(
-                        &self.mmap,
                         &self.meta,
                         ty,
                         val,
                         &kb.entries,
                         self.compression,
                         RcBlockCacheReader {
+                            backing: &self.backing,
                             cache: &mut self.value_block_cache,
                         },
                     )?
@@ -1101,8 +1320,12 @@ impl StaticSortedFileIter {
                 let base = self.index_pos * INDEX_BLOCK_ENTRY_SIZE;
                 let block_index = be::read_u16(&self.index_entries[base..]);
                 self.index_pos += 1;
-                self.current_key_block =
-                    Self::parse_key_block(&self.mmap, &self.meta, block_index, self.compression)?;
+                self.current_key_block = Self::parse_key_block(
+                    &self.backing,
+                    &self.meta,
+                    block_index,
+                    self.compression,
+                )?;
             } else {
                 return Ok(None);
             }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -1377,6 +1377,7 @@ impl<W: Write> IndexBlockBuilder<W> {
 mod tests {
     use super::*;
     use crate::{
+        AccessMode,
         key::hash_key,
         lookup_entry::LookupValue,
         static_sorted_file::{
@@ -1508,6 +1509,7 @@ mod tests {
                 block_count: meta.block_count,
             },
             Compression::Lz4,
+            AccessMode::Mmap,
         )
     }
 
@@ -1854,6 +1856,7 @@ mod tests {
                 block_count: meta1.block_count,
             },
             Compression::Lz4,
+            AccessMode::Mmap,
         )?;
         let sst2 = StaticSortedFile::open(
             dir.path(),
@@ -1862,6 +1865,7 @@ mod tests {
                 block_count: meta2.block_count,
             },
             Compression::Lz4,
+            AccessMode::Mmap,
         )?;
         let kc = make_cache();
         let vc = make_cache();

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -2,9 +2,10 @@ use std::{fs, path::Path, time::Instant};
 
 use anyhow::Result;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rstest::rstest;
 
 use crate::{
-    Compression, DbConfig, FamilyConfig, FamilyKind,
+    AccessMode, Compression, DbConfig, FamilyConfig, FamilyKind,
     constants::{MAX_INLINE_VALUE_SIZE, MAX_MEDIUM_VALUE_SIZE, MAX_SMALL_VALUE_SIZE},
     db::{CompactConfig, TurboPersistence, read_current_version},
     lookup_entry::IterValue,
@@ -113,8 +114,61 @@ fn tuple_key(prefix: u8, suffix: [u8; 4]) -> Box<[u8]> {
     key.into_boxed_slice()
 }
 
-#[test]
-fn full_cycle() -> Result<()> {
+fn config_with_mmap<const F: usize>(mmap: bool) -> DbConfig<F> {
+    DbConfig {
+        access_mode: if mmap {
+            AccessMode::Mmap
+        } else {
+            AccessMode::File
+        },
+        ..DbConfig::new()
+    }
+}
+
+fn open_db<const F: usize>(
+    path: &std::path::Path,
+    mmap: bool,
+) -> Result<TurboPersistence<RayonParallelScheduler, F>> {
+    open_db_with_config(path, config_with_mmap(mmap))
+}
+
+fn open_db_with_config<const F: usize>(
+    path: &std::path::Path,
+    config: DbConfig<F>,
+) -> Result<TurboPersistence<RayonParallelScheduler, F>> {
+    TurboPersistence::open_with_config_and_parallel_scheduler(
+        path.to_path_buf(),
+        config,
+        RayonParallelScheduler,
+    )
+}
+
+fn multi_value_config_with_mmap(mmap: bool) -> DbConfig<1> {
+    DbConfig {
+        family_configs: [FamilyConfig {
+            name: "test",
+            kind: FamilyKind::MultiValue,
+            compression: Compression::Lz4,
+        }],
+        access_mode: if mmap {
+            AccessMode::Mmap
+        } else {
+            AccessMode::File
+        },
+    }
+}
+
+fn open_multi_value_db(
+    path: &std::path::Path,
+    mmap: bool,
+) -> Result<TurboPersistence<RayonParallelScheduler, 1>> {
+    open_db_with_config(path, multi_value_config_with_mmap(mmap))
+}
+
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn full_cycle(#[case] mmap: bool) -> Result<()> {
     let mut test_cases = Vec::new();
     type TestCases = Vec<(
         &'static str,
@@ -335,10 +389,7 @@ fn full_cycle() -> Result<()> {
 
         {
             let start = Instant::now();
-            let db = TurboPersistence::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<16>(path, mmap)?;
             let mut batch = db.write_batch()?;
             write(&mut batch)?;
             db.commit_write_batch(batch)?;
@@ -354,10 +405,7 @@ fn full_cycle() -> Result<()> {
         }
         {
             let start = Instant::now();
-            let db = TurboPersistence::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<16>(path, mmap)?;
             println!("{name} restore time: {:?}", start.elapsed());
             let start = Instant::now();
             read(&db)?;
@@ -383,10 +431,7 @@ fn full_cycle() -> Result<()> {
         }
         {
             let start = Instant::now();
-            let db = TurboPersistence::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<16>(path, mmap)?;
             println!("{name} restore time after compact: {:?}", start.elapsed());
             let start = Instant::now();
             read(&db)?;
@@ -420,10 +465,7 @@ fn full_cycle() -> Result<()> {
 
         {
             let start = Instant::now();
-            let db = TurboPersistence::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<16>(path, mmap)?;
             let mut batch = db.write_batch()?;
             for (_, write, _) in test_cases.iter() {
                 write(&mut batch)?;
@@ -443,10 +485,7 @@ fn full_cycle() -> Result<()> {
         }
         {
             let start = Instant::now();
-            let db = TurboPersistence::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<16>(path, mmap)?;
             println!("All restore time: {:?}", start.elapsed());
             for (name, _, read) in test_cases.iter() {
                 let start = Instant::now();
@@ -478,10 +517,7 @@ fn full_cycle() -> Result<()> {
 
         {
             let start = Instant::now();
-            let db = TurboPersistence::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<16>(path, mmap)?;
             println!("All restore time after compact: {:?}", start.elapsed());
 
             for (name, _, read) in test_cases.iter() {
@@ -515,8 +551,10 @@ fn full_cycle() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn persist_changes() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn persist_changes(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
@@ -540,10 +578,7 @@ fn persist_changes() -> Result<()> {
     }
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
         let b = db.write_batch()?;
         put(&b, 1, 11)?;
         put(&b, 2, 21)?;
@@ -559,10 +594,7 @@ fn persist_changes() -> Result<()> {
 
     println!("---");
     {
-        let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
         let b = db.write_batch()?;
         put(&b, 1, 12)?;
         put(&b, 2, 22)?;
@@ -576,10 +608,7 @@ fn persist_changes() -> Result<()> {
     }
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
         let b = db.write_batch()?;
         put(&b, 1, 13)?;
         db.commit_write_batch(b)?;
@@ -593,10 +622,7 @@ fn persist_changes() -> Result<()> {
 
     println!("---");
     {
-        let db = TurboPersistence::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
 
         check(&db, 1, 13)?;
         check(&db, 2, 22)?;
@@ -607,10 +633,7 @@ fn persist_changes() -> Result<()> {
 
     println!("---");
     {
-        let db = TurboPersistence::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
 
         db.compact(&CompactConfig {
             optimal_merge_count: 4,
@@ -628,10 +651,7 @@ fn persist_changes() -> Result<()> {
 
     println!("---");
     {
-        let db = TurboPersistence::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
 
         check(&db, 1, 13)?;
         check(&db, 2, 22)?;
@@ -643,8 +663,10 @@ fn persist_changes() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn partial_compaction() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn partial_compaction(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
@@ -672,10 +694,7 @@ fn partial_compaction() -> Result<()> {
         println!("--- Iteration {i} ---");
         println!("Add more entries");
         {
-            let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<1>(path, mmap)?;
             let b = db.write_batch()?;
             put(&b, i, i)?;
             put(&b, i + 1, i)?;
@@ -694,10 +713,7 @@ fn partial_compaction() -> Result<()> {
 
         println!("Compaction");
         {
-            let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<1>(path, mmap)?;
 
             db.compact(&CompactConfig {
                 optimal_merge_count: 4,
@@ -718,10 +734,7 @@ fn partial_compaction() -> Result<()> {
 
         println!("Restore check");
         {
-            let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<1>(path, mmap)?;
 
             for j in 0..i {
                 check(&db, j, j)?;
@@ -737,8 +750,10 @@ fn partial_compaction() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn merge_file_removal() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn merge_file_removal(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
@@ -777,10 +792,7 @@ fn merge_file_removal() -> Result<()> {
 
     {
         println!("--- Init ---");
-        let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
         let b = db.write_batch()?;
         for j in 0..=255 {
             put(&b, j, 0)?;
@@ -796,10 +808,7 @@ fn merge_file_removal() -> Result<()> {
         let i = i * 37;
         println!("Add more entries");
         {
-            let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<1>(path, mmap)?;
             let b = db.write_batch()?;
             for j in iter_bits(i) {
                 println!("Put {j} = {i}");
@@ -817,10 +826,7 @@ fn merge_file_removal() -> Result<()> {
 
         println!("Compaction");
         {
-            let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<1>(path, mmap)?;
 
             db.compact(&CompactConfig {
                 optimal_merge_count: 4,
@@ -838,10 +844,7 @@ fn merge_file_removal() -> Result<()> {
 
         println!("Restore check");
         {
-            let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<1>(path, mmap)?;
 
             for j in 0..32 {
                 check(&db, j, expected_values[j as usize])?;
@@ -854,15 +857,14 @@ fn merge_file_removal() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_basic() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_basic(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write some test data
     let batch = db.write_batch()?;
@@ -886,15 +888,14 @@ fn batch_get_basic() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_all_existing() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_all_existing(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write test data
     let batch = db.write_batch()?;
@@ -916,15 +917,14 @@ fn batch_get_all_existing() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_none_existing() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_none_existing(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write some data but query different keys
     let batch = db.write_batch()?;
@@ -946,15 +946,14 @@ fn batch_get_none_existing() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_empty() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_empty(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write some data
     let batch = db.write_batch()?;
@@ -971,15 +970,14 @@ fn batch_get_empty() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_duplicate_keys() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_duplicate_keys(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write test data
     let batch = db.write_batch()?;
@@ -1008,15 +1006,14 @@ fn batch_get_duplicate_keys() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_large_batch() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_large_batch(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write many entries
     let batch = db.write_batch()?;
@@ -1049,18 +1046,16 @@ fn batch_get_large_batch() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_different_sizes() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_different_sizes(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let mut config = DbConfig::default();
+    let mut config = config_with_mmap(mmap);
     config.family_configs[0].compression = Compression::Zstd3;
-    let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
-        path.to_path_buf(),
-        config,
-        RayonParallelScheduler,
-    )?;
+    let db = open_db_with_config::<16>(path, config)?;
 
     // Write values of different sizes
     let batch = db.write_batch()?;
@@ -1106,19 +1101,17 @@ fn batch_get_different_sizes() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_across_families() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_across_families(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let mut config = DbConfig::default();
-    // set zstd on an arbitrary family, lz4 is used by default
+    let mut config = config_with_mmap(mmap);
+    // Set zstd on an arbitrary family; lz4 is used by default.
     config.family_configs[2].compression = Compression::Zstd3;
-    let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
-        path.to_path_buf(),
-        config.clone(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db_with_config::<16>(path, config.clone())?;
 
     // Write compressible values to multiple families so every configured codec is exercised.
     let batch = db.write_batch()?;
@@ -1187,18 +1180,16 @@ fn batch_get_across_families() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_after_compaction() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_after_compaction(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let mut config = DbConfig::default();
+    let mut config = config_with_mmap(mmap);
     config.family_configs[0].compression = Compression::Zstd3;
-    let db = TurboPersistence::<_, 16>::open_with_config_and_parallel_scheduler(
-        path.to_path_buf(),
-        config,
-        RayonParallelScheduler,
-    )?;
+    let db = open_db_with_config::<16>(path, config)?;
 
     // Write data across multiple batches to create multiple SST files
     for batch_num in 0..5u8 {
@@ -1235,15 +1226,14 @@ fn batch_get_after_compaction() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_with_overwrites() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_with_overwrites(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write initial data
     let batch = db.write_batch()?;
@@ -1285,15 +1275,14 @@ fn batch_get_with_overwrites() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_comparison_with_get() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_comparison_with_get(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write test data
     let batch = db.write_batch()?;
@@ -1339,17 +1328,16 @@ fn batch_get_comparison_with_get() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_after_restore() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_after_restore(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
     // Write data and close
     {
-        let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<16>(path, mmap)?;
 
         let batch = db.write_batch()?;
         for i in 0..100u8 {
@@ -1361,10 +1349,7 @@ fn batch_get_after_restore() -> Result<()> {
 
     // Reopen and test batch_get
     {
-        let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<16>(path, mmap)?;
 
         let keys_to_fetch: Vec<Vec<u8>> = (0..100u8).step_by(5).map(|i| vec![i]).collect();
         let results = db.batch_get(0, &keys_to_fetch)?;
@@ -1386,8 +1371,10 @@ fn batch_get_after_restore() -> Result<()> {
 
 /// Test that compaction works with many small values without overflowing block indices.
 /// Reproduces a CI benchmark failure with key_4/value_512/entries_1.98Mi/compacted.
-#[test]
-fn many_small_values_compaction() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn many_small_values_compaction(#[case] mmap: bool) -> Result<()> {
     use rand::{RngExt, SeedableRng, rngs::SmallRng};
 
     use crate::parallel_scheduler::SerialScheduler;
@@ -1395,7 +1382,10 @@ fn many_small_values_compaction() -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<SerialScheduler, 1>::open(path.to_path_buf())?;
+    let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
+        path.to_path_buf(),
+        config_with_mmap(mmap),
+    )?;
 
     let mut rng = SmallRng::seed_from_u64(42);
 
@@ -1427,8 +1417,10 @@ fn many_small_values_compaction() -> Result<()> {
 
 /// Test compaction with MAX_SMALL_VALUE_SIZE (4096-byte) values.
 /// Worst case for small value blocks: fewest entries per block.
-#[test]
-fn many_max_small_values_compaction() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn many_max_small_values_compaction(#[case] mmap: bool) -> Result<()> {
     use rand::{RngExt, SeedableRng, rngs::SmallRng};
 
     use crate::{constants::MAX_SMALL_VALUE_SIZE, parallel_scheduler::SerialScheduler};
@@ -1436,7 +1428,10 @@ fn many_max_small_values_compaction() -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<SerialScheduler, 1>::open(path.to_path_buf())?;
+    let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
+        path.to_path_buf(),
+        config_with_mmap(mmap),
+    )?;
 
     let mut rng = SmallRng::seed_from_u64(43);
 
@@ -1467,8 +1462,10 @@ fn many_max_small_values_compaction() -> Result<()> {
 
 /// Test compaction with 4097-byte values (minimum medium size).
 /// Each medium value gets its own dedicated block, so this is the worst case for block count.
-#[test]
-fn many_medium_values_compaction() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn many_medium_values_compaction(#[case] mmap: bool) -> Result<()> {
     use rand::{RngExt, SeedableRng, rngs::SmallRng};
 
     use crate::{constants::MAX_SMALL_VALUE_SIZE, parallel_scheduler::SerialScheduler};
@@ -1476,7 +1473,10 @@ fn many_medium_values_compaction() -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<SerialScheduler, 1>::open(path.to_path_buf())?;
+    let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
+        path.to_path_buf(),
+        config_with_mmap(mmap),
+    )?;
 
     let mut rng = SmallRng::seed_from_u64(44);
 
@@ -1506,21 +1506,17 @@ fn many_medium_values_compaction() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn compaction_multi_value_preserves_different_values() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn compaction_multi_value_preserves_different_values(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
-
-    let config = multi_value_config();
 
     let key = vec![42u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config,
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // Write same key with different values in separate batches
         let batch = db.write_batch()?;
@@ -1570,21 +1566,17 @@ fn multi_value_config() -> DbConfig<1> {
     config
 }
 
-#[test]
-fn compaction_multi_value_multiple_compactions() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn compaction_multi_value_multiple_compactions(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
-
-    let config = multi_value_config();
 
     let key = vec![42u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config.clone(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // Write initial values
         for value in [1u8, 2, 3] {
@@ -1634,11 +1626,7 @@ fn compaction_multi_value_multiple_compactions() -> Result<()> {
 
     // Reopen and verify persistence
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config,
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         let results = db.get_multiple(0, &key.as_slice())?;
         assert_eq!(results.len(), 6, "Should still have 6 values after reopen");
@@ -1649,20 +1637,17 @@ fn compaction_multi_value_multiple_compactions() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn multi_value_delete_key() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn multi_value_delete_key(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let config = multi_value_config();
     let key = vec![42u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config.clone(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // Write multiple values for the same key across separate batches
         for value in [1u8, 2, 3] {
@@ -1701,11 +1686,7 @@ fn multi_value_delete_key() -> Result<()> {
 
     // Reopen and verify deletion persists
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config,
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         let results = db.get_multiple(0, &key.as_slice())?;
         assert!(
@@ -1719,20 +1700,17 @@ fn multi_value_delete_key() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn multi_value_delete_then_rewrite() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn multi_value_delete_then_rewrite(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let config = multi_value_config();
     let key = vec![42u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config.clone(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // Write initial values
         for value in [1u8, 2, 3] {
@@ -1785,11 +1763,7 @@ fn multi_value_delete_then_rewrite() -> Result<()> {
 
     // Reopen and verify
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config,
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         let results = db.get_multiple(0, &key.as_slice())?;
         assert_eq!(results.len(), 2, "Should have 2 values after reopen");
@@ -1807,20 +1781,17 @@ fn multi_value_delete_then_rewrite() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn multi_value_delete_with_compaction_interleaved() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn multi_value_delete_with_compaction_interleaved(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let config = multi_value_config();
     let key = vec![42u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config.clone(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // Write values 1, 2
         for value in [1u8, 2] {
@@ -1877,11 +1848,7 @@ fn multi_value_delete_with_compaction_interleaved() -> Result<()> {
 
     // Reopen and verify
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config,
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         let results = db.get_multiple(0, &key.as_slice())?;
         assert_eq!(results.len(), 1, "Should have only value 4 after reopen");
@@ -1919,23 +1886,19 @@ fn single_value_duplicate_key_panics() {
     db.commit_write_batch(batch).unwrap(); // panics during commit
 }
 
-#[test]
-fn multi_value_tombstone_only_shadows_older_ssts() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn multi_value_tombstone_only_shadows_older_ssts(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
-
-    let config = multi_value_config();
 
     // For MultiValue, a tombstone only shadows entries from older SSTs.
     // Entries in the same batch are NOT shadowed by the tombstone.
     let key = vec![3u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config.clone(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // First write an older value in a separate batch (separate SST)
         let batch = db.write_batch()?;
@@ -1968,22 +1931,18 @@ fn multi_value_tombstone_only_shadows_older_ssts() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn multi_value_tombstone_shadows_older_sst_only() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn multi_value_tombstone_shadows_older_sst_only(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
-
-    let config = multi_value_config();
 
     // For MultiValue, tombstone in a batch shadows only entries from older SSTs.
     let key = vec![4u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config.clone(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // Write an older value in a separate batch
         let batch = db.write_batch()?;
@@ -2024,15 +1983,14 @@ fn count_blob_files(dir: &Path) -> usize {
 
 /// Test that compaction deletes blob files when their entries are superseded
 /// by newer values (SingleValue family).
-#[test]
-fn compaction_deletes_superseded_blob() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn compaction_deletes_superseded_blob(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<1>(path, mmap)?;
 
     let blob_value = vec![42u8; MAX_MEDIUM_VALUE_SIZE + 1];
 
@@ -2084,15 +2042,14 @@ fn compaction_deletes_superseded_blob() -> Result<()> {
 
 /// Test that compaction deletes blob files when a key is deleted via tombstone
 /// (SingleValue family).
-#[test]
-fn compaction_deletes_blob_on_tombstone() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn compaction_deletes_blob_on_tombstone(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<1>(path, mmap)?;
 
     let blob_value = vec![42u8; MAX_MEDIUM_VALUE_SIZE + 1];
 
@@ -2136,24 +2093,14 @@ fn compaction_deletes_blob_on_tombstone() -> Result<()> {
 
 /// Test that compaction deletes blob files for MultiValue families when a
 /// tombstone prunes older blob entries.
-#[test]
-fn compaction_deletes_blob_multi_value_tombstone() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn compaction_deletes_blob_multi_value_tombstone(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let config = DbConfig {
-        family_configs: [FamilyConfig {
-            name: "test",
-            kind: FamilyKind::MultiValue,
-            compression: Compression::Lz4,
-        }],
-    };
-
-    let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-        path.to_path_buf(),
-        config,
-        RayonParallelScheduler,
-    )?;
+    let db = open_multi_value_db(path, mmap)?;
 
     let blob_value = vec![42u8; MAX_MEDIUM_VALUE_SIZE + 1];
 
@@ -2195,15 +2142,14 @@ fn compaction_deletes_blob_multi_value_tombstone() -> Result<()> {
 
 /// Test that compaction preserves blob files that are still referenced
 /// (not superseded).
-#[test]
-fn compaction_preserves_active_blob() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn compaction_preserves_active_blob(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<1>(path, mmap)?;
 
     let blob_value = vec![42u8; MAX_MEDIUM_VALUE_SIZE + 1];
 
@@ -2510,7 +2456,7 @@ fn count_tombstones(
                 sequence_number: entry.sequence_number,
                 block_count: entry.block_count,
             };
-            for item in StaticSortedFileIter::open(path, sst, Compression::Lz4)? {
+            for item in StaticSortedFileIter::open(path, sst, Compression::Lz4, AccessMode::Mmap)? {
                 if matches!(
                     item?.value,
                     IterValue::KeyDeleted | IterValue::KeyValueDeleted { .. }

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -533,6 +533,7 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
             use core::panic;
 
             use crate::{
+                AccessMode,
                 collector_entry::CollectorEntryValue,
                 key::hash_key,
                 lookup_entry::LookupValue,
@@ -550,6 +551,7 @@ impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize
                     block_count: meta.block_count,
                 },
                 self.family_configs[usize_from_u32(family)].compression,
+                AccessMode::Mmap,
             )?;
             let cache2 = BlockCache::with(
                 10,

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -37,6 +37,7 @@ const MB: u64 = 1024 * 1024;
 pub fn db_config() -> DbConfig<FAMILIES> {
     DbConfig {
         family_configs: std::array::from_fn(|i| KeySpace::from_index(i).family_config()),
+        ..DbConfig::new()
     }
 }
 


### PR DESCRIPTION
## What?

Add `TURBO_PERSISTENCE_MMAP=0` to disable memory-mapped persistence I/O. The default remains mmap; file mode reads SST blocks positionally, keeps block offsets in memory for random access, and reads meta/blob data without creating mappings.

This is **1/3** in a dependent PR series.

- Next: #97888

## Why?

Some environments cannot use mmap reliably or have constrained virtual address space. The flag provides an opt-out without changing the on-disk format or penalizing the default mmap path.

## How?

- Thread a cached `AccessMode` through database configuration.
- Select mmap or file-backed storage independently for SST lookup, compaction, metadata, and blobs.
- Keep canary's existing `ArcBytes`/`RcBytes` split, zero-copy mmap filters, CRC-once bitmap, fast big-endian readers, mmap cache-bypass behavior, and key-order handling for blocks that omit hashes.
- Exercise lookup, restore, compaction, metadata, and blob behavior in both modes.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p turbo-persistence --all-targets --all-features`
- `cargo check -p turbo-tasks-backend`
- `cargo check -p turbo-persistence --benches`
- `cargo test -p turbo-persistence --all-features` — 109 passed

<!-- NEXT_JS_LLM -->


<!-- fleet 088efa77-2680-49f1-8941-92bb5f92b169 -->