### PR TITLE
fix: don't drop client references when the concatenated module id is 0

### DIFF
--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -523,7 +523,7 @@ export class ClientReferenceManifestPlugin {
                   const concatenatedMod = connection.module
                   const concatenatedModId =
                     compilation.chunkGraph.getModuleId(concatenatedMod)
-                  if (concatenatedModId) {
+                  if (concatenatedModId !== null) {
                     recordModule(concatenatedModId, clientEntryMod)
                   }
                 }


### PR DESCRIPTION
### What?
`getModuleId()` returns `string | number | null`, and `0` is a valid id. The`ConcatenatedModule` fallback guards it with a truthiness check, so when the concatenated module gets id `0` the client entry is left out of the client reference manifest.

### Why?
The [code](https://github.com/vercel/next.js/blob/d09816fdaf2fef7a23751de75a9dde6bb7c2403b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts#L516) right above it already checks `modId !== null`. The two checks sit a few lines apart and disagree about whether `0` is a valid id, which looks like an oversight. When it happens the build fails with `Could not find the module ... in the React Client Manifest`, which doesn't point at the cause.

Repro: https://github.com/jgruica/next-concat-modid-zero (needs `--webpack` plus `concatenateModules: true`, so it's rare in practice)

### How?
One line in `flight-manifest-plugin.ts`: `if (concatenatedModId)` becomes `if (concatenatedModId !== null)`. `null` is still skipped, so nothing elsechanges.
