### PR TITLE
Fix Turbopack re-export cycle deadlock

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -106,13 +106,14 @@ use turbopack_core::{
 };
 
 use crate::{
-    analyzer::graph::EvalContext,
+    analyzer::{graph::EvalContext, side_effects::compute_module_evaluation_side_effects},
     chunk::{
         EcmascriptChunkItemContent, EcmascriptChunkPlaceable, EcmascriptExports,
         ecmascript_chunk_item,
         placeable::{SideEffectsDeclaration, get_side_effect_free_declaration},
     },
     code_gen::{CodeGeneration, CodeGenerationHoistedStmt, CodeGens, ModifiableAst},
+    directive::parse_module_turbopack_directives,
     merged_module::MergedEcmascriptModule,
     parse::{IdentCollector, ParseResult, generate_js_source_map, parse},
     path_visitor::ApplyVisitors,
@@ -746,6 +747,45 @@ impl EcmascriptModuleAsset {
     }
 }
 
+/// Computes a module's side effects from parse data only.
+///
+/// This intentionally stays independent of [`EcmascriptModuleAsset::analyze`], since side-effect
+/// information is needed while resolving references during analysis.
+#[turbo_tasks::function]
+async fn compute_ecmascript_module_side_effects(
+    module: ResolvedVc<EcmascriptModuleAsset>,
+) -> Result<Vc<ModuleSideEffects>> {
+    let options = module.options().await?;
+    let parsed = module.failsafe_parse().await?;
+    let ParseResult::Ok {
+        program,
+        globals,
+        eval_context,
+        comments,
+        ..
+    } = &*parsed
+    else {
+        return Ok(ModuleSideEffects::SideEffectful.cell());
+    };
+
+    let directives = parse_module_turbopack_directives(program);
+    let side_effects = if directives.no_side_effects {
+        ModuleSideEffects::SideEffectFree
+    } else if directives.constants_module && options.cross_module_constants {
+        // If the module is marked as a constants module, it must be side effect free, otherwise
+        // constant folding would not be safe.
+        ModuleSideEffects::SideEffectFree
+    } else if options.infer_module_side_effects {
+        GLOBALS.set(globals, || {
+            compute_module_evaluation_side_effects(program, comments, eval_context.unresolved_mark)
+        })
+    } else {
+        ModuleSideEffects::SideEffectful
+    };
+
+    Ok(side_effects.cell())
+}
+
 impl EcmascriptModuleAsset {
     pub fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult> {
         analyze_ecmascript_module(self, None)
@@ -837,7 +877,7 @@ impl Module for EcmascriptModuleAsset {
         {
             SideEffectsDeclaration::SideEffectful => ModuleSideEffects::SideEffectful,
             SideEffectsDeclaration::SideEffectFree => ModuleSideEffects::SideEffectFree,
-            SideEffectsDeclaration::None => self.analyze().await?.side_effects,
+            SideEffectsDeclaration::None => *compute_ecmascript_module_side_effects(self).await?,
         })
         .cell())
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -78,7 +78,7 @@ use turbopack_core::{
     },
     environment::Rendering,
     issue::{IssueExt, IssueSeverity, IssueSource, StyledString, analyze::AnalyzeIssue},
-    module::{Module, ModuleSideEffects},
+    module::Module,
     reference::{ModuleReference, ModuleReferences},
     reference_type::{CommonJsReferenceSubType, InnerAssets},
     resolve::{
@@ -107,13 +107,12 @@ use crate::{
         graph::{ConditionalKind, Effect, EffectArg, VarGraph, create_graph},
         imports::{ImportAnnotations, ImportAttributes, ImportMap},
         linker::link,
-        parse_require_context, side_effects,
+        parse_require_context,
         top_level_await::has_top_level_await,
         well_known::replace_well_known,
     },
     chunk::CjsStaticExports,
     code_gen::{CodeGen, CodeGens, IntoCodeGenReference},
-    directive::parse_module_turbopack_directives,
     errors,
     module_fragments::{part_of_module, split_module},
     parse::ParseResult,
@@ -168,7 +167,6 @@ pub struct AnalyzeEcmascriptModuleResult {
 
     pub code_generation: ResolvedVc<CodeGens>,
     pub async_module: ResolvedVc<OptionAsyncModule>,
-    pub side_effects: ModuleSideEffects,
     /// `true` when the analysis was successful.
     pub successful: bool,
     pub source_map: Option<ResolvedVc<Box<dyn GenerateSourceMap>>>,
@@ -231,7 +229,6 @@ struct AnalyzeEcmascriptModuleResultBuilder {
     async_module: ResolvedVc<OptionAsyncModule>,
     successful: bool,
     source_map: Option<ResolvedVc<Box<dyn GenerateSourceMap>>>,
-    side_effects: ModuleSideEffects,
     cjs_static_exports: Option<CjsStaticExports>,
     #[cfg(debug_assertions)]
     ident: RcStr,
@@ -251,7 +248,6 @@ impl AnalyzeEcmascriptModuleResultBuilder {
             async_module: ResolvedVc::cell(None),
             successful: false,
             source_map: None,
-            side_effects: ModuleSideEffects::SideEffectful,
             cjs_static_exports: None,
             #[cfg(debug_assertions)]
             ident: Default::default(),
@@ -322,11 +318,6 @@ impl AnalyzeEcmascriptModuleResultBuilder {
     /// Sets the analysis result ES export.
     pub fn set_async_module(&mut self, async_module: ResolvedVc<AsyncModule>) {
         self.async_module = ResolvedVc::cell(Some(async_module));
-    }
-
-    /// Set whether this module is side-effect free according to a user-provided directive.
-    pub fn set_side_effects_mode(&mut self, value: ModuleSideEffects) {
-        self.side_effects = value;
     }
 
     /// Sets whether the analysis was successful.
@@ -436,7 +427,6 @@ impl AnalyzeEcmascriptModuleResultBuilder {
                 ),
                 code_generation: ResolvedVc::cell(code_generation),
                 async_module: self.async_module,
-                side_effects: self.side_effects,
                 successful: self.successful,
                 source_map: self.source_map,
                 cjs_static_exports: self.cjs_static_exports,
@@ -692,28 +682,6 @@ async fn analyze_ecmascript_module_internal(
     for i in esm_evaluation_reference_idxs {
         analysis.add_esm_evaluation_reference(*i);
     }
-
-    let directives = parse_module_turbopack_directives(program);
-    analysis.set_side_effects_mode(if directives.no_side_effects {
-        ModuleSideEffects::SideEffectFree
-    } else if directives.constants_module && options.cross_module_constants {
-        // If the module is marked as a constants module, it must be side effect free, otherwise
-        // the constant folding would not be safe. This makes a difference when doing `import *
-        // as foo from 'constants-module'`
-        ModuleSideEffects::SideEffectFree
-    } else if options.infer_module_side_effects {
-        // Analyze the AST to infer side effects
-        GLOBALS.set(globals, || {
-            side_effects::compute_module_evaluation_side_effects(
-                program,
-                comments,
-                eval_context.unresolved_mark,
-            )
-        })
-    } else {
-        // If inference is disabled, assume side effects
-        ModuleSideEffects::SideEffectful
-    });
 
     let is_esm = eval_context.is_esm(specified_type);
 

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-async-deadlock/input/A.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-async-deadlock/input/A.ts
@@ -1,0 +1,12 @@
+import { B } from './B'
+
+// This re-export is what forces the facade/locals split for this module
+// (`EcmascriptExports::split_locals_and_reexports` returns true as soon as a
+// module has any `ImportedBinding`/star re-export). No other option is needed.
+export { helper } from './helper'
+
+export function A(n: number) {
+  if (n > 0) {
+    B(n - 1)
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-async-deadlock/input/B.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-async-deadlock/input/B.ts
@@ -1,0 +1,11 @@
+import { C } from './C'
+import { asyncFn } from './asyncFn'
+
+export { helper } from './helper'
+
+export function B(n: number) {
+  if (n > 0) {
+    C(n - 1)
+    asyncFn()
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-async-deadlock/input/C.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-async-deadlock/input/C.ts
@@ -1,0 +1,9 @@
+import { A } from './A'
+
+export { helper } from './helper'
+
+export function C(n: number) {
+  if (n > 0) {
+    A(n - 1)
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-async-deadlock/input/asyncFn.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-async-deadlock/input/asyncFn.js
@@ -1,0 +1,8 @@
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+// Top-level await makes this an async module, which is what drags the whole
+// import cycle into async-module handling.
+await sleep(0)
+
+export function asyncFn() {}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-async-deadlock/input/helper.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-async-deadlock/input/helper.ts
@@ -1,0 +1,3 @@
+export function helper() {
+  return 'helper'
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-async-deadlock/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-async-deadlock/input/index.js
@@ -1,0 +1,36 @@
+import { A } from './A'
+
+/*
+ * Regression test: turbopack used to hang (deadlock) while building the module
+ * graph for an import cycle whose modules are split into facade + locals
+ * modules.
+ *
+ * Topology (same shape as ../../async-modules/cycle-2, plus re-exports):
+ *
+ *   index -> A
+ *            ^\
+ *            | v
+ *            C<-B -> asyncFn (top-level await)
+ *
+ * A, B and C each carry `export { helper } from './helper'`. That re-export is
+ * enough to make `EcmascriptExports::split_locals_and_reexports` return true,
+ * so each of them is split into an `EcmascriptModuleFacadeModule` plus an
+ * `EcmascriptModuleLocalsModule`.
+ *
+ * Resolving `import { A } from './A'` goes through `apply_reexport_tree_shaking`
+ * (module resolution, `turbopack/src/lib.rs`), which calls
+ * `follow_reexports(A_facade, "A")`. That walks facade -> locals, and the locals
+ * step used to ask the locals module for its side effects, which are derived
+ * from the original module's `analyze()` — already in flight further up the same
+ * import cycle. The result was a turbo-tasks await cycle: the process sat at
+ * ~0.5% CPU with completely flat RSS and never finished, so `next build` would
+ * hang with no output and no error.
+ *
+ * The async module is not required to trigger this; see
+ * `../reexport-cycle-deadlock` for the same cycle without a top-level `await`.
+ */
+
+it('should not deadlock building a re-exporting import cycle with an async module', () => {
+  A(10)
+  expect(true).toBe(true)
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-deadlock/input/A.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-deadlock/input/A.ts
@@ -1,0 +1,12 @@
+import { B } from './B'
+
+// This re-export is what forces the facade/locals split for this module
+// (`EcmascriptExports::split_locals_and_reexports` returns true as soon as a
+// module has any `ImportedBinding`/star re-export). No other option is needed.
+export { helper } from './helper'
+
+export function A(n: number) {
+  if (n > 0) {
+    B(n - 1)
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-deadlock/input/B.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-deadlock/input/B.ts
@@ -1,0 +1,11 @@
+import { C } from './C'
+import { syncFn } from './syncFn'
+
+export { helper } from './helper'
+
+export function B(n: number) {
+  if (n > 0) {
+    C(n - 1)
+    syncFn()
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-deadlock/input/C.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-deadlock/input/C.ts
@@ -1,0 +1,9 @@
+import { A } from './A'
+
+export { helper } from './helper'
+
+export function C(n: number) {
+  if (n > 0) {
+    A(n - 1)
+  }
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-deadlock/input/helper.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-deadlock/input/helper.ts
@@ -1,0 +1,3 @@
+export function helper() {
+  return 'helper'
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-deadlock/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-deadlock/input/index.js
@@ -1,0 +1,28 @@
+import { A } from './A'
+
+/*
+ * Regression test: turbopack used to hang (deadlock) while building the module
+ * graph for an import cycle whose modules are split into facade + locals
+ * modules.
+ *
+ * Topology:
+ *
+ *   index -> A
+ *            ^\
+ *            | v
+ *            C<-B -> syncFn
+ *
+ * A, B and C each carry `export { helper } from './helper'`. That re-export is
+ * enough to make `EcmascriptExports::split_locals_and_reexports` return true,
+ * so each of them is split into an `EcmascriptModuleFacadeModule` plus an
+ * `EcmascriptModuleLocalsModule`.
+ *
+ * This is the same bug as `../reexport-cycle-async-deadlock`, but without any
+ * async module: a top-level `await` anywhere in the cycle is not required to
+ * trigger it. The re-export cycle alone is enough.
+ */
+
+it('should not deadlock building a re-exporting import cycle', () => {
+  A(10)
+  expect(true).toBe(true)
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-deadlock/input/syncFn.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effect-optimization/reexport-cycle-deadlock/input/syncFn.js
@@ -1,0 +1,1 @@
+export function syncFn() {}


### PR DESCRIPTION
### What?

Prevents Turbopack from deadlocking while resolving re-exports through an import cycle by making ECMAScript side-effect classification independent of full module analysis.

The supplied async regression is added to the normal execution suite, along with a synchronous variant demonstrating that the facade/locals re-export cycle itself is sufficient to trigger the issue.

### Why?

Cross-module constant analysis resolves eligible imported bindings while the importing module's analysis is still running. Re-export following asks synthesized locals modules for side effects, which delegate to their original modules. The previous fallback obtained side effects from the full `AnalyzeEcmascriptModuleResult`, so an import cycle could re-enter an already-running analysis task and close a Turbo Tasks await cycle.

The actual static side-effect classifier only needs the parsed SWC program, comments, unresolved mark, directives, and module options. Reference analysis is not required.

This also unblocks the export-mangling work in #97770.

### How?

Side-effect classification now runs in a dedicated parse-only Turbo Task. Package/config declarations retain precedence; when none exists, the task uses `failsafe_parse()` and the existing AST classifier without resolving references or awaiting `analyze()`.

`AnalyzeEcmascriptModuleResult.side_effects` and its builder state are removed because the module-side-effects fallback was its only consumer. This also eliminates unused duplicate classification during module-part analysis.

`follow_reexports` and module-fragments side-effect handling remain unchanged from canary.

### Verification

- `cargo test -p turbopack-tests --test execution` — 265 passed, 0 failed
- `cargo test -p turbopack-ecmascript` — 525 passed, 0 failed
- Focused re-export-cycle and side-effect-retention tests in both optimization modes
- `cargo fmt -- --check`

<!-- NEXT_JS_LLM -->


<!-- fleet 4bbd5119-2442-4053-a856-f9d596924113 -->