### PR TITLE
fix: preserve intercepted catch-all route params

### DIFF
--- a/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.test.ts
@@ -1,8 +1,11 @@
 import {
   computeChangedPath,
+  getSelectedParams,
   segmentToSourcePagePathname,
 } from './compute-changed-path'
 import {
+  type DynamicParamTypesShort,
+  type FlightRouterState,
   type Segment,
   PrefetchHint,
 } from '../../../shared/lib/app-router-types'
@@ -85,4 +88,30 @@ describe('computeChangedPath', () => {
       )
     ).toBe('/')
   })
+})
+
+describe('getSelectedParams', () => {
+  const interceptedCatchAllTypes = [
+    'ci(.)',
+    'ci(..)',
+    'ci(..)(..)',
+    'ci(...)',
+  ] satisfies DynamicParamTypesShort[]
+
+  it.each(interceptedCatchAllTypes)(
+    'returns %s params as an array',
+    (paramType) => {
+      const tree: FlightRouterState = [
+        '',
+        {
+          children: [
+            ['slug', 'a/b', paramType, null],
+            { children: ['__PAGE__', {}] },
+          ],
+        },
+      ]
+
+      expect(getSelectedParams(tree)).toEqual({ slug: ['a', 'b'] })
+    }
+  )
 })

--- a/packages/next/src/client/components/router-reducer/compute-changed-path.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.ts
@@ -10,6 +10,7 @@ import {
   PAGE_SEGMENT_KEY,
 } from '../../../shared/lib/segment'
 import { matchSegment } from '../match-segments'
