### PR TITLE
[test] Drain build output before start

### DIFF
--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -130,7 +130,9 @@ export class NextStartInstance extends NextInstance {
         try {
           this.childProcess = spawn(buildArgs[0], buildArgs.slice(1), spawnOpts)
           this.handleStdio(this.childProcess)
-          this.childProcess.on('exit', (code, signal) => {
+          // Unlike `exit`, `close` fires after the stdio streams have closed.
+          // Wait for it so trailing build output is not lost before starting.
+          this.childProcess.on('close', (code, signal) => {
             this.childProcess = undefined
             if (code || signal)
               reject(


### PR DESCRIPTION
### What?

Make the production test harness wait for a build process's piped stdio to close before `NextStartInstance.start()` continues to launch the server or reports a build failure.

### Why?

A child process's `exit` event can fire before trailing stdout and stderr have been delivered to the parent. This can make start-mode tests intermittently miss diagnostics emitted near the end of a production build, even though the build itself reported them correctly.

The standalone `build()` helper already uses the later `close` lifecycle event to avoid this race. Applying the same rule to the build phase inside `start()` removes the equivalent latent output-drain hazard and makes child-process handling consistent across the harness.

### How?

Resolve the build phase on the child process's `close` event. Unlike `exit`, `close` is emitted after piped stdio closes, so all trailing build output has reached the harness before it starts the server or rejects the build. Exit-code and signal handling remain unchanged.

### Verification

- `pnpm types`
- `pnpm test-start-webpack test/production/production-build-dir/production-build-dir.test.ts`
- `pnpm test-start-webpack test/production/app-dir/sync-io-blocks-root/sync-io-blocks-root.test.ts`
- Repeated webpack stress campaign for the sync-IO suite: 5/5 runs, including 20/20 `--debug-prerender` route cases
- Prettier and ESLint on `test/lib/next-modes/next-start.ts`

<!-- NEXT_JS_LLM -->


<!-- fleet 821362ed-9f96-4e53-b56e-49bf00e878b9 -->