### PR TITLE
Fix optimistic routing for encoded dynamic params

### DIFF
--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -921,7 +921,7 @@ function matchKnownRoutePart(
         ) {
           resolvedParams.set(
             paramName,
-            pathnameParts.slice(partIndex).join('/')
+            pathnameParts.slice(partIndex).map(canonicalizeURLPart).join('/')
           )
           return { part: dynamicPart, pattern: dynamicPattern }
         }
@@ -932,7 +932,7 @@ function matchKnownRoutePart(
           if (urlPart !== null) {
             resolvedParams.set(
               paramName,
-              pathnameParts.slice(partIndex).join('/')
+              pathnameParts.slice(partIndex).map(canonicalizeURLPart).join('/')
             )
             return { part: dynamicPart, pattern: dynamicPattern }
           }
@@ -951,7 +951,7 @@ function matchKnownRoutePart(
         // Unlike catch-all which terminates here, regular dynamic must
         // continue recursing to find the leaf pattern.
         if (urlPart !== null) {
-          resolvedParams.set(paramName, urlPart)
+          resolvedParams.set(paramName, canonicalizeURLPart(urlPart))
           return matchKnownRoutePart(
             now,
             dynamicPart,

--- a/test/e2e/app-dir/use-router-bfcache-id/app/[group]/[page]/leaf-content.tsx
+++ b/test/e2e/app-dir/use-router-bfcache-id/app/[group]/[page]/leaf-content.tsx
@@ -31,6 +31,7 @@ export function LeafContent() {
       <span data-testid="search" data-value={search}>
         {search}
       </span>
+      <span data-testid="bfcache-id">{bfcacheId}</span>
       <form key={bfcacheId}>
         <input data-testid="leaf-input" defaultValue="" />
       </form>
@@ -38,6 +39,12 @@ export function LeafContent() {
       <LinkAccordion href={`${pathname}#section`}>
         same page (#section)
       </LinkAccordion>
+      <button
+        data-testid="query-only-replace"
+        onClick={() => router.replace(`?q=${Date.now()}`, { scroll: false })}
+      >
+        query-only replace
+      </button>
       <button data-testid="refresh" onClick={() => router.refresh()}>
         refresh
       </button>

--- a/test/e2e/app-dir/use-router-bfcache-id/app/catchall/[...slug]/page.tsx
+++ b/test/e2e/app-dir/use-router-bfcache-id/app/catchall/[...slug]/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import { LeafContent } from '../../[group]/[page]/leaf-content'
+
+async function DynamicLeafContent() {
+  await connection()
+  return <LeafContent />
+}
+
+export default function CatchAllPage() {
+  return (
+    <Suspense fallback={null}>
+      <DynamicLeafContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/use-router-bfcache-id/use-router-bfcache-id.test.ts
+++ b/test/e2e/app-dir/use-router-bfcache-id/use-router-bfcache-id.test.ts
@@ -107,6 +107,31 @@ describe('use-router-bfcache-id', () => {
     ).toBe('hello')
   })
 
+  it.each([
+    ['regular dynamic', '/ko/@alice'],
+    ['catch-all dynamic', '/catchall/@alice/nested%2Fvalue'],
+  ])(
+    'preserves form state across query-only replace with an encoded %s parameter',
+    async (_paramType, initialPath) => {
+      const { browser, act } = await setup(initialPath)
+      await browser.elementByCss('[data-testid="leaf-input"]').type('hello')
+      const initialBFCacheId = await browser
+        .elementByCss('[data-testid="bfcache-id"]')
+        .text()
+
+      await act(async () => {
+        await browser.elementByCss('[data-testid="query-only-replace"]').click()
+      })
+
+      expect(
+        await browser.elementByCss('[data-testid="bfcache-id"]').text()
+      ).toBe(initialBFCacheId)
+      expect(
+        await browser.elementByCss('[data-testid="leaf-input"]').getValue()
+      ).toBe('hello')
+    }
+  )
+
   it('preserves form state across router.refresh()', async () => {
     const { browser, act } = await setup('/x/1')
     await browser.elementByCss('[data-testid="leaf-input"]').type('hello')


### PR DESCRIPTION
## Summary

Fixes #97842 by canonicalizing encoded pathname parts before using them as dynamic segment cache keys in optimistic route predictions. This keeps predicted route trees consistent with server Flight data and prevents query-only navigation from remounting pages when regular or catch-all params contain encoded characters.

Add coverage that verifies bfcache IDs and form state are preserved for `@` in a regular dynamic param and for `@` plus `%2F` in a catch-all param.

## Verification

- Existing encoded-slash route-cache E2E suite in Turbopack and webpack production modes
- Existing optimistic-routing E2E suite in Turbopack and webpack production modes
- `pnpm test-types`
- `pnpm types`
- `pnpm prettier-check`
- `pnpm lint-ast-grep`
- `pnpm lint-language`
- Changed-file Prettier and ESLint checks via the pre-commit hook

<!-- NEXT_JS_LLM -->