### PR TITLE
fix(segment-cache): support non-Latin-1 characters in segment request keys

### DIFF
--- a/packages/next/src/shared/lib/segment-cache/segment-value-encoding.test.ts
+++ b/packages/next/src/shared/lib/segment-cache/segment-value-encoding.test.ts
@@ -1,0 +1,52 @@
+import {
+  createSegmentRequestKeyPart,
+  encodeToFilesystemAndURLSafeString,
+} from './segment-value-encoding'
+
+describe('encodeToFilesystemAndURLSafeString', () => {
+  it('returns simple values as-is', () => {
+    expect(encodeToFilesystemAndURLSafeString('about')).toBe('about')
+    expect(encodeToFilesystemAndURLSafeString('a-b_c@d')).toBe('a-b_c@d')
+  })
+
+  it('base64url-encodes values with unsafe ASCII characters', () => {
+    expect(encodeToFilesystemAndURLSafeString('(group)')).toBe('!KGdyb3VwKQ')
+    expect(encodeToFilesystemAndURLSafeString('a b')).toBe('!YSBi')
+  })
+
+  // `btoa` throws an InvalidCharacterError for any character outside the
+  // Latin-1 range, which crashed rendering for route groups and segments with
+  // non-ASCII names. The value must be UTF-8 encoded before base64url-encoding.
+  it.each([
+    ['Korean', '(안녕)', '!KOyViOuFlSk'],
+    ['Japanese', '日本', '!5pel5pys'],
+    ['Cyrillic', 'тест', '!0YLQtdGB0YI'],
+    ['Latin-1 supplement', 'café', '!Y2Fmw6k'],
+    ['emoji', '😀', '!8J-YgA'],
+  ])('encodes non-Latin-1 input as UTF-8 (%s)', (_name, input, expected) => {
+    expect(encodeToFilesystemAndURLSafeString(input)).toBe(expected)
+  })
+
+  it('produces filesystem and URL safe output', () => {
+    const encoded = encodeToFilesystemAndURLSafeString('(안녕)/😀+x')
+    expect(encoded).toMatch(/^![A-Za-z0-9\-_]+$/)
+  })
+
+  it('produces distinct keys for distinct non-ASCII inputs', () => {
+    expect(encodeToFilesystemAndURLSafeString('안녕')).not.toBe(
+      encodeToFilesystemAndURLSafeString('안녕하세요')
+    )
+  })
+})
+
+describe('createSegmentRequestKeyPart', () => {
+  it('handles non-Latin-1 static segments', () => {
+    expect(createSegmentRequestKeyPart('(안녕)')).toBe('!KOyViOuFlSk')
+  })
+
+  it('handles non-Latin-1 dynamic segment names', () => {
+    expect(createSegmentRequestKeyPart(['슬러그', 'value', 'd'])).toBe(
+      '$d$!7Iqs65-s6re4'
+    )
+  })
+})

--- a/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
@@ -74,13 +74,25 @@ export function appendSegmentRequestKeyPart(
 // by default for compactness, and for easier debugging.
 const simpleParamValueRegex = /^[a-zA-Z0-9\-_@]+$/
 
-function encodeToFilesystemAndURLSafeString(value: string) {
+const textEncoder = new TextEncoder()
+
+export function encodeToFilesystemAndURLSafeString(value: string) {
   if (simpleParamValueRegex.test(value)) {
     return value
   }
   // If there are any unsafe characters, base64url-encode the entire value.
   // We also add a ! prefix so it doesn't collide with the simple case.
-  const base64url = btoa(value)
+  //
+  // `btoa` only accepts Latin-1 input and throws an InvalidCharacterError for
+  // anything outside that range (e.g. Korean, Japanese, Cyrillic, emoji).
+  // Segment names can contain arbitrary Unicode (e.g. `app/(그룹)/page.tsx`),
+  // so encode the value as UTF-8 bytes first and base64url-encode those.
+  const bytes = textEncoder.encode(value)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  const base64url = btoa(binary)
     .replace(/\+/g, '-') // Replace '+' with '-'
     .replace(/\//g, '_') // Replace '/' with '_'
     .replace(/=+$/, '') // Remove trailing '='

--- a/test/e2e/app-dir/non-ascii-route-group/app/(안녕)/hello/page.tsx
+++ b/test/e2e/app-dir/non-ascii-route-group/app/(안녕)/hello/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="content">hello from non-ascii route group</p>
+}

--- a/test/e2e/app-dir/non-ascii-route-group/app/layout.tsx
+++ b/test/e2e/app-dir/non-ascii-route-group/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/non-ascii-route-group/next.config.js
+++ b/test/e2e/app-dir/non-ascii-route-group/next.config.js
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+module.exports = {}

--- a/test/e2e/app-dir/non-ascii-route-group/non-ascii-route-group.test.ts
+++ b/test/e2e/app-dir/non-ascii-route-group/non-ascii-route-group.test.ts
@@ -1,0 +1,17 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// Regression test: route group names containing non-Latin-1 characters
+// (e.g. `app/(안녕)/hello/page.tsx`) crashed with
+// `InvalidCharacterError: Invalid character` because the segment cache key
+// was encoded with `btoa`, which only accepts Latin-1 input.
+describe('non-ascii-route-group', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render a page inside a route group with non-ASCII name', async () => {
+    const res = await next.fetch('/hello')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('hello from non-ascii route group')
+  })
+})


### PR DESCRIPTION
### What?

Route groups and segments whose names contain characters outside the Latin-1
range (Korean, Japanese, Cyrillic, `café`, emoji, …) crash with
`InvalidCharacterError: Invalid character` — 500 in `next dev`, prerender
failure in `next build`.

```
app/(안녕)/hello/page.tsx   →  /hello  →  500 / build fails
```

Fixes #97890

### Why?

`encodeToFilesystemAndURLSafeString` in `segment-value-encoding.ts` passes the
raw segment name to `btoa`, which only accepts Latin-1 input and throws for
anything else. Since the segment cache is now on by default, every non-ASCII
segment name goes through this path. This worked in Next.js 15.

### How?

Encode the value as UTF-8 bytes first, then base64url-encode those — the same
pattern already used in `shared/lib/router/utils/cache-busting-search-param.ts`.

Keys for pure-ASCII names are unchanged. Keys for names that were previously
encodable but contained Latin-1 supplement characters (e.g. `café`) change;
these keys are build-scoped (server and client derive them with the same
function), so this is not a compatibility concern.

Tests:
- Unit: `segment-value-encoding.test.ts` — Korean/Japanese/Cyrillic/Latin-1
  supplement/emoji inputs, plus static + dynamic segment key parts.
- E2E: `test/e2e/app-dir/non-ascii-route-group` — `app/(안녕)/hello/page.tsx`
  renders in dev and production. Verified locally in `dev` and `start` modes
  (Turbopack).

Note: this does **not** address #10084 (non-ASCII *URL* segments like
`app/소개` → `/소개` returning 404), which also reproduces on Next 15 and is a
separate route-matching problem.
