### PR TITLE
fix(scripts): make unpack-next work on Windows

### DIFF
--- a/scripts/unpack-next.ts
+++ b/scripts/unpack-next.ts
@@ -20,11 +20,11 @@ const packages = {
   'next-swc': realPathIfAny(`${PROJECT_DIR}/node_modules/@next/swc`),
   'next-mdx': realPathIfAny(`${PROJECT_DIR}/node_modules/@next/mdx`),
   'next-bundle-analyzer': realPathIfAny(
-    `${PROJECT_DIR}/node_modules/@next/bundle-anlyzer`
+    `${PROJECT_DIR}/node_modules/@next/bundle-analyzer`
   ),
 }
 
 for (const [key, path] of Object.entries(packages)) {
   if (!path) continue
-  exec(`Unpack ${key}`, `tar -xf '${TARBALLS}/${key}.tar' -C '${path}'`)
+  exec(`Unpack ${key}`, ['tar', '-xf', `${TARBALLS}/${key}.tar`, '-C', path])
 }


### PR DESCRIPTION
Fixes #82233, open since 2025-07-31 with no comments.

## Cause

`scripts/unpack-next.ts` builds a shell string and wraps both paths in single quotes:

```ts
exec(`Unpack ${key}`, `tar -xf '${TARBALLS}/${key}.tar' -C '${path}'`)
```

`exec` with a string routes to `execSync`, which on Windows runs through `cmd.exe`. cmd.exe does not treat single quotes as quoting, so they reach tar as literal characters in the filename.

Windows ships bsdtar at `System32\tar.exe`, and it fails:

```
tar.exe: Error opening archive: Failed to open ''next.tar''
```

Reproduced on Windows 11, Node v24.12.0:

| invocation | result |
|---|---|
| `bsdtar -xf 't.tar' -C 'dest'` via execSync | fails, `Failed to open ''t.tar''` |
| `bsdtar -xf t.tar -C dest` via execSync | ok |
| `execFileSync('tar', ['-xf','t.tar','-C','dest'])` | ok |

This is why it looks intermittent. On a machine where Git Bash GNU tar precedes `System32` on PATH, GNU tar tolerates the stray quotes and the script appears to work. On a clean Windows install it does not.

## The change

`exec` already accepts an array, and that branch calls `execFileSync`, so no shell is involved and no quoting is needed on any platform. That is the whole fix, using the helper's existing API.

```ts
exec(`Unpack ${key}`, ['tar', '-xf', `${TARBALLS}/${key}.tar`, '-C', path])
```

It also removes the need to reason about quoting for paths containing spaces, which is the common case on Windows given `C:\Users\<name>\Documents`.

## Second, unrelated bug in the same file

The bundle analyzer lookup points at `@next/bundle-anlyzer`, missing an `a`. `@next/bundle-analyzer` returns 200 on the npm registry, `@next/bundle-anlyzer` returns 404. Because `realPathIfAny` swallows the failure and returns null, that package has silently never been unpacked, on any platform. Fixed here since it is two characters in the same file, but happy to split it into its own PR if that is preferred.

## Not verified

I did not run a full `pnpm pack-next --tar` followed by `unpack-next` end to end, since that needs a complete Next.js build. The quoting behaviour above is reproduced directly against bsdtar, and the array branch of `exec` is unchanged code that the repo already uses elsewhere.