### PR TITLE
ci: skip framework tests for agent evals and skills

### DIFF
--- a/scripts/run-for-change.mjs
+++ b/scripts/run-for-change.mjs
@@ -22,6 +22,11 @@ const CHANGE_ITEM_GROUPS = {
     '.github/ISSUE_TEMPLATE',
     '.github/actions/pr-auto-label/src/config.json',
     '.github/pull_request_template.md',
+    // Agent evals and skills do not affect the framework runtime. Keep them on
+    // the same lightweight CI path as documentation changes.
+    'evals',
+    'skills',
+    'run-evals.js',
     'packages/next-plugin-storybook/readme.md',
     'packages/next/license.md',
     'packages/next/README.md',


### PR DESCRIPTION
Agent evals, skills, and the eval runner do not affect the framework runtime, but they currently make `Determine changes` schedule the full Rust, native, deployment, and framework test matrices.

Classify changes confined to `evals/`, `skills/`, and `run-evals.js` with the existing lightweight documentation path. The always-on build and lint checks still run.

Validated with Node syntax checking, Prettier, ESLint, and `git diff --check`.