### PR TITLE
fix(telemetry): flush telemetry detached on next build

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1363,7 +1363,6 @@ export default async function build(
         const errorMessage =
           'The "exportPathMap" configuration cannot be used with the "app" directory. Please use generateStaticParams() instead.'
         Log.error(errorMessage)
-        await telemetry.flush()
         throw new Error(errorMessage)
       }
 
@@ -1597,7 +1596,6 @@ export default async function build(
           for (const [pagePath, appPath] of conflictingAppPagePaths) {
             Log.error(`  "${pagePath}" - "${appPath}"`)
           }
-          await telemetry.flush()
           throw new Error(errorMessage)
         }
       }
@@ -4645,9 +4643,9 @@ export default async function build(
           )
       }
 
-      await nextBuildSpan
+      nextBuildSpan
         .traceChild('telemetry-flush')
-        .traceAsyncFn(() => telemetry.flush())
+        .traceFn(() => telemetry.flushDetached('build', dir))
 
       await shutdownPromise
 
@@ -4701,7 +4699,7 @@ export default async function build(
     // Flush telemetry before finishing (waits for async operations like setTimeout in debug mode)
     const telemetry: Telemetry | undefined = traceGlobals.get('telemetry')
     if (telemetry) {
-      await telemetry.flush()
+      telemetry.flushDetached('build', dir)
     }
 
     // Ensure all buffered spans are on disk before `uploadTrace` reads the file.

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -1,5 +1,6 @@
 // Import cpu-profile first to start profiling early if enabled
 import { saveCpuProfile } from '../../server/lib/cpu-profile'
+import path from 'path'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import { stringBufferUtils } from 'next/dist/compiled/webpack-sources3'
 import { red } from '../../lib/picocolors'
@@ -415,7 +416,10 @@ export async function workerMain(workerData: {
 > {
   // Clone the telemetry for worker
   const telemetry = new Telemetry({
-    distDir: workerData.buildContext.config!.distDir,
+    distDir: path.join(
+      workerData.buildContext.dir!,
+      workerData.buildContext.config!.distDir
+    ),
   })
   setGlobal('telemetry', telemetry)
   // setup new build context from the serialized data passed from the parent
@@ -459,7 +463,7 @@ export async function workerMain(workerData: {
     result.buildTraceContext!.chunksTrace!.entryNameFilesMap = entryNameFilesMap
   }
   NextBuildContext.nextBuildSpan.stop()
-  await telemetry.flush()
+  telemetry.flushDetached('build', NextBuildContext.dir!)
 
   // Save CPU profile before worker exits
   await saveCpuProfile()

--- a/packages/next/src/telemetry/detached-flush.test.ts
+++ b/packages/next/src/telemetry/detached-flush.test.ts
@@ -26,10 +26,13 @@ describe('Telemetry flushDetached', () => {
 
   it('spawns detached process with "build" mode when events are queued', async () => {
     const telemetry = new Telemetry({ distDir })
-    telemetry.record({
-      eventName: 'NEXT_TEST_EVENT' as any,
-      fields: { feature: 'test' },
-    })
+    telemetry.record(
+      {
+        eventName: 'NEXT_TEST_EVENT',
+        payload: { feature: 'test' },
+      },
+      true
+    )
 
     telemetry.flushDetached('build', tmpDir)
 
@@ -52,10 +55,13 @@ describe('Telemetry flushDetached', () => {
 
   it('spawns detached process with "dev" mode when events are queued', async () => {
     const telemetry = new Telemetry({ distDir })
-    telemetry.record({
-      eventName: 'NEXT_DEV_EVENT' as any,
-      fields: { feature: 'dev' },
-    })
+    telemetry.record(
+      {
+        eventName: 'NEXT_DEV_EVENT',
+        payload: { feature: 'dev' },
+      },
+      true
+    )
 
     telemetry.flushDetached('dev', tmpDir)
 
@@ -68,16 +74,22 @@ describe('Telemetry flushDetached', () => {
 
   it('generates unique event files for consecutive flushes without collisions', async () => {
     const telemetry = new Telemetry({ distDir })
-    telemetry.record({
-      eventName: 'NEXT_EVENT_1' as any,
-      fields: { step: 1 },
-    })
+    telemetry.record(
+      {
+        eventName: 'NEXT_EVENT_1',
+        payload: { step: 1 },
+      },
+      true
+    )
     telemetry.flushDetached('build', tmpDir)
 
-    telemetry.record({
-      eventName: 'NEXT_EVENT_2' as any,
-      fields: { step: 2 },
-    })
+    telemetry.record(
+      {
+        eventName: 'NEXT_EVENT_2',
+        payload: { step: 2 },
+      },
+      true
+    )
     telemetry.flushDetached('build', tmpDir)
 
     expect(spawnSpy).toHaveBeenCalledTimes(2)
@@ -101,10 +113,13 @@ describe('Telemetry flushDetached', () => {
 
   it('clears queue and does not re-spawn on subsequent flushDetached calls', async () => {
     const telemetry = new Telemetry({ distDir })
-    telemetry.record({
-      eventName: 'NEXT_BUILD_EVENT' as any,
-      fields: { feature: 'build' },
-    })
+    telemetry.record(
+      {
+        eventName: 'NEXT_BUILD_EVENT',
+        payload: { feature: 'build' },
+      },
+      true
+    )
 
     telemetry.flushDetached('build', tmpDir)
     expect(spawnSpy).toHaveBeenCalledTimes(1)
@@ -112,6 +127,23 @@ describe('Telemetry flushDetached', () => {
     // Second call without new events should do nothing
     telemetry.flushDetached('build', tmpDir)
     expect(spawnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('aborts in-flight telemetry requests when flushDetached is called', async () => {
+    const telemetry = new Telemetry({ distDir })
+    telemetry.record({
+      eventName: 'NEXT_IN_FLIGHT_EVENT',
+      payload: { feature: 'in-flight' },
+    })
+
+    telemetry.flushDetached('build', tmpDir)
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1)
+    const eventsFile = path.join(distDir, spawnSpy.mock.calls[0][1][3])
+    expect(fs.existsSync(eventsFile)).toBe(true)
+    const writtenEvents = JSON.parse(fs.readFileSync(eventsFile, 'utf8'))
+    expect(writtenEvents).toHaveLength(1)
+    expect(writtenEvents[0].eventName).toBe('NEXT_IN_FLIGHT_EVENT')
   })
 
   it('does nothing when queue is empty', () => {

--- a/packages/next/src/telemetry/detached-flush.test.ts
+++ b/packages/next/src/telemetry/detached-flush.test.ts
@@ -14,7 +14,7 @@ describe('Telemetry flushDetached', () => {
     distDir = path.join(tmpDir, '.next')
     spawnSpy = jest
       .spyOn(childProcess, 'spawn')
-      .mockImplementation(() => ({} as any))
+      .mockImplementation(() => ({}) as any)
   })
 
   afterEach(() => {
@@ -131,13 +131,19 @@ describe('Telemetry flushDetached', () => {
 
   it('aborts in-flight telemetry requests when flushDetached is called', async () => {
     const telemetry = new Telemetry({ distDir })
-    telemetry.record({
-      eventName: 'NEXT_IN_FLIGHT_EVENT',
-      payload: { feature: 'in-flight' },
-    })
+    const recordPromise = telemetry.record(
+      {
+        eventName: 'NEXT_IN_FLIGHT_EVENT',
+        payload: { feature: 'in-flight' },
+      },
+      true
+    )
+
+    expect((recordPromise as any)._controller.signal.aborted).toBe(false)
 
     telemetry.flushDetached('build', tmpDir)
 
+    expect((recordPromise as any)._controller.signal.aborted).toBe(true)
     expect(spawnSpy).toHaveBeenCalledTimes(1)
     const eventsFile = path.join(distDir, spawnSpy.mock.calls[0][1][3])
     expect(fs.existsSync(eventsFile)).toBe(true)

--- a/packages/next/src/telemetry/detached-flush.test.ts
+++ b/packages/next/src/telemetry/detached-flush.test.ts
@@ -1,0 +1,90 @@
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import childProcess from 'child_process'
+import { Telemetry } from './storage'
+
+describe('Telemetry flushDetached', () => {
+  let tmpDir: string
+  let distDir: string
+  let spawnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'next-telemetry-test-'))
+    distDir = path.join(tmpDir, '.next')
+    spawnSpy = jest
+      .spyOn(childProcess, 'spawn')
+      .mockImplementation(() => ({} as any))
+  })
+
+  afterEach(() => {
+    spawnSpy.mockRestore()
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    } catch {}
+  })
+
+  it('spawns detached process with "build" mode when events are queued', async () => {
+    const telemetry = new Telemetry({ distDir })
+    telemetry.record({
+      eventName: 'NEXT_TEST_EVENT' as any,
+      fields: { feature: 'test' },
+    })
+
+    telemetry.flushDetached('build', tmpDir)
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1)
+    const [execPath, args, options] = spawnSpy.mock.calls[0]
+
+    expect(execPath).toBe(process.execPath)
+    expect(args[0]).toContain('detached-flush')
+    expect(args[1]).toBe('build')
+    expect(args[2]).toBe(tmpDir)
+    expect(args[3]).toMatch(/^_events_\d+\.json$/)
+    expect(options.detached).toBe(true)
+
+    const eventsFile = path.join(distDir, args[3])
+    expect(fs.existsSync(eventsFile)).toBe(true)
+    const writtenEvents = JSON.parse(fs.readFileSync(eventsFile, 'utf8'))
+    expect(writtenEvents).toHaveLength(1)
+    expect(writtenEvents[0].eventName).toBe('NEXT_TEST_EVENT')
+  })
+
+  it('spawns detached process with "dev" mode when events are queued', async () => {
+    const telemetry = new Telemetry({ distDir })
+    telemetry.record({
+      eventName: 'NEXT_DEV_EVENT' as any,
+      fields: { feature: 'dev' },
+    })
+
+    telemetry.flushDetached('dev', tmpDir)
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1)
+    const [, args] = spawnSpy.mock.calls[0]
+    expect(args[1]).toBe('dev')
+    expect(args[2]).toBe(tmpDir)
+  })
+
+  it('clears queue and does not re-spawn on subsequent flushDetached calls', async () => {
+    const telemetry = new Telemetry({ distDir })
+    telemetry.record({
+      eventName: 'NEXT_BUILD_EVENT' as any,
+      fields: { feature: 'build' },
+    })
+
+    telemetry.flushDetached('build', tmpDir)
+    expect(spawnSpy).toHaveBeenCalledTimes(1)
+
+    // Second call without new events should do nothing
+    telemetry.flushDetached('build', tmpDir)
+    expect(spawnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when queue is empty', () => {
+    const telemetry = new Telemetry({ distDir })
+    telemetry.flushDetached('build', tmpDir)
+
+    expect(spawnSpy).not.toHaveBeenCalled()
+    expect(fs.existsSync(distDir)).toBe(false)
+  })
+})

--- a/packages/next/src/telemetry/detached-flush.test.ts
+++ b/packages/next/src/telemetry/detached-flush.test.ts
@@ -40,7 +40,7 @@ describe('Telemetry flushDetached', () => {
     expect(args[0]).toContain('detached-flush')
     expect(args[1]).toBe('build')
     expect(args[2]).toBe(tmpDir)
-    expect(args[3]).toMatch(/^_events_\d+\.json$/)
+    expect(args[3]).toMatch(/^_events_\d+_[a-f0-9]+\.json$/)
     expect(options.detached).toBe(true)
 
     const eventsFile = path.join(distDir, args[3])
@@ -63,6 +63,40 @@ describe('Telemetry flushDetached', () => {
     const [, args] = spawnSpy.mock.calls[0]
     expect(args[1]).toBe('dev')
     expect(args[2]).toBe(tmpDir)
+    expect(args[3]).toMatch(/^_events_\d+_[a-f0-9]+\.json$/)
+  })
+
+  it('generates unique event files for consecutive flushes without collisions', async () => {
+    const telemetry = new Telemetry({ distDir })
+    telemetry.record({
+      eventName: 'NEXT_EVENT_1' as any,
+      fields: { step: 1 },
+    })
+    telemetry.flushDetached('build', tmpDir)
+
+    telemetry.record({
+      eventName: 'NEXT_EVENT_2' as any,
+      fields: { step: 2 },
+    })
+    telemetry.flushDetached('build', tmpDir)
+
+    expect(spawnSpy).toHaveBeenCalledTimes(2)
+    const firstFile = spawnSpy.mock.calls[0][1][3]
+    const secondFile = spawnSpy.mock.calls[1][1][3]
+
+    expect(firstFile).not.toBe(secondFile)
+    expect(fs.existsSync(path.join(distDir, firstFile))).toBe(true)
+    expect(fs.existsSync(path.join(distDir, secondFile))).toBe(true)
+
+    const firstEvents = JSON.parse(
+      fs.readFileSync(path.join(distDir, firstFile), 'utf8')
+    )
+    const secondEvents = JSON.parse(
+      fs.readFileSync(path.join(distDir, secondFile), 'utf8')
+    )
+
+    expect(firstEvents[0].eventName).toBe('NEXT_EVENT_1')
+    expect(secondEvents[0].eventName).toBe('NEXT_EVENT_2')
   })
 
   it('clears queue and does not re-spawn on subsequent flushDetached calls', async () => {

--- a/packages/next/src/telemetry/detached-flush.ts
+++ b/packages/next/src/telemetry/detached-flush.ts
@@ -57,7 +57,9 @@ import {
   // finished flushing events clean-up
   try {
     fs.unlinkSync(eventsPath)
-  } catch (_) {}
+  } catch (_) {
+    // the file may already be gone; nothing to clean up
+  }
   // Don't call process.exit() here - let Node.js exit naturally after
   // all pending work completes (e.g., setTimeout in debug telemetry)
 })()

--- a/packages/next/src/telemetry/detached-flush.ts
+++ b/packages/next/src/telemetry/detached-flush.ts
@@ -34,7 +34,9 @@ import {
   // Support both old format (no eventsFile arg) and new format (with eventsFile arg)
   const eventsPath = path.join(
     distDir,
-    eventsFile && !eventsFile.includes('/') ? eventsFile : '_events.json'
+    eventsFile && !eventsFile.includes('/') && !eventsFile.includes('\\')
+      ? eventsFile
+      : '_events.json'
   )
 
   let events: TelemetryEvent[]
@@ -53,7 +55,9 @@ import {
   await telemetry.flush()
 
   // finished flushing events clean-up
-  fs.unlinkSync(eventsPath)
+  try {
+    fs.unlinkSync(eventsPath)
+  } catch (_) {}
   // Don't call process.exit() here - let Node.js exit naturally after
   // all pending work completes (e.g., setTimeout in debug telemetry)
 })()

--- a/packages/next/src/telemetry/detached-flush.ts
+++ b/packages/next/src/telemetry/detached-flush.ts
@@ -31,7 +31,7 @@ import {
     mode === 'build' ? PHASE_PRODUCTION_BUILD : PHASE_DEVELOPMENT_SERVER,
     dir
   )
-  if (hasCustomExportOutput(config)) {
+  if (mode === 'build' && hasCustomExportOutput(config)) {
     config.distDir = '.next'
   }
   const distDir = path.join(dir, config.distDir || '.next')

--- a/packages/next/src/telemetry/detached-flush.ts
+++ b/packages/next/src/telemetry/detached-flush.ts
@@ -4,10 +4,13 @@ import type { TelemetryEvent } from './storage'
 import { Telemetry } from './storage'
 import loadConfig from '../server/config'
 import { getProjectDir } from '../lib/get-project-dir'
-import { PHASE_DEVELOPMENT_SERVER } from '../shared/lib/constants'
+import {
+  PHASE_DEVELOPMENT_SERVER,
+  PHASE_PRODUCTION_BUILD,
+} from '../shared/lib/constants'
 
 // this process should be started with following arg order
-// 1. mode e.g. dev, export, start
+// 1. mode e.g. dev, export, start, build
 // 2. project dir
 // 3. events filename (optional, defaults to _events.json)
 ;(async () => {
@@ -16,14 +19,17 @@ import { PHASE_DEVELOPMENT_SERVER } from '../shared/lib/constants'
   let dir = args.pop()
   const mode = args.pop()
 
-  if (!dir || mode !== 'dev') {
+  if (!dir || (mode !== 'dev' && mode !== 'build')) {
     throw new Error(
-      `Invalid flags should be run as node detached-flush dev ./path-to/project [eventsFile]`
+      `Invalid flags should be run as node detached-flush dev|build ./path-to/project [eventsFile]`
     )
   }
   dir = getProjectDir(dir)
 
-  const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, dir)
+  const config = await loadConfig(
+    mode === 'build' ? PHASE_PRODUCTION_BUILD : PHASE_DEVELOPMENT_SERVER,
+    dir
+  )
   const distDir = path.join(dir, config.distDir || '.next')
   // Support both old format (no eventsFile arg) and new format (with eventsFile arg)
   const eventsPath = path.join(

--- a/packages/next/src/telemetry/detached-flush.ts
+++ b/packages/next/src/telemetry/detached-flush.ts
@@ -4,6 +4,7 @@ import type { TelemetryEvent } from './storage'
 import { Telemetry } from './storage'
 import loadConfig from '../server/config'
 import { getProjectDir } from '../lib/get-project-dir'
+import { hasCustomExportOutput } from '../export/utils'
 import {
   PHASE_DEVELOPMENT_SERVER,
   PHASE_PRODUCTION_BUILD,
@@ -30,6 +31,9 @@ import {
     mode === 'build' ? PHASE_PRODUCTION_BUILD : PHASE_DEVELOPMENT_SERVER,
     dir
   )
+  if (hasCustomExportOutput(config)) {
+    config.distDir = '.next'
+  }
   const distDir = path.join(dir, config.distDir || '.next')
   // Support both old format (no eventsFile arg) and new format (with eventsFile arg)
   const eventsPath = path.join(

--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -175,6 +175,7 @@ export class Telemetry {
     _events: TelemetryEvent | TelemetryEvent[],
     deferred?: boolean
   ): Promise<RecordObject> => {
+    const controller = new AbortController()
     const prom = (
       deferred
         ? // if we know we are going to immediately call
@@ -187,7 +188,7 @@ export class Telemetry {
               value: _events,
             })
           )
-        : this.submitRecord(_events)
+        : this.submitRecord(_events, controller.signal)
     )
       .then((value) => ({
         isFulfilled: true,
@@ -209,7 +210,7 @@ export class Telemetry {
       })
 
     ;(prom as any)._events = Array.isArray(_events) ? _events : [_events]
-    ;(prom as any)._controller = (prom as any)._controller
+    ;(prom as any)._controller = controller
     // Track this `Promise` so we can flush pending events
     this.queue.add(prom)
 
@@ -279,7 +280,8 @@ export class Telemetry {
   }
 
   private submitRecord = async (
-    _events: TelemetryEvent | TelemetryEvent[]
+    _events: TelemetryEvent | TelemetryEvent[],
+    signal?: any
   ): Promise<any> => {
     let events: TelemetryEvent[]
     if (Array.isArray(_events)) {
@@ -317,8 +319,7 @@ export class Telemetry {
       return Promise.resolve()
     }
 
-    const postController = new AbortController()
-    const res = postNextTelemetryPayload(
+    return postNextTelemetryPayload(
       {
         context: {
           anonymousId: this.anonymousId,
@@ -331,9 +332,7 @@ export class Telemetry {
           fields: payload,
         })),
       },
-      postController.signal
+      signal
     )
-    res._controller = postController
-    return res
   }
 }

--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -243,8 +243,9 @@ export class Telemetry {
     }
 
     fs.mkdirSync(this.distDir, { recursive: true })
-    // Use unique filename per process to avoid race conditions between parent/child
-    const eventsFile = `_events_${process.pid}.json`
+    // Use unique filename per flush to avoid race conditions between parent/child
+    // and prevent collisions between multiple flushes in the same process
+    const eventsFile = `_events_${process.pid}_${randomBytes(6).toString('hex')}.json`
     fs.writeFileSync(
       path.join(this.distDir, eventsFile),
       JSON.stringify(allEvents)

--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -223,7 +223,7 @@ export class Telemetry {
   // writes current events to disk and spawns separate
   // detached process to submit the records without blocking
   // the main process from exiting
-  flushDetached = (mode: 'dev', dir: string) => {
+  flushDetached = (mode: 'dev' | 'build', dir: string) => {
     const allEvents: TelemetryEvent[] = []
 
     this.queue.forEach((item: any) => {
@@ -234,6 +234,8 @@ export class Telemetry {
         // if we fail to abort ignore this event
       }
     })
+
+    this.queue.clear()
 
     if (allEvents.length === 0) {
       // No events to flush

--- a/test/unit/TurbopackInternalError.test.ts
+++ b/test/unit/TurbopackInternalError.test.ts
@@ -34,13 +34,16 @@ describe('TurbopackInternalError', () => {
 
       expect(internalError).toBeInstanceOf(TurbopackInternalError)
 
-      expect(submitRecord).toHaveBeenCalledWith({
-        eventName: 'NEXT_ERROR_THROWN',
-        payload: {
-          errorCode: 'TurbopackInternalError',
-          location: 'file.rs:120:1',
+      expect(submitRecord).toHaveBeenCalledWith(
+        {
+          eventName: 'NEXT_ERROR_THROWN',
+          payload: {
+            errorCode: 'TurbopackInternalError',
+            location: 'file.rs:120:1',
+          },
         },
-      })
+        expect.anything()
+      )
     } finally {
       setGlobal('telemetry', oldTelemetry)
     }


### PR DESCRIPTION
### What?

Switches `next build` telemetry flushing from blocking synchronous `await telemetry.flush()` to non-blocking `telemetry.flushDetached('build', dir)`.

Fixes #97929.

### Why?

`next build` previously awaited `telemetry.flush()` synchronously on the critical exit path, blocking process completion on outbound HTTP requests to the telemetry endpoint. This added 200ms–1.1s of latency to build times across environments. `next dev` and server shutdown already use `flushDetached` to prevent blocking process exit.

### How?

1. `packages/next/src/telemetry/storage.ts`: update `flushDetached` to accept `mode: 'dev' | 'build'` and clear `this.queue` after draining events.
2. `packages/next/src/telemetry/detached-flush.ts`: accept `build` mode and load config with `PHASE_PRODUCTION_BUILD` when running in build mode.
3. `packages/next/src/build/index.ts`: replace blocking `await telemetry.flush()` with `telemetry.flushDetached('build', dir)`.
4. `packages/next/src/telemetry/detached-flush.test.ts`: add unit tests covering detached telemetry spawning and queue handling for `build` and `dev` modes.
