### PR TITLE
Fix intercepted route params after Proxy rewrites

### DIFF
--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -888,12 +888,17 @@ export function getResolveRoutes(
             (!parsedDestination.origin || isAllowedOrigin)
           ) {
             // We set the rewritten path and query headers on the response now
-            // that we know that the it's not an external rewrite.
+            // that we know that the it's not an external rewrite. Mirror the
+            // path in resHeaders because those are applied after route
+            // resolution; otherwise, an earlier Proxy rewrite would overwrite
+            // the final route destination.
             if (parsedUrl.pathname !== parsedDestination.pathname) {
               res.setHeader(
                 NEXT_REWRITTEN_PATH_HEADER,
                 parsedDestination.pathname
               )
+              resHeaders[NEXT_REWRITTEN_PATH_HEADER] =
+                parsedDestination.pathname
             }
             if (parsedUrl.search !== parsedDestination.search) {
               res.setHeader(

--- a/test/e2e/app-dir/interception-dynamic-segment-middleware/interception-dynamic-segment-middleware.test.ts
+++ b/test/e2e/app-dir/interception-dynamic-segment-middleware/interception-dynamic-segment-middleware.test.ts
@@ -65,4 +65,22 @@ describe('interception-dynamic-segment-middleware', () => {
       })
     }
   })
+
+  it('should preserve the final interception rewrite after a middleware rewrite', async () => {
+    let rewrittenPath: string | undefined
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        page.on('response', (response) => {
+          if (new URL(response.url()).pathname === '/foo/p/1') {
+            rewrittenPath = response.headers()['x-nextjs-rewritten-path']
+          }
+        })
+      },
+    })
+
+    await browser.elementByCss('[href="/foo/p/1"]').click()
+    await retry(() => {
+      expect(rewrittenPath).toBe('/en/(.)foo/p/1')
+    })
+  })
 })


### PR DESCRIPTION
## What?

Preserve the final internal rewrite pathname in the RSC response when an earlier Proxy rewrite has already populated the rewritten-path header.

This also adds an end-to-end regression assertion for a dynamic interception route behind a locale-injecting middleware rewrite.

## Why?

The route resolver set the final marker-bearing pathname directly on the response, but router-server later reapplied the accumulated Proxy response headers. That restored the earlier markerless pathname. The client then parsed an intercepted dynamic param against that stale path and removed three real characters from the value.

## How?

Mirror the final internal rewrite pathname into the accumulated response-header map. When router-server applies that map after route resolution, the last rewrite remains authoritative.

Fixes #97939

## Tests

- Production interception regression suite: 4/4 passed
- Development interception regression suite: 4/4 passed
- Related production rewrite/interception suites: 43/43 passed
- Next package build, targeted ESLint, Prettier, and git diff checks passed
