### PR TITLE
Show performance summary with verbose traces

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/request-insights/request-insights-panel.tsx
@@ -930,7 +930,7 @@ function RequestDetails({
     [request, verbose]
   )
   const overview = useMemo(() => getRequestOverview(request), [request])
-  const diagnosis = getDiagnosis(request, traceItems)
+  const diagnosis = verbose ? getDiagnosis(request, traceItems) : null
   const requestUrl = getRequestDisplayUrl(request)
 
   return (
@@ -960,7 +960,9 @@ function RequestDetails({
       {overview.errorSummary ? (
         <div className="request-insights-error">{overview.errorSummary}</div>
       ) : null}
-      <div className="request-insights-diagnosis">{diagnosis}</div>
+      {diagnosis ? (
+        <div className="request-insights-diagnosis">{diagnosis}</div>
+      ) : null}
 
       <Trace
         items={traceItems}

--- a/test/development/app-dir/request-insights/request-insights.test.ts
+++ b/test/development/app-dir/request-insights/request-insights.test.ts
@@ -576,6 +576,7 @@ describe('request insights', () => {
     function getSettingsMenuState(): Promise<{
       open: boolean
       checked: string | null
+      diagnosisVisible: boolean
     }> {
       return browser.eval(() => {
         const root = document.querySelector('nextjs-portal')?.shadowRoot
@@ -588,6 +589,9 @@ describe('request insights', () => {
             item
               ?.querySelector('.request-insights-settings-checkbox')
               ?.getAttribute('data-checked') ?? null,
+          diagnosisVisible: Boolean(
+            root?.querySelector('.request-insights-diagnosis')
+          ),
         }
       })
     }
@@ -620,6 +624,7 @@ describe('request insights', () => {
       expect(await getSettingsMenuState()).toEqual({
         open: true,
         checked: null,
+        diagnosisVisible: false,
       })
     })
 
@@ -639,6 +644,7 @@ describe('request insights', () => {
       expect(await getSettingsMenuState()).toEqual({
         open: true,
         checked: 'true',
+        diagnosisVisible: true,
       })
       expect(await getSpanRowCount()).toBeGreaterThan(defaultSpanRowCount)
     })
@@ -663,6 +669,7 @@ describe('request insights', () => {
       expect(await getSettingsMenuState()).toEqual({
         open: true,
         checked: 'true',
+        diagnosisVisible: true,
       })
     })
   })


### PR DESCRIPTION
## Summary

- show the slowest recorded operation summary only when Verbose traces is enabled
- leave the recorded trace and request data unchanged

The summary is useful while inspecting the full framework trace, but it adds noise to the default request view. This keeps the default panel focused and reveals the derived performance hint with the existing verbose setting.

Stacked on #97796.

## Verification

- `pnpm --filter=next build`
- focused Request Insights E2E with Turbopack and webpack
