### PR TITLE
fix : handle UTF-8 route paths safely

### DIFF
--- a/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
@@ -80,7 +80,9 @@ function encodeToFilesystemAndURLSafeString(value: string) {
   }
   // If there are any unsafe characters, base64url-encode the entire value.
   // We also add a ! prefix so it doesn't collide with the simple case.
-  const base64url = btoa(value)
+  const base64url = btoa(
+    String.fromCharCode(...new TextEncoder().encode(value))
+  )
     .replace(/\+/g, '-') // Replace '+' with '-'
     .replace(/\//g, '_') // Replace '/' with '_'
     .replace(/=+$/, '') // Remove trailing '='

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -307,7 +307,7 @@ impl AssetIdent {
         }
         const MAX_FILENAME: usize = 80;
         if name.len() - i > MAX_FILENAME {
-            i = name.len() - MAX_FILENAME;
+            i = name.floor_char_boundary(name.len()-MAX_FILENAME);
             if let Some(j) = name[i..].find('_')
                 && j < 20
             {


### PR DESCRIPTION
### Summary

- Encode non-Latin route segments as UTF-8 bytes before Base64URL encoding to prevent "InvalidCharacterError"
- Ensure Turbopack truncates generated filenames only at valid UTF-8 character boundaries

### Verification

- Manually verified that a Korean route renders successfully with Turbopack (`HTTP 200`)
- `pnpm --filter=next types`
- `cargo fmt -- --check`