### PR TITLE
test: re-enable sync IO root coverage

### DIFF
--- a/test/production/app-dir/sync-io-blocks-root/sync-io-blocks-root.test.ts
+++ b/test/production/app-dir/sync-io-blocks-root/sync-io-blocks-root.test.ts
@@ -1,8 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(lubieowoce): reenable when the cause of flakiness is found and fixed
-// (seems to have increased sharply around 2026-08-24/25)
-describe.skip('sync IO that blocks the root', () => {
+describe('sync IO that blocks the root', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,


### PR DESCRIPTION
## Summary

Re-enable the `sync-io-blocks-root` production suite now that #97900 waits for child stdio to close before capturing build CLI output.

This reverts the temporary skip from #97986 so CI flake detection exercises the route-specific sync I/O diagnostics again.

## Verification

- `HEADLESS=true IS_WEBPACK_TEST=1 pnpm test-start-webpack test/production/app-dir/sync-io-blocks-root/sync-io-blocks-root.test.ts`

<!-- NEXT_JS_LLM -->