### PR TITLE
Fix ISR misses with backslashes in segments when deployed on Windows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1030,7 +1030,8 @@ jobs:
           test/e2e/app-dir/app-edge/app-edge.test.ts \
           test/e2e/app-dir/metadata-edge/index.test.ts \
           test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts \
-          test/e2e/app-dir/proxy-runtime-nodejs/proxy-runtime-nodejs.test.ts
+          test/e2e/app-dir/proxy-runtime-nodejs/proxy-runtime-nodejs.test.ts \
+          test/e2e/incremental-cache-path-traversal/index.test.ts
       stepName: 'test-prod-windows'
       runs_on_labels: '["windows-latest-8-core-oss"]'
     secrets: inherit

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -456,26 +456,31 @@ export default class FileSystemCache implements CacheHandler {
     await writer.wait()
   }
 
-  private getFilePath(pathname: string, kind: IncrementalCacheKind): string {
+  private getFilePath(key: string, kind: IncrementalCacheKind): string {
+    let rootDir: string
     switch (kind) {
       case IncrementalCacheKind.FETCH:
         // we store in .next/cache/fetch-cache so it can be persisted
         // across deploys
-        return path.join(
-          this.serverDistDir,
-          '..',
-          'cache',
-          'fetch-cache',
-          pathname
-        )
+        rootDir = path.join(this.serverDistDir, '..', 'cache', 'fetch-cache')
+        break
       case IncrementalCacheKind.PAGES:
-        return path.join(this.serverDistDir, 'pages', pathname)
+        rootDir = path.join(this.serverDistDir, 'pages')
+        break
       case IncrementalCacheKind.IMAGE:
       case IncrementalCacheKind.APP_PAGE:
       case IncrementalCacheKind.APP_ROUTE:
-        return path.join(this.serverDistDir, 'app', pathname)
+        rootDir = path.join(this.serverDistDir, 'app')
+        break
       default:
         throw new Error(`Unexpected file path kind: ${kind}`)
     }
+
+    const filePath = path.join(rootDir, key)
+    if (!(filePath.startsWith(rootDir + path.sep) || filePath === rootDir)) {
+      throw new Error(`Invalid file path: ${filePath}`)
+    }
+
+    return filePath
   }
 }

--- a/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
+++ b/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
@@ -4,7 +4,7 @@ export default function escapePathDelimiters(
   escapeEncoded?: boolean
 ): string {
   return segment.replace(
-    new RegExp(`([/#?]${escapeEncoded ? '|%(2f|23|3f|5c)' : ''})`, 'gi'),
+    new RegExp(`([/#?\\\\]${escapeEncoded ? '|%(2f|23|3f|5c)' : ''})`, 'gi'),
     (char: string) => encodeURIComponent(char)
   )
 }

--- a/test/e2e/incremental-cache-path-traversal/app/app-cache/[...rest]/page.js
+++ b/test/e2e/incremental-cache-path-traversal/app/app-cache/[...rest]/page.js
@@ -1,0 +1,28 @@
+export const revalidate = 3600
+
+export function generateStaticParams() {
+  return [{ rest: ['seed'] }]
+}
+
+export default async function AppCachePage({ params }) {
+  const { rest } = await params
+  const captured = `ordinary-bound-value:${rest.join('/')}`
+
+  // A closure-bound "use server" action. Its presence makes `next build` emit
+  // server-reference-manifest.json (with an encryptionKey), which is the private
+  // file the traversal later discloses.
+  async function harmlessBoundAction(formData) {
+    'use server'
+    return `${captured}:${formData.get('value')}`
+  }
+
+  return (
+    <main>
+      <p id="app-rest">{rest.join('/')}</p>
+      <form action={harmlessBoundAction}>
+        <input name="value" defaultValue="harmless" />
+        <button type="submit">submit</button>
+      </form>
+    </main>
+  )
+}

--- a/test/e2e/incremental-cache-path-traversal/app/layout.js
+++ b/test/e2e/incremental-cache-path-traversal/app/layout.js
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'incremental-cache path traversal repro',
+}
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/incremental-cache-path-traversal/index.test.ts
+++ b/test/e2e/incremental-cache-path-traversal/index.test.ts
@@ -1,0 +1,45 @@
+import { nextTestSetup } from 'e2e-utils'
+import path from 'path'
+
+const enableCacheComponents = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
+
+const describeSkipCacheComponents = enableCacheComponents
+  ? describe.skip
+  : describe
+
+describeSkipCacheComponents('incremental-cache path traversal', () => {
+  const { isNextDeploy, next } = nextTestSetup({ files: __dirname })
+
+  it('serves arbitrary json files', async () => {
+    const sep = path.sep
+    const trav = `..${encodeURIComponent(sep)}..${encodeURIComponent(sep)}server-reference-manifest`
+
+    await next.fetch(`/app-cache/${trav}`)
+
+    const res = await next.fetch(
+      `/_next/data/${encodeURIComponent(next.buildId)}/pages-cache/${trav}.json`
+    )
+    const text = await res.text()
+    let json: { encryptionKey?: unknown } | undefined
+    try {
+      json = JSON.parse(text)
+    } catch {
+      json = undefined
+    }
+
+    expect({ status: res.status, json: json }).toEqual({
+      status: 200,
+      json: {
+        pageProps: {
+          rest: isNextDeploy
+            ? isAdapterTest
+              ? ['..', '..', 'server-reference-manifest']
+              : ['../../server-reference-manifest']
+            : [`..${sep}..${sep}server-reference-manifest`],
+        },
+        __N_SSG: true,
+      },
+    })
+  })
+})

--- a/test/e2e/incremental-cache-path-traversal/next.config.js
+++ b/test/e2e/incremental-cache-path-traversal/next.config.js
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+module.exports = {}

--- a/test/e2e/incremental-cache-path-traversal/pages/pages-cache/[...rest].js
+++ b/test/e2e/incremental-cache-path-traversal/pages/pages-cache/[...rest].js
@@ -1,0 +1,19 @@
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  }
+}
+
+export async function getStaticProps({ params }) {
+  return {
+    props: {
+      rest: params?.rest ?? [],
+    },
+    revalidate: 3600,
+  }
+}
+
+export default function PagesCachePage({ rest }) {
+  return <main id="pages-rest">{rest.join('/')}</main>
+}


### PR DESCRIPTION
https://github.com/vercel/next-js-mirror/pull/150
Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>