### PR TITLE
test: make Turbopack config assertion fixture-specific

### DIFF
--- a/test/production/page-config/page-config.test.ts
+++ b/test/production/page-config/page-config.test.ts
@@ -24,8 +24,9 @@ describe('Page Config', () => {
       if (isTurbopack) {
         // Turbopack rejects the config in its own transform, and the build
         // stops there. It never reads the value with the segment config schema.
+        expect(cliOutput).toContain('./pages/invalid/string-config.js')
         expect(cliOutput).toContain(
-          "Next.js can't recognize the exported `config` field"
+          "Next.js can't recognize the exported `config` field in route. It needs to be a static object."
         )
       } else {
         // Webpack reads the value with the segment config schema, and the


### PR DESCRIPTION
### What?

Tighten the Turbopack assertion for the Pages Router string-config production test so it identifies both the exact fixture path and the complete static-object diagnostic.

### Why?

The broad diagnostic prefix is shared by several invalid-config fixtures. Matching only that prefix does not prove that the string-config case produced the expected error; output from a different fixture could satisfy it.

The existing bundler-specific structure on `canary` already handles Webpack’s timing-sensitive output. This change keeps that design and makes the Turbopack branch equally fixture-specific.

### How?

Require `./pages/invalid/string-config.js` in Turbopack output and match the full reason that this export needs to be a static object.

### Verification

- `pnpm test-start-webpack test/production/page-config/page-config.test.ts`
- `pnpm test-start-turbo test/production/page-config/page-config.test.ts`
- Prettier, ESLint, and `git diff --check`

<!-- NEXT_JS_LLM -->

<!-- fleet cb160491-78c1-4b22-bd90-d07b7e4259fb -->