### PR TITLE
Fix Turbopack HMR recovery after dropped connections

### DIFF
--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -386,6 +386,7 @@ export function processMessage(
         type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_CONNECTED,
         data: {
           sessionId: message.data.sessionId,
+          hmrVersion: message.data.hmrVersion,
         },
       })
       break
@@ -396,6 +397,7 @@ export function processMessage(
       processTurbopackMessage({
         type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_MESSAGE,
         data: message.data,
+        hmrVersion: message.hmrVersion,
       })
       if (RuntimeErrorHandler.hadRuntimeError) {
         console.warn(REACT_REFRESH_FULL_RELOAD_FROM_ERROR)
@@ -406,6 +408,10 @@ export function processMessage(
     }
     // TODO-APP: make server component change more granular
     case HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES: {
+      processTurbopackMessage({
+        type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+        hmrVersion: message.hmrVersion,
+      })
       turbopackHmr?.onServerComponentChanges()
       sendMessage(
         JSON.stringify({

--- a/packages/next/src/client/dev/hot-reloader/pages/hot-reloader-pages.ts
+++ b/packages/next/src/client/dev/hot-reloader/pages/hot-reloader-pages.ts
@@ -340,6 +340,9 @@ function processMessage(message: HmrMessageSentToBrowser) {
       return handleSuccess()
     }
     case HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES: {
+      for (const listener of turbopackMessageListeners) {
+        listener(message)
+      }
       turbopackHmr?.onServerComponentChanges()
       if (hasCompileErrors || RuntimeErrorHandler.hadRuntimeError) {
         window.location.reload()
@@ -376,6 +379,7 @@ function processMessage(message: HmrMessageSentToBrowser) {
         listener({
           type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_MESSAGE,
           data: message.data,
+          hmrVersion: message.hmrVersion,
         })
       }
       if (RuntimeErrorHandler.hadRuntimeError) {

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -815,7 +815,7 @@ export async function createHotReloaderTurbopack(
   }
 
   let hmrEventHappened = false
-  // A counter identifying the current version of the compiled output, included
+  // A counter identifying the current version of the server component output, included
   // by `"use cache"` in dev cache keys so that cached entries revalidate after
   // an edit. It advances once per HMR change event (for App Router pages that
   // is an RSC change, which is what a cached render depends on), independent of
@@ -823,7 +823,9 @@ export async function createHotReloaderTurbopack(
   // messages: those are sent per connected client on every compilation, so
   // advancing there would both churn the hash without an edit and fail to
   // advance it at all when no client is connected.
-  let hmrHash = 0
+  let serverComponentsHmrRefreshVersion = 0
+  let clientHmrVersion = 0
+  let clientHmrEventHappened = false
   // Undefined until the first entrypoints emission. That one has nothing to
   // compare against, so every route it lists would look added.
   let previousRouteKeys: Set<string> | undefined
@@ -913,6 +915,7 @@ export async function createHotReloaderTurbopack(
         sendToClient(client, {
           type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_MESSAGE,
           data: state.turbopackUpdates,
+          hmrVersion: String(clientHmrVersion),
         })
         state.turbopackUpdates.length = 0
       }
@@ -922,14 +925,23 @@ export async function createHotReloaderTurbopack(
 
   const sendHmr: SendHmr = (id: string, message: HmrMessageSentToBrowser) => {
     pendingBuilding.flush()
+
+    if (message.type === HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES) {
+      if (!clientHmrEventHappened) {
+        clientHmrVersion++
+        clientHmrEventHappened = true
+      }
+      message.hmrVersion = String(clientHmrVersion)
+    }
+
+    hmrEventHappened = true
+
     for (const client of [
       ...clientsWithoutHtmlRequestId,
       ...clientsByHtmlRequestId.values(),
     ]) {
       clientStates.get(client)?.messages.set(id, message)
     }
-
-    hmrEventHappened = true
     sendEnqueuedMessagesDebounce()
   }
 
@@ -948,6 +960,10 @@ export async function createHotReloaderTurbopack(
       clientStates.get(client)?.turbopackUpdates.push(payload)
     }
 
+    if (!clientHmrEventHappened) {
+      clientHmrVersion++
+      clientHmrEventHappened = true
+    }
     hmrEventHappened = true
     sendEnqueuedMessagesDebounce()
   }
@@ -978,7 +994,10 @@ export async function createHotReloaderTurbopack(
       for await (const change of changed) {
         processIssues(currentEntryIssues, key, change, false, true)
         // TODO: Get an actual content hash from Turbopack.
-        const message = await createMessage(change, String(++hmrHash))
+        const message = await createMessage(
+          change,
+          String(++serverComponentsHmrRefreshVersion)
+        )
         if (message) {
           sendHmr(key, message)
         }
@@ -1575,6 +1594,16 @@ export async function createHotReloaderTurbopack(
           // Turbopack messages
           switch (parsedData.type) {
             case 'turbopack-subscribe':
+              if (
+                parsedData.hmrVersion !== undefined &&
+                parsedData.hmrVersion !== String(clientHmrVersion)
+              ) {
+                sendToClient(client, {
+                  type: HMR_MESSAGE_SENT_TO_BROWSER.RELOAD_PAGE,
+                  data: 'HMR hash mismatch',
+                })
+                break
+              }
               subscribeToClientHmrEvents(client, parsedData.path)
               break
 
@@ -1591,7 +1620,7 @@ export async function createHotReloaderTurbopack(
 
         const turbopackConnectedMessage: TurbopackConnectedMessage = {
           type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_CONNECTED,
-          data: { sessionId },
+          data: { sessionId, hmrVersion: String(clientHmrVersion) },
         }
         sendToClient(client, turbopackConnectedMessage)
 
@@ -1652,13 +1681,9 @@ export async function createHotReloaderTurbopack(
     },
 
     getServerComponentsHmrRefreshHash() {
-      // Only the change subscription (an actual recompile) advances `hmrHash`;
-      // reloads and config invalidations don't, so the value stays stable
-      // across requests until a real edit. `sessionId` stands in for a key
-      // derived from the compiled implementation, which would let entries
-      // outlive a restart when the code didn't change (see the note on Action
-      // IDs in `use-cache-wrapper.ts`).
-      return `${sessionId}-${hmrHash}`
+      // Only a change subscription advances the refresh version, so reloads
+      // and config invalidations leave cache keys stable until a real edit.
+      return `${sessionId}-${serverComponentsHmrRefreshVersion}`
     },
 
     sendToLegacyClients(action) {
@@ -2099,7 +2124,7 @@ export async function createHotReloaderTurbopack(
               // Report the current version without advancing it: a completed
               // compilation is not itself an edit, and this hash is not
               // consumed by the Turbopack client.
-              hash: String(hmrHash),
+              hash: String(serverComponentsHmrRefreshVersion),
               errors: [...clientErrors.values()],
               warnings: [],
             })
@@ -2112,6 +2137,7 @@ export async function createHotReloaderTurbopack(
             Log.event(`Compiled in ${timeMessage}`)
             hmrEventHappened = false
           }
+          clientHmrEventHappened = false
 
           // Call onBeforeDeferredEntries after compilation completes during HMR
           // This ensures the callback is invoked even when non-deferred entries change

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -65,6 +65,7 @@ export interface ServerErrorMessage {
 export interface TurbopackMessage {
   type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_MESSAGE
   data: TurbopackUpdate | TurbopackUpdate[]
+  hmrVersion: string
 }
 
 export interface BuildingMessage {
@@ -117,6 +118,7 @@ export interface ReloadPageMessage {
 
 export interface ServerComponentChangesMessage {
   type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES
+  hmrVersion?: string
 }
 
 /**
@@ -151,7 +153,7 @@ export interface DevPagesManifestUpdateMessage {
 
 export interface TurbopackConnectedMessage {
   type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_CONNECTED
-  data: { sessionId: number }
+  data: { sessionId: number; hmrVersion: string }
 }
 
 export interface AppIsrManifestMessage {
@@ -232,10 +234,15 @@ export type TurbopackMessageSentToBrowser =
   | {
       type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_MESSAGE
       data: any
+      hmrVersion: string
     }
   | {
       type: HMR_MESSAGE_SENT_TO_BROWSER.TURBOPACK_CONNECTED
-      data: { sessionId: number }
+      data: { sessionId: number; hmrVersion: string }
+    }
+  | {
+      type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES
+      hmrVersion?: string
     }
 
 export interface NextJsHotReloaderInterface {

--- a/test/development/app-hmr/fixtures/default-template/app/hmr-reconnect/page.js
+++ b/test/development/app-hmr/fixtures/default-template/app/hmr-reconnect/page.js
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Page() {
+  return <p id="hmr-value">Initial</p>
+}

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -1,4 +1,4 @@
-import { FileRef, nextTestSetup } from 'e2e-utils'
+import { FileRef, nextTestSetup, Playwright } from 'e2e-utils'
 import { retry, waitFor } from 'next-test-utils'
 import path from 'path'
 
@@ -11,6 +11,86 @@ describe(`app-dir-hmr`, () => {
   })
 
   describe('filesystem changes', () => {
+    // @force-gate turbopack
+    it('reloads the page if the server advanced while the client was disconnected', async () => {
+      const componentPath = 'app/hmr-reconnect/page.js'
+      const originalComponent = await next.readFile(componentPath)
+      let forwardHmrTraffic = true
+      let droppedHmrMessages = 0
+      let reconnectHmr = () => {}
+      const subscriptionHashes: Array<string | undefined> = []
+
+      const getHmrValue = (browser: Playwright<unknown>) =>
+        browser.eval(`document.querySelector('#hmr-value')?.textContent`)
+
+      try {
+        const browser = await next.browser('/hmr-reconnect', {
+          async beforePageLoad(page) {
+            await page.routeWebSocket(/\/_next\/hmr/, (clientSocket) => {
+              const serverSocket = clientSocket.connectToServer()
+              function connectServerSocket() {
+                serverSocket.onMessage((message) => {
+                  if (forwardHmrTraffic) {
+                    clientSocket.send(message)
+                  } else {
+                    droppedHmrMessages++
+                  }
+                })
+              }
+              connectServerSocket()
+              clientSocket.onMessage((message) => {
+                if (typeof message === 'string') {
+                  const parsed = JSON.parse(message)
+                  if (parsed.type === 'turbopack-subscribe') {
+                    subscriptionHashes.push(parsed.hmrVersion)
+                  }
+                }
+                serverSocket.send(message)
+              })
+              reconnectHmr = () => serverSocket.close()
+            })
+          },
+        })
+        await retry(async () => {
+          expect(await getHmrValue(browser)).toBe('Initial')
+        })
+
+        await next.patchFile(
+          componentPath,
+          originalComponent.replace('Initial', 'First edit')
+        )
+        await retry(async () => {
+          expect(await getHmrValue(browser)).toBe('First edit')
+        })
+        await browser.eval(`window.__hmrTestDocument = true`)
+
+        forwardHmrTraffic = false
+        await next.patchFile(
+          componentPath,
+          originalComponent.replace('Initial', 'Second edit')
+        )
+        await retry(async () => {
+          expect(droppedHmrMessages).toBeGreaterThan(0)
+        })
+        expect(await getHmrValue(browser)).not.toBe('Second edit')
+        expect(await browser.eval(`window.__hmrTestDocument`)).toBe(true)
+
+        forwardHmrTraffic = true
+        reconnectHmr()
+        await retry(async () => {
+          expect(subscriptionHashes.some((hash) => hash !== undefined)).toBe(
+            true
+          )
+        })
+        await retry(async () => {
+          expect(await getHmrValue(browser)).toBe('Second edit')
+        }, 10_000)
+        expect(await browser.eval(`window.__hmrTestDocument`)).toBeUndefined()
+      } finally {
+        await next.patchFile(componentPath, originalComponent)
+      }
+    })
+
     it('should not continously poll when hitting a not found page', async () => {
       let requestCount = 0
 

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/dev/hmr-client/hmr-client.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/dev/hmr-client/hmr-client.ts
@@ -7,10 +7,16 @@ type SendMessage = (msg: any) => void
 export type WebSocketMessage =
   | {
       type: 'turbopack-connected'
+      data?: { hmrVersion: string }
     }
   | {
       type: 'turbopack-message'
       data: Record<string, any>
+      hmrVersion?: string
+    }
+  | {
+      type: 'server-component-changes'
+      hmrVersion?: string
     }
 
 export type ClientOptions = {
@@ -23,6 +29,8 @@ export type ClientOptions = {
 export const TURBOPACK_CHUNK_UPDATE_LISTENERS_GLOBAL =
   'TURBOPACK_CHUNK_UPDATE_LISTENERS'
 
+let lastSeenHmrVersion: string | undefined
+
 export function connect({
   addMessageListener,
   sendMessage,
@@ -32,9 +40,13 @@ export function connect({
   addMessageListener((msg) => {
     switch (msg.type) {
       case 'turbopack-connected':
+        if (lastSeenHmrVersion === undefined && msg.data !== undefined) {
+          lastSeenHmrVersion = msg.data.hmrVersion
+        }
         handleSocketConnected(sendMessage)
         break
-      default:
+      case 'turbopack-message':
+        lastSeenHmrVersion = msg.hmrVersion
         try {
           if (Array.isArray(msg.data)) {
             for (let i = 0; i < msg.data.length; i++) {
@@ -56,6 +68,11 @@ export function connect({
           onUpdateError(e)
           location.reload()
         }
+        break
+      case 'server-component-changes':
+        lastSeenHmrVersion = msg.hmrVersion
+        break
+      default:
         break
     }
   })
@@ -108,6 +125,7 @@ function subscribeToUpdates(
   sendJSON(sendMessage, {
     type: 'turbopack-subscribe',
     ...resource,
+    hmrVersion: lastSeenHmrVersion,
   })
 
   return () => {

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/dev-protocol.d.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/dev-protocol.d.ts
@@ -98,6 +98,7 @@ type ResourceIdentifier = {
 
 type ClientMessageSubscribe = {
   type: 'turbopack-subscribe'
+  hmrVersion?: string
 } & ResourceIdentifier
 
 type ClientMessageUnsubscribe = {


### PR DESCRIPTION
### What?

Track the latest applied Turbopack HMR 'hash' in the browser runtime and include it when subscriptions are restored after reconnecting. Reload the page when the client's hash differs from the server's current hash.

Add an App Router development test that interrupts HMR traffic, misses an update, restores the connection, and verifies the page reloads into the current revision.

### Why?

A browser that temporarily loses its HMR connection can miss updates and remain out of sync after reconnecting.

### How?

Attach the current HMR hash to Turbopack connection and update messages. The runtime records the last hash it processed and sends it with each subscription. The development server compares that value against its current hash and requests a full reload on mismatch.

<!-- NEXT_JS_LLM -->