### PR TITLE
Turbopack: call loadActionManifest for app-route

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1090,18 +1090,23 @@ pub fn app_entry_point_to_route(
                 }
                 .resolved_cell(),
             ),
+            has_action_manifest: true,
         },
-        AppEntrypoint::AppMetadata { page, metadata, .. } => Route::AppRoute {
-            original_name: page.to_string().into(),
-            endpoint: ResolvedVc::upcast(
-                AppEndpoint {
-                    ty: AppEndpointType::Metadata { metadata },
-                    app_project,
-                    page,
-                }
-                .resolved_cell(),
-            ),
-        },
+        AppEntrypoint::AppMetadata { page, metadata, .. } => {
+            let has_action_manifest = matches!(metadata, MetadataItem::Dynamic { .. });
+            Route::AppRoute {
+                original_name: page.to_string().into(),
+                endpoint: ResolvedVc::upcast(
+                    AppEndpoint {
+                        ty: AppEndpointType::Metadata { metadata },
+                        app_project,
+                        page,
+                    }
+                    .resolved_cell(),
+                ),
+                has_action_manifest,
+            }
+        }
     }
     .cell()
 }

--- a/crates/next-api/src/operation.rs
+++ b/crates/next-api/src/operation.rs
@@ -100,9 +100,14 @@ fn pick_route(entrypoints: OperationVc<Entrypoints>, key: RcStr, route: &Route) 
                 })
                 .collect(),
         ),
-        Route::AppRoute { original_name, .. } => RouteOperation::AppRoute {
+        Route::AppRoute {
+            original_name,
+            has_action_manifest,
+            ..
+        } => RouteOperation::AppRoute {
             original_name: original_name.clone(),
             endpoint: pick_endpoint(entrypoints, EndpointSelector::RouteAppRoute(key)),
+            has_action_manifest: *has_action_manifest,
         },
         Route::Conflict => RouteOperation::Conflict,
     }
@@ -220,6 +225,7 @@ pub enum RouteOperation {
     AppRoute {
         original_name: RcStr,
         endpoint: OperationVc<OptionEndpoint>,
+        has_action_manifest: bool,
     },
     Conflict,
 }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1370,6 +1370,7 @@ impl Project {
                 Route::AppRoute {
                     original_name: _,
                     endpoint,
+                    ..
                 } => {
                     endpoint_groups.push((
                         EndpointGroupKey::Route(key.clone()),

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -38,6 +38,7 @@ pub enum Route {
     AppRoute {
         original_name: RcStr,
         endpoint: ResolvedVc<Box<dyn Endpoint>>,
+        has_action_manifest: bool,
     },
     Conflict,
 }

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -784,7 +784,12 @@ pub async fn map_server_actions(
         .map(async |module| {
             // TODO: compare module contexts instead?
             let layer = match module.ident().await?.layer.as_ref() {
-                Some(layer) if layer.name() == "app-rsc" || layer.name() == "app-edge-rsc" => {
+                Some(layer)
+                    if layer.name() == "app-rsc"
+                        || layer.name() == "app-edge-rsc"
+                        || layer.name() == "app-route"
+                        || layer.name() == "app-edge-route" =>
+                {
                     ActionLayer::Rsc
                 }
                 Some(layer) if layer.name() == "app-client" => ActionLayer::ActionBrowser,

--- a/crates/next-build-test/src/lib.rs
+++ b/crates/next-build-test/src/lib.rs
@@ -204,6 +204,7 @@ pub async fn render_routes(
                         Route::AppRoute {
                             original_name: _,
                             endpoint,
+                            ..
                         } => {
                             endpoint_write_to_disk_with_apply(endpoint).await?;
                         }

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -841,6 +841,8 @@ pub struct NapiRoute {
 
     pub pages: Option<Vec<AppPageNapiRoute>>,
 
+    pub has_action_manifest: Option<bool>,
+
     // Different representations of the endpoint
     pub endpoint: Option<External<ExternalEndpoint>>,
     pub html_endpoint: Option<External<ExternalEndpoint>>,
@@ -895,11 +897,13 @@ impl NapiRoute {
             RouteOperation::AppRoute {
                 original_name,
                 endpoint,
+                has_action_manifest,
             } => NapiRoute {
                 pathname,
                 original_name: Some(original_name),
                 r#type: "app-route",
                 endpoint: convert_endpoint(endpoint),
+                has_action_manifest: Some(has_action_manifest),
                 ..Default::default()
             },
             RouteOperation::Conflict => NapiRoute {

--- a/packages/next/src/build/handle-entrypoints.ts
+++ b/packages/next/src/build/handle-entrypoints.ts
@@ -118,6 +118,7 @@ export async function handleRouteType({
       const key = getEntryKey('app', 'server', page)
 
       manifestLoader.loadAppPathsManifest(page)
+      manifestLoader.loadActionManifest(page)
 
       const middlewareManifestWritten = manifestLoader.loadMiddlewareManifest(
         page,

--- a/packages/next/src/build/handle-entrypoints.ts
+++ b/packages/next/src/build/handle-entrypoints.ts
@@ -118,7 +118,9 @@ export async function handleRouteType({
       const key = getEntryKey('app', 'server', page)
 
       manifestLoader.loadAppPathsManifest(page)
-      manifestLoader.loadActionManifest(page)
+      if (route.hasActionManifest) {
+        manifestLoader.loadActionManifest(page)
+      }
 
       const middlewareManifestWritten = manifestLoader.loadMiddlewareManifest(
         page,

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -487,6 +487,7 @@ export interface NapiRoute {
   /** The type of route, eg a Page or App */
   type: string
   pages?: Array<AppPageNapiRoute>
+  hasActionManifest?: boolean
   endpoint?: ExternalObject<ExternalEndpoint>
   htmlEndpoint?: ExternalObject<ExternalEndpoint>
   rscHmrEndpoint?: ExternalObject<ExternalEndpoint>

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -551,6 +551,7 @@ function bindingToApi(
     | {
         type: 'app-route'
         originalName: string
+        hasActionManifest: boolean
         endpoint: NapiEndpoint
       }
     | {
@@ -1205,6 +1206,7 @@ function bindingToApi(
           route = {
             type: 'app-route',
             originalName: nativeRoute.originalName,
+            hasActionManifest: nativeRoute.hasActionManifest,
             endpoint: new EndpointImpl(nativeRoute.endpoint),
           }
           break

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -384,6 +384,7 @@ export type Route =
   | {
       type: 'app-route'
       originalName: string
+      hasActionManifest: boolean
       endpoint: Endpoint
     }
   | {
@@ -528,6 +529,7 @@ export type AppRoute =
     }
   | {
       type: 'app-route'
+      hasActionManifest: boolean
       endpoint: Endpoint
     }
 

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -460,6 +460,7 @@ export async function handleRouteType({
       const type = writtenEndpoint.type
 
       manifestLoader.loadAppPathsManifest(page)
+      manifestLoader.loadActionManifest(page)
 
       if (type === 'edge') {
         warnAboutEdgeRuntime()

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -460,7 +460,9 @@ export async function handleRouteType({
       const type = writtenEndpoint.type
 
       manifestLoader.loadAppPathsManifest(page)
-      manifestLoader.loadActionManifest(page)
+      if (route.hasActionManifest) {
+        manifestLoader.loadActionManifest(page)
+      }
 
       if (type === 'edge') {
         warnAboutEdgeRuntime()


### PR DESCRIPTION
For #95233, I need to read server-reference-manifest.json even for App Routes, which previously didn't emit server action manifest entries at all (because thus far, it was unnecessary).