### PR TITLE
Next.js CSS Docs: fix "alternatives" to "alternative"

### DIFF
--- a/docs/01-app/01-getting-started/11-css.mdx
+++ b/docs/01-app/01-getting-started/11-css.mdx
@@ -3,7 +3,7 @@ title: CSS
 description: Learn about the different ways to add CSS to your application, including Tailwind CSS, CSS Modules, Global CSS, and more.
 related:
   title: Next Steps
-  description: Learn more about the alternatives ways you can use CSS in your application.
+  description: Learn more about the alternative ways you can use CSS in your application.
   links:
     - app/guides/tailwind-v3-css
     - app/guides/sass


### PR DESCRIPTION
…"alternative."

Changed "alternatives" to  "alternative."

### What?

Updated a documentation sentence by changing **“alternatives”** to **“alternative”** so the wording is grammatically correct in context.

### Why?

The original wording incorrectly used the plural form **“alternatives”** when the sentence referred to a single alternative. This change improves readability in the documentation.

### How?

Changed the affected word from **“alternatives”** to **“alternative.”** No functionality or code behavior was modified.

Closes NEXT-
Fixes #

