### PR TITLE
Turbopack: allow `get_definable_name` to return a list

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/mod.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use bumpalo::boxed::Box as BumpBox;
 use num_bigint::BigInt;
-use smallvec::SmallVec;
+use smallvec::{SmallVec, smallvec};
 use swc_core::ecma::{ast::Id, atoms::Atom};
 use turbo_rcstr::{RcStr, rcstr};
 use turbopack_core::compile_time_info::{
@@ -1268,7 +1268,7 @@ impl JsValue<'_> {
     pub fn get_definable_name(
         &self,
         var_graph: Option<&VarGraph<'_>>,
-    ) -> Option<(DefinableNameSegmentRefs<'_>, bool)> {
+    ) -> SmallVec<[(DefinableNameSegmentRefs<'_>, bool); 1]> {
         let mut current = self;
         let mut segments = SmallVec::new();
         let mut potentially_reassigned = false;
@@ -1288,12 +1288,18 @@ impl JsValue<'_> {
                     break;
                 }
                 JsValue::Member(_, obj, prop) => {
-                    segments.push(DefinableNameSegmentRef::Name(prop.as_str()?));
+                    let Some(prop) = prop.as_str() else {
+                        return Default::default();
+                    };
+                    segments.push(DefinableNameSegmentRef::Name(prop));
                     current = obj;
                 }
                 JsValue::WellKnownObject(obj) => {
+                    let Some(obj_name) = obj.as_define_name() else {
+                        return Default::default();
+                    };
                     segments.extend(
-                        obj.as_define_name()?
+                        obj_name
                             .iter()
                             .rev()
                             .copied()
@@ -1302,8 +1308,11 @@ impl JsValue<'_> {
                     break;
                 }
                 JsValue::WellKnownFunction(func) => {
+                    let Some(func_name) = func.as_define_name() else {
+                        return Default::default();
+                    };
                     segments.extend(
-                        func.as_define_name()?
+                        func_name
                             .iter()
                             .rev()
                             .copied()
@@ -1312,18 +1321,27 @@ impl JsValue<'_> {
                     break;
                 }
                 JsValue::MemberCall(_, call) if call.args().is_empty() => {
-                    segments.push(DefinableNameSegmentRef::Call(call.prop().as_str()?));
+                    let Some(call_prop) = call.prop().as_str() else {
+                        return Default::default();
+                    };
+                    segments.push(DefinableNameSegmentRef::Call(call_prop));
                     current = call.obj();
                 }
                 JsValue::TypeOf(_, arg) => {
                     segments.push(DefinableNameSegmentRef::TypeOf);
                     current = arg;
                 }
-                _ => return None,
+                JsValue::Alternatives { values, .. } => {
+                    return values
+                        .iter()
+                        .flat_map(|v| v.get_definable_name(var_graph))
+                        .collect();
+                }
+                _ => return Default::default(),
             }
         }
         segments.reverse();
-        Some((DefinableNameSegmentRefs(segments), potentially_reassigned))
+        smallvec![(DefinableNameSegmentRefs(segments), potentially_reassigned)]
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/jsvalue/mod.rs
@@ -1257,6 +1257,8 @@ impl<'a> JsValue<'a> {
 
 // Definable name management
 impl JsValue<'_> {
+    // Clippy is wrong. It's not the same lifetime
+    #[allow(mismatched_lifetime_syntaxes)]
     /// When the value has a user-definable name, return it in segments. Otherwise
     /// returns None.
     /// It also returns a boolean whether the variable was potentially reassigned.
@@ -1265,83 +1267,76 @@ impl JsValue<'_> {
     /// - some well-known objects/functions have a user-definable names: ["import"]
     /// - member calls without arguments also have a user-definable name: ["foo", Call("func")]
     /// - typeof expressions add `typeof` after the argument's segments: ["foo", "typeof"]
-    pub fn get_definable_name(
-        &self,
+    pub fn get_definable_name<'v>(
+        &'v self,
         var_graph: Option<&VarGraph<'_>>,
-    ) -> SmallVec<[(DefinableNameSegmentRefs<'_>, bool); 1]> {
-        let mut current = self;
-        let mut segments = SmallVec::new();
-        let mut potentially_reassigned = false;
-        loop {
-            match current {
-                JsValue::FreeVar(name) => {
-                    if var_graph.is_some_and(|var_graph| {
-                        var_graph
-                            .free_var_ids
-                            .get(name)
-                            .is_some_and(|id| var_graph.values.contains_key(id))
-                    }) {
-                        // `foo` was potentially reassigned
-                        potentially_reassigned = true;
+    ) -> SmallVec<[Option<(DefinableNameSegmentRefs<'_>, bool)>; 1]> {
+        let inner = |value: &'v JsValue| {
+            let mut current = value;
+            let mut segments = SmallVec::new();
+            let mut potentially_reassigned = false;
+            loop {
+                match current {
+                    JsValue::FreeVar(name) => {
+                        if var_graph.is_some_and(|var_graph| {
+                            var_graph
+                                .free_var_ids
+                                .get(name)
+                                .is_some_and(|id| var_graph.values.contains_key(id))
+                        }) {
+                            // `foo` was potentially reassigned
+                            potentially_reassigned = true;
+                        }
+                        segments.push(DefinableNameSegmentRef::Name(name));
+                        break;
                     }
-                    segments.push(DefinableNameSegmentRef::Name(name));
-                    break;
+                    JsValue::Member(_, obj, prop) => {
+                        segments.push(DefinableNameSegmentRef::Name(prop.as_str()?));
+                        current = obj;
+                    }
+                    JsValue::WellKnownObject(obj) => {
+                        segments.extend(
+                            obj.as_define_name()?
+                                .iter()
+                                .rev()
+                                .copied()
+                                .map(DefinableNameSegmentRef::Name),
+                        );
+                        break;
+                    }
+                    JsValue::WellKnownFunction(func) => {
+                        segments.extend(
+                            func.as_define_name()?
+                                .iter()
+                                .rev()
+                                .copied()
+                                .map(DefinableNameSegmentRef::Name),
+                        );
+                        break;
+                    }
+                    JsValue::MemberCall(_, call) if call.args().is_empty() => {
+                        let Some(call_prop) = call.prop().as_str() else {
+                            return Default::default();
+                        };
+                        segments.push(DefinableNameSegmentRef::Call(call_prop));
+                        current = call.obj();
+                    }
+                    JsValue::TypeOf(_, arg) => {
+                        segments.push(DefinableNameSegmentRef::TypeOf);
+                        current = arg;
+                    }
+                    _ => return None,
                 }
-                JsValue::Member(_, obj, prop) => {
-                    let Some(prop) = prop.as_str() else {
-                        return Default::default();
-                    };
-                    segments.push(DefinableNameSegmentRef::Name(prop));
-                    current = obj;
-                }
-                JsValue::WellKnownObject(obj) => {
-                    let Some(obj_name) = obj.as_define_name() else {
-                        return Default::default();
-                    };
-                    segments.extend(
-                        obj_name
-                            .iter()
-                            .rev()
-                            .copied()
-                            .map(DefinableNameSegmentRef::Name),
-                    );
-                    break;
-                }
-                JsValue::WellKnownFunction(func) => {
-                    let Some(func_name) = func.as_define_name() else {
-                        return Default::default();
-                    };
-                    segments.extend(
-                        func_name
-                            .iter()
-                            .rev()
-                            .copied()
-                            .map(DefinableNameSegmentRef::Name),
-                    );
-                    break;
-                }
-                JsValue::MemberCall(_, call) if call.args().is_empty() => {
-                    let Some(call_prop) = call.prop().as_str() else {
-                        return Default::default();
-                    };
-                    segments.push(DefinableNameSegmentRef::Call(call_prop));
-                    current = call.obj();
-                }
-                JsValue::TypeOf(_, arg) => {
-                    segments.push(DefinableNameSegmentRef::TypeOf);
-                    current = arg;
-                }
-                JsValue::Alternatives { values, .. } => {
-                    return values
-                        .iter()
-                        .flat_map(|v| v.get_definable_name(var_graph))
-                        .collect();
-                }
-                _ => return Default::default(),
             }
+            segments.reverse();
+            Some((DefinableNameSegmentRefs(segments), potentially_reassigned))
+        };
+
+        if let JsValue::Alternatives { values, .. } = self {
+            values.iter().map(inner).collect()
+        } else {
+            smallvec![inner(self)]
         }
-        segments.reverse();
-        smallvec![(DefinableNameSegmentRefs(segments), potentially_reassigned)]
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/cross_module_constants.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cross_module_constants.rs
@@ -260,8 +260,8 @@ pub async fn get_constants(
                 value.clone_in(arena.get_or_default()),
                 &|value| early_value_visitor(&arena, value),
                 &async |v| {
-                    if let Some((name, _)) = v.get_definable_name(Some(&var_graph))
-                        && let Some(value) = compile_time_info_ref.defines.get(&name).await?
+                    if let [Some((name, _))] = &*v.get_definable_name(Some(&var_graph))
+                        && let Some(value) = compile_time_info_ref.defines.get(name).await?
                     {
                         return Ok((
                             JsValue::from_compile_time_define_value_in(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3977,7 +3977,7 @@ async fn value_visitor_inner<'a>(
         && let Some(left) = left.as_str()
         && let right_name = right.get_definable_name(Some(var_graph))
         && right_name.len() == 1
-        && let Some((mut right_name, _)) = right_name.into_iter().next().unwrap()
+        && let Some((mut right_name, false)) = right_name.into_iter().next().unwrap()
     {
         right_name.0.push(DefinableNameSegmentRef::Name(left));
         if compile_time_info_ref
@@ -3989,7 +3989,7 @@ async fn value_visitor_inner<'a>(
         }
     }
 
-    if let [Some((name, _))] = &*v.get_definable_name(Some(var_graph))
+    if let [Some((name, false))] = &*v.get_definable_name(Some(var_graph))
         && let Some(value) = compile_time_info_ref.defines.get(name).await?
     {
         return Ok((

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1299,15 +1299,20 @@ async fn analyze_ecmascript_module_internal(
                             .link_value(take(&mut *obj), ImportAttributes::empty_ref())
                             .await?;
 
-                        if let Some((name, false)) =
-                            obj.get_definable_name(Some(&analysis_state.var_graph))
-                            && matches!(
-                                name.0.as_slice(),
-                                [
-                                    DefinableNameSegmentRef::Name("process"),
-                                    DefinableNameSegmentRef::Name("env")
-                                ]
-                            )
+                        if obj
+                            .get_definable_name(Some(&analysis_state.var_graph))
+                            .iter()
+                            .flatten()
+                            .any(|(name, reassigned)| {
+                                !reassigned
+                                    && matches!(
+                                        name.0.as_slice(),
+                                        [
+                                            DefinableNameSegmentRef::Name("process"),
+                                            DefinableNameSegmentRef::Name("env")
+                                        ]
+                                    )
+                            })
                         {
                             analysis.add_runtime_env_var_reference(RcStr::from(prop));
                         }
@@ -3443,68 +3448,73 @@ async fn handle_membership<'a>(
         let obj = link_obj.await?;
         let obj_name = obj.get_definable_name(Some(&state.var_graph));
 
-        if has_member && let Some((mut name, false)) = obj_name.clone() {
-            name.0.push(DefinableNameSegmentRef::Name(prop));
-            match ty {
-                MembershipType::Member => {
-                    if let Some(value) = state
-                        .compile_time_info_ref
-                        .free_var_references
-                        .get(&name)
-                        .await?
-                    {
-                        // Inline env var
-                        handle_free_var_reference(ast_path, &value, span, state, analysis).await?;
-                        return Ok(());
+        if let [obj_name] = &*obj_name {
+            // Exactly one name. We can potentially inline
+            if has_member && let Some((mut name, false)) = obj_name.clone() {
+                name.0.push(DefinableNameSegmentRef::Name(prop));
+                match ty {
+                    MembershipType::Member => {
+                        if let Some(value) = state
+                            .compile_time_info_ref
+                            .free_var_references
+                            .get(&name)
+                            .await?
+                        {
+                            // Inline env var
+                            handle_free_var_reference(ast_path, &value, span, state, analysis)
+                                .await?;
+                            return Ok(());
+                        }
                     }
-                }
-                MembershipType::In => {
-                    if state
-                        .compile_time_info_ref
-                        .free_var_references
-                        .get(&name)
-                        .await?
-                        .is_some()
-                    {
-                        analysis.add_code_gen(ConstantValueCodeGen::new(
-                            CompileTimeDefineValue::Bool(true),
-                            ast_path.to_vec().into(),
-                        ));
-                        return Ok(());
+                    MembershipType::In => {
+                        if state
+                            .compile_time_info_ref
+                            .free_var_references
+                            .get(&name)
+                            .await?
+                            .is_some()
+                        {
+                            analysis.add_code_gen(ConstantValueCodeGen::new(
+                                CompileTimeDefineValue::Bool(true),
+                                ast_path.to_vec().into(),
+                            ));
+                            return Ok(());
+                        }
                     }
                 }
             }
+            if is_prop_cache
+                && let JsValue::WellKnownFunction(WellKnownFunctionKind::Require) = &obj
+            {
+                analysis.add_code_gen::<CodeGen>(match ty {
+                    MembershipType::Member => {
+                        CjsRequireCacheAccess::new(ast_path.to_vec().into()).into()
+                    }
+                    MembershipType::In => ConstantValueCodeGen::new(
+                        CompileTimeDefineValue::Bool(true),
+                        ast_path.to_vec().into(),
+                    )
+                    .into(),
+                });
+                return Ok(());
+            }
         }
 
-        if is_prop_cache && let JsValue::WellKnownFunction(WellKnownFunctionKind::Require) = &obj {
-            analysis.add_code_gen::<CodeGen>(match ty {
-                MembershipType::Member => {
-                    CjsRequireCacheAccess::new(ast_path.to_vec().into()).into()
-                }
-                MembershipType::In => ConstantValueCodeGen::new(
-                    CompileTimeDefineValue::Bool(true),
-                    ast_path.to_vec().into(),
+        // Not inlined, potentially register as runtime env var.
+        if obj_name.iter().flatten().any(|(name, reassigned)| {
+            !reassigned
+                && matches!(
+                    name.0.as_slice(),
+                    [
+                        DefinableNameSegmentRef::Name("process"),
+                        DefinableNameSegmentRef::Name("env")
+                    ]
                 )
-                .into(),
-            });
-            return Ok(());
-        }
-
-        if let Some((name, false)) = &obj_name
-            && matches!(
-                name.0.as_slice(),
-                [
-                    DefinableNameSegmentRef::Name("process"),
-                    DefinableNameSegmentRef::Name("env")
-                ]
-            )
-        {
-            // non-inlined env var
+        }) {
             analysis.add_runtime_env_var_reference(RcStr::from(prop));
             return Ok(());
         }
     }
-
     Ok(())
 }
 
@@ -3515,7 +3525,11 @@ async fn handle_typeof<'a>(
     state: &AnalysisState<'a>,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
 ) -> Result<()> {
-    if let Some((mut name, false)) = arg.get_definable_name(Some(&state.var_graph)) {
+    let arg_name = arg.get_definable_name(Some(&state.var_graph));
+    if arg_name.len() == 1
+        && let Some((mut name, false)) = arg_name.into_iter().next().unwrap()
+    {
+        // Exactly one name. We can potentially inline
         name.0.push(DefinableNameSegmentRef::TypeOf);
         if let Some(value) = state
             .compile_time_info_ref
@@ -3538,11 +3552,12 @@ async fn handle_free_var<'a>(
     state: &AnalysisState<'a>,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
 ) -> Result<()> {
-    if let Some((name, _)) = var.get_definable_name(None)
+    // Exactly one name. We can potentially inline
+    if let [Some((name, _))] = &*var.get_definable_name(None)
         && let Some(value) = state
             .compile_time_info_ref
             .free_var_references
-            .get(&name)
+            .get(name)
             .await?
     {
         handle_free_var_reference(ast_path, &value, span, state, analysis).await?;
@@ -3960,16 +3975,22 @@ async fn value_visitor_inner<'a>(
 ) -> Result<(JsValue<'a>, Modified)> {
     if let JsValue::In(_, left, right) = &v
         && let Some(left) = left.as_str()
-        && let Some((mut name, _)) = right.get_definable_name(Some(var_graph))
+        && let right_name = right.get_definable_name(Some(var_graph))
+        && right_name.len() == 1
+        && let Some((mut right_name, _)) = right_name.into_iter().next().unwrap()
     {
-        name.0.push(DefinableNameSegmentRef::Name(left));
-        if compile_time_info_ref.defines.contains_key(&name).await? {
+        right_name.0.push(DefinableNameSegmentRef::Name(left));
+        if compile_time_info_ref
+            .defines
+            .contains_key(&right_name)
+            .await?
+        {
             return Ok((JsValue::Constant(JsConstantValue::True), Modified::Yes));
         }
     }
 
-    if let Some((name, _)) = v.get_definable_name(Some(var_graph))
-        && let Some(value) = compile_time_info_ref.defines.get(&name).await?
+    if let [Some((name, _))] = &*v.get_definable_name(Some(var_graph))
+        && let Some(value) = compile_time_info_ref.defines.get(name).await?
     {
         return Ok((
             JsValue::from_compile_time_define_value_in(arena.get_or_default(), &value)?,

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default-rest-spread/env-vars.codegen.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default-rest-spread/env-vars.codegen.snapshot
@@ -1,1 +1,3 @@
-runtime: []
+runtime: [
+    "FOO1",
+]

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default-rest-spread/env-vars.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default-rest-spread/env-vars.snapshot
@@ -1,1 +1,3 @@
-runtime: []
+runtime: [
+    "FOO1",
+]

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default-rest-spread/env-vars.tracing.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default-rest-spread/env-vars.tracing.snapshot
@@ -1,1 +1,3 @@
-runtime: []
+runtime: [
+    "FOO1",
+]

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default-rest-spread/input.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default-rest-spread/input.js
@@ -1,4 +1,3 @@
-// TODO properly handle Pat::Assign
 function readEnv({ FOO1, ...rest } = process.env) {
   return rest
 }

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default/env-vars.codegen.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default/env-vars.codegen.snapshot
@@ -1,1 +1,3 @@
-runtime: []
+runtime: [
+    "FOO1",
+]

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default/env-vars.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default/env-vars.snapshot
@@ -1,1 +1,3 @@
-runtime: []
+runtime: [
+    "FOO1",
+]

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default/env-vars.tracing.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default/env-vars.tracing.snapshot
@@ -1,1 +1,3 @@
-runtime: []
+runtime: [
+    "FOO1",
+]

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default/input.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/dynamic-fn-default/input.js
@@ -1,4 +1,3 @@
-// TODO properly handle Pat::Assign
 function readEnv(env = process.env) {
   return env.FOO1
 }

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static-assign-obj/env-vars.codegen.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static-assign-obj/env-vars.codegen.snapshot
@@ -5,4 +5,6 @@ runtime: [
     "FOO4",
     "FOO5",
     "FOO6",
+    "FOO7",
+    "FOO8",
 ]

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static-assign-obj/env-vars.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static-assign-obj/env-vars.snapshot
@@ -5,4 +5,6 @@ runtime: [
     "FOO4",
     "FOO5",
     "FOO6",
+    "FOO7",
+    "FOO8",
 ]

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static-assign-obj/env-vars.tracing.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static-assign-obj/env-vars.tracing.snapshot
@@ -5,4 +5,6 @@ runtime: [
     "FOO4",
     "FOO5",
     "FOO6",
+    "FOO7",
+    "FOO8",
 ]

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static-assign-obj/input.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static-assign-obj/input.js
@@ -38,7 +38,6 @@ if (foo) {
 } else {
   e = process.env
 }
-// TODO currently not tracked
 console.log(e.FOO7)
 
 // ---
@@ -50,5 +49,4 @@ if (foo) {
 } else {
   p2 = process
 }
-// TODO currently not tracked
 console.log(p2.env.FOO8)

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static/env-vars.codegen.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static/env-vars.codegen.snapshot
@@ -5,4 +5,6 @@ runtime: [
     "FOO4",
     "FOO5",
     "INLINED3",
+    "FOO6",
+    "INLINED4",
 ]

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static/env-vars.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static/env-vars.snapshot
@@ -5,4 +5,6 @@ runtime: [
     "FOO4",
     "FOO5",
     "INLINED3",
+    "FOO6",
+    "INLINED4",
 ]

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static/env-vars.tracing.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static/env-vars.tracing.snapshot
@@ -5,4 +5,6 @@ runtime: [
     "FOO4",
     "FOO5",
     "INLINED3",
+    "FOO6",
+    "INLINED4",
 ]

--- a/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static/input.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/references/env-var-info/static/input.js
@@ -20,15 +20,6 @@ console.log(FOO4, renamed)
 // TODO this is actually not inlined yet
 console.log(INLINED3)
 
-// TODO not tracked yet
-// The re-entered object pattern now receives:
-// Alternatives [
-//   Argument(...),
-//   process.env
-// ]
-// add_object_pat_effects() therefore creates DestructuredMember with that Alternatives object.
-// Later, Effect::DestructuredMember calls get_definable_name(). That function does not handle JsValue::Alternatives, so it returns None instead of recognizing the process.env alternative.
-// Thus FOO6 and INLINED4 remain untracked in `function readEnv({ FOO6, INLINED4 } = process.env)`.
 function readEnv({ FOO6, INLINED4 } = process.env) {
   // TODO this is actually not inlined yet
   return FOO6 + INLINED4

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/code-gen/typeof-exports-module/input/exports-reassign.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/code-gen/typeof-exports-module/input/exports-reassign.js
@@ -1,3 +1,5 @@
 exports = () => 'hello'
-if (typeof exports === 'object') throw 'oh no'
+if (typeof exports === 'object') {
+  throw new Error("exports-reassign: it's an object, so incorrectly inlined")
+}
 module.exports = 1234

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/code-gen/typeof-exports-module/input/module-reassign.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/code-gen/typeof-exports-module/input/module-reassign.js
@@ -1,3 +1,5 @@
 module = () => 'hello'
-if (typeof module === 'object') throw 'oh no'
+if (typeof module === 'object') {
+  throw new Error("module-reassign: it's an object, so incorrectly inlined")
+}
 exports.foo = 1234


### PR DESCRIPTION
Followup to #95310

Now we can correctly track env vars in cases like these were a `JsValue::Alternative` is involved
```js
// An alternative (process|unknown).env
let p2
if (foo) {
  p2 = foo
} else {
  p2 = process
}
console.log(p2.env.FOO8)
```

The inlining logic behaves the same as before:
- If `get_definable_name` returns exactly one result, we can inline.
- Otherwise, we can't inline (previously this case returned `None`)


A bit of trivia why we need that boolean in the return type in the first place (because conceptually it should be possible to just model it via `JsValue::Alternative` anyway:

> but why is that a problem? if the value is reassigned, then there should just an alternative, then get_definable_name returns multiple values and it should still not be inlining
>
> Because module is a `FreeVar`, not a normal `Variable`.
>
> The assignment is stored separately in `VarGraph`:
>
> ```
> free_var_ids["module"] -> id
> values[id] -> assigned function
> ```
>
> But later reads still evaluate to:
>
> `JsValue::FreeVar("module")`
>
> The linker expands JsValue::Variable, but not JsValue::FreeVar. Therefore there is no JsValue::Alternatives at this call site.
>
> Instead, `get_definable_name()` detects the graph entry and returns:
>
> `[Some((["module", TypeOf], true))]`
>
> That boolean is how reassignment is represented for free variables. Cardinality remains one, so ignoring the boolean at references/mod.rs:4007 incorrectly permits inlining.
>
> Actual `Alternatives` primarily represent multiple values assigned to tracked variables. For free globals, the original ambient value plus reassignment is represented by `FreeVar` plus `potentially_reassigned`.


No perf impact:

```
commit cfc7da3049f91669a1b61a0f7a5edef503cddc53 (HEAD -> canary, origin/canary, origin/HEAD)
393.17s user 31.34s system 722% cpu 58.775 total
391.91s user 35.37s system 746% cpu 57.256 total
389.48s user 30.40s system 770% cpu 54.513 total

commit 38f2708659be31538c951b12ba806ef53710f074 (HEAD -> mischnic/get-definable-name-list)
392.86s user 34.00s system 745% cpu 57.221 total
388.10s user 32.72s system 766% cpu 54.912 total
391.84s user 37.82s system 717% cpu 59.865 total
```