### PR TITLE
fix: keep multi-segment params for intercepting catch-all routes

### DIFF
--- a/packages/next/src/client/components/router-reducer/compute-changed-path.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.ts
@@ -234,9 +234,16 @@ export function getSelectedParams(
     const segmentValue = isDynamicParameter ? segment[1] : segment
     if (!segmentValue || segmentValue.startsWith(PAGE_SEGMENT_KEY)) continue
 
-    // Ensure catchAll and optional catchall are turned into an array
+    // Ensure catchAll / optional / intercepted catchalls are turned into arrays.
+    // Intercepted short types (`ci(.)`, …) must match getParamValueFromCacheKey.
+    const paramType = isDynamicParameter ? segment[2] : null
     const isCatchAll =
-      isDynamicParameter && (segment[2] === 'c' || segment[2] === 'oc')
+      paramType === 'c' ||
+      paramType === 'oc' ||
+      paramType === 'ci(.)' ||
+      paramType === 'ci(..)' ||
+      paramType === 'ci(...)' ||
+      paramType === 'ci(..)(..)'
 
     if (isCatchAll) {
       params[segment[0]] = segment[1].split('/')

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -246,7 +246,16 @@ export function getParamValueFromCacheKey(
 ) {
   // Turn the cache key string sent by the server (as part of FlightRouterState)
   // into a value that can be passed to `useParams` and client components.
-  const isCatchAll = paramType === 'c' || paramType === 'oc'
+  // Keep in sync with intercepted catchall short types on DynamicParamTypesShort
+  // (`ci(.)`, …). Server-side `isCatchAll()` already includes those; splitting
+  // only `c`/`oc` leaves intercepted catchalls as a single joined string.
+  const isCatchAll =
+    paramType === 'c' ||
+    paramType === 'oc' ||
+    paramType === 'ci(.)' ||
+    paramType === 'ci(..)' ||
+    paramType === 'ci(...)' ||
+    paramType === 'ci(..)(..)'
   if (isCatchAll) {
     // Catch-all param keys are a concatenation of the path segments.
     // See equivalent logic in `getSelectedParams`.

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
@@ -1,4 +1,4 @@
-import { parseDestination } from './prepare-destination'
+import { parseDestination, prepareDestination } from './prepare-destination'
 
 describe('parseDestination', () => {
   it('should parse the destination', () => {
@@ -86,5 +86,20 @@ describe('parseDestination', () => {
        "slashes": true,
      }
     `)
+  })
+})
+
+describe('prepareDestination interception repeating params', () => {
+  it('should not concatenate array catchall segments without slashes', () => {
+    const { parsedDestination } = prepareDestination({
+      appendParamsToQuery: false,
+      destination: '/photos/(.):nxtIslug+',
+      params: {
+        nxtIslug: ['a', 'b'],
+      },
+      query: {},
+    })
+
+    expect(parsedDestination.pathname).toBe('/photos/(.)a/b')
   })
 })

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.ts
@@ -319,6 +319,17 @@ export function prepareDestination(args: {
         break
       }
     }
+
+    // Marker-adjacent repeating params compile with an empty path-to-regexp
+    // prefix after `_NEXTSEP_` normalization. Passing an array then concatenates
+    // segments without `/` (['a','b'] -> 'ab'). Join first so destinations keep
+    // path separators.
+    for (const key of Object.keys(args.params)) {
+      const value = args.params[key]
+      if (Array.isArray(value)) {
+        args.params[key] = value.join('/')
+      }
+    }
   }
 
   try {

--- a/packages/next/src/shared/lib/router/utils/route-match-utils.test.ts
+++ b/packages/next/src/shared/lib/router/utils/route-match-utils.test.ts
@@ -1,4 +1,4 @@
-import { safeCompile } from './route-match-utils'
+import { safeCompile, safePathToRegexp } from './route-match-utils'
 import {
   PARAM_SEPARATOR,
   stripNormalizedSeparators,
@@ -103,6 +103,25 @@ describe('safeCompile', () => {
       const result = compile({ path: ['folder', 'subfolder', 'file.txt'] })
 
       expect(result).toBe('/files/folder/subfolder/file.txt')
+    })
+  })
+
+  describe('interception marker adjacent to repeating param', () => {
+    it('should compile string catchall values with path separators preserved', () => {
+      const compile = safeCompile('/photos/(.):slug+', { validate: false })
+      expect(
+        compile({
+          '0': '(.)',
+          slug: 'a/b/c',
+        })
+      ).toBe('/photos/(.)a/b/c')
+    })
+
+    it('should parse marker-adjacent catchall destinations via safePathToRegexp', () => {
+      const keys: Array<{ name: string | number }> = []
+      const re = safePathToRegexp('/photos/(.):slug+', keys)
+      expect(re).toBeInstanceOf(RegExp)
+      expect(keys.some((key) => key.name === 'slug')).toBe(true)
     })
   })
 

--- a/packages/next/src/shared/lib/router/utils/route-match-utils.ts
+++ b/packages/next/src/shared/lib/router/utils/route-match-utils.ts
@@ -13,10 +13,13 @@ import {
   pathToRegexp,
   compile,
   regexpToFunction,
+  parse,
+  tokensToRegexp,
 } from 'next/dist/compiled/path-to-regexp'
 import {
   hasAdjacentParameterIssues,
   normalizeAdjacentParameters,
+  normalizeTokensForRegexp,
   stripParameterSeparators,
   stripNormalizedSeparators,
 } from '../../../../lib/route-pattern-normalizer'
@@ -43,17 +46,25 @@ export function safePathToRegexp(
   try {
     return pathToRegexp(routeToUse, keys, options)
   } catch (error) {
-    // Only try normalization if we haven't already normalized
-    if (!needsNormalization) {
-      try {
-        const normalizedRoute = normalizeAdjacentParameters(route)
-        return pathToRegexp(normalizedRoute, keys, options)
-      } catch (retryError) {
-        // If that doesn't work, fall back to original error
-        throw error
+    try {
+      // After `_NEXTSEP_` normalization, interception marker + catchall
+      // (`/(.)_NEXTSEP_:param+`) has an empty path-to-regexp prefix/suffix.
+      // path-to-regexp 6.3+ rejects that; normalize tokens so key extraction
+      // (used by prepareDestination) can succeed for those destinations.
+      const tokens = normalizeTokensForRegexp(parse(routeToUse))
+      return tokensToRegexp(tokens, keys, options)
+    } catch {
+      // Only try adjacent-parameter normalization if we haven't already normalized
+      if (!needsNormalization) {
+        try {
+          const normalizedRoute = normalizeAdjacentParameters(route)
+          return pathToRegexp(normalizedRoute, keys, options)
+        } catch {
+          throw error
+        }
       }
+      throw error
     }
-    throw error
   }
 }
 

--- a/packages/next/src/shared/lib/router/utils/route-regex.test.ts
+++ b/packages/next/src/shared/lib/router/utils/route-regex.test.ts
@@ -1,4 +1,4 @@
-import { getNamedRouteRegex } from './route-regex'
+import { getNamedRouteRegex, getRouteRegex } from './route-regex'
 import { parseParameter } from './get-dynamic-param'
 import { pathToRegexp } from 'next/dist/compiled/path-to-regexp'
 
@@ -851,6 +851,20 @@ describe('getNamedRouteRegex - Edge Cases', () => {
     // Should match multiple segments after the static segment
     expect(regex.re.test('/photos/(.)images/a')).toBe(true)
     expect(regex.re.test('/photos/(.)images/a/b/c')).toBe(true)
+  })
+
+  it('should match multi-segment paths for catchall adjacent to interception marker', () => {
+    // getParametrizedRoute previously ignored `repeat` in this branch.
+    const regex = getRouteRegex('/photos/(.)[...slug]')
+
+    expect(regex.groups.slug).toEqual({
+      pos: 1,
+      repeat: true,
+      optional: false,
+    })
+    expect(regex.re.test('/photos/(.)a')).toBe(true)
+    expect(regex.re.test('/photos/(.)a/b/c')).toBe(true)
+    expect(regex.re.exec('/photos/(.)a/b/c')?.[1]).toBe('a/b/c')
   })
 
   it('should handle dynamic segment with interception marker prefix', () => {

--- a/packages/next/src/shared/lib/router/utils/route-regex.ts
+++ b/packages/next/src/shared/lib/router/utils/route-regex.ts
@@ -108,7 +108,15 @@ function getParametrizedRoute(
     if (markerMatch && paramMatches && paramMatches[2]) {
       const { key, optional, repeat } = parseMatchedParameter(paramMatches[2])
       groups[key] = { pos: groupIndex++, repeat, optional }
-      segments.push(`/${escapeStringRegexp(markerMatch)}([^/]+?)`)
+      // Must honor `repeat`/`optional` here — the non-intercepted branch below
+      // and `getNamedParametrizedRoute` already do. Hardcoding `([^/]+?)` makes
+      // routes like `/(.)[...slug]` fail to match multi-segment paths.
+      const paramPattern = repeat ? '(.+?)' : '([^/]+?)'
+      segments.push(
+        optional
+          ? `(?:/${escapeStringRegexp(markerMatch)}${paramPattern})?`
+          : `/${escapeStringRegexp(markerMatch)}${paramPattern}`
+      )
     } else if (paramMatches && paramMatches[2]) {
       const { key, repeat, optional } = parseMatchedParameter(paramMatches[2])
       groups[key] = { pos: groupIndex++, repeat, optional }

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/layout.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/page.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/page.tsx
@@ -1,0 +1,5 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return <Link href="/photos">photos</Link>
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/photos/@modal/(.)[...slug]/page.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/photos/@modal/(.)[...slug]/page.tsx
@@ -1,0 +1,8 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>
+}) {
+  const { slug } = await params
+  return <pre id="intercepted">{JSON.stringify(slug)}</pre>
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/photos/@modal/default.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/photos/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/photos/[...slug]/page.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/photos/[...slug]/page.tsx
@@ -1,0 +1,8 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>
+}) {
+  const { slug } = await params
+  return <pre id="page">{JSON.stringify(slug)}</pre>
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/photos/layout.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/photos/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode
+  modal: React.ReactNode
+}) {
+  return (
+    <>
+      <div id="children">{children}</div>
+      <div id="modal">{modal}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/photos/page.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/photos/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <Link href="/photos/a/b">multi</Link>
+      <Link href="/photos/only">single</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/intercept-catchall-route-params.test.ts
+++ b/test/e2e/app-dir/intercept-catchall-route-params/intercept-catchall-route-params.test.ts
@@ -1,0 +1,21 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('intercept-catchall-route-params', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should keep multi-segment catchall params as an array when intercepting', async () => {
+    const browser = await next.browser('/photos')
+    await browser.elementByCss('a[href="/photos/a/b"]').click()
+    const text = await browser.waitForElementByCss('#intercepted').text()
+    expect(JSON.parse(text)).toEqual(['a', 'b'])
+  })
+
+  it('should keep single-segment catchall params as an array when intercepting', async () => {
+    const browser = await next.browser('/photos')
+    await browser.elementByCss('a[href="/photos/only"]').click()
+    const text = await browser.waitForElementByCss('#intercepted').text()
+    expect(JSON.parse(text)).toEqual(['only'])
+  })
+})


### PR DESCRIPTION
## For Contributors

### Fixing a bug

- [x] Related issues linked using `fixes #number`
- [x] Tests added
- [ ] Errors have a helpful link attached (N/A)

## Summary

Fixes #97910

Related to #73104 (same intercepted catch-all params issue; #97910 was closed as duplicate).

Intercepting routes that use a catch-all segment (for example `@modal/(.)[...slug]`) do not behave like normal catch-alls on soft navigation.

On canary, multi-segment paths such as `/photos/a/b` can fail to match the intercepted route correctly, and intercepted catch-all params are not always restored as `string[]` on the client. Single-segment cases may still appear to work, which makes the mismatch easy to miss.

This change aligns the intercept + catch-all path with the existing non-intercept catch-all behavior:

- `getParametrizedRoute` honors `repeat` / `optional` for interception params (same idea as the named-route path)
- `prepareDestination` joins array catch-all values with `/` before compiling marker-adjacent destinations
- `safePathToRegexp` falls back through token normalization when marker-adjacent repeating params fail path-to-regexp validation
- client param helpers treat intercepted catch-all short types (`ci(.)`, `ci(..)`, `ci(...)`, `ci(..)(..)`) as catch-alls, matching server `isCatchAll()`

## Test plan

- [x] Unit: `route-regex` / `prepare-destination` / `route-match-utils`
- [x] e2e: `test/e2e/app-dir/intercept-catchall-route-params`
- [x] Reproduction: https://github.com/scs0209/nextjs-intercept-catchall-repro
  - `npm install && npm run dev`
  - open `/photos`, click multi-segment link, confirm `#intercepted` shows `["a","b"]`