### PR TITLE
[test] Fix flaky build CLI output capture

### DIFF
--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -305,7 +305,9 @@ export class NextStartInstance extends NextInstance {
       this.childProcess = spawn(buildArgs[0], buildArgs.slice(1), spawnOpts)
       this.handleStdio(this.childProcess)
 
-      this.childProcess.on('exit', (code, signal) => {
+      // Unlike `exit`, `close` fires after the stdio streams have closed. Wait
+      // for it before snapshotting cliOutput so trailing diagnostics are not lost.
+      this.childProcess.on('close', (code, signal) => {
         this.childProcess = undefined
         resolve({
           exitCode: signal || code,


### PR DESCRIPTION
### What?

Stabilize `NextStartInstance.build()` CLI output capture so failed production builds return all trailing stdout/stderr diagnostics.

The existing `sync-io-blocks-root` behavioral assertions remain unchanged, including the route-specific `Date.now()` diagnostic, timeout/retry guard, and exit-code check.

### Why?

The `--debug-prerender` cases intermittently lost the detailed `Date.now()` diagnostic from `result.cliOutput` in CI even though builds exited normally. Across the reported CI run and two retries, the missing route set varied from 4 to 2 to 3 routes, consistent with an output-drain race rather than a rendering or resource failure.

On latest canary with Node 20, `NEXT_TEST_MODE=start`, and `IS_WEBPACK_TEST=1`, 5 baseline campaigns completed 24 builds (20 debug-prerender) without reproducing the intermittent failure locally. A controlled Node 20 reproduction established the lifecycle race directly: the child `exit` event observed no trailing output, while `close` observed the trailing diagnostic.

### How?

Wait for the child process `close` event before snapshotting `cliOutput`. Unlike `exit`, `close` is emitted after the piped stdout and stderr streams close, so diagnostics emitted near process shutdown are fully drained before the build result is returned.

This is intentionally limited to the affected start-mode build harness and is independent of the mmap persistence PR stack (#97873, #97888, #97889).

### Verification

- Baseline on Node 20.20.2 / start mode / Webpack: 5 campaigns, 24 builds total, 20 debug-prerender; 0 failures and no affected local routes
- Deterministic child-process lifecycle reproduction: `exit` captured empty output; `close` captured the trailing diagnostic
- Post-fix focused test: 5/5 runs passed, covering 20/20 debug-prerender cases
- Post-fix complete test: 3/3 runs passed, covering 24/24 cases (12 debug-prerender and 12 normal production)
- `pnpm build-all`
- Prettier and ESLint for `test/lib/next-modes/next-start.ts`
- `pnpm types`

<!-- NEXT_JS_LLM -->


<!-- fleet a8a423ef-2679-4cb0-ba51-92592630165e -->