### PR TITLE
fix(accept-header): reject out-of-range accept-language weights

### DIFF
--- a/packages/next/src/server/accept-header.test.ts
+++ b/packages/next/src/server/accept-header.test.ts
@@ -1,0 +1,27 @@
+import { acceptLanguage } from './accept-header'
+
+describe('acceptLanguage', () => {
+  it('drops languages with a zero weight', () => {
+    expect(acceptLanguage('da;q=0, en;q=1', ['da', 'en'])).toEqual('en')
+    expect(acceptLanguage('da;q=0.0, en;q=1', ['da', 'en'])).toEqual('en')
+  })
+
+  it('accepts weights at the valid range boundaries', () => {
+    expect(acceptLanguage('en;q=0.001, da;q=1', ['en', 'da'])).toEqual('da')
+    expect(acceptLanguage('en;q=1.0, da;q=0.5', ['en', 'da'])).toEqual('en')
+  })
+
+  it('ranks near-zero weights below valid ones', () => {
+    expect(acceptLanguage('da;q=0.0001, en;q=1', ['da', 'en'])).toEqual('en')
+  })
+
+  it('rejects weights above the valid range', () => {
+    expect(() => acceptLanguage('da;q=2, en;q=1')).toThrow()
+    expect(() => acceptLanguage('da;q=1.5')).toThrow()
+  })
+
+  it('rejects non-numeric weights', () => {
+    expect(() => acceptLanguage('da;q=abc')).toThrow()
+    expect(() => acceptLanguage('da;q=NaN')).toThrow()
+  })
+})

--- a/packages/next/src/server/accept-header.ts
+++ b/packages/next/src/server/accept-header.ts
@@ -71,13 +71,15 @@ function parse(
       }
 
       const score = parseFloat(value)
+      if (!Number.isFinite(score) || score < 0 || score > 1) {
+        throw new Error(`Invalid ${options.type} header`)
+      }
+
       if (score === 0) {
         continue
       }
 
-      if (Number.isFinite(score) && score <= 1 && score >= 0.001) {
-        selection.q = score
-      }
+      selection.q = score
     }
 
     selections.push(selection)


### PR DESCRIPTION
acceptLanguage now rejects non-finite or out-of-range q-values (for instance: q=2, q=-0.5, q=abc, q=NaN) with the existing Invalid accept-language header error, instead of silently treating them as q=1. Near-zero weight values like q=0.0001 now rank as low priority. Their true position.

In the current state a disfavoured language was being sorted to the top. This was wrong. RFC 9110 defines q-values as strictly 0-1, this fix brings the implementation into spec.

I added new tests at:
 packages/next/src/server/accept-header.test.ts 
covering 5 cases:
1. q=0 drop
2. Valid boundary values
3. Near-zero ranking
4. Out-of-range throws
5. Non-numeric throws