### PR TITLE
[ci] Run flake detection and new deploy tests when merged and on backport branches

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -54,7 +54,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 1
+          # Changing the checked out ref has wide implications:
+          # Be aware that all git-diff operations in the repo rely on the
+          # default behavior of GitHub actions (ref on push, merge-commit on PR).
+          # 2 last commits so that we can create a diff with HEAD~1
+          fetch-depth: 2
           persist-credentials: false
       - run: echo "${{ github.event.after }}"
       - name: Setup node

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -747,9 +747,7 @@ jobs:
   test-new-tests-dev:
     name: Test new and changed tests for flakes (dev)
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
-    # test-new-tests-if
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
-    # test-new-tests-end-if
 
     strategy:
       fail-fast: false
@@ -776,9 +774,7 @@ jobs:
   test-new-tests-start:
     name: Test new and changed tests for flakes (prod)
     needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
-    # test-new-tests-if
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
-    # test-new-tests-end-if
 
     strategy:
       fail-fast: false
@@ -814,9 +810,7 @@ jobs:
     needs: ['optimize-ci', 'changes']
     # `docs-only` and `is-release` mirror the cases where `build-and-deploy`
     # resolves its deploy target to `skipped` and never publishes a tarball.
-    # test-new-tests-if
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' && needs.changes.outputs.is-release == 'false' }}
-    # test-new-tests-end-if
     runs-on: ubuntu-latest
     # Outer bound only. The script gives up first, so a tarball that never
     # arrives is reported by it rather than by the runner killing the job.
@@ -850,9 +844,7 @@ jobs:
   test-new-tests-deploy:
     name: Test new and changed tests when deployed
     needs: ['optimize-ci', 'changes', 'wait-for-preview-tarball']
-    # test-new-tests-if
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
-    # test-new-tests-end-if
 
     strategy:
       fail-fast: false
@@ -883,9 +875,7 @@ jobs:
   test-new-tests-deploy-cache-components:
     name: Test new and changed tests when deployed (cache components)
     needs: ['optimize-ci', 'changes', 'wait-for-preview-tarball']
-    # test-new-tests-if
     if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
-    # test-new-tests-end-if
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -181,6 +181,9 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # Changing the checked out ref has wide implications:
+          # Be aware that all git-diff operations in the repo rely on the
+          # default behavior of GitHub actions (ref on push, merge-commit on PR).
           fetch-depth: 25
           persist-credentials: false
 

