### PR TITLE
fix(turbopack): trace child_process.fork paths as file assets

### DIFF
--- a/test/production/turbopack-child-process-fork/app/api/x/route.ts
+++ b/test/production/turbopack-child-process-fork/app/api/x/route.ts
@@ -1,0 +1,6 @@
+import { spawnWorker } from '../../../lib/spawn-it'
+
+export function GET() {
+  spawnWorker()
+  return new Response('ok')
+}

--- a/test/production/turbopack-child-process-fork/app/layout.tsx
+++ b/test/production/turbopack-child-process-fork/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/turbopack-child-process-fork/app/page.tsx
+++ b/test/production/turbopack-child-process-fork/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return null
+}

--- a/test/production/turbopack-child-process-fork/lib/spawn-it.ts
+++ b/test/production/turbopack-child-process-fork/lib/spawn-it.ts
@@ -1,0 +1,7 @@
+import { fork } from 'node:child_process'
+import path from 'node:path'
+
+export function spawnWorker() {
+  const script = path.join(process.cwd(), 'worker.mjs')
+  return fork(script, [])
+}

--- a/test/production/turbopack-child-process-fork/turbopack-child-process-fork.test.ts
+++ b/test/production/turbopack-child-process-fork/turbopack-child-process-fork.test.ts
@@ -1,0 +1,22 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('turbopack child_process.fork path tracing', () => {
+  const { next, isTurbopack, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+  if (skipped) return
+
+  // Regression for https://github.com/vercel/next.js/issues/97952
+  // Turbopack previously resolved fork()'s path argument as a module request,
+  // so absolute / path.join(cwd, …) paths failed the build.
+  ;(isTurbopack ? it : it.skip)(
+    'should build when fork() receives a cwd-joined worker path',
+    async () => {
+      const { exitCode, cliOutput } = await next.build()
+      expect(cliOutput).not.toContain("Can't resolve")
+      expect(exitCode).toBe(0)
+    }
+  )
+})

--- a/test/production/turbopack-child-process-fork/worker.mjs
+++ b/test/production/turbopack-child-process-fork/worker.mjs
@@ -1,0 +1,1 @@
+console.log('worker up')

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -2659,11 +2659,15 @@ where
             )
         }
         WellKnownFunctionKind::ChildProcessFork if analysis.analyze_mode.is_tracing_assets() => {
+            // `fork()` takes a filesystem path to a module, same as `spawn()`/`execFile()`
+            // take a command path. Trace it as a file asset rather than resolving it as a
+            // module request — absolute/`path.join(cwd, …)` paths are not import specifiers.
             let args = linked_args().await?;
             if !args.is_empty() {
                 let first_arg = &args[0];
                 let pat = js_value_to_pattern(first_arg);
-                if !pat.has_constant_parts() {
+                let dynamic = !pat.has_constant_parts();
+                if dynamic {
                     let (args, hints) = explain_args(args);
                     handler.span_warn_with_code(
                         span,
@@ -2676,17 +2680,17 @@ where
                         return Ok(());
                     }
                 }
-                let error_mode = if in_try {
-                    ResolveErrorMode::Warn
-                } else {
-                    ResolveErrorMode::Error
-                };
                 analysis.add_reference(
-                    CjsAssetReference::new(
-                        *origin,
-                        Request::parse(pat),
-                        issue_source(source, span),
-                        error_mode,
+                    FileSourceReference::new(
+                        get_traced_project_dir().await?,
+                        Pattern::new(pat),
+                        collect_affecting_sources,
+                        IssueSource::from_swc_offsets(
+                            source,
+                            span.lo.to_u32(),
+                            span.hi.to_u32(),
+                        ),
+                        rcstr!("child_process.fork"),
                     )
                     .to_resolved()
                     .await?,


### PR DESCRIPTION
## What?

Turbopack treated the first argument to `child_process.fork()` as a module request (`CjsAssetReference`). Absolute paths and `path.join(process.cwd(), …)` therefore failed during `next build` with `Module not found: Can't resolve '/ROOT/…'`.

`spawn()` / `execFile()` already trace the same kind of path as a filesystem asset via `FileSourceReference`.

## Why?

`fork()` takes a filesystem path to a Node module, not an import specifier. Resolving it as a CJS request breaks valid absolute / cwd-joined worker paths (see #97952).

## How?

- Change `ChildProcessFork` asset tracing to use `FileSourceReference`, matching `child_process.spawn` / `execFile`
- Add a Turbopack production regression test that builds an App Route calling `fork(path.join(process.cwd(), 'worker.mjs'))`

Fixes #97952