### PR TITLE
fix(tracing): include dlopen'd native shared libraries in standalone output

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -7,6 +7,7 @@ import {
   TRACE_IGNORES,
   type BuildTraceContext,
   getFilesMapFromReasons,
+  expandPackageTraces,
 } from './webpack/plugins/next-trace-entrypoints-plugin'
 
 import path from 'path'
@@ -377,6 +378,7 @@ export async function collectBuildTraces({
         for (const file of result.esmFileList) {
           fileList.add(file)
         }
+        await expandPackageTraces(outputFileTracingRoot, fileList, reasons)
 
         const parentFilesMap = getFilesMapFromReasons(fileList, reasons)
         const cachedLookupIgnore = new Map<string, boolean>()

--- a/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/next-trace-entrypoints-plugin.ts
@@ -1,4 +1,5 @@
 import nodePath from 'path'
+import fs from 'fs/promises'
 import type { Span } from '../../../trace'
 import isError from '../../../lib/is-error'
 import { nodeFileTrace } from 'next/dist/compiled/@vercel/nft'
@@ -99,6 +100,80 @@ export function getFilesMapFromReasons(
     propagateToParents(reason.parents, file)
   }
   return parentFilesMap
+}
+
+export async function expandPackageTraces(
+  outputFileTracingRoot: string,
+  fileList: Set<string>,
+  reasons: NodeFileTraceReasons
+): Promise<void> {
+  const processedPackageDirs = new Set<string>()
+
+  for (const relFile of Array.from(fileList)) {
+    if (
+      !relFile.includes('@img/sharp-libvips') &&
+      !relFile.includes('@img+sharp-libvips')
+    ) {
+      continue
+    }
+
+    const absFile = nodePath.join(outputFileTracingRoot, relFile)
+    let packageDir = nodePath.dirname(absFile)
+
+    while (
+      packageDir.length >= outputFileTracingRoot.length &&
+      !processedPackageDirs.has(packageDir)
+    ) {
+      const pkgJsonPath = nodePath.join(packageDir, 'package.json')
+      const stat = await fs.stat(pkgJsonPath).catch(() => null)
+      if (stat && stat.isFile()) {
+        try {
+          const pkgJson = JSON.parse(await fs.readFile(pkgJsonPath, 'utf8'))
+          if (pkgJson.name && pkgJson.name.startsWith('@img/sharp-libvips')) {
+            processedPackageDirs.add(packageDir)
+            break
+          }
+        } catch {}
+      }
+
+      const parentDir = nodePath.dirname(packageDir)
+      if (parentDir === packageDir) break
+      packageDir = parentDir
+    }
+
+    if (!processedPackageDirs.has(packageDir)) {
+      continue
+    }
+
+    const reason = reasons.get(relFile)
+    const parents = reason?.parents || new Set<string>()
+
+    async function walkDir(currentDir: string) {
+      const entries = await fs
+        .readdir(currentDir, { withFileTypes: true })
+        .catch(() => [])
+      for (const entry of entries) {
+        const fullPath = nodePath.join(currentDir, entry.name)
+        if (entry.isDirectory()) {
+          await walkDir(fullPath)
+        } else if (entry.isFile()) {
+          const relPath = nodePath
+            .relative(outputFileTracingRoot, fullPath)
+            .replace(/\\/g, '/')
+          if (!fileList.has(relPath)) {
+            fileList.add(relPath)
+            reasons.set(relPath, {
+              type: ['dependency'],
+              ignored: reason?.ignored ?? false,
+              parents: new Set(parents),
+            })
+          }
+        }
+      }
+    }
+
+    await walkDir(packageDir)
+  }
 }
 
 export interface TurbotraceAction {
@@ -512,6 +587,7 @@ export class TraceEntryPointsPlugin implements webpack.WebpackPluginInstance {
                 fileList = result.fileList
                 result.esmFileList.forEach((file) => fileList.add(file))
                 reasons = result.reasons
+                await expandPackageTraces(this.tracingRoot, fileList, reasons)
               })
 
             await finishModulesSpan

--- a/test/production/standalone-mode/tracing-native-dlopen/app/page.js
+++ b/test/production/standalone-mode/tracing-native-dlopen/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>native dlopen tracing test</div>
+}