--- a/scripts/create-release-branch.js
+++ b/scripts/create-release-branch.js
@@ -117,12 +117,6 @@ async function main() {
     .replace(`['canary']`, `['${branchName}']`)
     .replace(/[\s]{1,}('test-new-tests-.+',)/g, '')
 
-  buildAndTest = buildAndTest.replace(
-    /(^[ \t]*)# test-new-tests-if\n(^[ \t]*)if:.*\n(^[ \t]*)# test-new-tests-end-if/gm,
-    (_, indent1, indent2, indent3) =>
-      `${indent1}# test-new-tests-if\n${indent2}if: false\n${indent3}# test-new-tests-end-if`
-  )
-
   await fs.promises.writeFile(buildAndTestPath, buildAndTest)
 
   const commitMessage = 'setup release branch'

--- a/scripts/get-changed-tests.mjs
+++ b/scripts/get-changed-tests.mjs
@@ -110,7 +110,7 @@ export function getDeployManifestChangedTests(
 }
 
 /**
- * Detects changed tests files by comparing the current branch with `origin/canary`
+ * Detects changed (see {@link getDiffRevision}) tests files.
  * Returns tests separated by test mode (dev/prod), as well as the corresponding commit hash
  * that the current branch is pointing to
  */
@@ -118,12 +118,7 @@ export default async function getChangedTests() {
   /** @type import('execa').Options */
   const EXECA_OPTS = { shell: true }
 
-  const { branchName, remoteUrl, commitSha, isCanary } = await getGitInfo()
-
-  if (isCanary) {
-    console.log(`Skipping flake detection for canary`)
-    return { devTests: [], prodTests: [], deployTests: [], commitSha }
-  }
+  const { branchName, remoteUrl, commitSha } = await getGitInfo()
 
   const diffRevision = await getDiffRevision()
 
@@ -138,7 +133,6 @@ export default async function getChangedTests() {
     {
       branchName,
       remoteUrl,
-      isCanary,
       commitSha,
     },
     `\ngit diff:\n${changesResult.stderr}\n${changesResult.stdout}`

--- a/scripts/git-info.mjs
+++ b/scripts/git-info.mjs
@@ -7,7 +7,7 @@ const exec = promisify(execOrig)
 
 /**
  * Gets git repository information from the environment
- * @returns {Promise<{branchName: string, remoteUrl: string, commitSha: string, isCanary: boolean}>}
+ * @returns {Promise<{branchName: string, remoteUrl: string, commitSha: string}>}
  */
 export async function getGitInfo() {
   let eventData = {}
@@ -34,10 +34,7 @@ export async function getGitInfo() {
     process.env.GITHUB_SHA ||
     (await exec('git rev-parse HEAD')).stdout.trim()
 
-  const isCanary =
-    branchName === 'canary' && remoteUrl.includes('vercel/next.js')
-
-  return { branchName, remoteUrl, commitSha, isCanary }
+  return { branchName, remoteUrl, commitSha }
 }
 
 /**
@@ -45,19 +42,23 @@ export async function getGitInfo() {
  * @returns {Promise<string>} The git revision to diff against
  */
 export async function getDiffRevision() {
-  if (
-    process.env.GITHUB_ACTIONS === 'true' &&
-    process.env.GITHUB_EVENT_NAME === 'pull_request'
-  ) {
-    // GH Actions for `pull_request` run on the merge commit so HEAD~1:
-    // 1. includes all changes in the PR
-    //    e.g. in
-    //    A-B-C-main - F
-    //     \          /
-    //      D-E-branch
-    //    GH actions for `branch` runs on F, so a diff for HEAD~1 includes the diff of D and E combined
-    // 2. Includes all changes of the commit for pushes
-    return 'HEAD~1'
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    const eventName = process.env.GITHUB_EVENT_NAME
+    switch (eventName) {
+      // GH Actions for `pull_request` run on the merge commit by default so HEAD~1:
+      // 1. includes all changes in the PR
+      //    e.g. in
+      //    A-B-C-main - F
+      //     \          /
+      //      D-E-branch
+      //    GH actions for `branch` runs on F, so a diff for HEAD~1 includes the diff of D and E combined
+      // 2. Includes all changes of the commit for pushes (assuming the push event is from a squash merge)
+      case 'pull_request':
+      case 'push':
+        return 'HEAD~1'
+      default:
+        throw new Error(`Unsupported GITHUB_EVENT_NAME: ${eventName}`)
+    }
   } else {
     try {
       await exec('git remote set-branches --add origin canary')

--- a/scripts/run-for-change.mjs
+++ b/scripts/run-for-change.mjs
@@ -67,7 +67,7 @@ const CHANGE_ITEM_GROUPS = {
 }
 
 async function main() {
-  const { branchName, remoteUrl, isCanary } = await getGitInfo()
+  const { branchName, remoteUrl } = await getGitInfo()
   const diffRevision = await getDiffRevision()
 
   const changesResult = await exec(
@@ -77,7 +77,7 @@ async function main() {
     return { stdout: '' }
   })
 
-  console.error({ branchName, remoteUrl, isCanary, changesResult })
+  console.error({ branchName, remoteUrl, changesResult })
   const changedFilesOutput = changesResult.stdout
 
   const typeIndex = process.argv.indexOf('--type')


### PR DESCRIPTION
The previous detection mechanism special-cased `canary` which lead to large diffs when backport branches ran CI.

We stop special casing `canary` reducing complexity and giving us another flake-detecting attempt when the change is merged. 

That way we can safely enable flake detection on backport branches without having to test large diffs when PRs are merged targetting backport branches. New backport branches will no longer have flake detecton and new deploy test runs disabled.