### PR TITLE
[backport] Fix unset crossOrigin in Turbopack manifests

### DIFF
--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -70,7 +70,12 @@ pub struct CssResource {
 #[serde(rename_all = "camelCase")]
 pub struct ModuleLoading {
     pub prefix: RcStr,
+    #[serde(skip_serializing_if = "is_cross_origin_none")]
     pub cross_origin: CrossOrigin,
+}
+
+fn is_cross_origin_none(cross_origin: &CrossOrigin) -> bool {
+    matches!(cross_origin, CrossOrigin::None)
 }
 
 #[derive(Serialize, Default, Debug, Clone)]

--- a/test/e2e/app-dir/app-config-crossorigin/default/app/dynamic/page.js
+++ b/test/e2e/app-dir/app-config-crossorigin/default/app/dynamic/page.js
@@ -1,0 +1,18 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+async function DynamicContent() {
+  if (!process.env.NEXT_TEST_OUTPUT_EXPORT) {
+    await connection()
+  }
+
+  return <p>dynamic page</p>
+}
+
+export default function DynamicPage() {
+  return (
+    <Suspense fallback={<p>loading dynamic page</p>}>
+      <DynamicContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/app-config-crossorigin/default/app/layout.js
+++ b/test/e2e/app-dir/app-config-crossorigin/default/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/app-config-crossorigin/default/app/page.js
+++ b/test/e2e/app-dir/app-config-crossorigin/default/app/page.js
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/app-config-crossorigin/default/next.config.js
+++ b/test/e2e/app-dir/app-config-crossorigin/default/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  assetPrefix: 'https://example.vercel.sh',
+  crossOrigin: undefined,
+  output: process.env.NEXT_TEST_OUTPUT_EXPORT ? 'export' : undefined,
+}

--- a/test/e2e/app-dir/app-config-crossorigin/default/server.mjs
+++ b/test/e2e/app-dir/app-config-crossorigin/default/server.mjs
@@ -1,0 +1,30 @@
+import { createReadStream } from 'node:fs'
+import { createServer } from 'node:http'
+import { extname, join } from 'node:path'
+
+const outputDirectory = join(process.cwd(), 'out')
+
+const server = createServer((request, response) => {
+  let pathname = new URL(request.url, 'http://localhost').pathname
+
+  if (pathname.endsWith('/')) {
+    pathname += 'index.html'
+  } else if (!extname(pathname)) {
+    pathname += '.html'
+  }
+
+  const stream = createReadStream(
+    join(outputDirectory, pathname.replace(/^\/+/, ''))
+  )
+  stream.on('error', () => {
+    response.writeHead(404)
+    response.end('Not found')
+  })
+  stream.pipe(response)
+})
+
+server.listen(Number(process.env.PORT), () => {
+  const address = server.address()
+  const port = typeof address === 'object' && address ? address.port : 0
+  console.log(`- Local: http://localhost:${port}`)
+})

--- a/test/e2e/app-dir/app-config-crossorigin/index.test.ts
+++ b/test/e2e/app-dir/app-config-crossorigin/index.test.ts
@@ -1,39 +1,102 @@
-import { nextTestSetup } from 'e2e-utils'
+import path from 'path'
+import { isNextStart, nextTestSetup } from 'e2e-utils'
 
-describe('app dir - crossOrigin config', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
-    files: __dirname,
-    skipDeployment: true,
+const assetPrefix = 'https://example.vercel.sh'
+
+if (!isNextStart) {
+  describe('app dir - crossOrigin config', () => {
+    const { next, skipped } = nextTestSetup({
+      files: __dirname,
+      skipDeployment: true,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    it('should render correctly with assetPrefix: "/"', async () => {
+      const $ = await next.render$('/')
+      // Only potential external (assetPrefix) <script /> and <link /> should have crossorigin attribute
+      $(
+        'script[src*="https://example.vercel.sh"], link[href*="https://example.vercel.sh"]'
+      ).each((_, el) => {
+        const crossOrigin = $(el).attr('crossorigin')
+        expect(crossOrigin).toBe('use-credentials')
+      })
+
+      // Inline <script /> (including RSC payload) and <link /> should not have crossorigin attribute
+      $('script:not([src]), link:not([href])').each((_, el) => {
+        const crossOrigin = $(el).attr('crossorigin')
+        expect(crossOrigin).toBeUndefined()
+      })
+
+      // Same origin <script /> and <link /> should not have crossorigin attribute either
+      $('script[src^="/"], link[href^="/"]').each((_, el) => {
+        const crossOrigin = $(el).attr('crossorigin')
+        expect(crossOrigin).toBeUndefined()
+      })
+    })
   })
+} else {
+  describe('app dir - unset crossOrigin config', () => {
+    describe('default output', () => {
+      const { next } = nextTestSetup({
+        files: path.join(__dirname, 'default'),
+        skipDeployment: true,
+      })
 
-  if (skipped) {
-    return
-  }
+      function expectCrossOriginAttributesToBeOmitted(
+        $: Awaited<ReturnType<typeof next.render$>>
+      ) {
+        const scripts = $(`script[src^="${assetPrefix}"]`)
 
-  if (isNextStart) {
-    it('skip in start mode', () => {})
-    return
-  }
-  it('should render correctly with assetPrefix: "/"', async () => {
-    const $ = await next.render$('/')
-    // Only potential external (assetPrefix) <script /> and <link /> should have crossorigin attribute
-    $(
-      'script[src*="https://example.vercel.sh"], link[href*="https://example.vercel.sh"]'
-    ).each((_, el) => {
-      const crossOrigin = $(el).attr('crossorigin')
-      expect(crossOrigin).toBe('use-credentials')
+        expect(scripts.length).toBeGreaterThan(0)
+        scripts.each((_, script) => {
+          expect($(script).attr('crossorigin')).toBeUndefined()
+        })
+      }
+
+      it('does not add crossorigin attributes to statically generated scripts', async () => {
+        expectCrossOriginAttributesToBeOmitted(await next.render$('/'))
+      })
+
+      it('does not add crossorigin attributes to dynamically rendered scripts', async () => {
+        expectCrossOriginAttributesToBeOmitted(await next.render$('/dynamic'))
+      })
     })
 
-    // Inline <script /> (including RSC payload) and <link /> should not have crossorigin attribute
-    $('script:not([src]), link:not([href])').each((_, el) => {
-      const crossOrigin = $(el).attr('crossorigin')
-      expect(crossOrigin).toBeUndefined()
-    })
+    if (process.env.__NEXT_CACHE_COMPONENTS !== 'true') {
+      describe('output: export', () => {
+        const { next } = nextTestSetup({
+          files: path.join(__dirname, 'default'),
+          env: {
+            NEXT_TEST_OUTPUT_EXPORT: '1',
+          },
+          skipStart: true,
+          skipDeployment: true,
+          startCommand: 'node server.mjs',
+          serverReadyPattern: /- Local:/,
+        })
 
-    // Same origin <script /> and <link /> should not have crossorigin attribute either
-    $('script[src^="/"], link[href^="/"]').each((_, el) => {
-      const crossOrigin = $(el).attr('crossorigin')
-      expect(crossOrigin).toBeUndefined()
-    })
+        function expectCrossOriginAttributesToBeOmitted(
+          $: Awaited<ReturnType<typeof next.render$>>
+        ) {
+          const scripts = $(`script[src^="${assetPrefix}"]`)
+
+          expect(scripts.length).toBeGreaterThan(0)
+          scripts.each((_, script) => {
+            expect($(script).attr('crossorigin')).toBeUndefined()
+          })
+        }
+
+        it('does not add crossorigin attributes to exported scripts', async () => {
+          await next.build()
+          await next.start({ skipBuild: true })
+
+          expectCrossOriginAttributesToBeOmitted(await next.render$('/'))
+          expectCrossOriginAttributesToBeOmitted(await next.render$('/dynamic'))
+        })
+      })
+    }
   })
-})
+}


### PR DESCRIPTION
Backports [Fix unset crossOrigin in Turbopack manifests](https://github.com/vercel/next.js/pull/97164) to `next-16-3`.

<!-- NEXT_JS_LLM -->
