### PR TITLE
[ci] Use presigned URLs to upload preview builds

### DIFF
--- a/.github/workflows/upload_preview_tarballs.yml
+++ b/.github/workflows/upload_preview_tarballs.yml
@@ -67,5 +67,4 @@ jobs:
           github.event.workflow_run.head_sha }}" "${{ runner.temp
           }}/preview-tarballs"
         env:
-          BLOB_ACCESS: ${{ vars.PREVIEW_BUILDS_ACCESS }}
           PREVIEW_BUILDS_BASE_URL: ${{ vars.PREVIEW_BUILDS_BASE_URL }}

--- a/scripts/upload-preview-tarballs.js
+++ b/scripts/upload-preview-tarballs.js
@@ -1,5 +1,4 @@
 // @ts-check
-const { put } = require('@vercel/blob/client')
 const fs = require('node:fs/promises')
 const path = require('node:path')
 
@@ -116,12 +115,6 @@ async function main() {
     )
   }
 
-  const blobAccess = process.env.BLOB_ACCESS
-  if (blobAccess !== 'private' && blobAccess !== 'public') {
-    throw new Error(
-      `BLOB_ACCESS environment variable can only be "private" or "public" but got "${blobAccess}".`
-    )
-  }
   const baseUrl =
     process.env.PREVIEW_BUILDS_BASE_URL || DEFAULT_PREVIEW_BUILDS_BASE_URL
   const getOidcToken = createGitHubOidcTokenGetter()
@@ -129,8 +122,8 @@ async function main() {
   for await (const { packageName, tarballPath } of findTarballs(
     tarballDirectory
   )) {
-    // vercel-packages authorizes the OIDC token and answers with a client
-    // token scoped to this exact blob path. The bytes then flow directly to
+    // vercel-packages authorizes the OIDC token and answers with a presigned
+    // upload URL scoped to this exact blob path. The bytes flow directly to
     // the store, so the tarball size is not limited by a function's request
     // body limit.
     const response = await fetch(
@@ -146,20 +139,21 @@ async function main() {
           `Response headers: ${JSON.stringify(Object.fromEntries(response.headers))}`
       )
     }
-    const { clientToken } = await response.json()
+    const body = await response.json()
 
     const fileBuffer = await fs.readFile(tarballPath)
-    const { url } = await put(
-      `next/commits/${githubHeadSha}/${packageName}.tgz`,
-      fileBuffer,
-      {
-        access: blobAccess,
-        token: clientToken,
-        contentType: 'application/gzip',
-        multipart: true,
-      }
-    )
-    console.info(`Uploaded ${packageName} -> ${url}`)
+    const putResponse = await fetch(body.url, {
+      method: 'PUT',
+      body: new Uint8Array(fileBuffer),
+      headers: { 'content-type': 'application/gzip' },
+    })
+    if (!putResponse.ok) {
+      throw new Error(
+        `Failed to upload ${packageName}: ${putResponse.status}. ` +
+          `Response headers: ${JSON.stringify(Object.fromEntries(putResponse.headers))}`
+      )
+    }
+    console.info(`Uploaded ${packageName} -> ${body.downloadUrl}`)
   }
 
   console.info('All tarballs uploaded')


### PR DESCRIPTION
Follow-up to #97256, pairing with [vercel/vercel-packages#107](https://github.com/vercel/vercel-packages/pull/107). The token exchange endpoint no longer returns a client-upload token derived from a store read-write token; it presigns the upload URL with the deployment's own Vercel OIDC identity and returns the URL, pinning the pathname, expiry, size cap, and access and overwrite policy server-side. No store credential exists anywhere after this lands, and no Blob SDK is needed here for the new path — the script PUTs the tarball bytes to the URL directly.

The client only uses presigned-URL. The server still supports client tokens until we landed this and synced the mirror.

## Test plan

- [x] the throwaway probe branch uploads via the presigned URL returned by the vercel-packages preview deployment of the endpoint change, and production rejects it with 403 — https://github.com/vercel/next.js/actions/runs/32995975519