--- a/test/production/standalone-mode/tracing-native-dlopen/next.config.js
+++ b/test/production/standalone-mode/tracing-native-dlopen/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  output: 'standalone',
+}

--- a/test/production/standalone-mode/tracing-native-dlopen/tracing-native-dlopen.test.ts
+++ b/test/production/standalone-mode/tracing-native-dlopen/tracing-native-dlopen.test.ts
@@ -1,0 +1,65 @@
+import { nextTestSetup } from 'e2e-utils'
+import { join } from 'path'
+import fs from 'fs-extra'
+import { expandPackageTraces } from 'next/dist/build/webpack/plugins/next-trace-entrypoints-plugin'
+
+describe('standalone mode - tracing-native-dlopen', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('expands package traces for @img/sharp-libvips native packages', async () => {
+    const root = next.testDir
+    const pkgDir = join(root, 'node_modules/@img/sharp-libvips-test')
+    await fs.ensureDir(join(pkgDir, 'lib'))
+    await fs.writeFile(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({ name: '@img/sharp-libvips-test', version: '1.0.0' })
+    )
+    await fs.writeFile(join(pkgDir, 'index.js'), 'module.exports = {}')
+    await fs.writeFile(
+      join(pkgDir, 'lib/libvips-cpp.8.18.3.dylib'),
+      'binary-data'
+    )
+
+    const fileList = new Set<string>([
+      'node_modules/@img/sharp-libvips-test/index.js',
+      'node_modules/@img/sharp-libvips-test/package.json',
+    ])
+    const parentReason = {
+      type: ['dependency' as const],
+      ignored: false,
+      parents: new Set(['app/page.js']),
+    }
+    const reasons = new Map<string, any>([
+      ['node_modules/@img/sharp-libvips-test/index.js', parentReason],
+      ['node_modules/@img/sharp-libvips-test/package.json', parentReason],
+    ])
+
+    await expandPackageTraces(root, fileList, reasons)
+
+    expect(
+      fileList.has(
+        'node_modules/@img/sharp-libvips-test/lib/libvips-cpp.8.18.3.dylib'
+      )
+    ).toBe(true)
+    const dylibReason = reasons.get(
+      'node_modules/@img/sharp-libvips-test/lib/libvips-cpp.8.18.3.dylib'
+    )
+    expect(dylibReason).toBeDefined()
+    expect(dylibReason.parents).toEqual(new Set(['app/page.js']))
+  })
+
+  it('should build in standalone mode without errors', async () => {
+    const { exitCode } = await next.build()
+    expect(exitCode).toBe(0)
+
+    const standaloneDir = join(next.testDir, '.next/standalone')
+    expect(await fs.pathExists(standaloneDir)).toBe(true)
+  })
+})


### PR DESCRIPTION
### What?

Ensures native shared library binaries loaded dynamically via C++ `dlopen()` (such as `sharp`'s `@img/sharp-libvips-*` package binaries) are included when tracing files for `output: 'standalone'`.

### Why?

`@vercel/nft` (`nodeFileTrace`) uses static JS AST analysis to trace dependencies. Packages like `sharp` (v0.33+) depend on `@img/sharp-<platform>`, which depends on `@img/sharp-libvips-<platform>`. 

Because `@img/sharp-libvips-<platform>` contains `index.js`, `package.json`, and C++ shared libraries (`lib/libvips-cpp.*`) that are loaded dynamically at runtime via `dlopen()` in native code rather than static JS `require()` / `fs.readFile()` statements, `@vercel/nft` only traces `index.js` and `package.json`. When building in standalone mode, `libvips-cpp.*` is omitted from `.next/standalone`, resulting in `ERR_DLOPEN_FAILED` runtime crashes.

### How?

- Added `expandPackageTraces` to scan package directories when any file from a native shared library package like `@img/sharp-libvips-*` is traced.
- Populated `fileList` and `reasons` with all package assets using the parent entry's reason linkage so `getFilesMapFromReasons` propagates the shared library files to `.nft.json` entries and standalone file copiers.
- Added a standalone production test suite in `test/production/standalone-mode/tracing-native-dlopen/`.

Fixes #97973

<!-- NEXT_JS_LLM -->
