### PR TITLE
fix(types): correctly apply AppType initial props to component props

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -31,7 +31,7 @@ export type DocumentType = NextComponentType<
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
   P,
-  AppPropsType<any, P>
+  AppPropsType<NextRouter, any> & P
 >
 
 export type AppTreeType = ComponentType<


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/42846

This PR fixes an issue where the \AppType\ generic parameter was incorrectly passed as \PageProps\ to \AppPropsType\, causing it to apply to \props.pageProps\ instead of the component's \props\.

By extracting \P\ (the return type of \getInitialProps\) and intersecting it with \AppPropsType<NextRouter, any>\, \AppType\ now accurately mirrors the runtime behavior where \getInitialProps\ return value is merged into the App component's props.