### PR TITLE
Migrate from box_patterns to deref_patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10134,7 +10134,6 @@ dependencies = [
  "mockito",
  "quick_cache",
  "reqwest",
- "rustc-hash 2.1.1",
  "rustls",
  "serde",
  "tokio",

--- a/crates/next-custom-transforms/src/lib.rs
+++ b/crates/next-custom-transforms/src/lib.rs
@@ -28,7 +28,7 @@ DEALINGS IN THE SOFTWARE.
 
 #![recursion_limit = "2048"]
 #![deny(clippy::all)]
-#![feature(box_patterns)]
+#![feature(deref_patterns)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 

--- a/crates/next-custom-transforms/src/transforms/import_analyzer.rs
+++ b/crates/next-custom-transforms/src/transforms/import_analyzer.rs
@@ -34,7 +34,7 @@ impl ImportMap {
             }
 
             Expr::Member(MemberExpr {
-                obj: box Expr::Ident(obj),
+                obj: Expr::Ident(obj),
                 prop: MemberProp::Ident(prop),
                 ..
             }) => {

--- a/crates/next-custom-transforms/src/transforms/optimize_server_react.rs
+++ b/crates/next-custom-transforms/src/transforms/optimize_server_react.rs
@@ -51,7 +51,7 @@ fn effect_has_side_effect_deps(call: &CallExpr) -> bool {
     if let Expr::Array(arr) = &*call.args[1].expr {
         for elem in arr.elems.iter().flatten() {
             if let ExprOrSpread {
-                expr: box Expr::Call(_),
+                expr: Expr::Call(_),
                 ..
             } = elem
             {
@@ -137,7 +137,7 @@ impl Fold for OptimizeServerReact {
 
     fn fold_expr(&mut self, expr: Expr) -> Expr {
         if let Expr::Call(call) = &expr {
-            if let Callee::Expr(box Expr::Ident(f)) = &call.callee {
+            if let Callee::Expr(Expr::Ident(f)) = &call.callee {
                 // Mark `useEffect` as DCE'able
                 if let Some(use_effect_ident) = &self.use_effect_ident
                     && &f.to_id() == use_effect_ident
@@ -154,7 +154,7 @@ impl Fold for OptimizeServerReact {
                     return wrap_expr_with_env_prod_condition(call.clone());
                 }
             } else if let Some(react_ident) = &self.react_ident
-                && let Callee::Expr(box Expr::Member(member)) = &call.callee
+                && let Callee::Expr(Expr::Member(member)) = &call.callee
                 && let Expr::Ident(f) = &*member.obj
                 && &f.to_id() == react_ident
                 && let MemberProp::Ident(i) = &member.prop
@@ -179,8 +179,8 @@ impl Fold for OptimizeServerReact {
 
         if let Pat::Array(array_pat) = &decl.name
             && array_pat.elems.len() == 2
-            && let Some(box Expr::Call(call)) = &decl.init
-            && let Callee::Expr(box Expr::Ident(f)) = &call.callee
+            && let Some(Expr::Call(call)) = &decl.init
+            && let Callee::Expr(Expr::Ident(f)) = &call.callee
             && let Some(use_state_ident) = &self.use_state_ident
             && &f.to_id() == use_state_ident
             && call.args.len() == 1

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1567,15 +1567,15 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         let old_current_export_name = self.current_export_name.take();
 
         match n {
-            PropOrSpread::Prop(box Prop::KeyValue(KeyValueProp {
+            PropOrSpread::Prop(Prop::KeyValue(KeyValueProp {
                 key: PropName::Ident(ident_name),
-                value: box Expr::Arrow(_) | box Expr::Fn(_),
+                value: Expr::Arrow(_) | Expr::Fn(_),
                 ..
             })) => {
                 self.current_export_name = None;
                 self.arrow_or_fn_expr_ident = Some(ident_name.clone().into());
             }
-            PropOrSpread::Prop(box Prop::Method(MethodProp { key, .. })) => {
+            PropOrSpread::Prop(Prop::Method(MethodProp { key, .. })) => {
                 let key = key.clone();
 
                 if let PropName::Ident(ident_name) = &key {
@@ -1603,7 +1603,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
 
         if !self.in_module_level
             && self.should_track_names
-            && let PropOrSpread::Prop(box Prop::Shorthand(i)) = n
+            && let PropOrSpread::Prop(Prop::Shorthand(i)) = n
         {
             self.names.push(Name::from(&*i));
             self.should_track_names = false;
@@ -1686,7 +1686,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
     }
 
     fn visit_mut_call_expr(&mut self, n: &mut CallExpr) {
-        if let Callee::Expr(box Expr::Ident(Ident { sym, .. })) = &mut n.callee
+        if let Callee::Expr(Expr::Ident(Ident { sym, .. })) = &mut n.callee
             && (sym == "jsxDEV" || sym == "_jsxDEV")
         {
             // Do not visit the 6th arg in a generated jsxDEV call, which is a `this`
@@ -2837,7 +2837,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
             (&attr.value, &attr.name)
         {
             match &container.expr {
-                JSXExpr::Expr(box Expr::Arrow(_)) | JSXExpr::Expr(box Expr::Fn(_)) => {
+                JSXExpr::Expr(Expr::Arrow(_)) | JSXExpr::Expr(Expr::Fn(_)) => {
                     self.arrow_or_fn_expr_ident = Some(ident_name.clone().into());
                 }
                 _ => {}
@@ -2852,7 +2852,7 @@ impl<C: Comments> VisitMut for ServerActions<C> {
         let old_current_export_name = self.current_export_name.take();
         let old_arrow_or_fn_expr_ident = self.arrow_or_fn_expr_ident.take();
 
-        if let (Pat::Ident(ident), Some(box Expr::Arrow(_) | box Expr::Fn(_))) =
+        if let (Pat::Ident(ident), Some(Expr::Arrow(_) | Expr::Fn(_))) =
             (&var_declarator.name, &var_declarator.init)
         {
             if self.in_module_level
@@ -3301,7 +3301,7 @@ fn has_body_directive(maybe_body: &Option<BlockStmt>) -> (bool, bool) {
         for stmt in body.stmts.iter() {
             match stmt {
                 Stmt::Expr(ExprStmt {
-                    expr: box Expr::Lit(Lit::Str(Str { value, .. })),
+                    expr: Expr::Lit(Lit::Str(Str { value, .. })),
                     ..
                 }) => {
                     if value == "use server" {
@@ -3440,7 +3440,7 @@ impl DirectiveVisitor<'_> {
 
         match stmt {
             Stmt::Expr(ExprStmt {
-                expr: box Expr::Lit(Lit::Str(Str { value, span, .. })),
+                expr: Expr::Lit(Lit::Str(Str { value, span, .. })),
                 ..
             }) => {
                 if value == "use server" {
@@ -3575,8 +3575,8 @@ impl DirectiveVisitor<'_> {
             }
             Stmt::Expr(ExprStmt {
                 expr:
-                    box Expr::Paren(ParenExpr {
-                        expr: box Expr::Lit(Lit::Str(Str { value, .. })),
+                    Expr::Paren(ParenExpr {
+                        expr: Expr::Lit(Lit::Str(Str { value, .. })),
                         ..
                     }),
                 span,
@@ -3668,7 +3668,7 @@ impl VisitMut for ClosureReplacer<'_> {
     fn visit_mut_prop_or_spread(&mut self, n: &mut PropOrSpread) {
         n.visit_mut_children_with(self);
 
-        if let PropOrSpread::Prop(box Prop::Shorthand(i)) = n {
+        if let PropOrSpread::Prop(Prop::Shorthand(i)) = n {
             let name = Name::from(&*i);
             if let Some(index) = self.used_ids.iter().position(|used_id| *used_id == name) {
                 *n = PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -551,13 +551,13 @@ impl TurboTasksBackend {
                         done_event,
                     ))))
                 }
-                Some(InProgressState::InProgress(box InProgressStateInner {
-                    done_event, ..
-                })) => Some(Ok(ReadOutcome::InProgress(listen_to_done_event(
-                    reader_description,
-                    tracking,
-                    done_event,
-                )))),
+                Some(InProgressState::InProgress(InProgressStateInner { done_event, .. })) => {
+                    Some(Ok(ReadOutcome::InProgress(listen_to_done_event(
+                        reader_description,
+                        tracking,
+                        done_event,
+                    ))))
+                }
                 Some(InProgressState::Canceled) => Some(Err(anyhow::anyhow!(
                     "{} was canceled",
                     task.get_task_description()
@@ -1869,7 +1869,7 @@ impl TurboTasksBackend {
                     done_event,
                     reason: _,
                 } => done_event.notify(usize::MAX),
-                InProgressState::InProgress(box InProgressStateInner { done_event, .. }) => {
+                InProgressState::InProgress(InProgressStateInner { done_event, .. }) => {
                     done_event.notify(usize::MAX)
                 }
                 InProgressState::Canceled => {}
@@ -2210,7 +2210,7 @@ impl TurboTasksBackend {
                 is_session_dependent,
             });
         }
-        let &mut InProgressState::InProgress(box InProgressStateInner {
+        let &mut InProgressState::InProgress(InProgressStateInner {
             stale,
             ref mut new_children,
             once_task: is_once_task,
@@ -2224,7 +2224,7 @@ impl TurboTasksBackend {
         #[cfg(not(feature = "no_fast_stale"))]
         if stale && !is_once_task {
             let stale_priority = compute_stale_priority(&task);
-            let Some(InProgressState::InProgress(box InProgressStateInner {
+            let Some(InProgressState::InProgress(InProgressStateInner {
                 done_event,
                 mut new_children,
                 ..
@@ -2609,7 +2609,7 @@ impl TurboTasksBackend {
             // Task was canceled in the meantime, so we don't connect the children
             return None;
         }
-        let InProgressState::InProgress(box InProgressStateInner {
+        let InProgressState::InProgress(InProgressStateInner {
             #[cfg(not(feature = "no_fast_stale"))]
             stale,
             once_task: is_once_task,
@@ -2623,7 +2623,7 @@ impl TurboTasksBackend {
         #[cfg(not(feature = "no_fast_stale"))]
         if *stale && !is_once_task {
             let stale_priority = compute_stale_priority(&task);
-            let Some(InProgressState::InProgress(box InProgressStateInner { done_event, .. })) =
+            let Some(InProgressState::InProgress(InProgressStateInner { done_event, .. })) =
                 task.take_in_progress()
             else {
                 unreachable!();
@@ -2685,7 +2685,7 @@ impl TurboTasksBackend {
             // Task was canceled in the meantime, so we don't finish it
             return (None, None);
         }
-        let InProgressState::InProgress(box InProgressStateInner {
+        let InProgressState::InProgress(InProgressStateInner {
             done_event,
             once_task: is_once_task,
             stale,
@@ -3250,7 +3250,7 @@ impl TurboTasksBackend {
     fn mark_own_task_as_finished(&self, task: TaskId, turbo_tasks: &TurboTasks<TurboTasksBackend>) {
         let mut ctx = self.execute_context(turbo_tasks);
         let mut task = ctx.task(task, TaskDataCategory::Data);
-        if let Some(InProgressState::InProgress(box InProgressStateInner {
+        if let Some(InProgressState::InProgress(InProgressStateInner {
             marked_as_completed,
             ..
         })) = task.get_in_progress_mut()

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1431,7 +1431,7 @@ impl AggregationUpdateQueue {
                         self.inner_of_upper_lost_followers(ctx, lost_follower_ids, upper_id, retry);
                     }
                 }
-                AggregationUpdateJob::AggregatedDataUpdate(box AggregatedDataUpdateJob {
+                AggregationUpdateJob::AggregatedDataUpdate(AggregatedDataUpdateJob {
                     upper_ids,
                     update,
                 }) => {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -33,9 +33,8 @@ impl ConnectChildOperation {
     ) {
         if let Some(parent_task_id) = parent_task_id {
             let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::Meta);
-            let Some(InProgressState::InProgress(box InProgressStateInner {
-                new_children, ..
-            })) = parent_task.get_in_progress()
+            let Some(InProgressState::InProgress(InProgressStateInner { new_children, .. })) =
+                parent_task.get_in_progress()
             else {
                 panic!("Task is not in progress while calling another task: {parent_task:?}");
             };
@@ -49,9 +48,8 @@ impl ConnectChildOperation {
             if parent_task.children_contains(&child_task_id) {
                 // It is already connected, we can skip the rest
                 // but we still need to update the new_children set
-                let Some(InProgressState::InProgress(box InProgressStateInner {
-                    new_children,
-                    ..
+                let Some(InProgressState::InProgress(InProgressStateInner {
+                    new_children, ..
                 })) = parent_task.get_in_progress_mut()
                 else {
                     unreachable!();
@@ -118,9 +116,8 @@ impl ConnectChildOperation {
 
         if let Some(parent_task_id) = parent_task_id {
             let mut parent_task = ctx.task(parent_task_id, TaskDataCategory::Meta);
-            let Some(InProgressState::InProgress(box InProgressStateInner {
-                new_children, ..
-            })) = parent_task.get_in_progress_mut()
+            let Some(InProgressState::InProgress(InProgressStateInner { new_children, .. })) =
+                parent_task.get_in_progress_mut()
             else {
                 panic!("Task is not in progress while calling another task: {parent_task:?}");
             };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -132,7 +132,7 @@ pub fn make_task_dirty_internal(
     #[cfg(feature = "trace_task_dirty")]
     let task_name = task.get_task_name();
     if make_stale
-        && let Some(InProgressState::InProgress(box InProgressStateInner { stale, .. })) =
+        && let Some(InProgressState::InProgress(InProgressStateInner { stale, .. })) =
             task.get_in_progress_mut()
         && !*stale
     {

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(anonymous_lifetime_in_impl_trait)]
-#![feature(box_patterns)]
+#![feature(deref_patterns)]
 
 mod backend;
 mod backing_storage;

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/eval_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/eval_context.rs
@@ -175,13 +175,13 @@ impl EvalContext {
                 // Only treat literals as constant undefined, allowing arbitrary values inside here
                 // would mean that they can have sideeffects, and `JsValue::Constant` can't model
                 // that.
-                arg: box Expr::Lit(_),
+                arg: Expr::Lit(_),
                 ..
             }) => JsValue::Constant(ConstantValue::Undefined),
 
             Expr::Unary(UnaryExpr {
                 op: op!(unary, "-"),
-                arg: box Expr::Lit(Lit::Num(n)),
+                arg: Expr::Lit(Lit::Num(n)),
                 ..
             }) => JsValue::Constant(ConstantValue::Num(ConstantNumber(-n.value))),
 
@@ -288,9 +288,9 @@ impl EvalContext {
             }) => JsValue::r#in(arena, self.eval(arena, left), self.eval(arena, right)),
 
             &Expr::Cond(CondExpr {
-                box ref cons,
-                box ref alt,
-                box ref test,
+                ref cons,
+                ref alt,
+                ref test,
                 ..
             }) => {
                 let test = self.eval(arena, test);
@@ -309,8 +309,8 @@ impl EvalContext {
 
             Expr::TaggedTpl(TaggedTpl {
                 tag:
-                    box Expr::Member(MemberExpr {
-                        obj: box Expr::Ident(tag_obj),
+                    Expr::Member(MemberExpr {
+                        obj: Expr::Ident(tag_obj),
                         prop: MemberProp::Ident(tag_prop),
                         ..
                     }),
@@ -380,11 +380,7 @@ impl EvalContext {
                 JsValue::member(arena, obj, prop)
             }
 
-            Expr::New(NewExpr {
-                callee: box callee,
-                args,
-                ..
-            }) => {
+            Expr::New(NewExpr { callee, args, .. }) => {
                 let args = args.as_deref().unwrap_or(&[]);
                 // We currently do not handle spreads.
                 if args.iter().any(|arg| arg.spread.is_some()) {
@@ -402,7 +398,7 @@ impl EvalContext {
             }
 
             Expr::Call(CallExpr {
-                callee: Callee::Expr(box callee),
+                callee: Callee::Expr(callee),
                 args,
                 ..
             }) => {
@@ -505,13 +501,13 @@ impl EvalContext {
                     PropOrSpread::Spread(SpreadElement { expr, .. }) => {
                         ObjectPart::Spread(self.eval(arena, expr))
                     }
-                    PropOrSpread::Prop(box Prop::KeyValue(KeyValueProp { key, box value })) => {
+                    PropOrSpread::Prop(Prop::KeyValue(KeyValueProp { key, value })) => {
                         ObjectPart::KeyValue(
                             self.eval_prop_name(arena, key),
                             self.eval(arena, value),
                         )
                     }
-                    PropOrSpread::Prop(box Prop::Shorthand(ident)) => ObjectPart::KeyValue(
+                    PropOrSpread::Prop(Prop::Shorthand(ident)) => ObjectPart::KeyValue(
                         ident.sym.clone().into(),
                         self.eval(arena, &Expr::Ident(ident.clone())),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph/visitor.rs
@@ -1259,7 +1259,7 @@ impl<'a> Analyzer<'a, '_> {
                             Some(path)
                         }
                         Expr::Arrow(ArrowExpr {
-                            body: box BlockStmtOrExpr::BlockStmt(_),
+                            body: BlockStmtOrExpr::BlockStmt(_),
                             ..
                         }) => {
                             let mut path = as_parent_path(&ast_path);
@@ -1272,7 +1272,7 @@ impl<'a> Analyzer<'a, '_> {
                             Some(path)
                         }
                         Expr::Arrow(ArrowExpr {
-                            body: box BlockStmtOrExpr::Expr(_),
+                            body: BlockStmtOrExpr::Expr(_),
                             ..
                         }) => {
                             let mut path = as_parent_path(&ast_path);
@@ -1343,7 +1343,7 @@ impl<'a> Analyzer<'a, '_> {
                     export_usage,
                 });
             }
-            Callee::Expr(box expr) => {
+            Callee::Expr(expr) => {
                 if let Expr::Member(MemberExpr { obj, prop, .. }) = unparen(expr) {
                     let obj_value =
                         BumpBox::new_in(self.eval_context.eval(self.arena, obj), self.arena);
@@ -3091,7 +3091,7 @@ impl<'a> Analyzer<'a, '_> {
                     }
                     self.add_value(
                         key.to_id(),
-                        if let Some(box value) = value {
+                        if let Some(value) = value {
                             let value = self.eval_context.eval(self.arena, value);
                             JsValue::alternatives(BumpVec::from_iter_in(
                                 self.arena,

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -1400,7 +1400,7 @@ impl Visit for Analyzer<'_> {
             MemberProp::Ident(..)
                 | MemberProp::PrivateName(..)
                 | MemberProp::Computed(ComputedPropName {
-                    expr: box Expr::Lit(Lit::Str(_)),
+                    expr: Expr::Lit(Lit::Str(_)),
                     ..
                 })
         ) && let Expr::Ident(ident) = &*node.obj

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known/require_context.rs
@@ -47,7 +47,7 @@ pub fn parse_require_context(args: &[JsValue<'_>]) -> Result<RequireContextOptio
     };
 
     let filter = if let Some(filter) = args.get(2) {
-        if let JsValue::Constant(ConstantValue::Regex(box (pattern, flags))) = filter {
+        if let JsValue::Constant(ConstantValue::Regex((pattern, flags))) = filter {
             EsRegex::new(pattern, flags)?
         } else {
             bail!("require.context(..., ..., filter) requires filter to be a regex");

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -1,6 +1,6 @@
 // Needed for swc visit_ macros
 #![allow(non_local_definitions)]
-#![feature(box_patterns)]
+#![feature(deref_patterns)]
 #![feature(min_specialization)]
 #![feature(iter_intersperse)]
 #![feature(arbitrary_self_types)]

--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/graph.rs
@@ -642,7 +642,7 @@ impl DepGraph {
 
                 // Skip directives, as we copy them to each modules.
                 if let ModuleItem::Stmt(Stmt::Expr(ExprStmt {
-                    expr: box Expr::Lit(Lit::Str(s)),
+                    expr: Expr::Lit(Lit::Str(s)),
                     ..
                 })) = &data[g].content
                     && s.value.starts_with("use ")
@@ -1367,7 +1367,7 @@ impl DepGraph {
                 }
 
                 ModuleItem::Stmt(Stmt::Expr(ExprStmt {
-                    expr: box Expr::Assign(assign),
+                    expr: Expr::Assign(assign),
                     ..
                 })) => {
                     let mut used_ids = ids_used_by_ignoring_nested(
@@ -1680,17 +1680,17 @@ pub(crate) fn create_turbopack_part_id_assert(dep: PartId) -> ObjectLit {
 
 pub(crate) fn find_turbopack_part_id_in_asserts(asserts: &ObjectLit) -> Option<PartId> {
     asserts.props.iter().find_map(|prop| match prop {
-        PropOrSpread::Prop(box Prop::KeyValue(KeyValueProp {
+        PropOrSpread::Prop(Prop::KeyValue(KeyValueProp {
             key: PropName::Ident(key),
-            value: box Expr::Lit(Lit::Num(chunk_id)),
+            value: Expr::Lit(Lit::Num(chunk_id)),
         })) if &*key.sym == ASSERT_CHUNK_KEY => Some(PartId::Internal(
             chunk_id.value.abs() as u32,
             chunk_id.value.is_sign_positive(),
         )),
 
-        PropOrSpread::Prop(box Prop::KeyValue(KeyValueProp {
+        PropOrSpread::Prop(Prop::KeyValue(KeyValueProp {
             key: PropName::Ident(key),
-            value: box Expr::Lit(Lit::Str(s)),
+            value: Expr::Lit(Lit::Str(s)),
         })) if &*key.sym == ASSERT_CHUNK_KEY => match s.value.as_str()? {
             "module evaluation" => Some(PartId::ModuleEvaluation),
             "exports" => Some(PartId::Exports),

--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/mod.rs
@@ -524,7 +524,7 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
                     matches!(
                         item,
                         ModuleItem::Stmt(Stmt::Expr(ExprStmt {
-                            expr: box Expr::Lit(Lit::Str(..)),
+                            expr: Expr::Lit(Lit::Str(..)),
                             ..
                         }))
                     )

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
@@ -74,7 +74,7 @@ impl EsmModuleItem {
                                         Default::default(),
                                     )
                                     .into(),
-                                    init: Some(Box::new(expr)),
+                                    init: Some(expr),
                                     definite: false,
                                 }],
                             }));

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_item.rs
@@ -53,7 +53,7 @@ impl EsmModuleItem {
                 let item = replace(module_item, ModuleItem::Stmt(quote!(";" as Stmt)));
                 if let ModuleItem::ModuleDecl(module_decl) = item {
                     match module_decl {
-                        ModuleDecl::ExportDefaultExpr(ExportDefaultExpr { box expr, .. }) => {
+                        ModuleDecl::ExportDefaultExpr(ExportDefaultExpr { expr, .. }) => {
                             let decl = Decl::Var(Box::new(VarDecl {
                                 span: DUMMY_SP,
                                 ctxt: Default::default(),

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -271,18 +271,14 @@ impl UrlAssetReferenceCodeGen {
                                     args: Some(args), ..
                                 }) = new_expr
                                 {
-                                    if let Some(ExprOrSpread {
-                                        box expr,
-                                        spread: None,
-                                    }) = args.get_mut(0)
+                                    if let Some(ExprOrSpread { expr, spread: None }) =
+                                        args.get_mut(0)
                                     {
                                         *expr = url_segment_resolver.clone();
                                     }
 
-                                    if let Some(ExprOrSpread {
-                                        box expr,
-                                        spread: None,
-                                    }) = args.get_mut(1)
+                                    if let Some(ExprOrSpread { expr, spread: None }) =
+                                        args.get_mut(1)
                                     {
                                         if let Some(rewrite) = &rewrite_url_base {
                                             *expr = rewrite.clone();
@@ -308,19 +304,15 @@ impl UrlAssetReferenceCodeGen {
                                     args: Some(args), ..
                                 }) = new_expr
                                 {
-                                    if let Some(ExprOrSpread {
-                                        box expr,
-                                        spread: None,
-                                    }) = args.get_mut(0)
+                                    if let Some(ExprOrSpread { expr, spread: None }) =
+                                        args.get_mut(0)
                                     {
                                         *expr = request.as_str().into()
                                     }
 
                                     if let Some(rewrite) = &rewrite_url_base
-                                        && let Some(ExprOrSpread {
-                                            box expr,
-                                            spread: None,
-                                        }) = args.get_mut(1)
+                                        && let Some(ExprOrSpread { expr, spread: None }) =
+                                            args.get_mut(1)
                                     {
                                         *expr = rewrite.clone();
                                     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -274,14 +274,14 @@ impl UrlAssetReferenceCodeGen {
                                     if let Some(ExprOrSpread { expr, spread: None }) =
                                         args.get_mut(0)
                                     {
-                                        *expr = url_segment_resolver.clone();
+                                        **expr = url_segment_resolver.clone();
                                     }
 
                                     if let Some(ExprOrSpread { expr, spread: None }) =
                                         args.get_mut(1)
                                     {
                                         if let Some(rewrite) = &rewrite_url_base {
-                                            *expr = rewrite.clone();
+                                            **expr = rewrite.clone();
                                         } else {
                                             // If rewrite for the base doesn't exists, means
                                             // __turbopack_resolve_module_id_path__
@@ -314,7 +314,7 @@ impl UrlAssetReferenceCodeGen {
                                         && let Some(ExprOrSpread { expr, spread: None }) =
                                             args.get_mut(1)
                                     {
-                                        *expr = rewrite.clone();
+                                        **expr = rewrite.clone();
                                     }
                                 }
                             }

--- a/turbopack/crates/turbopack-ecmascript/src/utils.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/utils.rs
@@ -35,7 +35,7 @@ pub(crate) fn extract_name_from_member_prop(prop: &MemberProp) -> Option<SmallVe
     match prop {
         MemberProp::Ident(ident) => Some(SmallVec::from_buf([ident.sym.as_str().into()])),
         MemberProp::Computed(ComputedPropName {
-            expr: box Expr::Lit(Lit::Str(s)),
+            expr: Expr::Lit(Lit::Str(s)),
             ..
         }) => s.value.as_str().map(|v| SmallVec::from_buf([v.into()])),
         _ => None,
@@ -83,7 +83,7 @@ pub fn js_value_to_pattern(value: &JsValue<'_>) -> Pattern {
             ConstantValue::Null => rcstr!("null"),
             ConstantValue::Num(ConstantNumber(n)) => n.to_string().into(),
             ConstantValue::BigInt(n) => n.to_string().into(),
-            ConstantValue::Regex(box (exp, flags)) => format!("/{exp}/{flags}").into(),
+            ConstantValue::Regex((exp, flags)) => format!("/{exp}/{flags}").into(),
             ConstantValue::Undefined => rcstr!("undefined"),
         }),
         JsValue::Url(v, JsValueUrlKind::Relative) => Pattern::Constant(v.as_rcstr()),

--- a/turbopack/crates/turbopack-trace-server/src/lib.rs
+++ b/turbopack/crates/turbopack-trace-server/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(box_patterns)]
+#![feature(deref_patterns)]
 #![feature(bufreader_peek)]
 
 use std::{

--- a/turbopack/crates/turbopack-trace-server/src/main.rs
+++ b/turbopack/crates/turbopack-trace-server/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(box_patterns)]
+#![feature(deref_patterns)]
 #![feature(bufreader_peek)]
 
 #[global_allocator]

--- a/turbopack/crates/turbopack-trace-server/src/self_time_tree.rs
+++ b/turbopack/crates/turbopack-trace-server/src/self_time_tree.rs
@@ -135,7 +135,7 @@ impl<T> SelfTimeTree<T> {
     }
 
     fn rebalance(&mut self) {
-        if let Some(box SelfTimeChildren {
+        if let Some(SelfTimeChildren {
             left,
             split_point,
             right,
@@ -159,7 +159,7 @@ impl<T> SelfTimeTree<T> {
                 // right' = (left.right, right) with self.split_point
                 // split_point' = left.split_point
                 // direct entries in self and left are put in self and are redistributed
-                if let Some(box SelfTimeChildren {
+                if let Some(SelfTimeChildren {
                     left: left_left,
                     split_point: left_split_point,
                     right: left_right,
@@ -189,7 +189,7 @@ impl<T> SelfTimeTree<T> {
                 // right' = right.right
                 // split_point' = right.split_point
                 // direct entries in self and right are put in self and are redistributed
-                if let Some(box SelfTimeChildren {
+                if let Some(SelfTimeChildren {
                     left: right_left,
                     split_point: right_split_point,
                     right: right_right,


### PR DESCRIPTION
TLDR: just enable `deref_patterns` and remove the `box` syntax. And it just works

`box_patterns` will be removed entirely in the next Rust nightly: https://github.com/rust-lang/rust/pull/156749