### PR TITLE
[test] Pin Vercel CLI to Node 20.9 compatible version

### DIFF
--- a/test/production/deterministic-build/deployment-id.test.ts
+++ b/test/production/deterministic-build/deployment-id.test.ts
@@ -242,7 +242,8 @@ async function runTest(
         },
         // We use NEXT_TEST_PREFER_OFFLINE, so just declaring `vercel: latest` as a dependency still
         // doesn't force the latest version.
-        buildCommand: 'pnpm dlx vercel@latest build',
+        // TODO: Go back to integration testing with latest once breakage in 59.6.2 is resolved.
+        buildCommand: 'pnpm dlx vercel@59.6.1 build',
         env:
           mode === 'adapter'
             ? {

--- a/test/production/deterministic-build/deployment-id.test.ts
+++ b/test/production/deterministic-build/deployment-id.test.ts
@@ -243,7 +243,7 @@ async function runTest(
         // We use NEXT_TEST_PREFER_OFFLINE, so just declaring `vercel: latest` as a dependency still
         // doesn't force the latest version.
         // TODO: Go back to integration testing with latest once breakage in 59.6.2 is resolved.
-        buildCommand: 'pnpm dlx vercel@59.6.1 build',
+        buildCommand: 'pnpm dlx vercel@59.5.0 build',
         env:
           mode === 'adapter'
             ? {


### PR DESCRIPTION
- latest resolved to vercel@59.6.2.
- It loads `@vercel/node@8.1.0` -> `@vercel/static-config@3.4.2`.
- `@vercel/static-config` is CommonJS and calls `require("oxc-parser")`.
- `oxc-parser@0.121.0` is ESM-only and requires Node `^20.19.0 || >=22.12.0`.
- CI is running Node 20.9.0, which cannot synchronously