### PR TITLE
Fix/segment key non latin1 btoa

### DIFF
--- a/packages/next/src/shared/lib/segment-cache/segment-value-encoding.test.ts
+++ b/packages/next/src/shared/lib/segment-cache/segment-value-encoding.test.ts
@@ -1,0 +1,84 @@
+import {
+  appendSegmentRequestKeyPart,
+  createSegmentRequestKeyPart,
+  ROOT_SEGMENT_REQUEST_KEY,
+} from './segment-value-encoding'
+import { PAGE_SEGMENT_KEY } from '../segment'
+import type { Segment } from '../app-router-types'
+
+function base64url(value: string): string {
+  const bytes = new TextEncoder().encode(value)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+describe('createSegmentRequestKeyPart', () => {
+  it('leaves filesystem-safe segments unencoded', () => {
+    expect(createSegmentRequestKeyPart('blog')).toBe('blog')
+    expect(createSegmentRequestKeyPart('post-1_v2')).toBe('post-1_v2')
+  })
+
+  it('strips search params from page segments', () => {
+    expect(createSegmentRequestKeyPart(`${PAGE_SEGMENT_KEY}?a=1`)).toBe(
+      PAGE_SEGMENT_KEY
+    )
+  })
+
+  it('base64url-encodes segments containing unsafe characters', () => {
+    expect(createSegmentRequestKeyPart('(marketing)')).toBe(
+      '!' + base64url('(marketing)')
+    )
+  })
+
+  // Route group and param names are directory names, so they may contain any
+  // character the filesystem allows. `btoa` only accepts code points up to
+  // U+00FF, so these used to throw `InvalidCharacterError`.
+  describe.each([
+    ['Hangul', '(안녕)'],
+    ['Japanese', '日本'],
+    ['Cyrillic', 'тест'],
+    ['emoji', '😀'],
+    ['mixed scripts', '(안녕)-café'],
+  ])('non-Latin-1 segments (%s)', (_name, value) => {
+    it('encodes without throwing', () => {
+      expect(() => createSegmentRequestKeyPart(value)).not.toThrow()
+      expect(createSegmentRequestKeyPart(value)).toBe('!' + base64url(value))
+    })
+
+    it('produces a filesystem- and URL-safe key', () => {
+      const key = createSegmentRequestKeyPart(value)
+      expect(key).toMatch(/^![a-zA-Z0-9\-_]*$/)
+      expect(encodeURIComponent(key)).toBe(key)
+    })
+
+    it('encodes a dynamic segment with that param name', () => {
+      const segment: Segment = [value, 'v', 'd', null]
+      expect(() => createSegmentRequestKeyPart(segment)).not.toThrow()
+      expect(createSegmentRequestKeyPart(segment)).toBe(
+        '$d$!' + base64url(value)
+      )
+    })
+  })
+
+  it('encodes distinct non-Latin-1 segments to distinct keys', () => {
+    const keys = ['안녕', '日本', 'тест', '😀'].map((value) =>
+      createSegmentRequestKeyPart(value)
+    )
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+})
+
+describe('appendSegmentRequestKeyPart', () => {
+  it('encodes non-Latin-1 parallel route keys', () => {
+    const part = createSegmentRequestKeyPart('page')
+    expect(() =>
+      appendSegmentRequestKeyPart(ROOT_SEGMENT_REQUEST_KEY, '모달', part)
+    ).not.toThrow()
+    expect(
+      appendSegmentRequestKeyPart(ROOT_SEGMENT_REQUEST_KEY, '모달', part)
+    ).toBe(`/@!${base64url('모달')}/page`)
+  })
+})

--- a/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
@@ -74,13 +74,25 @@ export function appendSegmentRequestKeyPart(
 // by default for compactness, and for easier debugging.
 const simpleParamValueRegex = /^[a-zA-Z0-9\-_@]+$/
 
+const textEncoder = new TextEncoder()
+
 function encodeToFilesystemAndURLSafeString(value: string) {
   if (simpleParamValueRegex.test(value)) {
     return value
   }
   // If there are any unsafe characters, base64url-encode the entire value.
   // We also add a ! prefix so it doesn't collide with the simple case.
-  const base64url = btoa(value)
+  //
+  // `btoa` only accepts code points up to U+00FF and throws an
+  // InvalidCharacterError otherwise, so encode to UTF-8 first and widen each
+  // byte into its own code unit. Segment values come from directory names and
+  // route params, both of which can hold any character the filesystem allows.
+  const bytes = textEncoder.encode(value)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  const base64url = btoa(binary)
     .replace(/\+/g, '-') // Replace '+' with '-'
     .replace(/\//g, '_') // Replace '/' with '_'
     .replace(/=+$/, '') // Remove trailing '='

--- a/test/e2e/app-dir/non-latin1-segments/app/(안녕)/hello/page.tsx
+++ b/test/e2e/app-dir/non-latin1-segments/app/(안녕)/hello/page.tsx
@@ -1,0 +1,5 @@
+// The route group name is not part of the URL, but it is still a segment in
+// the FlightRouterState, so it gets encoded into the segment cache key.
+export default function Page() {
+  return <h1 id="hello">hello from a route group</h1>
+}

--- a/test/e2e/app-dir/non-latin1-segments/app/docs/[제목]/page.tsx
+++ b/test/e2e/app-dir/non-latin1-segments/app/docs/[제목]/page.tsx
@@ -1,0 +1,5 @@
+// A dynamic segment whose *param name* is non-Latin-1. The param name is what
+// gets encoded into the segment cache key.
+export default function Page() {
+  return <h1 id="unicode-param">hello from a unicode param name</h1>
+}

--- a/test/e2e/app-dir/non-latin1-segments/app/layout.tsx
+++ b/test/e2e/app-dir/non-latin1-segments/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/non-latin1-segments/app/page.tsx
+++ b/test/e2e/app-dir/non-latin1-segments/app/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <main>
+      <h1 id="home">home</h1>
+      <Link href="/hello" id="to-route-group">
+        to route group
+      </Link>
+      <Link href="/docs/intro" id="to-unicode-param">
+        to unicode param
+      </Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/non-latin1-segments/next.config.js
+++ b/test/e2e/app-dir/non-latin1-segments/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/non-latin1-segments/non-latin1-segments.test.ts
+++ b/test/e2e/app-dir/non-latin1-segments/non-latin1-segments.test.ts
@@ -1,0 +1,45 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// Route group and dynamic param names are directory names, so they can hold
+// characters outside Latin-1. They reach the segment cache key encoder, which
+// used to hand them straight to `btoa` and throw `InvalidCharacterError`.
+describe('non-latin1-segments', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('renders a page nested in a non-Latin-1 route group', async () => {
+    const res = await next.fetch('/hello')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('hello from a route group')
+  })
+
+  it('renders a route whose dynamic param name is non-Latin-1', async () => {
+    const res = await next.fetch('/docs/intro')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('hello from a unicode param name')
+  })
+
+  // Navigating on the client builds the same segment keys through the segment
+  // cache, so it covers the other half of the encoder's callers.
+  it('navigates to both routes on the client', async () => {
+    const browser = await next.browser('/')
+
+    await browser.elementByCss('#to-route-group').click()
+    expect(await browser.waitForElementByCss('#hello').text()).toBe(
+      'hello from a route group'
+    )
+
+    await browser.back()
+    await browser.waitForElementByCss('#home')
+
+    await browser.elementByCss('#to-unicode-param').click()
+    expect(await browser.waitForElementByCss('#unicode-param').text()).toBe(
+      'hello from a unicode param name'
+    )
+  })
+
+  it('does not log an InvalidCharacterError', async () => {
+    expect(next.cliOutput).not.toContain('InvalidCharacterError')
+  })
+})


### PR DESCRIPTION
### What?

Route groups and dynamic params whose names contain characters outside Latin-1 break the app router. With a route group like `app/(안녕)/hello/page.tsx`, `next dev` returns a 500 for `/hello`, and `next build` dies while prerendering it:

```
Error [InvalidCharacterError]: Invalid character
Error occurred prerendering page "/hello".
Export encountered an error on /(안녕)/hello/page: /hello, exiting the build.
```

Japanese, Cyrillic and emoji names fail the same way — anything above U+00FF. It isn't bundler specific, webpack and Turbopack both hit it. This worked in 15.

Fixes #97890

### Why?

Segment cache keys are built by `encodeToFilesystemAndURLSafeString` in `packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts`. Values that are plain `[a-zA-Z0-9-_@]` pass through untouched; everything else falls back to base64url, and that fallback handed the raw string straight to `btoa`.

`btoa` only accepts code points up to U+00FF and throws `InvalidCharacterError` on anything higher. A route group name never appears in the URL, but it's still a segment in the FlightRouterState, so it reaches this encoder and takes the base64 path. The segment cache being on by default is what turned this into a hard failure rather than something you'd never hit.

Non-Latin-1 dynamic param names (`app/docs/[제목]/page.tsx`) and parallel route slot names go through the same function and break identically.

### How?

Encode to UTF-8 with `TextEncoder` and widen each byte into its own code unit before calling `btoa`. That's exactly what `cache-busting-search-param.ts` already does for the same base64url encoding, so I followed it rather than inventing a second approach. It uses a loop rather than spreading into `String.fromCharCode` so long values can't blow the stack.

Things worth knowing while reviewing:

- The encoding is one-way. Nothing decodes these keys — they're only ever cache keys and output filenames.
- The server (`collect-segment-data`, `export`) and the client (`segment-cache`) both derive keys from this one function, so the two sides stay in agreement.
- ASCII is byte-identical under UTF-8, so existing output names don't move. The segment paths asserted in `app-static` (`!KG5ldyk` for `(new)`) are untouched.
- The one behaviour change beyond fixing the crash: values in U+0080–U+00FF (`café`, say) used to encode as single bytes and now encode as two-byte UTF-8. Those never threw before, so their key does change. Keys are regenerated at build time and both sides compute them from the same function, so this is a rebuild rather than a break — but flagging it in case you'd rather special-case it.

Tests:

- Unit test beside the encoder covering Hangul, Japanese, Cyrillic, emoji and mixed segments, dynamic param names, parallel route keys, and that distinct inputs stay distinct. 17 of the 20 fail on canary with `InvalidCharacterError`.
- e2e app at `test/e2e/app-dir/non-latin1-segments` with a Hangul route group and a Hangul param name, exercised over both a server request and a client navigation, since keys get built on both sides. On canary the build fails outright and all four fail.

I checked the fix against the reproduction from the issue: `next build --webpack`, `next build` on Turbopack, `next start` and `next dev` all serve `/hello` with a 200 and no `InvalidCharacterError` in the logs. The generated segment directory comes out as `!KOyViOuFlSk`, which decodes back to `(안녕)`.

Two things I ran into while testing that look unrelated to the encoding and that I've deliberately left alone:

- `/문서` (a literal non-ASCII path segment) serves fine when requested unencoded, but 404s when the path arrives percent-encoded.
- For `app/docs/[제목]`, the param comes back empty from `params`, so the page renders without it.

Both reproduce with and without this change.
