### PR TITLE
test: disable flaky sync-io-blocks-root.test.ts

### DIFF
--- a/test/production/app-dir/sync-io-blocks-root/sync-io-blocks-root.test.ts
+++ b/test/production/app-dir/sync-io-blocks-root/sync-io-blocks-root.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
-describe('sync IO that blocks the root', () => {
+// TODO(lubieowoce): reenable when the cause of flakiness is found and fixed
+// (seems to have increased sharply around 2026-08-24/25)
+describe.skip('sync IO that blocks the root', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,


### PR DESCRIPTION
Something made this test very flaky on Aug 24/Aug 25

https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.status%3A%22fail%22%20%40test.suite%3A%22sync%20IO%20that%20blocks%20the%20root%22%20-%40test.type%3Aturbopack&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1787237730805&end=1787842530805&paused=true

Disabling until we can investigate.