### PR TITLE
fix: suppress missing package manager errors in next info

### DIFF
--- a/packages/next/src/cli/next-info.ts
+++ b/packages/next/src/cli/next-info.ts
@@ -78,7 +78,7 @@ async function getNextConfig() {
 function getBinaryVersion(binaryName: string) {
   try {
     return childProcess
-      .execFileSync(binaryName, ['--version'])
+      .execFileSync(binaryName, ['--version'], { stdio: 'pipe' })
       .toString()
       .trim()
   } catch {

--- a/packages/next/src/cli/next-info.ts
+++ b/packages/next/src/cli/next-info.ts
@@ -83,7 +83,10 @@ function getBinaryVersion(binaryName: string) {
       .trim()
   } catch {
     try {
-      return childProcess.execSync(`${binaryName} --version`).toString().trim()
+      return childProcess
+        .execSync(`${binaryName} --version`, { stdio: 'pipe' })
+        .toString()
+        .trim()
     } catch {
       return 'N/A'
     }

--- a/test/e2e/cli/cli.test.ts
+++ b/test/e2e/cli/cli.test.ts
@@ -4,6 +4,7 @@ import path, { join } from 'path'
 // @ts-expect-error
 import pkg from 'next/package'
 import http from 'http'
+import { promises as fs } from 'fs'
 import stripAnsi from 'strip-ansi'
 import type { ChildProcess } from 'child_process'
 
@@ -1145,13 +1146,43 @@ Next.js Config:
     })
 
     test('should print output', async () => {
-      const info = await next.runCommand(['info'], {
-        env: { npm_config_user_agent: 'npm' },
-      })
+      const info = await next.runCommand(['info'])
 
       expect((info.stderr || '').toLowerCase()).not.toContain('error')
-      expect(info.stderr).not.toMatch(/(?:yarn|pnpm): (?:command )?not found/i)
       matchInfoOutput(info.stdout)
+    })
+
+    test('should not leak package manager command errors', async () => {
+      const marker = 'next-info-yarn-command-not-found'
+      const binDir = await fs.mkdtemp(join(next.testDir, 'next-info-bin-'))
+      const yarnPath = join(
+        binDir,
+        process.platform === 'win32' ? 'yarn.cmd' : 'yarn'
+      )
+
+      try {
+        await fs.writeFile(
+          yarnPath,
+          process.platform === 'win32'
+            ? `@echo off\r\necho ${marker} 1>&2\r\nexit /b 1\r\n`
+            : `#!/bin/sh\necho ${marker} >&2\nexit 1\n`
+        )
+        if (process.platform !== 'win32') {
+          await fs.chmod(yarnPath, 0o755)
+        }
+
+        const info = await next.runCommand(['info'], {
+          env: {
+            PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+            npm_config_user_agent: 'npm',
+          },
+        })
+
+        expect(info.stdout).toContain('Yarn: N/A')
+        expect(info.stderr).not.toContain(marker)
+      } finally {
+        await fs.rm(binDir, { recursive: true, force: true })
+      }
     })
 
     test('should print output with next.config.mjs', async () => {

--- a/test/e2e/cli/cli.test.ts
+++ b/test/e2e/cli/cli.test.ts
@@ -1145,10 +1145,12 @@ Next.js Config:
     })
 
     test('should print output', async () => {
-      const info = await next.runCommand(['info'])
+      const info = await next.runCommand(['info'], {
+        env: { npm_config_user_agent: 'npm' },
+      })
 
       expect((info.stderr || '').toLowerCase()).not.toContain('error')
-      expect(info.stderr).not.toMatch(/not found/i)
+      expect(info.stderr).not.toMatch(/(?:yarn|pnpm): (?:command )?not found/i)
       matchInfoOutput(info.stdout)
     })
 

--- a/test/e2e/cli/cli.test.ts
+++ b/test/e2e/cli/cli.test.ts
@@ -1148,6 +1148,7 @@ Next.js Config:
       const info = await next.runCommand(['info'])
 
       expect((info.stderr || '').toLowerCase()).not.toContain('error')
+      expect(info.stderr).not.toContain('command not found')
       matchInfoOutput(info.stdout)
     })
 

--- a/test/e2e/cli/cli.test.ts
+++ b/test/e2e/cli/cli.test.ts
@@ -1148,7 +1148,7 @@ Next.js Config:
       const info = await next.runCommand(['info'])
 
       expect((info.stderr || '').toLowerCase()).not.toContain('error')
-      expect(info.stderr).not.toContain('command not found')
+      expect(info.stderr).not.toMatch(/not found/i)
       matchInfoOutput(info.stdout)
     })
 

--- a/test/e2e/cli/cli.test.ts
+++ b/test/e2e/cli/cli.test.ts
@@ -1155,6 +1155,9 @@ Next.js Config:
     test('should not leak package manager command errors', async () => {
       const marker = 'next-info-yarn-command-not-found'
       const binDir = await fs.mkdtemp(join(next.testDir, 'next-info-bin-'))
+      const pathKey =
+        Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ??
+        'PATH'
       const yarnPath = join(
         binDir,
         process.platform === 'win32' ? 'yarn.cmd' : 'yarn'
@@ -1173,7 +1176,9 @@ Next.js Config:
 
         const info = await next.runCommand(['info'], {
           env: {
-            PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+            [pathKey]: `${binDir}${path.delimiter}${process.env[pathKey] ?? ''}`,
+            // Match issue #97932's npm project so the fake Yarn only exercises
+            // binary version detection, not registry discovery.
             npm_config_user_agent: 'npm',
           },
         })


### PR DESCRIPTION
## What

- capture stdout and stderr for both direct and shell-fallback package-manager version probes
- keep successful version output unchanged and return `N/A` when a probe fails
- add deterministic cross-platform regression coverage with a failing Yarn shim

Closes #97932

## Why

PR #71134 added an `execSync` fallback so package-manager command shims can be resolved on Windows. When `stdio` is omitted, Node mirrors stderr from failed synchronous child processes to the parent, so an unavailable Yarn or pnpm can print raw shell errors before `next info` reports `N/A`.

Passing `{ stdio: "pipe" }` to both probes preserves captured stdout and the Windows fallback while keeping expected probe failures silent. The change stays scoped to package-manager version detection; shared registry discovery is unchanged.

## Testing

- `pnpm --filter next typescript`
- `pnpm --filter next build`
- `pnpm test-types --pretty false`
- ESLint and Prettier on both changed files
- `pnpm test-start test/e2e/cli/cli.test.ts` (66 passed, 1 skipped)
- built-CLI reproduction with npm available and Yarn/pnpm absent: both report `N/A` with no Yarn/pnpm command-not-found output
- autoreview with GPT-5.6 Sol xhigh and Claude Opus 5 xhigh: zero findings