### PR TITLE
fix(next): canonicalize percent-encoded param before bfcacheId compare

### DIFF
--- a/packages/next/src/client/components/match-segments.ts
+++ b/packages/next/src/client/components/match-segments.ts
@@ -1,6 +1,18 @@
 import type { Segment } from '../../shared/lib/app-router-types'
 import { canonicalizeURLPart } from '../route-params'
 
+// `paramCacheKey` (segment[1]) is a single canonicalized URL part for
+// dynamic params, but for catch-all params it's multiple parts joined by
+// `/` (see `getCacheKeyForDynamicParam` / `getParamValueFromCacheKey` in
+// route-params.ts). Canonicalizing the joined string as a whole would
+// re-encode those literal `/` separators, making genuinely different
+// catch-all segments (e.g. `["a", "b"]` vs `["a%2Fb"]`) compare as equal.
+// Canonicalizing each `/`-delimited part individually keeps the separators
+// intact while still normalizing encoding within each part.
+function canonicalizeParamCacheKey(paramCacheKey: string): string {
+  return paramCacheKey.split('/').map(canonicalizeURLPart).join('/')
+}
+
 export const matchSegment = (
   existingSegment: Segment,
   segment: Segment
@@ -19,6 +31,7 @@ export const matchSegment = (
   }
   return (
     existingSegment[0] === segment[0] &&
-    canonicalizeURLPart(existingSegment[1]) === canonicalizeURLPart(segment[1])
+    canonicalizeParamCacheKey(existingSegment[1]) ===
+      canonicalizeParamCacheKey(segment[1])
   )
 }

--- a/packages/next/src/client/components/match-segments.ts
+++ b/packages/next/src/client/components/match-segments.ts
@@ -1,4 +1,5 @@
 import type { Segment } from '../../shared/lib/app-router-types'
+import { canonicalizeURLPart } from '../route-params'
 
 export const matchSegment = (
   existingSegment: Segment,
@@ -16,5 +17,8 @@ export const matchSegment = (
   if (typeof segment === 'string') {
     return false
   }
-  return existingSegment[0] === segment[0] && existingSegment[1] === segment[1]
+  return (
+    existingSegment[0] === segment[0] &&
+    canonicalizeURLPart(existingSegment[1]) === canonicalizeURLPart(segment[1])
+  )
 }


### PR DESCRIPTION
Fixes a Cache Components bfcache mismatch on search-param-only navigations.

A search-param-only navigation mints a new bfcacheId when the dynamic param is percent-encoded. `matchSegment` in `packages/next/src/client/components/match-segments.ts` compared `existingSegment[1] === segment[1]` directly, so `%2F` versus `%252F`, or decoded versus encoded forms, were treated as different segments.

`matchSegment` now compares both cache keys through `canonicalizeParamCacheKey`, which splits catch-all keys on `/`, canonicalizes each part with `canonicalizeURLPart` from `route-params` (`decodeURIComponent` then `encodeURIComponent`), and rejoins, so `/` separators are preserved (535e17f).

Verified RED to GREEN. Formatting changes are limited to the touched file.
