### PR TITLE
Prevent DNS rebinding in image optimizer requests

### DIFF
--- a/packages/next/next-runtime.webpack-config.js
+++ b/packages/next/next-runtime.webpack-config.js
@@ -66,6 +66,7 @@ const sharedExternals = [
   'next/dist/compiled/edge-runtime',
   'next/dist/compiled/@edge-runtime/ponyfill',
   'next/dist/compiled/undici',
+  'undici',
   'next/dist/compiled/raw-body',
   'next/dist/server/capsize-font-metrics.json',
   'critters',

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -105,7 +105,8 @@
     "baseline-browser-mapping": "^2.9.19",
     "caniuse-lite": "^1.0.30001579",
     "postcss": "8.5.23",
-    "styled-jsx": "5.1.6"
+    "styled-jsx": "5.1.6",
+    "undici": "6.24.1"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.1.0",

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -35,6 +35,7 @@ import { InvariantError } from '../shared/lib/invariant-error'
 import { lookup } from 'dns/promises'
 import { isIP } from 'net'
 import { ALL } from 'dns'
+import { Agent, fetch as undiciFetch } from 'undici'
 
 type XCacheHeader = 'MISS' | 'HIT' | 'STALE'
 
@@ -862,24 +863,97 @@ function isRedirect(statusCode: number) {
   return [301, 302, 303, 307, 308].includes(statusCode)
 }
 
+type ResolvedAddress = {
+  address: string
+  family: number
+}
+
+function createPinnedDispatcher(
+  hostname: string,
+  addresses: ResolvedAddress[]
+) {
+  return new Agent({
+    autoSelectFamily: true,
+    connect: {
+      lookup: (lookupHostname, options, callback) => {
+        if (lookupHostname !== hostname) {
+          const error = new Error(
+            `Unexpected hostname during image fetch: ${lookupHostname}`
+          ) as NodeJS.ErrnoException
+          error.code = 'ENOTFOUND'
+          callback(error, '', 0)
+          return
+        }
+
+        const matchingAddresses =
+          options.family === 4 || options.family === 6
+            ? addresses.filter((record) => record.family === options.family)
+            : addresses
+
+        if (matchingAddresses.length === 0) {
+          const error = new Error(
+            `No validated address for image hostname: ${hostname}`
+          ) as NodeJS.ErrnoException
+          error.code = 'ENOTFOUND'
+          callback(error, '', 0)
+          return
+        }
+
+        if (options.all) {
+          callback(null, matchingAddresses)
+          return
+        }
+
+        const record = matchingAddresses[0]
+        callback(null, record.address, record.family)
+      },
+    },
+  })
+}
+
 export async function fetchExternalImage(
   href: string,
   dangerouslyAllowLocalIP: boolean,
   maximumResponseBody: number,
   count = 3
 ): Promise<ImageUpstream> {
+  const parsedUrl = new URL(href)
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    throw new ImageError(
+      400,
+      '"url" parameter is valid but upstream response is invalid'
+    )
+  }
+
+  let dispatcher: Agent | undefined
+  let cancelResponseBody: (() => Promise<void>) | undefined
+
   if (!dangerouslyAllowLocalIP) {
-    const { hostname } = new URL(href)
-    let ips = [hostname]
-    if (!isIP(hostname)) {
-      const records = await lookup(hostname, {
-        family: 0,
-        all: true,
-        hints: ALL,
-      }).catch((_) => [{ address: hostname }])
-      ips = records.map((record) => record.address)
+    const hostname = parsedUrl.hostname.replace(/^\[|\]$/g, '')
+    const addressFamily = isIP(hostname)
+    let records: ResolvedAddress[]
+
+    if (addressFamily) {
+      records = [{ address: hostname, family: addressFamily }]
+    } else {
+      try {
+        records = await lookup(hostname, {
+          family: 0,
+          all: true,
+          hints: ALL,
+        })
+      } catch {
+        throw new ImageError(400, '"url" parameter is not allowed')
+      }
     }
-    const privateIps = ips.filter((ip) => isPrivateIp(ip))
+
+    if (records.length === 0) {
+      throw new ImageError(400, '"url" parameter is not allowed')
+    }
+
+    const privateIps = records
+      .map((record) => record.address)
+      .filter((ip) => isPrivateIp(ip))
     if (privateIps.length > 0) {
       Log.error(
         'upstream image',
@@ -890,87 +964,110 @@ export async function fetchExternalImage(
       )
       throw new ImageError(400, '"url" parameter is not allowed')
     }
-  }
-  const res = await fetch(href, {
-    signal: AbortSignal.timeout(7_000),
-    redirect: 'manual',
-  }).catch((err) => err as Error)
 
-  if (res instanceof Error) {
-    const err = res as Error
-    if (err.name === 'TimeoutError') {
-      Log.error('upstream image response timed out for', href)
-      throw new ImageError(
-        504,
-        '"url" parameter is valid but upstream response timed out'
+    if (!addressFamily) {
+      dispatcher = createPinnedDispatcher(hostname, records)
+    }
+  }
+
+  try {
+    const signal = AbortSignal.timeout(7_000)
+    const res = await (
+      dispatcher
+        ? undiciFetch(href, {
+            signal,
+            redirect: 'manual',
+            dispatcher,
+          })
+        : fetch(href, {
+            signal,
+            redirect: 'manual',
+          })
+    ).catch((err) => err as Error)
+
+    if (res instanceof Error) {
+      const err = res as Error
+      if (err.name === 'TimeoutError') {
+        Log.error('upstream image response timed out for', href)
+        throw new ImageError(
+          504,
+          '"url" parameter is valid but upstream response timed out'
+        )
+      }
+      throw err
+    }
+
+    const responseBody = res.body
+    cancelResponseBody = () => responseBody?.cancel() ?? Promise.resolve()
+
+    const locationHeader = res.headers.get('Location')
+    if (
+      isRedirect(res.status) &&
+      locationHeader &&
+      URL.canParse(locationHeader, href)
+    ) {
+      if (count === 0) {
+        Log.error('upstream image response had too many redirects', href)
+        throw new ImageError(
+          508,
+          '"url" parameter is valid but upstream response is invalid'
+        )
+      }
+      await res.body?.cancel()
+      const redirect = new URL(locationHeader, href).href
+      return fetchExternalImage(
+        redirect,
+        dangerouslyAllowLocalIP,
+        maximumResponseBody,
+        count - 1
       )
     }
-    throw err
-  }
 
-  const locationHeader = res.headers.get('Location')
-  if (
-    isRedirect(res.status) &&
-    locationHeader &&
-    URL.canParse(locationHeader, href)
-  ) {
-    if (count === 0) {
-      Log.error('upstream image response had too many redirects', href)
+    if (!res.ok) {
+      Log.error('upstream image response failed for', href, res.status)
       throw new ImageError(
-        508,
+        res.status,
         '"url" parameter is valid but upstream response is invalid'
       )
     }
-    const redirect = new URL(locationHeader, href).href
-    return fetchExternalImage(
-      redirect,
-      dangerouslyAllowLocalIP,
-      maximumResponseBody,
-      count - 1
-    )
-  }
 
-  if (!res.ok) {
-    Log.error('upstream image response failed for', href, res.status)
-    throw new ImageError(
-      res.status,
-      '"url" parameter is valid but upstream response is invalid'
-    )
-  }
-
-  if (!res.body) {
-    Log.error('upstream image response is empty for', href)
-    throw new ImageError(
-      400,
-      '"url" parameter is valid but upstream response is invalid'
-    )
-  }
-
-  const chunks: Buffer[] = []
-  let totalSize = 0
-
-  for await (const c of res.body) {
-    const chunk = Buffer.from(c)
-    totalSize += chunk.byteLength
-    if (totalSize > maximumResponseBody) {
-      Log.error(
-        'upstream image response exceeded maximum size for',
-        href,
-        totalSize
-      )
+    if (!res.body) {
+      Log.error('upstream image response is empty for', href)
       throw new ImageError(
-        413,
+        400,
         '"url" parameter is valid but upstream response is invalid'
       )
     }
-    chunks.push(chunk)
-  }
 
-  const buffer = Buffer.concat(chunks)
-  const contentType = res.headers.get('Content-Type')
-  const cacheControl = res.headers.get('Cache-Control')
-  const etag = extractEtag(res.headers.get('ETag'), buffer)
-  return { buffer, contentType, cacheControl, etag }
+    const chunks: Buffer[] = []
+    let totalSize = 0
+
+    for await (const c of res.body) {
+      const chunk = Buffer.from(c)
+      totalSize += chunk.byteLength
+      if (totalSize > maximumResponseBody) {
+        Log.error(
+          'upstream image response exceeded maximum size for',
+          href,
+          totalSize
+        )
+        throw new ImageError(
+          413,
+          '"url" parameter is valid but upstream response is invalid'
+        )
+      }
+      chunks.push(chunk)
+    }
+
+    const buffer = Buffer.concat(chunks)
+    const contentType = res.headers.get('Content-Type')
+    const cacheControl = res.headers.get('Cache-Control')
+    const etag = extractEtag(res.headers.get('ETag'), buffer)
+    return { buffer, contentType, cacheControl, etag }
+  } finally {
+    await cancelResponseBody?.().catch(() => {})
+    await dispatcher?.close()
+  }
 }
 
 export async function fetchInternalImage(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1133,6 +1133,9 @@ importers:
       styled-jsx:
         specifier: 5.1.6
         version: 5.1.6(@babel/core@7.26.10)(babel-plugin-macros@3.1.0)(react@19.3.0-canary-f789f203-20260825)
+      undici:
+        specifier: 6.24.1
+        version: 6.24.1
     devDependencies:
       '@babel/core':
         specifier: 7.26.10

--- a/test/unit/image-optimizer/fetch-external-image.test.ts
+++ b/test/unit/image-optimizer/fetch-external-image.test.ts
@@ -3,8 +3,39 @@ import {
   fetchExternalImage,
   ImageError,
 } from 'next/dist/server/image-optimizer'
+import { lookup } from 'dns/promises'
+import { fetch as undiciFetch, Response as UndiciResponse } from 'undici'
+
+jest.mock('dns/promises', () => ({
+  lookup: jest.fn(),
+}))
+jest.mock('undici', () => ({
+  ...jest.requireActual('undici'),
+  fetch: jest.fn(),
+}))
+
+const lookupMock = lookup as jest.MockedFunction<typeof lookup>
+const undiciFetchMock = undiciFetch as jest.MockedFunction<typeof undiciFetch>
+
+function createImageResponse() {
+  return new UndiciResponse(new Uint8Array([1, 2, 3]), {
+    status: 200,
+    headers: {
+      'Content-Type': 'image/jpeg',
+    },
+  })
+}
 
 describe('fetchExternalImage', () => {
+  beforeEach(() => {
+    undiciFetchMock.mockReset()
+    lookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }])
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('private IP / SSRF guard', () => {
     it('should reject a literal private IP hostname with a generic error message', async () => {
       const fetchMock = jest.fn()
@@ -25,22 +56,7 @@ describe('fetchExternalImage', () => {
     })
 
     it('should allow a literal private IP when dangerouslyAllowLocalIP is true', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        body: new ReadableStream({
-          start(controller) {
-            controller.enqueue(new Uint8Array([1, 2, 3]))
-            controller.close()
-          },
-        }),
-        headers: {
-          get: jest.fn((header: string) => {
-            if (header === 'Content-Type') return 'image/jpeg'
-            return null
-          }),
-        },
-      })
+      global.fetch = jest.fn().mockResolvedValue(createImageResponse())
 
       const result = await fetchExternalImage(
         'http://192.168.0.1/private.jpg',
@@ -50,19 +66,115 @@ describe('fetchExternalImage', () => {
 
       expect(result.buffer).toBeInstanceOf(Buffer)
       expect(global.fetch).toHaveBeenCalled()
+      expect(lookupMock).not.toHaveBeenCalled()
+      expect(jest.mocked(global.fetch).mock.calls[0][1]).not.toHaveProperty(
+        'dispatcher'
+      )
+    })
+
+    it('should pin a public hostname to the validated DNS result', async () => {
+      undiciFetchMock.mockResolvedValue(createImageResponse())
+      const globalFetchMock = jest.fn()
+      global.fetch = globalFetchMock
+
+      await fetchExternalImage(
+        'http://example.com/public.jpg',
+        false,
+        50_000_000
+      )
+
+      expect(lookupMock).toHaveBeenCalledTimes(1)
+      expect(lookupMock).toHaveBeenCalledWith('example.com', {
+        family: 0,
+        all: true,
+        hints: expect.any(Number),
+      })
+      expect(undiciFetchMock.mock.calls[0][1]).toHaveProperty('dispatcher')
+      expect(globalFetchMock).not.toHaveBeenCalled()
+    })
+
+    it('should fail closed when DNS resolution fails', async () => {
+      lookupMock.mockRejectedValueOnce(new Error('DNS unavailable'))
+      const fetchMock = undiciFetchMock
+
+      const error = await fetchExternalImage(
+        'http://example.com/private.jpg',
+        false,
+        50_000_000
+      ).catch((e) => e)
+
+      expect(error).toBeInstanceOf(ImageError)
+      expect((error as ImageError).statusCode).toBe(400)
+      expect((error as ImageError).message).toBe(
+        '"url" parameter is not allowed'
+      )
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('should fail closed when DNS returns no addresses', async () => {
+      lookupMock.mockResolvedValueOnce([])
+      const fetchMock = undiciFetchMock
+
+      const error = await fetchExternalImage(
+        'http://example.com/private.jpg',
+        false,
+        50_000_000
+      ).catch((e) => e)
+
+      expect(error).toBeInstanceOf(ImageError)
+      expect((error as ImageError).statusCode).toBe(400)
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('should reject the whole DNS result when any address is private', async () => {
+      lookupMock.mockResolvedValueOnce([
+        { address: '93.184.216.34', family: 4 },
+        { address: '127.0.0.1', family: 4 },
+      ])
+      const fetchMock = undiciFetchMock
+
+      const error = await fetchExternalImage(
+        'http://example.com/private.jpg',
+        false,
+        50_000_000
+      ).catch((e) => e)
+
+      expect(error).toBeInstanceOf(ImageError)
+      expect((error as ImageError).statusCode).toBe(400)
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('should resolve and validate each redirect destination independently', async () => {
+      lookupMock
+        .mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
+        .mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }])
+      undiciFetchMock.mockResolvedValueOnce(
+        new UndiciResponse(null, {
+          status: 302,
+          headers: { Location: 'http://private.example/image.jpg' },
+        })
+      )
+
+      const error = await fetchExternalImage(
+        'http://public.example/image.jpg',
+        false,
+        50_000_000
+      ).catch((e) => e)
+
+      expect(error).toBeInstanceOf(ImageError)
+      expect((error as ImageError).statusCode).toBe(400)
+      expect(lookupMock).toHaveBeenCalledTimes(2)
+      expect(undiciFetchMock).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('response size limit', () => {
     it('should throw error when response has no body', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        body: null,
-        headers: {
-          get: jest.fn(() => null),
-        },
-      })
+      undiciFetchMock.mockResolvedValue(
+        new UndiciResponse(null, {
+          status: 200,
+        })
+      )
 
       const error = await fetchExternalImage(
         'http://example.com/no-body.jpg',
@@ -82,7 +194,7 @@ describe('fetchExternalImage', () => {
       const chunkSize = 1_000 // 1KB chunks
       const numChunks = 3 // 3KB total, exceeds custom 2KB limit
 
-      global.fetch = jest.fn().mockImplementation(() => {
+      undiciFetchMock.mockImplementation(() => {
         let chunksRead = 0
         const mockReadableStream = new ReadableStream({
           async pull(controller) {
@@ -95,17 +207,14 @@ describe('fetchExternalImage', () => {
           },
         })
 
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          body: mockReadableStream,
-          headers: {
-            get: jest.fn((header: string) => {
-              if (header === 'Content-Type') return 'image/jpeg'
-              return null
-            }),
-          },
-        })
+        return Promise.resolve(
+          new UndiciResponse(mockReadableStream, {
+            status: 200,
+            headers: {
+              'Content-Type': 'image/jpeg',
+            },
+          })
+        )
       })
 
       const error = await fetchExternalImage(
@@ -124,7 +233,7 @@ describe('fetchExternalImage', () => {
     it('should throw error when exceeding maximumResponseBody config on first chunk', async () => {
       const maximumResponseBody = 2_000 // 2KB custom limit
 
-      global.fetch = jest.fn().mockImplementation(() => {
+      undiciFetchMock.mockImplementation(() => {
         const mockReadableStream = new ReadableStream({
           async pull(controller) {
             controller.enqueue(new Uint8Array(maximumResponseBody + 1))
@@ -132,17 +241,14 @@ describe('fetchExternalImage', () => {
           },
         })
 
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          body: mockReadableStream,
-          headers: {
-            get: jest.fn((header: string) => {
-              if (header === 'Content-Type') return 'image/jpeg'
-              return null
-            }),
-          },
-        })
+        return Promise.resolve(
+          new UndiciResponse(mockReadableStream, {
+            status: 200,
+            headers: {
+              'Content-Type': 'image/jpeg',
+            },
+          })
+        )
       })
 
       const error = await fetchExternalImage(
@@ -161,7 +267,7 @@ describe('fetchExternalImage', () => {
     it('should succeed when exactly matching maximumResponseBody config on first chunk', async () => {
       const maximumResponseBody = 3_000 // 3KB custom limit
 
-      global.fetch = jest.fn().mockImplementation(() => {
+      undiciFetchMock.mockImplementation(() => {
         const mockReadableStream = new ReadableStream({
           async pull(controller) {
             controller.enqueue(new Uint8Array(maximumResponseBody))
@@ -169,17 +275,14 @@ describe('fetchExternalImage', () => {
           },
         })
 
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          body: mockReadableStream,
-          headers: {
-            get: jest.fn((header: string) => {
-              if (header === 'Content-Type') return 'image/jpeg'
-              return null
-            }),
-          },
-        })
+        return Promise.resolve(
+          new UndiciResponse(mockReadableStream, {
+            status: 200,
+            headers: {
+              'Content-Type': 'image/jpeg',
+            },
+          })
+        )
       })
 
       const result = await fetchExternalImage(
@@ -197,7 +300,7 @@ describe('fetchExternalImage', () => {
       const chunkSize = 1_000 // 1KB chunks
       const numChunks = 3 // 3KB total
 
-      global.fetch = jest.fn().mockImplementation(() => {
+      undiciFetchMock.mockImplementation(() => {
         let chunksRead = 0
         const mockReadableStream = new ReadableStream({
           async pull(controller) {
@@ -210,17 +313,14 @@ describe('fetchExternalImage', () => {
           },
         })
 
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          body: mockReadableStream,
-          headers: {
-            get: jest.fn((header: string) => {
-              if (header === 'Content-Type') return 'image/jpeg'
-              return null
-            }),
-          },
-        })
+        return Promise.resolve(
+          new UndiciResponse(mockReadableStream, {
+            status: 200,
+            headers: {
+              'Content-Type': 'image/jpeg',
+            },
+          })
+        )
       })
 
       const result = await fetchExternalImage(


### PR DESCRIPTION
## What?

Prevents DNS rebinding during remote image optimization.

## Why?

The image optimizer validated resolved addresses, but the subsequent request could perform another DNS lookup and connect to a private address.

## How?

- Resolve and validate the hostname once per request and redirect.
- Reject failed, empty, or private DNS results.
- Pin the outbound connection to the validated addresses.
- Preserve the original hostname for HTTP Host and TLS SNI.
- Keep `dangerouslyAllowLocalIP` as the explicit opt-out.

## Testing

- Image optimizer unit tests: 12/12 passed
- Type generation passed
- Next.js release build passed
- DNS-rebinding and loopback tests passed
- Public HTTPS image fetching still works
- `git diff --check` passed