+import { isCatchAllParamType } from '../../route-params'
 
 const removeLeadingSlash = (segment: string): string => {
   return segment[0] === '/' ? segment.slice(1) : segment
@@ -234,11 +235,8 @@ export function getSelectedParams(
     const segmentValue = isDynamicParameter ? segment[1] : segment
     if (!segmentValue || segmentValue.startsWith(PAGE_SEGMENT_KEY)) continue
 
-    // Ensure catchAll and optional catchall are turned into an array
-    const isCatchAll =
-      isDynamicParameter && (segment[2] === 'c' || segment[2] === 'oc')
-
-    if (isCatchAll) {
+    // Ensure catchalls are turned into arrays.
+    if (isDynamicParameter && isCatchAllParamType(segment[2])) {
       params[segment[0]] = segment[1].split('/')
     } else if (isDynamicParameter) {
       params[segment[0]] = segment[1]

--- a/packages/next/src/client/components/router-reducer/compute-changed-path.ts
+++ b/packages/next/src/client/components/router-reducer/compute-changed-path.ts
@@ -10,7 +10,7 @@ import {
   PAGE_SEGMENT_KEY,
 } from '../../../shared/lib/segment'
 import { matchSegment } from '../match-segments'
-import { isCatchAllParamType } from '../../route-params'
+import { getParamValueFromCacheKey } from '../../route-params'
 
 const removeLeadingSlash = (segment: string): string => {
   return segment[0] === '/' ? segment.slice(1) : segment
@@ -235,11 +235,8 @@ export function getSelectedParams(
     const segmentValue = isDynamicParameter ? segment[1] : segment
     if (!segmentValue || segmentValue.startsWith(PAGE_SEGMENT_KEY)) continue
 
-    // Ensure catchalls are turned into arrays.
-    if (isDynamicParameter && isCatchAllParamType(segment[2])) {
-      params[segment[0]] = segment[1].split('/')
-    } else if (isDynamicParameter) {
-      params[segment[0]] = segment[1]
+    if (isDynamicParameter) {
+      params[segment[0]] = getParamValueFromCacheKey(segment[1], segment[2])
     }
 
     params = getSelectedParams(parallelRoute, params)

--- a/packages/next/src/client/route-params.test.ts
+++ b/packages/next/src/client/route-params.test.ts
@@ -1,0 +1,29 @@
+import type { DynamicParamTypesShort } from '../shared/lib/app-router-types'
+import { getParamValueFromCacheKey } from './route-params'
+
+describe('getParamValueFromCacheKey', () => {
+  const catchAllTypes = [
+    'c',
+    'oc',
+    'ci(.)',
+    'ci(..)',
+    'ci(..)(..)',
+    'ci(...)',
+  ] satisfies DynamicParamTypesShort[]
+
+  it.each(catchAllTypes)('returns %s params as an array', (paramType) => {
+    expect(getParamValueFromCacheKey('a/b', paramType)).toEqual(['a', 'b'])
+  })
+
+  const dynamicTypes = [
+    'd',
+    'di(.)',
+    'di(..)',
+    'di(..)(..)',
+    'di(...)',
+  ] satisfies DynamicParamTypesShort[]
+
+  it.each(dynamicTypes)('returns %s params as a string', (paramType) => {
+    expect(getParamValueFromCacheKey('a', paramType)).toBe('a')
+  })
+})

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -246,19 +246,6 @@ export function getParamValueFromCacheKey(
 ) {
   // Turn the cache key string sent by the server (as part of FlightRouterState)
   // into a value that can be passed to `useParams` and client components.
-  if (isCatchAllParamType(paramType)) {
-    // Catch-all param keys are a concatenation of the path segments.
-    // See equivalent logic in `getSelectedParams`.
-    // TODO: We should just pass the array directly, rather than concatenate
-    // it to a string and then split it back to an array. It needs to be an
-    // array in some places, like when passing a key React, but we can convert
-    // it at runtime in those places.
-    return paramCacheKey.split('/')
-  }
-  return paramCacheKey
-}
-
-export function isCatchAllParamType(paramType: DynamicParamTypesShort) {
   switch (paramType) {
     case 'c':
     case 'oc':
@@ -266,16 +253,22 @@ export function isCatchAllParamType(paramType: DynamicParamTypesShort) {
     case 'ci(..)':
     case 'ci(...)':
     case 'ci(..)(..)':
-      return true
+      // Catch-all param keys are a concatenation of the path segments.
+      // See equivalent logic in `getSelectedParams`.
+      // TODO: We should just pass the array directly, rather than concatenate
+      // it to a string and then split it back to an array. It needs to be an
+      // array in some places, like when passing a key React, but we can convert
+      // it at runtime in those places.
+      return paramCacheKey.split('/')
     case 'd':
     case 'di(.)':
     case 'di(..)':
     case 'di(...)':
     case 'di(..)(..)':
-      return false
+      return paramCacheKey
     default:
       paramType satisfies never
-      return false
+      return paramCacheKey
   }
 }
 

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -246,8 +246,7 @@ export function getParamValueFromCacheKey(
 ) {
   // Turn the cache key string sent by the server (as part of FlightRouterState)
   // into a value that can be passed to `useParams` and client components.
-  const isCatchAll = paramType === 'c' || paramType === 'oc'
-  if (isCatchAll) {
+  if (isCatchAllParamType(paramType)) {
     // Catch-all param keys are a concatenation of the path segments.
     // See equivalent logic in `getSelectedParams`.
     // TODO: We should just pass the array directly, rather than concatenate
@@ -257,6 +256,27 @@ export function getParamValueFromCacheKey(
     return paramCacheKey.split('/')
   }
   return paramCacheKey
+}
+
+export function isCatchAllParamType(paramType: DynamicParamTypesShort) {
+  switch (paramType) {
+    case 'c':
+    case 'oc':
+    case 'ci(.)':
+    case 'ci(..)':
+    case 'ci(...)':
+    case 'ci(..)(..)':
+      return true
+    case 'd':
+    case 'di(.)':
+    case 'di(..)':
+    case 'di(...)':
+    case 'di(..)(..)':
+      return false
+    default:
+      paramType satisfies never
+      return false
+  }
 }
 
 export function urlSearchParamsToParsedUrlQuery(

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
@@ -1,4 +1,4 @@
-import { parseDestination } from './prepare-destination'
+import { parseDestination, prepareDestination } from './prepare-destination'
 
 describe('parseDestination', () => {
   it('should parse the destination', () => {
@@ -86,5 +86,123 @@ describe('parseDestination', () => {
        "slashes": true,
      }
     `)
+  })
+})
+
+describe('prepareDestination interception repeating params', () => {
+  it.each(['(.)', '(..)', '(...)', '(..)(..)'])(
+    'should preserve slashes for catchalls adjacent to %s',
+    (marker) => {
+      const { parsedDestination } = prepareDestination({
+        appendParamsToQuery: false,
+        destination: `/photos/${marker}:nxtIslug+`,
+        params: {
+          nxtIslug: ['a', 'b'],
+        },
+        query: {},
+      })
+
+      expect(parsedDestination.pathname).toBe(`/photos/${marker}a/b`)
+    }
+  )
+
+  it.each(['(.)', '(..)', '(...)', '(..)(..)'])(
+    'should preserve suffixes for catchalls adjacent to %s',
+    (marker) => {
+      const { parsedDestination } = prepareDestination({
+        appendParamsToQuery: false,
+        destination: `/photos/${marker}:nxtIslug+.json`,
+        params: {
+          nxtIslug: ['a', 'b'],
+        },
+        query: {},
+      })
+
+      expect(parsedDestination.pathname).toBe(`/photos/${marker}a/b.json`)
+    }
+  )
+
+  it('should leave non-adjacent repeating params unchanged', () => {
+    const { parsedDestination } = prepareDestination({
+      appendParamsToQuery: false,
+      destination: '/photos/(.)album/:nxtPslug+',
+      params: {
+        nxtPslug: ['a', 'b'],
+      },
+      query: {},
+    })
+
+    expect(parsedDestination.pathname).toBe('/photos/(.)album/a/b')
+  })
+
+  it('should leave inline-pattern params unchanged', () => {
+    const { parsedDestination } = prepareDestination({
+      appendParamsToQuery: false,
+      destination: '/photos/(.):slug(.*)',
+      params: {
+        slug: 'a/b',
+      },
+      query: {},
+    })
+
+    expect(parsedDestination.pathname).toBe('/photos/(.)a/b')
+  })
+
+  it('should preserve optional catchall behavior', () => {
+    const withValue = prepareDestination({
+      appendParamsToQuery: false,
+      destination: '/photos/(.):nxtIslug*',
+      params: {
+        nxtIslug: ['a', 'b'],
+      },
+      query: {},
+    })
+    const withoutValue = prepareDestination({
+      appendParamsToQuery: false,
+      destination: '/photos/(.):nxtIslug*',
+      params: {},
+      query: {},
+    })
+
+    expect(withValue.parsedDestination.pathname).toBe('/photos/(.)a/b')
+    expect(withoutValue.parsedDestination.pathname).toBe('/photos/(.)')
+  })
+
+  it('should preserve suffixes for optional catchalls', () => {
+    const withValue = prepareDestination({
+      appendParamsToQuery: false,
+      destination: '/photos/(.):nxtIslug*.json',
+      params: {
+        nxtIslug: ['a', 'b'],
+      },
+      query: {},
+    })
+    const withoutValue = prepareDestination({
+      appendParamsToQuery: false,
+      destination: '/photos/(.):nxtIslug*.json',
+      params: {},
+      query: {},
+    })
+
+    expect(withValue.parsedDestination.pathname).toBe('/photos/(.)a/b.json')
+    expect(withoutValue.parsedDestination.pathname).toBe('/photos/(.).json')
+  })
+
+  it('should only join the marker-adjacent param', () => {
+    const params = {
+      nxtIslug: ['a', 'b'],
+      unrelated: ['x', 'y'],
+    }
+
+    const { parsedDestination } = prepareDestination({
+      appendParamsToQuery: false,
+      destination: '/photos/(.):nxtIslug+?copy=:nxtIslug',
+      params,
+      query: {},
+    })
+
+    expect(parsedDestination.query.copy).toBe('a/b')
+    expect(params.nxtIslug).toEqual(['a', 'b'])
+    expect(params.unrelated).toEqual(['x', 'y'])
   })
 })

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.test.ts
@@ -148,46 +148,6 @@ describe('prepareDestination interception repeating params', () => {
     expect(parsedDestination.pathname).toBe('/photos/(.)a/b')
   })
 
-  it('should preserve optional catchall behavior', () => {
-    const withValue = prepareDestination({
-      appendParamsToQuery: false,
-      destination: '/photos/(.):nxtIslug*',
-      params: {
-        nxtIslug: ['a', 'b'],
-      },
-      query: {},
-    })
-    const withoutValue = prepareDestination({
-      appendParamsToQuery: false,
-      destination: '/photos/(.):nxtIslug*',
-      params: {},
-      query: {},
-    })
-
-    expect(withValue.parsedDestination.pathname).toBe('/photos/(.)a/b')
-    expect(withoutValue.parsedDestination.pathname).toBe('/photos/(.)')
-  })
-
-  it('should preserve suffixes for optional catchalls', () => {
-    const withValue = prepareDestination({
-      appendParamsToQuery: false,
-      destination: '/photos/(.):nxtIslug*.json',
-      params: {
-        nxtIslug: ['a', 'b'],
-      },
-      query: {},
-    })
-    const withoutValue = prepareDestination({
-      appendParamsToQuery: false,
-      destination: '/photos/(.):nxtIslug*.json',
-      params: {},
-      query: {},
-    })
-
-    expect(withValue.parsedDestination.pathname).toBe('/photos/(.)a/b.json')
-    expect(withoutValue.parsedDestination.pathname).toBe('/photos/(.).json')
-  })
-
   it('should only join the marker-adjacent param', () => {
     const params = {
       nxtIslug: ['a', 'b'],
@@ -204,5 +164,19 @@ describe('prepareDestination interception repeating params', () => {
     expect(parsedDestination.query.copy).toBe('a/b')
     expect(params.nxtIslug).toEqual(['a', 'b'])
     expect(params.unrelated).toEqual(['x', 'y'])
+  })
+
+  it('should not append a compiled catchall param to the query', () => {
+    const { parsedDestination } = prepareDestination({
+      appendParamsToQuery: true,
+      destination: '/photos/(.):nxtIslug+',
+      params: {
+        nxtIslug: ['a', 'b'],
+      },
+      query: {},
+    })
+
+    expect(parsedDestination.pathname).toBe('/photos/(.)a/b')
+    expect(parsedDestination.query).not.toHaveProperty('nxtIslug')
   })
 })

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.ts
@@ -231,7 +231,7 @@ export function prepareDestination(args: {
   // The following code assumes that the pathname here includes the hash if it's
   // present.
   let destPath = parsedDestination.pathname
-  let markerAdjacentRepeatingParam: string | undefined
+  let markerAdjacentCatchAllParam: string | undefined
   if (isInterceptionRouteAppPath(destPath)) {
     // path-to-regexp cannot repeat a param that has no prefix or suffix. An
     // intercepted catchall is adjacent to its marker, so compile its captured
@@ -244,11 +244,14 @@ export function prepareDestination(args: {
         )
         if (!marker) return segment
 
-        const param = segment.slice(marker.length).match(/^:(\w+)([+*])(.*)$/)
+        // `+` is the generated form of a required catch-all. Optional
+        // intercepted catch-alls are not supported end-to-end, so leave their
+        // `*` tokens unchanged.
+        const param = segment.slice(marker.length).match(/^:(\w+)\+(.*)$/)
         if (!param) return segment
 
-        markerAdjacentRepeatingParam = param[1]
-        return `${marker}:${param[1]}${param[2] === '*' ? '?' : ''}${param[3]}`
+        markerAdjacentCatchAllParam = param[1]
+        return `${marker}:${param[1]}${param[2]}`
       })
       .join('/')
   }
@@ -258,10 +261,10 @@ export function prepareDestination(args: {
   }
 
   const compileParams = { ...args.params }
-  if (markerAdjacentRepeatingParam) {
-    const value = compileParams[markerAdjacentRepeatingParam]
+  if (markerAdjacentCatchAllParam) {
+    const value = compileParams[markerAdjacentCatchAllParam]
     if (Array.isArray(value)) {
-      compileParams[markerAdjacentRepeatingParam] = value.join('/')
+      compileParams[markerAdjacentCatchAllParam] = value.join('/')
     }
   }
 

--- a/packages/next/src/shared/lib/router/utils/prepare-destination.ts
+++ b/packages/next/src/shared/lib/router/utils/prepare-destination.ts
@@ -231,8 +231,38 @@ export function prepareDestination(args: {
   // The following code assumes that the pathname here includes the hash if it's
   // present.
   let destPath = parsedDestination.pathname
+  let markerAdjacentRepeatingParam: string | undefined
+  if (isInterceptionRouteAppPath(destPath)) {
+    // path-to-regexp cannot repeat a param that has no prefix or suffix. An
+    // intercepted catchall is adjacent to its marker, so compile its captured
+    // segments as one slash-delimited value instead.
+    destPath = destPath
+      .split('/')
+      .map((segment) => {
+        const marker = INTERCEPTION_ROUTE_MARKERS.find((candidate) =>
+          segment.startsWith(candidate)
+        )
+        if (!marker) return segment
+
+        const param = segment.slice(marker.length).match(/^:(\w+)([+*])(.*)$/)
+        if (!param) return segment
+
+        markerAdjacentRepeatingParam = param[1]
+        return `${marker}:${param[1]}${param[2] === '*' ? '?' : ''}${param[3]}`
+      })
+      .join('/')
+  }
+
   if (parsedDestination.hash) {
     destPath = `${destPath}${parsedDestination.hash}`
+  }
+
+  const compileParams = { ...args.params }
+  if (markerAdjacentRepeatingParam) {
+    const value = compileParams[markerAdjacentRepeatingParam]
+    if (Array.isArray(value)) {
+      compileParams[markerAdjacentRepeatingParam] = value.join('/')
+    }
   }
 
   const destParams: (string | number)[] = []
@@ -276,10 +306,13 @@ export function prepareDestination(args: {
     // correctly
     if (Array.isArray(strOrArray)) {
       destQuery[key] = strOrArray.map((value) =>
-        compileNonPath(unescapeSegments(value), args.params)
+        compileNonPath(unescapeSegments(value), compileParams)
       )
     } else if (typeof strOrArray === 'string') {
-      destQuery[key] = compileNonPath(unescapeSegments(strOrArray), args.params)
+      destQuery[key] = compileNonPath(
+        unescapeSegments(strOrArray),
+        compileParams
+      )
     }
   }
 
@@ -311,10 +344,10 @@ export function prepareDestination(args: {
       )
       if (marker) {
         if (marker === '(..)(..)') {
-          args.params['0'] = '(..)'
-          args.params['1'] = '(..)'
+          compileParams['0'] = '(..)'
+          compileParams['1'] = '(..)'
         } else {
-          args.params['0'] = marker
+          compileParams['0'] = marker
         }
         break
       }
@@ -322,16 +355,16 @@ export function prepareDestination(args: {
   }
 
   try {
-    newUrl = destPathCompiler(args.params)
+    newUrl = destPathCompiler(compileParams)
 
     const [pathname, hash] = newUrl.split('#', 2)
     if (destHostnameCompiler) {
-      parsedDestination.hostname = destHostnameCompiler(args.params)
+      parsedDestination.hostname = destHostnameCompiler(compileParams)
     }
     parsedDestination.pathname = pathname
     parsedDestination.hash = `${hash ? '#' : ''}${hash || ''}`
     parsedDestination.search = destSearch
-      ? compileNonPath(destSearch, args.params)
+      ? compileNonPath(destSearch, compileParams)
       : ''
   } catch (err: any) {
     if (err.message.match(/Expected .*? to not repeat, but got an array/)) {

--- a/packages/next/src/shared/lib/router/utils/route-regex.test.ts
+++ b/packages/next/src/shared/lib/router/utils/route-regex.test.ts
@@ -1,4 +1,4 @@
-import { getNamedRouteRegex } from './route-regex'
+import { getNamedRouteRegex, getRouteRegex } from './route-regex'
 import { parseParameter } from './get-dynamic-param'
 import { pathToRegexp } from 'next/dist/compiled/path-to-regexp'
 
@@ -852,6 +852,58 @@ describe('getNamedRouteRegex - Edge Cases', () => {
     expect(regex.re.test('/photos/(.)images/a')).toBe(true)
     expect(regex.re.test('/photos/(.)images/a/b/c')).toBe(true)
   })
+
+  it.each(['(.)', '(..)', '(...)', '(..)(..)'])(
+    'should match multi-segment catchalls adjacent to %s',
+    (marker) => {
+      // getParametrizedRoute previously ignored `repeat` in this branch.
+      const regex = getRouteRegex(`/photos/${marker}[...slug]`)
+      const namedRouteRegex = getNamedRouteRegex(`/photos/${marker}[...slug]`, {
+        prefixRouteKeys: true,
+      })
+      const namedRegex = new RegExp(namedRouteRegex.namedRegex)
+
+      expect(regex.groups.slug).toEqual({
+        pos: 1,
+        repeat: true,
+        optional: false,
+      })
+      expect(regex.re.test(`/photos/${marker}a`)).toBe(true)
+      expect(regex.re.test(`/photos/${marker}a/b/c`)).toBe(true)
+      expect(regex.re.exec(`/photos/${marker}a/b/c`)?.[1]).toBe('a/b/c')
+      expect(regex.re.test(`/photos/${marker}/`)).toBe(false)
+      expect(namedRegex.test(`/photos/${marker}a/b/c`)).toBe(true)
+      expect(namedRegex.exec(`/photos/${marker}a/b/c`)?.groups?.nxtIslug).toBe(
+        'a/b/c'
+      )
+      expect(namedRegex.test(`/photos/${marker}/`)).toBe(false)
+      expect(namedRouteRegex.pathToRegexpPattern).toBe(
+        `/photos/${marker}:nxtIslug+`
+      )
+    }
+  )
+
+  it.each(['(.)', '(..)', '(...)', '(..)(..)'])(
+    'should keep %s required while allowing an optional catchall value',
+    (marker) => {
+      const regex = getRouteRegex(`/photos/${marker}[[...slug]]`)
+      const namedRouteRegex = getNamedRouteRegex(
+        `/photos/${marker}[[...slug]]`,
+        { prefixRouteKeys: true }
+      )
+      const namedRegex = new RegExp(namedRouteRegex.namedRegex)
+
+      for (const matcher of [regex.re, namedRegex]) {
+        expect(matcher.test('/photos')).toBe(false)
+        expect(matcher.test(`/photos/${marker}`)).toBe(true)
+        expect(matcher.test(`/photos/${marker}/`)).toBe(true)
+        expect(matcher.test(`/photos/${marker}a/b`)).toBe(true)
+      }
+      expect(namedRouteRegex.pathToRegexpPattern).toBe(
+        `/photos/${marker}:nxtIslug*`
+      )
+    }
+  )
 
   it('should handle dynamic segment with interception marker prefix', () => {
     // Interception marker can be adjacent to dynamic segment

--- a/packages/next/src/shared/lib/router/utils/route-regex.test.ts
+++ b/packages/next/src/shared/lib/router/utils/route-regex.test.ts
@@ -883,28 +883,6 @@ describe('getNamedRouteRegex - Edge Cases', () => {
     }
   )
 
-  it.each(['(.)', '(..)', '(...)', '(..)(..)'])(
-    'should keep %s required while allowing an optional catchall value',
-    (marker) => {
-      const regex = getRouteRegex(`/photos/${marker}[[...slug]]`)
-      const namedRouteRegex = getNamedRouteRegex(
-        `/photos/${marker}[[...slug]]`,
-        { prefixRouteKeys: true }
-      )
-      const namedRegex = new RegExp(namedRouteRegex.namedRegex)
-
-      for (const matcher of [regex.re, namedRegex]) {
-        expect(matcher.test('/photos')).toBe(false)
-        expect(matcher.test(`/photos/${marker}`)).toBe(true)
-        expect(matcher.test(`/photos/${marker}/`)).toBe(true)
-        expect(matcher.test(`/photos/${marker}a/b`)).toBe(true)
-      }
-      expect(namedRouteRegex.pathToRegexpPattern).toBe(
-        `/photos/${marker}:nxtIslug*`
-      )
-    }
-  )
-
   it('should handle dynamic segment with interception marker prefix', () => {
     // Interception marker can be adjacent to dynamic segment
     const regex = getNamedRouteRegex('/photos/(.)[id]', {

--- a/packages/next/src/shared/lib/router/utils/route-regex.ts
+++ b/packages/next/src/shared/lib/router/utils/route-regex.ts
@@ -7,6 +7,8 @@ import { escapeStringRegexp } from '../../escape-regexp'
 import { removeTrailingSlash } from './remove-trailing-slash'
 import { PARAMETER_PATTERN, parseMatchedParameter } from './get-dynamic-param'
 
+const INTERCEPTED_REPEAT_PARAM_PATTERN = '[^/]+?(?:/[^/]+?)*?'
+
 export interface Group {
   pos: number
   repeat: boolean
@@ -108,7 +110,18 @@ function getParametrizedRoute(
     if (markerMatch && paramMatches && paramMatches[2]) {
       const { key, optional, repeat } = parseMatchedParameter(paramMatches[2])
       groups[key] = { pos: groupIndex++, repeat, optional }
-      segments.push(`/${escapeStringRegexp(markerMatch)}([^/]+?)`)
+      // Must honor `repeat` here. Hardcoding `([^/]+?)` makes
+      // routes like `/(.)[...slug]` fail to match multi-segment paths.
+      // Each repeated segment must remain non-empty so that the route's
+      // optional trailing slash cannot satisfy a required catch-all.
+      const paramPattern = repeat
+        ? `(${INTERCEPTED_REPEAT_PARAM_PATTERN})`
+        : '([^/]+?)'
+      segments.push(
+        `/${escapeStringRegexp(markerMatch)}${
+          optional && repeat ? `(?:${paramPattern})?` : paramPattern
+        }`
+      )
     } else if (paramMatches && paramMatches[2]) {
       const { key, repeat, optional } = parseMatchedParameter(paramMatches[2])
       groups[key] = { pos: groupIndex++, repeat, optional }
@@ -249,16 +262,21 @@ function getSafeKeyFromSegment({
     // in each of the placeholders.
     pattern = `\\k<${cleanedKey}>`
   } else if (repeat) {
-    pattern = `(?<${cleanedKey}>.+?)`
+    pattern = `(?<${cleanedKey}>${
+      interceptionMarker ? INTERCEPTED_REPEAT_PARAM_PATTERN : '.+?'
+    })`
   } else {
     pattern = `(?<${cleanedKey}>[^/]+?)`
   }
 
   return {
     key,
-    pattern: optional
-      ? `(?:/${interceptionPrefix}${pattern})?`
-      : `/${interceptionPrefix}${pattern}`,
+    pattern:
+      optional && repeat && interceptionMarker
+        ? `/${interceptionPrefix}(?:${pattern})?`
+        : optional
+          ? `(?:/${interceptionPrefix}${pattern})?`
+          : `/${interceptionPrefix}${pattern}`,
     cleanedKey: cleanedKey,
     optional,
     repeat,

--- a/packages/next/src/shared/lib/router/utils/route-regex.ts
+++ b/packages/next/src/shared/lib/router/utils/route-regex.ts
@@ -114,14 +114,13 @@ function getParametrizedRoute(
       // routes like `/(.)[...slug]` fail to match multi-segment paths.
       // Each repeated segment must remain non-empty so that the route's
       // optional trailing slash cannot satisfy a required catch-all.
-      const paramPattern = repeat
-        ? `(${INTERCEPTED_REPEAT_PARAM_PATTERN})`
-        : '([^/]+?)'
-      segments.push(
-        `/${escapeStringRegexp(markerMatch)}${
-          optional && repeat ? `(?:${paramPattern})?` : paramPattern
-        }`
-      )
+      // Optional intercepted catch-alls do not have a marker-aware dynamic
+      // param type, so keep their existing behavior unchanged.
+      const paramPattern =
+        repeat && !optional
+          ? `(${INTERCEPTED_REPEAT_PARAM_PATTERN})`
+          : '([^/]+?)'
+      segments.push(`/${escapeStringRegexp(markerMatch)}${paramPattern}`)
     } else if (paramMatches && paramMatches[2]) {
       const { key, repeat, optional } = parseMatchedParameter(paramMatches[2])
       groups[key] = { pos: groupIndex++, repeat, optional }
@@ -262,8 +261,10 @@ function getSafeKeyFromSegment({
     // in each of the placeholders.
     pattern = `\\k<${cleanedKey}>`
   } else if (repeat) {
+    // Optional intercepted catch-alls do not have a marker-aware dynamic
+    // param type, so only required catch-alls use the marker-aware pattern.
     pattern = `(?<${cleanedKey}>${
-      interceptionMarker ? INTERCEPTED_REPEAT_PARAM_PATTERN : '.+?'
+      interceptionMarker && !optional ? INTERCEPTED_REPEAT_PARAM_PATTERN : '.+?'
     })`
   } else {
     pattern = `(?<${cleanedKey}>[^/]+?)`
@@ -271,12 +272,9 @@ function getSafeKeyFromSegment({
 
   return {
     key,
-    pattern:
-      optional && repeat && interceptionMarker
-        ? `/${interceptionPrefix}(?:${pattern})?`
-        : optional
-          ? `(?:/${interceptionPrefix}${pattern})?`
-          : `/${interceptionPrefix}${pattern}`,
+    pattern: optional
+      ? `(?:/${interceptionPrefix}${pattern})?`
+      : `/${interceptionPrefix}${pattern}`,
     cleanedKey: cleanedKey,
     optional,
     repeat,

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/layout.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/page.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/page.tsx
@@ -1,0 +1,5 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return <Link href="/photos">photos</Link>
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/photos/@modal/(.)[...slug]/page.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/photos/@modal/(.)[...slug]/page.tsx
@@ -1,0 +1,15 @@
+import { ClientParams } from './params'
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>
+}) {
+  const { slug } = await params
+  return (
+    <>
+      <pre id="server-params">{JSON.stringify(slug)}</pre>
+      <ClientParams />
+    </>
+  )
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/photos/@modal/(.)[...slug]/page.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/photos/@modal/(.)[...slug]/page.tsx
@@ -1,15 +1,24 @@
+import { Suspense } from 'react'
 import { ClientParams } from './params'
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ slug: string[] }>
-}) {
+async function Params({ params }: { params: Promise<{ slug: string[] }> }) {
   const { slug } = await params
   return (
     <>
       <pre id="server-params">{JSON.stringify(slug)}</pre>
       <ClientParams />
     </>
+  )
+}
+
+export default function Page({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>
+}) {
+  return (
+    <Suspense fallback={null}>
+      <Params params={params} />
+    </Suspense>
   )
 }

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/photos/@modal/(.)[...slug]/params.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/photos/@modal/(.)[...slug]/params.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+
+export function ClientParams() {
+  const { slug } = useParams<{ slug: string[] }>()
+  return <pre id="client-params">{JSON.stringify(slug)}</pre>
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/photos/@modal/default.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/photos/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/photos/[...slug]/page.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/photos/[...slug]/page.tsx
@@ -1,8 +1,18 @@
-export default async function Page({
+import { Suspense } from 'react'
+
+async function Params({ params }: { params: Promise<{ slug: string[] }> }) {
+  const { slug } = await params
+  return <pre id="page">{JSON.stringify(slug)}</pre>
+}
+
+export default function Page({
   params,
 }: {
   params: Promise<{ slug: string[] }>
 }) {
-  const { slug } = await params
-  return <pre id="page">{JSON.stringify(slug)}</pre>
+  return (
+    <Suspense fallback={null}>
+      <Params params={params} />
+    </Suspense>
+  )
 }

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/photos/[...slug]/page.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/photos/[...slug]/page.tsx
@@ -1,0 +1,8 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>
+}) {
+  const { slug } = await params
+  return <pre id="page">{JSON.stringify(slug)}</pre>
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/photos/layout.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/photos/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode
+  modal: React.ReactNode
+}) {
+  return (
+    <>
+      <div id="children">{children}</div>
+      <div id="modal">{modal}</div>
+    </>
+  )
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/app/photos/page.tsx
+++ b/test/e2e/app-dir/intercept-catchall-route-params/app/photos/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <Link href="/photos/a/b">multi</Link>
+      <Link href="/photos/only">single</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/intercept-catchall-route-params/intercept-catchall-route-params.test.ts
+++ b/test/e2e/app-dir/intercept-catchall-route-params/intercept-catchall-route-params.test.ts
@@ -1,0 +1,35 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('intercept-catchall-route-params', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it.each([
+    ['/photos/a/b', ['a', 'b']],
+    ['/photos/only', ['only']],
+  ])(
+    'keeps %s params as an array when intercepting',
+    async (href, expected) => {
+      const browser = await next.browser('/photos')
+      await browser.elementByCss(`a[href="${href}"]`).click()
+
+      const serverParams = await browser
+        .waitForElementByCss('#server-params')
+        .text()
+      const clientParams = await browser
+        .waitForElementByCss('#client-params')
+        .text()
+
+      expect(JSON.parse(serverParams)).toEqual(expected)
+      expect(JSON.parse(clientParams)).toEqual(expected)
+    }
+  )
+
+  it('does not intercept a hard navigation', async () => {
+    const browser = await next.browser('/photos/a/b')
+    const params = await browser.waitForElementByCss('#page').text()
+
+    expect(JSON.parse(params)).toEqual(['a', 'b'])
+  })
+})


### PR DESCRIPTION
### What?

Fixes intercepted required catch-all routes such as `@modal/(.)[...slug]`, ensuring catch-all params remain arrays across server matching, destination compilation, and client-side param reconstruction.

### Why?

PR #64805 sanitized dynamic parameter names before checking whether they were catch-all parameters. This removed the repeat marker from intercepted catch-all routes and generated an invalid `path-to-regexp` destination, causing soft navigations to fail and fall back to hard navigations.

### How?

- Preserve non-empty slash-delimited repeat semantics for marker-adjacent required catch-all params in named and unnamed route regexes.
- Normalize generated intercepted catch-all destination values using a shallow copy so compilation succeeds without mutating caller-owned params.
- Restore all existing intercepted catch-all dynamic-param types as arrays in both client reconstruction paths.
- Add unit coverage for all interception markers, destination suffixes, query handling, immutability, and client param restoration.
- Add end-to-end coverage for single- and multi-segment soft navigation, server and client params, and hard-navigation fallback.

Optional intercepted catch-all routes are intentionally unchanged because supporting them requires a separate Flight parameter-type contract.

Fixes #97910

