### PR TITLE
Fix request-context retention in the default use cache handler

### DIFF
--- a/packages/next/src/server/lib/cache-handlers/default.test.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment node
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { runInNewContext } from 'node:vm'
+import { setFlagsFromString } from 'node:v8'
+import { createDefaultCacheHandler } from './default'
+import type { CacheEntry, CacheHandler } from './types'
+
+setFlagsFromString('--expose-gc')
+const forceGarbageCollection = runInNewContext('gc') as () => void
+
+describe('default use cache handler', () => {
+  it('does not retain the async context that populated an entry', async () => {
+    const handler = createDefaultCacheHandler(1024 * 1024)
+    const requestStoreRef = await runInRequestContext(() =>
+      populateCache(handler)
+    )
+
+    await expectCollected(requestStoreRef)
+
+    expect(await readCache(handler)).toBe('cached value')
+  })
+
+  it('does not retain the async context that read an entry', async () => {
+    const handler = createDefaultCacheHandler(1024 * 1024)
+    await populateCache(handler)
+
+    const requestStoreRef = await runInRequestContext(async () => {
+      expect(await readCache(handler)).toBe('cached value')
+    })
+
+    await expectCollected(requestStoreRef)
+  })
+})
+
+async function runInRequestContext(
+  callback: () => Promise<void>
+): Promise<WeakRef<object>> {
+  const requestStorage = new AsyncLocalStorage<object>()
+  let requestStoreRef: WeakRef<object> | undefined
+
+  await requestStorage.run({ requestId: 'request' }, async () => {
+    const requestStore = requestStorage.getStore()
+
+    if (!requestStore) {
+      throw new Error('Expected a request store')
+    }
+
+    requestStoreRef = new WeakRef(requestStore)
+    await callback()
+  })
+
+  if (!requestStoreRef) {
+    throw new Error('Expected a request store reference')
+  }
+
+  return requestStoreRef
+}
+
+async function populateCache(handler: CacheHandler): Promise<void> {
+  const entry: CacheEntry = {
+    value: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('cached value'))
+        controller.close()
+      },
+    }),
+    tags: [],
+    stale: 60,
+    timestamp: Date.now(),
+    expire: 120,
+    revalidate: 60,
+  }
+
+  await handler.set('key', Promise.resolve(entry))
+}
+
+async function readCache(handler: CacheHandler): Promise<string> {
+  const entry = await handler.get('key', [])
+  if (!entry) {
+    throw new Error('Expected a cache entry')
+  }
+
+  return new Response(entry.value).text()
+}
+
+async function expectCollected(ref: WeakRef<object>): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    forceGarbageCollection()
+    await new Promise<void>((resolve) => setImmediate(resolve))
+  }
+
+  expect(ref.deref()).toBeUndefined()
+}

--- a/packages/next/src/server/lib/cache-handlers/default.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.ts
@@ -21,9 +21,14 @@ import {
   type TagManifestEntry,
 } from '../incremental-cache/tags-manifest.external'
 import { MIN_PRERENDERABLE_EXPIRE } from '../../use-cache/constants'
+import {
+  streamFromBuffer,
+  streamToBuffer,
+} from '../../stream-utils/node-web-streams-helper'
 
 type PrivateCacheEntry = {
-  entry: CacheEntry
+  entry: Omit<CacheEntry, 'value'>
+  value: Buffer
 
   // For the default cache we store errored cache
   // entries and allow them to be used up to 3 times
@@ -131,9 +136,6 @@ export function createDefaultCacheHandler(maxSize: number): CacheHandler {
         revalidate = -1
       }
 
-      const [returnStream, newSaved] = entry.value.tee()
-      entry.value = newSaved
-
       debug?.('get', cacheKey, 'found', {
         tags: entry.tags,
         timestamp: entry.timestamp,
@@ -144,7 +146,7 @@ export function createDefaultCacheHandler(maxSize: number): CacheHandler {
       return {
         ...entry,
         revalidate,
-        value: returnStream,
+        value: streamFromBuffer(privateEntry.value),
       }
     },
 
@@ -159,8 +161,6 @@ export function createDefaultCacheHandler(maxSize: number): CacheHandler {
 
       const entry = await pendingEntry
 
-      let size = 0
-
       try {
         // In production an `expire: 0` entry is dynamic: the "use cache"
         // wrapper regenerates it on every read instead of serving the stored
@@ -174,19 +174,15 @@ export function createDefaultCacheHandler(maxSize: number): CacheHandler {
           return
         }
 
-        const [value, clonedValue] = entry.value.tee()
-        entry.value = value
-        const reader = clonedValue.getReader()
-
-        for (let chunk; !(chunk = await reader.read()).done; ) {
-          size += Buffer.from(chunk.value).byteLength
-        }
+        const value = await streamToBuffer(entry.value)
+        const { value: _, ...entryMetadata } = entry
 
         memoryCache.set(cacheKey, {
-          entry,
+          entry: entryMetadata,
+          value,
           isErrored: false,
           errorRetryCount: 0,
-          size,
+          size: value.byteLength,
         })
 
         debug?.('set', cacheKey, 'done')


### PR DESCRIPTION
Fixes #97934.

The default use cache handler uses live ReadableStream objects. Those streams retain references to the request’s async context and closed HTTP response, causing memory to grow with cached entries and potentially produce OOMs.

The fix converts each stream into a plain Buffer before caching it. Every cache hit then gets a fresh temporary stream created from those bytes. The content remains cached, but completed requests can now be garbage-collected.

---

Basically - the LRU cache stores live ReadableStream objects, which keep completed request contexts and closed responses in memory until that cache is evicted.