### PR TITLE
Expose durableUseCacheEntries config in workStore

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2285,6 +2285,9 @@ export default async function build(
               cacheComponents: isAppCacheComponentsEnabled,
               authInterrupts: isAuthInterruptsEnabled,
               useCacheTimeout: config.experimental.useCacheTimeout,
+              durableUseCacheEntries: Boolean(
+                config.experimental.durableUseCacheEntries
+              ),
               staticPageGenerationTimeout: config.staticPageGenerationTimeout,
               httpAgentOptions: config.httpAgentOptions,
               locales: config.i18n?.locales,
@@ -2517,6 +2520,9 @@ export default async function build(
                             authInterrupts: isAuthInterruptsEnabled,
                             useCacheTimeout:
                               config.experimental.useCacheTimeout,
+                            durableUseCacheEntries: Boolean(
+                              config.experimental.durableUseCacheEntries
+                            ),
                             staticPageGenerationTimeout:
                               config.staticPageGenerationTimeout,
                             cacheHandler: config.cacheHandler,

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -823,6 +823,7 @@ export async function buildAppStaticPaths({
   cacheComponents,
   authInterrupts,
   useCacheTimeout,
+  durableUseCacheEntries,
   staticPageGenerationTimeout,
   segments,
   isrFlushToDisk,
@@ -845,6 +846,7 @@ export async function buildAppStaticPaths({
   cacheComponents: boolean
   authInterrupts: boolean
   useCacheTimeout: number
+  durableUseCacheEntries: boolean
   staticPageGenerationTimeout: number
   segments: readonly Readonly<AppSegment>[]
   distDir: string
@@ -910,6 +912,7 @@ export async function buildAppStaticPaths({
       experimental: {
         authInterrupts,
         useCacheTimeout,
+        durableUseCacheEntries,
       },
       waitUntil: afterRunner.context.waitUntil,
       onClose: afterRunner.context.onClose,

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -948,6 +948,9 @@ export function createAppPageEntrypoint({
                 nextConfig.experimental.serverComponentsHmrCancellation
               ),
               useCacheTimeout: nextConfig.experimental.useCacheTimeout,
+              durableUseCacheEntries: Boolean(
+                nextConfig.experimental.durableUseCacheEntries
+              ),
               cachedNavigations:
                 nextConfig.experimental.cachedNavigations ?? false,
               clientTraceMetadata:

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -237,6 +237,9 @@ export async function handler(
       experimental: {
         authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
         useCacheTimeout: nextConfig.experimental.useCacheTimeout,
+        durableUseCacheEntries: Boolean(
+          nextConfig.experimental.durableUseCacheEntries
+        ),
       },
       cacheComponents: Boolean(nextConfig.cacheComponents),
       validationLevel: nextConfig.experimental.instantInsights.validationLevel,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -180,6 +180,9 @@ async function requestHandler(
         // no-op.
         serverComponentsHmrCancellation: false,
         useCacheTimeout: nextConfig.experimental.useCacheTimeout,
+        durableUseCacheEntries: Boolean(
+          nextConfig.experimental.durableUseCacheEntries
+        ),
         cachedNavigations: nextConfig.experimental.cachedNavigations ?? false,
         clientTraceMetadata:
           nextConfig.experimental.clientTraceMetadata || ([] as any),

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -699,6 +699,7 @@ export async function isPageStatic({
   cacheComponents,
   authInterrupts,
   useCacheTimeout,
+  durableUseCacheEntries,
   staticPageGenerationTimeout,
   originalAppPath,
   isrFlushToDisk,
@@ -718,6 +719,7 @@ export async function isPageStatic({
   cacheComponents: boolean
   authInterrupts: boolean
   useCacheTimeout: number
+  durableUseCacheEntries: boolean
   staticPageGenerationTimeout: number
   configFileName: string
   httpAgentOptions: NextConfigComplete['httpAgentOptions']
@@ -904,6 +906,7 @@ export async function isPageStatic({
               cacheComponents,
               authInterrupts,
               useCacheTimeout,
+              durableUseCacheEntries,
               staticPageGenerationTimeout,
               segments,
               distDir,

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -525,6 +525,9 @@ async function exportAppImpl(
       authInterrupts: !!nextConfig.experimental.authInterrupts,
       reactBrowserBailout: nextConfig.experimental.reactBrowserBailout ?? false,
       useCacheTimeout: nextConfig.experimental.useCacheTimeout,
+      durableUseCacheEntries: Boolean(
+        nextConfig.experimental.durableUseCacheEntries
+      ),
       cachedNavigations: nextConfig.experimental.cachedNavigations ?? false,
       maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
         nextConfig.experimental.maxPostponedStateSize

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -46,7 +46,10 @@ export async function exportAppRoute(
   cacheComponents: boolean,
   staticPageGenerationTimeout: number,
   experimental: Required<
-    Pick<ExperimentalConfig, 'authInterrupts' | 'useCacheTimeout'>
+    Pick<
+      ExperimentalConfig,
+      'authInterrupts' | 'useCacheTimeout' | 'durableUseCacheEntries'
+    >
   >,
   buildId: string,
   deploymentId: string

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -6577,6 +6577,8 @@ function buildDevValidationWorkStore(
     forceStatic: message.forceStatic,
     isDraftMode: message.request.isDraftMode,
     useCacheTimeout: message.nextConfigSerializable.useCacheTimeout,
+    durableUseCacheEntries:
+      message.nextConfigSerializable.durableUseCacheEntries,
     staticPageGenerationTimeout:
       message.nextConfigSerializable.staticPageGenerationTimeout,
     cacheLifeProfiles: message.nextConfigSerializable.cacheLifeProfiles,
@@ -8224,6 +8226,7 @@ async function validateInstantConfigInBuildWithSample(
     incrementalCache: outerWorkStore.incrementalCache,
     cacheLifeProfiles: outerWorkStore.cacheLifeProfiles,
     useCacheTimeout: outerWorkStore.useCacheTimeout,
+    durableUseCacheEntries: outerWorkStore.durableUseCacheEntries,
     staticPageGenerationTimeout: outerWorkStore.staticPageGenerationTimeout,
     isBuildTimePrerendering: false,
     fetchCache: outerWorkStore.fetchCache,

--- a/packages/next/src/server/app-render/dev-validation-worker-globals.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-globals.ts
@@ -122,6 +122,7 @@ export interface DevValidationInstallFields {
     httpAgentOptions: NextConfigComplete['httpAgentOptions']
     cacheLifeProfiles: NextConfigComplete['cacheLife']
     useCacheTimeout: number
+    durableUseCacheEntries: boolean
     staticPageGenerationTimeout: number
   }
 }

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -169,6 +169,7 @@ export interface RenderOptsPartial {
     reactBrowserBailout: boolean
     serverComponentsHmrCancellation?: boolean
     useCacheTimeout: number
+    durableUseCacheEntries: boolean
     cachedNavigations: boolean
 
     /**

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -29,6 +29,7 @@ export interface WorkStore {
   readonly incrementalCache?: IncrementalCache
   readonly cacheLifeProfiles: ResolvedCacheLifeProfiles
   readonly useCacheTimeout: number
+  readonly durableUseCacheEntries: boolean
   readonly staticPageGenerationTimeout: number
 
   readonly isOnDemandRevalidate?: boolean

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -41,7 +41,10 @@ export type WorkStoreContext = {
     pendingWaitUntil?: Promise<any>
     experimental: Pick<
       RenderOpts['experimental'],
-      'isRoutePPREnabled' | 'authInterrupts' | 'useCacheTimeout'
+      | 'isRoutePPREnabled'
+      | 'authInterrupts'
+      | 'useCacheTimeout'
+      | 'durableUseCacheEntries'
     >
 
     /**
@@ -119,6 +122,7 @@ function createWorkStoreImpl(
       renderOpts.incrementalCache || (globalThis as any).__incrementalCache,
     cacheLifeProfiles: renderOpts.cacheLifeProfiles,
     useCacheTimeout: renderOpts.experimental.useCacheTimeout,
+    durableUseCacheEntries: renderOpts.experimental.durableUseCacheEntries,
     staticPageGenerationTimeout: renderOpts.staticPageGenerationTimeout,
     isBuildTimePrerendering: renderOpts.isBuildTimePrerendering,
     fetchCache: renderOpts.fetchCache,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -614,6 +614,9 @@ export default abstract class Server<
         serverComponentsHmrCancellation:
           this.nextConfig.experimental.serverComponentsHmrCancellation,
         useCacheTimeout: this.nextConfig.experimental.useCacheTimeout,
+        durableUseCacheEntries: Boolean(
+          this.nextConfig.experimental.durableUseCacheEntries
+        ),
         cachedNavigations:
           this.nextConfig.experimental.cachedNavigations ?? false,
         maxPostponedStateSizeBytes: parseMaxPostponedStateSize(

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -2430,6 +2430,7 @@ export interface NextConfigRuntime {
     | 'authInterrupts'
     | 'reactBrowserBailout'
     | 'useCacheTimeout'
+    | 'durableUseCacheEntries'
     | 'clientTraceMetadata'
     | 'clientParamParsingOrigins'
     | 'allowedRevalidateHeaderKeys'
@@ -2498,6 +2499,7 @@ export function getNextConfigRuntime(
     authInterrupts: ex.authInterrupts,
     reactBrowserBailout: ex.reactBrowserBailout,
     useCacheTimeout: ex.useCacheTimeout,
+    durableUseCacheEntries: ex.durableUseCacheEntries,
     clientTraceMetadata: ex.clientTraceMetadata,
     clientParamParsingOrigins: ex.clientParamParsingOrigins,
     allowedRevalidateHeaderKeys: ex.allowedRevalidateHeaderKeys,

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -242,4 +242,40 @@ describe('loadConfig', () => {
       expect(result.experimental.cssChunking).toBe('graph')
     })
   })
+
+  describe('experimental.durableUseCacheEntries', () => {
+    const originalTurbopack = process.env.TURBOPACK
+
+    afterEach(() => {
+      if (originalTurbopack === undefined) {
+        delete process.env.TURBOPACK
+      } else {
+        process.env.TURBOPACK = originalTurbopack
+      }
+    })
+
+    it('is forced to false when using webpack', async () => {
+      delete process.env.TURBOPACK
+
+      const result = await loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+        customConfig: {
+          experimental: { durableUseCacheEntries: true },
+        },
+      })
+
+      expect(result.experimental.durableUseCacheEntries).toBe(false)
+    })
+
+    it('is preserved when using Turbopack', async () => {
+      process.env.TURBOPACK = '1'
+
+      const result = await loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+        customConfig: {
+          experimental: { durableUseCacheEntries: true },
+        },
+      })
+
+      expect(result.experimental.durableUseCacheEntries).toBe(true)
+    })
+  })
 })

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -254,16 +254,16 @@ describe('loadConfig', () => {
       }
     })
 
-    it('is forced to false when using webpack', async () => {
+    it('throws when using webpack', async () => {
       delete process.env.TURBOPACK
 
-      const result = await loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
-        customConfig: {
-          experimental: { durableUseCacheEntries: true },
-        },
-      })
-
-      expect(result.experimental.durableUseCacheEntries).toBe(false)
+      await expect(
+        loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
+          customConfig: {
+            experimental: { durableUseCacheEntries: true },
+          },
+        })
+      ).rejects.toThrow(/only supported with Turbopack/)
     })
 
     it('is preserved when using Turbopack', async () => {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -515,6 +515,10 @@ function assignDefaultsAndValidate(
   // Only validate during build/dev — `next start` doesn't pick a bundler and would otherwise
   // see `process.env.TURBOPACK` unset and reject a valid `cssChunking: "graph"` config.
   if (phase !== PHASE_PRODUCTION_SERVER && phase !== PHASE_INFO) {
+    if (!process.env.TURBOPACK) {
+      result.experimental.durableUseCacheEntries = false
+    }
+
     const cssChunkingValue = result.experimental.cssChunking
     const cssChunkingMode = resolveCssChunkingMode(cssChunkingValue)
     if (cssChunkingMode === 'graph' && !process.env.TURBOPACK) {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -515,8 +515,11 @@ function assignDefaultsAndValidate(
   // Only validate during build/dev — `next start` doesn't pick a bundler and would otherwise
   // see `process.env.TURBOPACK` unset and reject a valid `cssChunking: "graph"` config.
   if (phase !== PHASE_PRODUCTION_SERVER && phase !== PHASE_INFO) {
-    if (!process.env.TURBOPACK) {
-      result.experimental.durableUseCacheEntries = false
+    if (result.experimental.durableUseCacheEntries && !process.env.TURBOPACK) {
+      throw new Error(
+        `\`experimental.durableUseCacheEntries: true\` is only supported with Turbopack. ` +
+          `Please remove the option or run Next.js with Turbopack in ${configFileName}.`
+      )
     }
 
     const cssChunkingValue = result.experimental.cssChunking

--- a/packages/next/src/server/dev/dev-validation-worker-pool.ts
+++ b/packages/next/src/server/dev/dev-validation-worker-pool.ts
@@ -222,6 +222,9 @@ export function installDevValidationWorker(options: InstallOptions): void {
         httpAgentOptions: nextConfig.httpAgentOptions,
         cacheLifeProfiles: nextConfig.cacheLife,
         useCacheTimeout: nextConfig.experimental.useCacheTimeout,
+        durableUseCacheEntries: Boolean(
+          nextConfig.experimental.durableUseCacheEntries
+        ),
         staticPageGenerationTimeout: nextConfig.staticPageGenerationTimeout,
       },
     }

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -772,6 +772,9 @@ export default class DevServer extends Server {
           deploymentId: this.deploymentId,
           authInterrupts: Boolean(this.nextConfig.experimental.authInterrupts),
           useCacheTimeout: this.nextConfig.experimental.useCacheTimeout,
+          durableUseCacheEntries: Boolean(
+            this.nextConfig.experimental.durableUseCacheEntries
+          ),
           staticPageGenerationTimeout:
             this.nextConfig.staticPageGenerationTimeout,
           sriEnabled: Boolean(this.nextConfig.experimental.sri?.algorithm),

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -54,6 +54,7 @@ export async function loadStaticPaths({
   deploymentId,
   authInterrupts,
   useCacheTimeout,
+  durableUseCacheEntries,
   staticPageGenerationTimeout,
   sriEnabled,
 }: {
@@ -78,6 +79,7 @@ export async function loadStaticPaths({
   deploymentId: string
   authInterrupts: boolean
   useCacheTimeout: number
+  durableUseCacheEntries: boolean
   staticPageGenerationTimeout: number
   sriEnabled: boolean
 }): Promise<StaticPathsResult> {
@@ -149,6 +151,7 @@ export async function loadStaticPaths({
       deploymentId,
       authInterrupts,
       useCacheTimeout,
+      durableUseCacheEntries,
       staticPageGenerationTimeout,
       rootParamKeys,
     })

--- a/packages/next/src/server/dev/use-cache-probe-pool.ts
+++ b/packages/next/src/server/dev/use-cache-probe-pool.ts
@@ -187,6 +187,9 @@ export function installUseCacheProbe(options: InstallOptions): void {
         httpAgentOptions: nextConfig.httpAgentOptions,
         cacheLifeProfiles: nextConfig.cacheLife,
         useCacheTimeout: nextConfig.experimental.useCacheTimeout,
+        durableUseCacheEntries: Boolean(
+          nextConfig.experimental.durableUseCacheEntries
+        ),
         staticPageGenerationTimeout: nextConfig.staticPageGenerationTimeout,
       },
       timeoutMs: args.timeoutMs,

--- a/packages/next/src/server/dev/use-cache-probe-worker.ts
+++ b/packages/next/src/server/dev/use-cache-probe-worker.ts
@@ -57,6 +57,7 @@ export type ProbeMessage = {
     httpAgentOptions: NextConfigComplete['httpAgentOptions']
     cacheLifeProfiles: NextConfigComplete['cacheLife']
     useCacheTimeout: number
+    durableUseCacheEntries: boolean
     staticPageGenerationTimeout: number
   }
   timeoutMs: number
@@ -202,6 +203,7 @@ function buildProbeWorkStore(msg: ProbeMessage): WorkStore {
     useCacheProbeMode: { timeoutMs: msg.timeoutMs },
     isDraftMode: msg.request.isDraftMode,
     useCacheTimeout: msg.nextConfigSerializable.useCacheTimeout,
+    durableUseCacheEntries: msg.nextConfigSerializable.durableUseCacheEntries,
     staticPageGenerationTimeout:
       msg.nextConfigSerializable.staticPageGenerationTimeout,
     cacheLifeProfiles: msg.nextConfigSerializable.cacheLifeProfiles,

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -341,6 +341,7 @@ export async function adapter(
                   // the cache fill will time out immediately and surface the
                   // bug.
                   useCacheTimeout: 0,
+                  durableUseCacheEntries: false,
                 },
                 waitUntil,
                 onClose: closeController.onClose.bind(closeController),

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -132,6 +132,7 @@ export class EdgeRouteModuleWrapper {
           // never read. 0 is a sentinel: if something ever reads it, the cache
           // fill will time out immediately and surface the bug.
           useCacheTimeout: 0,
+          durableUseCacheEntries: false,
         },
         cacheLifeProfiles: nextConfig.cacheLife,
         // Edge runtime doesn't do static generation, so this value does not


### PR DESCRIPTION
https://github.com/vercel/next.js/pull/95233 needs this to decide whether to perform the manifest lookup.