### PR TITLE
[test] Fix incremental cache path traversal test for non-adapter deploy tests

### DIFF
--- a/test/e2e/incremental-cache-path-traversal/index.test.ts
+++ b/test/e2e/incremental-cache-path-traversal/index.test.ts
@@ -34,8 +34,8 @@ describeSkipCacheComponents('incremental-cache path traversal', () => {
         pageProps: {
           rest: isNextDeploy
             ? isAdapterTest
-              ? '../../server-reference-manifest'
-              : ['..', '..', 'server-reference-manifest']
+              ? ['..', '..', 'server-reference-manifest']
+              : ['../../server-reference-manifest']
             : [`..${sep}..${sep}server-reference-manifest`],
         },
         __N_SSG: true,


### PR DESCRIPTION
Just matching how the test is structured on `canary` and `next-15-5`. Backport of the test was faulty.