### PR TITLE
fix(cache): don't write app router notFound() responses to disk

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -362,6 +362,22 @@ export default class FileSystemCache implements CacheHandler {
 
     if (!this.flushToDisk || !data) return
 
+    // A `notFound()` response for an app route/page (e.g. an on-demand ISR
+    // request for a `generateStaticParams` param that doesn't exist) is kept
+    // in the in-memory cache above for per-worker dedup, but must not be
+    // persisted to disk: every distinct unmatched param a client requests
+    // (including from bots crawling for nonexistent paths) would otherwise
+    // leave a permanent, never-evicted static artifact behind. This mirrors
+    // the Pages Router, which never reaches this method for a `{ notFound:
+    // true }` result from `getStaticProps` in the first place.
+    if (
+      (data.kind === CachedRouteKind.APP_PAGE ||
+        data.kind === CachedRouteKind.APP_ROUTE) &&
+      data.status === 404
+    ) {
+      return
+    }
+
     // Create a new writer that will prepare to write all the files to disk
     // after their containing directory is created.
     const writer = new MultiFileWriter(this.fs)

--- a/test/production/app-dir/isr-notfound-no-disk-write/app/isr-route/[slug]/route.ts
+++ b/test/production/app-dir/isr-notfound-no-disk-write/app/isr-route/[slug]/route.ts
@@ -1,0 +1,22 @@
+import { notFound } from 'next/navigation'
+import { NextResponse } from 'next/server'
+
+export const revalidate = 60
+export const dynamicParams = true
+
+export function generateStaticParams() {
+  return [{ slug: 'known' }]
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params
+
+  if (slug !== 'known') {
+    notFound()
+  }
+
+  return NextResponse.json({ slug })
+}

--- a/test/production/app-dir/isr-notfound-no-disk-write/app/isr/[slug]/page.tsx
+++ b/test/production/app-dir/isr-notfound-no-disk-write/app/isr/[slug]/page.tsx
@@ -1,0 +1,22 @@
+import { notFound } from 'next/navigation'
+
+export const revalidate = 60
+export const dynamicParams = true
+
+export function generateStaticParams() {
+  return [{ slug: 'known' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  if (slug !== 'known') {
+    notFound()
+  }
+
+  return <p id="slug">{slug}</p>
+}

--- a/test/production/app-dir/isr-notfound-no-disk-write/app/layout.tsx
+++ b/test/production/app-dir/isr-notfound-no-disk-write/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/isr-notfound-no-disk-write/app/page.tsx
+++ b/test/production/app-dir/isr-notfound-no-disk-write/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/isr-notfound-no-disk-write/isr-notfound-no-disk-write.test.ts
+++ b/test/production/app-dir/isr-notfound-no-disk-write/isr-notfound-no-disk-write.test.ts
@@ -1,0 +1,68 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('isr-notfound-no-disk-write', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  const pageArtifacts = (slug: string) => [
+    `.next/server/app/isr/${slug}.html`,
+    `.next/server/app/isr/${slug}.rsc`,
+    `.next/server/app/isr/${slug}.meta`,
+  ]
+
+  const routeArtifacts = (slug: string) => [
+    `.next/server/app/isr-route/${slug}.body`,
+    `.next/server/app/isr-route/${slug}.meta`,
+  ]
+
+  it('persists the build-time generateStaticParams entry to disk', async () => {
+    for (const file of pageArtifacts('known')) {
+      expect(await next.hasFile(file)).toBe(true)
+    }
+    for (const file of routeArtifacts('known')) {
+      expect(await next.hasFile(file)).toBe(true)
+    }
+  })
+
+  it('does not persist a page notFound() response for an unknown slug to disk', async () => {
+    for (const file of pageArtifacts('missing')) {
+      expect(await next.hasFile(file)).toBe(false)
+    }
+
+    const first = await next.fetch('/isr/missing')
+    expect(first.status).toBe(404)
+
+    for (const file of pageArtifacts('missing')) {
+      expect(await next.hasFile(file)).toBe(false)
+    }
+
+    // Requesting it again should still 404 and still not write anything.
+    const second = await next.fetch('/isr/missing')
+    expect(second.status).toBe(404)
+
+    for (const file of pageArtifacts('missing')) {
+      expect(await next.hasFile(file)).toBe(false)
+    }
+  })
+
+  it('does not persist a route handler notFound() response for an unknown slug to disk', async () => {
+    for (const file of routeArtifacts('missing')) {
+      expect(await next.hasFile(file)).toBe(false)
+    }
+
+    const first = await next.fetch('/isr-route/missing')
+    expect(first.status).toBe(404)
+
+    for (const file of routeArtifacts('missing')) {
+      expect(await next.hasFile(file)).toBe(false)
+    }
+  })
+
+  it('still serves a valid revalidated page correctly', async () => {
+    const res = await next.fetch('/isr/known')
+    expect(res.status).toBe(200)
+    const $ = await next.render$('/isr/known')
+    expect($('#slug').text()).toBe('known')
+  })
+})

--- a/test/production/app-dir/isr-notfound-no-disk-write/next.config.js
+++ b/test/production/app-dir/isr-notfound-no-disk-write/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/unit/incremental-cache/file-system-cache.test.ts
+++ b/test/unit/incremental-cache/file-system-cache.test.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'node:fs'
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import FileSystemCache from 'next/dist/server/lib/incremental-cache/file-system-cache'
 import { nodeFs } from 'next/dist/server/lib/node-fs-methods'
@@ -8,6 +9,15 @@ import {
 } from 'next/dist/server/response-cache'
 
 const cacheDir = fileURLToPath(new URL('./cache', import.meta.url))
+
+async function fileExists(...segments: string[]) {
+  try {
+    await fs.access(path.join(cacheDir, 'app', ...segments))
+    return true
+  } catch {
+    return false
+  }
+}
 
 describe('FileSystemCache', () => {
   it('set image route', async () => {
@@ -51,6 +61,84 @@ describe('FileSystemCache', () => {
       status: 200,
       kind: IncrementalCacheKind.APP_ROUTE,
     })
+  })
+
+  it('does not write a 404 app page response to disk', async () => {
+    const fsCache = new FileSystemCache({
+      _requestHeaders: {},
+      flushToDisk: true,
+      fs: nodeFs,
+      serverDistDir: cacheDir,
+      revalidatedTags: [],
+    })
+
+    await fsCache.set(
+      'isr-not-found-page',
+      {
+        kind: CachedRouteKind.APP_PAGE,
+        html: '<html>not found</html>',
+        rscData: Buffer.from('not found'),
+        headers: {},
+        status: 404,
+        postponed: undefined,
+        segmentData: undefined,
+      },
+      {}
+    )
+
+    expect(await fileExists('isr-not-found-page.html')).toBe(false)
+    expect(await fileExists('isr-not-found-page.rsc')).toBe(false)
+    expect(await fileExists('isr-not-found-page.meta')).toBe(false)
+  })
+
+  it('does not write a 404 app route response to disk', async () => {
+    const fsCache = new FileSystemCache({
+      _requestHeaders: {},
+      flushToDisk: true,
+      fs: nodeFs,
+      serverDistDir: cacheDir,
+      revalidatedTags: [],
+    })
+
+    await fsCache.set(
+      'isr-not-found-route',
+      {
+        kind: CachedRouteKind.APP_ROUTE,
+        body: Buffer.from('not found'),
+        headers: {},
+        status: 404,
+      },
+      {}
+    )
+
+    expect(await fileExists('isr-not-found-route.body')).toBe(false)
+    expect(await fileExists('isr-not-found-route.meta')).toBe(false)
+  })
+
+  it('still writes a 200 app page response to disk', async () => {
+    const fsCache = new FileSystemCache({
+      _requestHeaders: {},
+      flushToDisk: true,
+      fs: nodeFs,
+      serverDistDir: cacheDir,
+      revalidatedTags: [],
+    })
+
+    await fsCache.set(
+      'isr-found-page',
+      {
+        kind: CachedRouteKind.APP_PAGE,
+        html: '<html>found</html>',
+        rscData: Buffer.from('found'),
+        headers: {},
+        status: 200,
+        postponed: undefined,
+        segmentData: undefined,
+      },
+      {}
+    )
+
+    expect(await fileExists('isr-found-page.html')).toBe(true)
   })
 })
 


### PR DESCRIPTION
## What?

Fix an issue where App Router ISR pages and route handlers that call `notFound()` could still write a 404 response to the incremental cache on disk.

For dynamic routes, requesting a path that does not match `generateStaticParams` could create `.html`, `.rsc`, `.meta` (or `.body`, `.meta`) cache files even though the response was a 404. Since these entries were not useful cached pages and were not evicted, repeatedly requesting different nonexistent paths could cause the cache directory to grow indefinitely.

This change skips the filesystem cache write for 404 responses from `APP_PAGE` and `APP_ROUTE` entries.

## Why?

The Pages Router already avoids writing `getStaticProps` results with `notFound: true` to the filesystem cache, but the App Router did not have the same behavior.

The App Router's response generation path still produced a cache value for a `notFound()` response, which was then passed to the incremental filesystem cache and persisted to disk.

This can become a practical disk exhaustion issue when crawlers or bots request a large number of nonexistent dynamic URLs.

Returning `value: null` from the App Router response generation path is not a suitable fix because the cache entry is also used as part of the current response pipeline. Doing so causes the existing invariant check in `app-page-runtime.ts` to fail.

Therefore, the fix keeps the cache value available for the current request while preventing only the unnecessary filesystem write.

## How?

Added a guard to the `set()` method in `file-system-cache.ts`.

When the cache entry is an `APP_PAGE` or `APP_ROUTE` and its response status is `404`, the filesystem write is skipped.

Added regression coverage for both:

* App Router ISR pages using `notFound()`
* App Router ISR route handlers using `notFound()`
* Unit-level filesystem cache behavior for 404 `APP_PAGE` and `APP_ROUTE` entries

The regression was also verified by temporarily reverting the fix and rebuilding the test application. The two relevant end-to-end tests failed without the fix and passed after restoring it.

Fixes #73101
Fixes #96581
