### PR TITLE
fix(server-actions): respond 4xx instead of 500 to invalid action requests

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -58,6 +58,7 @@ import {
   getServerModuleMap,
   getActionNotFoundError,
   getInvalidServerReferenceIdError,
+  isActionNotFoundError,
 } from './manifests-singleton'
 import { isNodeNextRequest, isWebNextRequest } from '../base-http/helpers'
 import { normalizeFilePath } from './segment-explorer-path'
@@ -647,6 +648,18 @@ export async function handleAction({
     }
   }
 
+  /**
+   * Turns a failure from the Flight decoder into a response. A payload can fail
+   * to decode because it references a server action that no longer exists in
+   * this build -- for instance a bound argument holding a stale server
+   * reference -- which is skew, and gets the same 404 the client router already
+   * knows how to recover from. Anything else is a payload we couldn't parse.
+   */
+  const handleActionDecodeFailure = (err: unknown): HandleActionResult =>
+    isActionNotFoundError(err)
+      ? handleUnrecognizedAction(err)
+      : handleMalformedActionRequest(err)
+
   // If it can't be a Server Action, skip handling.
   // Note that this can be a false positive -- any multipart/urlencoded POST can get us here,
   // But won't know if it's an MPA action or not until we call `decodeAction` below.
@@ -919,17 +932,21 @@ export async function handleAction({
                   { temporaryReferences }
                 )
               } catch (err) {
-                return handleMalformedActionRequest(err)
+                return handleActionDecodeFailure(err)
               }
             } else {
               // Multipart POST, but not a fetch action.
               // Potentially an MPA action, we have to try decoding it to check.
-              if (areAllActionIdsValid(formData, serverModuleMap) === false) {
+              const invalidPayloadError = findInvalidActionPayloadError(
+                formData,
+                serverModuleMap
+              )
+              if (invalidPayloadError) {
                 // The payload references action IDs that don't exist in this build.
                 // This can be deployment skew or manipulated input -- either way it's
                 // not a server fault, so we respond like any other unrecognized action
                 // (404) rather than throwing, which used to surface as a 500.
-                return handleUnrecognizedAction(getActionNotFoundError(null))
+                return handleUnrecognizedAction(invalidPayloadError)
               }
 
               const action = await decodeAction(formData, serverModuleMap)
@@ -1015,7 +1032,7 @@ export async function handleAction({
                 { temporaryReferences }
               )
             } catch (err) {
-              return handleMalformedActionRequest(err)
+              return handleActionDecodeFailure(err)
             }
           }
         } else if (
@@ -1104,7 +1121,7 @@ export async function handleAction({
                 // The size limit runs concurrently with decoding here, so a
                 // body size violation can surface as this rejection.
                 if (isBodySizeLimitError(err)) throw err
-                return handleMalformedActionRequest(err)
+                return handleActionDecodeFailure(err)
               }
             } else {
               // Multipart POST, but not a fetch action.
@@ -1139,12 +1156,16 @@ export async function handleAction({
                 return handleMalformedActionRequest(err)
               }
 
-              if (areAllActionIdsValid(formData, serverModuleMap) === false) {
+              const invalidPayloadError = findInvalidActionPayloadError(
+                formData,
+                serverModuleMap
+              )
+              if (invalidPayloadError) {
                 // The payload references action IDs that don't exist in this build.
                 // This can be deployment skew or manipulated input -- either way it's
                 // not a server fault, so we respond like any other unrecognized action
                 // (404) rather than throwing, which used to surface as a 500.
-                return handleUnrecognizedAction(getActionNotFoundError(null))
+                return handleUnrecognizedAction(invalidPayloadError)
               }
 
               // TODO: Refactor so it is harder to accidentally decode an action before you have validated that the
@@ -1222,7 +1243,7 @@ export async function handleAction({
                 { temporaryReferences }
               )
             } catch (err) {
-              return handleMalformedActionRequest(err)
+              return handleActionDecodeFailure(err)
             }
           }
         } else {
@@ -1576,11 +1597,15 @@ const $ACTION_ID_ = '$ACTION_ID_'
  * This function mirrors logic inside React's decodeAction and should be kept in sync with that.
  * It pre-parses the FormData to ensure that any action IDs referred to are actual action IDs for
  * this Next.js application.
+ *
+ * Returns `null` when the payload can be decoded as an MPA action, or the error
+ * to report when it can't. The error names the offending action ID whenever one
+ * could be extracted, since that is the useful part when diagnosing skew.
  */
-function areAllActionIdsValid(
+function findInvalidActionPayloadError(
   mpaFormData: FormData,
   serverModuleMap: ServerModuleMap
-): boolean {
+): Error | null {
   let seenActionRefs = 0
   let hasAtLeastOneAction = false
   // Before we attempt to decode the payload for a possible MPA action, assert that all
@@ -1593,8 +1618,9 @@ function areAllActionIdsValid(
 
     if (key.startsWith($ACTION_ID_)) {
       // No Bound args case
-      if (isInvalidActionIdFieldName(key, serverModuleMap)) {
-        return false
+      const error = getInvalidActionIdFieldNameError(key, serverModuleMap)
+      if (error) {
+        return error
       }
 
       hasAtLeastOneAction = true
@@ -1603,7 +1629,7 @@ function areAllActionIdsValid(
         // We only expect to see at most 2 $ACTION_REF_ fields in the form data:
         // one from <form action="..." method="post">
         // and one from <input action="..." type="submit">
-        return false
+        return getActionNotFoundError(null)
       }
 
       // Bound args case
@@ -1611,50 +1637,55 @@ function areAllActionIdsValid(
         $ACTION_ + key.slice($ACTION_REF_.length) + ':0'
       const actionFields = mpaFormData.getAll(actionDescriptorField)
       if (actionFields.length !== 1) {
-        return false
+        return getActionNotFoundError(null)
       }
       const actionField = actionFields[0]
       if (typeof actionField !== 'string') {
-        return false
+        return getActionNotFoundError(null)
       }
 
-      if (isInvalidStringActionDescriptor(actionField, serverModuleMap)) {
-        return false
+      const error = getInvalidStringActionDescriptorError(
+        actionField,
+        serverModuleMap
+      )
+      if (error) {
+        return error
       }
       hasAtLeastOneAction = true
     }
   }
-  return hasAtLeastOneAction
+
+  return hasAtLeastOneAction ? null : getActionNotFoundError(null)
 }
 
 const ACTION_DESCRIPTOR_ID_PREFIX = '{"id":"'
-function isInvalidStringActionDescriptor(
+function getInvalidStringActionDescriptorError(
   actionDescriptor: string,
   serverModuleMap: ServerModuleMap
-): unknown {
+): Error | null {
   if (actionDescriptor.startsWith(ACTION_DESCRIPTOR_ID_PREFIX) === false) {
-    return true
+    return getActionNotFoundError(null)
   }
 
   const from = ACTION_DESCRIPTOR_ID_PREFIX.length
   const to = actionDescriptor.indexOf('"', from)
   if (to === -1) {
-    return true
+    return getActionNotFoundError(null)
   }
 
   // We expect actionDescriptor to be '{"id":"<actionId>",...}'
   const actionId = actionDescriptor.slice(from, to)
   if (!mightBeServerReferenceId(actionId)) {
-    return true
+    return getInvalidServerReferenceIdError(actionId)
   }
 
-  return lookupServerModuleEntry(actionId, serverModuleMap) == null
+  return getUnresolvedActionIdError(actionId, serverModuleMap)
 }
 
-function isInvalidActionIdFieldName(
+function getInvalidActionIdFieldNameError(
   actionIdFieldName: string,
   serverModuleMap: ServerModuleMap
-): boolean {
+): Error | null {
   // The field name must always start with $ACTION_ID_ but since it is
   // the id is extracted from the key of the field we have already validated
   // this before entering this function
@@ -1662,26 +1693,28 @@ function isInvalidActionIdFieldName(
   if (!mightBeServerReferenceId(actionId)) {
     // this field name has too few or too many characters
     // or it is otherwise in the wrong format
-    return true
+    return getInvalidServerReferenceIdError(actionId)
   }
 
-  return lookupServerModuleEntry(actionId, serverModuleMap) == null
+  return getUnresolvedActionIdError(actionId, serverModuleMap)
 }
 
 /**
- * `serverModuleMap` is a proxy that throws for IDs that aren't registered in
- * this build (rather than returning `undefined`), so callers that only want to
- * know whether an ID resolves have to tolerate that. An unresolvable ID is not
- * a server fault -- it's skew or manipulated input -- and the caller turns this
- * into a 404 rather than letting the throw surface as a 500.
+ * Returns the error explaining why `actionId` doesn't resolve in this build, or
+ * `null` if it does. `serverModuleMap` is a proxy that throws for unregistered
+ * IDs rather than returning `undefined`, so the throw is captured and returned:
+ * an unresolvable ID is skew or manipulated input rather than a server fault,
+ * and the caller answers 404 instead of letting it surface as a 500.
  */
-function lookupServerModuleEntry(
+function getUnresolvedActionIdError(
   actionId: string,
   serverModuleMap: ServerModuleMap
-): ServerModuleMap[string] | null {
+): Error | null {
   try {
-    return serverModuleMap[actionId] ?? null
-  } catch {
-    return null
+    return serverModuleMap[actionId] == null
+      ? getActionNotFoundError(actionId)
+      : null
+  } catch (err) {
+    return err instanceof Error ? err : getActionNotFoundError(actionId)
   }
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -610,7 +610,7 @@ export async function handleAction({
     isPossibleServerAction,
   } = getServerActionRequestMetadata(req)
 
-  const handleUnrecognizedFetchAction = (err: unknown): HandleActionResult => {
+  const handleUnrecognizedAction = (err: unknown): HandleActionResult => {
     // If the deployment doesn't have skew protection, this is expected to occasionally happen,
     // so we use a warning instead of an error.
     console.warn(err)
@@ -625,6 +625,25 @@ export async function handleAction({
     return {
       type: 'done',
       result: RenderResult.fromStatic('Server action not found.', 'text/plain'),
+    }
+  }
+
+  /**
+   * The request could not be parsed or decoded as a Server Action payload.
+   * This is malformed client input -- a truncated upload, a hand-crafted
+   * request, or (most commonly) automated vulnerability scanner traffic --
+   * rather than a server fault, so it should not be reported as a 500.
+   */
+  const handleMalformedActionRequest = (err: unknown): HandleActionResult => {
+    // Malformed payloads are common in the wild, so this is a warning, not an error.
+    console.warn(err)
+
+    res.setHeader('content-type', 'text/plain')
+    res.statusCode = 400
+    metadata.statusCode = 400
+    return {
+      type: 'done',
+      result: RenderResult.fromStatic('Bad Request', 'text/plain'),
     }
   }
 
@@ -654,7 +673,7 @@ export async function handleAction({
       actionId !== null && !mightBeServerReferenceId(actionId)
         ? getInvalidServerReferenceIdError(actionId)
         : getActionNotFoundError(actionId)
-    return handleUnrecognizedFetchAction(error)
+    return handleUnrecognizedAction(error)
   }
 
   let temporaryReferences: TemporaryReferenceSet | undefined
@@ -663,15 +682,33 @@ export async function handleAction({
   workStore.fetchCache = 'default-no-store'
 
   const originHeader = req.headers['origin']
-  const originHost =
-    typeof originHeader === 'string'
-      ? // 'null' is a valid origin e.g. from privacy-sensitive contexts like sandboxed iframes.
-        // However, these contexts can still send along credentials like cookies,
-        // so we need to check if they're allowed cross-origin requests.
-        originHeader === 'null'
-        ? 'null'
-        : new URL(originHeader).host
-      : undefined
+  let originHost: string | undefined
+
+  if (typeof originHeader === 'string') {
+    if (originHeader === 'null') {
+      // 'null' is a valid origin e.g. from privacy-sensitive contexts like sandboxed iframes.
+      // However, these contexts can still send along credentials like cookies,
+      // so we need to check if they're allowed cross-origin requests.
+      originHost = 'null'
+    } else {
+      let parsedOrigin: URL
+      try {
+        parsedOrigin = new URL(originHeader)
+      } catch {
+        // The `origin` header is not a parseable URL (e.g. `Origin: http://`).
+        // `new URL()` would throw a `TypeError` here and surface as a 500, but
+        // this is malformed client input, so we reject it as a bad request.
+        return handleMalformedActionRequest(
+          new Error(
+            `Invalid \`origin\` header from a forwarded Server Actions request: ${limitUntrustedHeaderValueForLogs(
+              originHeader
+            )}.`
+          )
+        )
+      }
+      originHost = parsedOrigin.host
+    }
+  }
   const host = parseHostHeader(req.headers)
 
   let warning: string | undefined = undefined
@@ -857,34 +894,45 @@ export async function handleAction({
             // would fail to match and `formData()` would throw. An explicit header
             // on the Request takes precedence over the Blob's normalized type.
             const edgeBodyBlob = new Blob(edgeChunks as BlobPart[])
-            const formData = await new Request('http://n/', {
-              method: 'POST',
-              headers: { 'content-type': req.headers['content-type'] ?? '' },
-              body: edgeBodyBlob,
-            }).formData()
+            let formData: FormData
+            try {
+              formData = await new Request('http://n/', {
+                method: 'POST',
+                headers: { 'content-type': req.headers['content-type'] ?? '' },
+                body: edgeBodyBlob,
+              }).formData()
+            } catch (err) {
+              // The body could not be parsed as multipart form data.
+              return handleMalformedActionRequest(err)
+            }
             if (isFetchAction) {
               // A fetch action with a multipart body.
 
               try {
                 actionModId = getActionModIdOrError(actionId, serverModuleMap)
               } catch (err) {
-                return handleUnrecognizedFetchAction(err)
+                return handleUnrecognizedAction(err)
               }
 
-              boundActionArguments = await decodeReply<unknown[]>(
-                formData,
-                serverModuleMap,
-                { temporaryReferences }
-              )
+              try {
+                boundActionArguments = await decodeReply<unknown[]>(
+                  formData,
+                  serverModuleMap,
+                  { temporaryReferences }
+                )
+              } catch (err) {
+                if (isBodySizeLimitError(err)) throw err
+                return handleMalformedActionRequest(err)
+              }
             } else {
               // Multipart POST, but not a fetch action.
               // Potentially an MPA action, we have to try decoding it to check.
               if (areAllActionIdsValid(formData, serverModuleMap) === false) {
-                // TODO: This can be from skew or manipulated input. We should handle this case
-                // more gracefully but this preserves the prior behavior where decodeAction would throw instead.
-                throw new Error(
-                  `Failed to find Server Action. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
-                )
+                // The payload references action IDs that don't exist in this build.
+                // This can be deployment skew or manipulated input -- either way it's
+                // not a server fault, so we respond like any other unrecognized action
+                // (404) rather than throwing, which used to surface as a 500.
+                return handleUnrecognizedAction(getActionNotFoundError(null))
               }
 
               const action = await decodeAction(formData, serverModuleMap)
@@ -932,7 +980,7 @@ export async function handleAction({
             try {
               actionModId = getActionModIdOrError(actionId, serverModuleMap)
             } catch (err) {
-              return handleUnrecognizedFetchAction(err)
+              return handleUnrecognizedAction(err)
             }
 
             // A fetch action with a non-multipart body.
@@ -963,11 +1011,16 @@ export async function handleAction({
 
             const actionData = Buffer.concat(chunks).toString('utf-8')
 
-            boundActionArguments = await decodeReply<unknown[]>(
-              actionData,
-              serverModuleMap,
-              { temporaryReferences }
-            )
+            try {
+              boundActionArguments = await decodeReply<unknown[]>(
+                actionData,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            } catch (err) {
+              if (isBodySizeLimitError(err)) throw err
+              return handleMalformedActionRequest(err)
+            }
           }
         } else if (
           // The type check here ensures that `req` is correctly typed, and the
@@ -1029,7 +1082,7 @@ export async function handleAction({
               try {
                 actionModId = getActionModIdOrError(actionId, serverModuleMap)
               } catch (err) {
-                return handleUnrecognizedFetchAction(err)
+                return handleUnrecognizedAction(err)
               }
 
               const busboy = (
@@ -1052,7 +1105,10 @@ export async function handleAction({
                 ])
               } catch (err) {
                 abortController.abort()
-                throw err
+                // A body size violation has its own status code (413) and is
+                // handled below; anything else is an unparseable payload.
+                if (isBodySizeLimitError(err)) throw err
+                return handleMalformedActionRequest(err)
               }
             } else {
               // Multipart POST, but not a fetch action.
@@ -1083,15 +1139,16 @@ export async function handleAction({
                 ])
               } catch (err) {
                 abortController.abort()
-                throw err
+                if (isBodySizeLimitError(err)) throw err
+                return handleMalformedActionRequest(err)
               }
 
               if (areAllActionIdsValid(formData, serverModuleMap) === false) {
-                // TODO: This can be from skew or manipulated input. We should handle this case
-                // more gracefully but this preserves the prior behavior where decodeAction would throw instead.
-                throw new Error(
-                  `Failed to find Server Action. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
-                )
+                // The payload references action IDs that don't exist in this build.
+                // This can be deployment skew or manipulated input -- either way it's
+                // not a server fault, so we respond like any other unrecognized action
+                // (404) rather than throwing, which used to surface as a 500.
+                return handleUnrecognizedAction(getActionNotFoundError(null))
               }
 
               // TODO: Refactor so it is harder to accidentally decode an action before you have validated that the
@@ -1141,7 +1198,7 @@ export async function handleAction({
             try {
               actionModId = getActionModIdOrError(actionId, serverModuleMap)
             } catch (err) {
-              return handleUnrecognizedFetchAction(err)
+              return handleUnrecognizedAction(err)
             }
 
             // A fetch action with a non-multipart body.
@@ -1162,11 +1219,16 @@ export async function handleAction({
 
             const actionData = Buffer.concat(chunks).toString('utf-8')
 
-            boundActionArguments = await decodeReply<unknown[]>(
-              actionData,
-              serverModuleMap,
-              { temporaryReferences }
-            )
+            try {
+              boundActionArguments = await decodeReply<unknown[]>(
+                actionData,
+                serverModuleMap,
+                { temporaryReferences }
+              )
+            } catch (err) {
+              if (isBodySizeLimitError(err)) throw err
+              return handleMalformedActionRequest(err)
+            }
           }
         } else {
           throw new Error('Invariant: Unknown request type.')
@@ -1482,6 +1544,15 @@ function getActionModIdOrError(
   return entry.id
 }
 
+/**
+ * Body size limit violations are surfaced as `ApiError`s carrying their own
+ * status code, so they must not be reported as malformed input.
+ */
+function isBodySizeLimitError(err: unknown): boolean {
+  const { ApiError } = require('../api-utils') as typeof import('../api-utils')
+  return err instanceof ApiError
+}
+
 const $ACTION_ = '$ACTION_'
 const $ACTION_REF_ = '$ACTION_REF_'
 const $ACTION_ID_ = '$ACTION_ID_'
@@ -1562,13 +1633,7 @@ function isInvalidStringActionDescriptor(
     return true
   }
 
-  const entry = serverModuleMap[actionId]
-
-  if (entry == null) {
-    return true
-  }
-
-  return false
+  return lookupServerModuleEntry(actionId, serverModuleMap) == null
 }
 
 function isInvalidActionIdFieldName(
@@ -1585,11 +1650,23 @@ function isInvalidActionIdFieldName(
     return true
   }
 
-  const entry = serverModuleMap[actionId]
+  return lookupServerModuleEntry(actionId, serverModuleMap) == null
+}
 
-  if (entry == null) {
-    return true
+/**
+ * `serverModuleMap` is a proxy that throws for IDs that aren't registered in
+ * this build (rather than returning `undefined`), so callers that only want to
+ * know whether an ID resolves have to tolerate that. An unresolvable ID is not
+ * a server fault -- it's skew or manipulated input -- and the caller turns this
+ * into a 404 rather than letting the throw surface as a 500.
+ */
+function lookupServerModuleEntry(
+  actionId: string,
+  serverModuleMap: ServerModuleMap
+): ServerModuleMap[string] | null {
+  try {
+    return serverModuleMap[actionId] ?? null
+  } catch {
+    return null
   }
-
-  return false
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -503,7 +503,7 @@ type Host =
 /**
  * Ensures the value of the header can't create long logs.
  */
-function limitUntrustedHeaderValueForLogs(value: string) {
+function limitUntrustedValueForLogs(value: string) {
   return value.length > 100 ? value.slice(0, 100) + '...' : value
 }
 
@@ -636,7 +636,7 @@ export async function handleAction({
    */
   const handleMalformedActionRequest = (err: unknown): HandleActionResult => {
     // Malformed payloads are common in the wild, so this is a warning, not an error.
-    console.warn(err)
+    console.warn(describeDecodeFailureForLogs(err))
 
     res.setHeader('content-type', 'text/plain')
     res.statusCode = 400
@@ -700,7 +700,7 @@ export async function handleAction({
         // this is malformed client input, so we reject it as a bad request.
         return handleMalformedActionRequest(
           new Error(
-            `Invalid \`origin\` header from a forwarded Server Actions request: ${limitUntrustedHeaderValueForLogs(
+            `Invalid \`origin\` header from a forwarded Server Actions request: ${limitUntrustedValueForLogs(
               originHeader
             )}.`
           )
@@ -736,11 +736,9 @@ export async function handleAction({
       if (host) {
         // This seems to be an CSRF attack. We should not proceed the action.
         console.error(
-          `\`${
-            host.type
-          }\` header with value \`${limitUntrustedHeaderValueForLogs(
+          `\`${host.type}\` header with value \`${limitUntrustedValueForLogs(
             host.value
-          )}\` does not match \`origin\` header with value \`${limitUntrustedHeaderValueForLogs(
+          )}\` does not match \`origin\` header with value \`${limitUntrustedValueForLogs(
             originHost
           )}\` from a forwarded Server Actions request. Aborting the action.`
         )
@@ -921,7 +919,6 @@ export async function handleAction({
                   { temporaryReferences }
                 )
               } catch (err) {
-                if (isBodySizeLimitError(err)) throw err
                 return handleMalformedActionRequest(err)
               }
             } else {
@@ -1018,7 +1015,6 @@ export async function handleAction({
                 { temporaryReferences }
               )
             } catch (err) {
-              if (isBodySizeLimitError(err)) throw err
               return handleMalformedActionRequest(err)
             }
           }
@@ -1105,8 +1101,8 @@ export async function handleAction({
                 ])
               } catch (err) {
                 abortController.abort()
-                // A body size violation has its own status code (413) and is
-                // handled below; anything else is an unparseable payload.
+                // The size limit runs concurrently with decoding here, so a
+                // body size violation can surface as this rejection.
                 if (isBodySizeLimitError(err)) throw err
                 return handleMalformedActionRequest(err)
               }
@@ -1226,7 +1222,6 @@ export async function handleAction({
                 { temporaryReferences }
               )
             } catch (err) {
-              if (isBodySizeLimitError(err)) throw err
               return handleMalformedActionRequest(err)
             }
           }
@@ -1545,12 +1540,32 @@ function getActionModIdOrError(
 }
 
 /**
- * Body size limit violations are surfaced as `ApiError`s carrying their own
- * status code, so they must not be reported as malformed input.
+ * Body size limit violations are surfaced as `ApiError`s. They currently end up
+ * as a 500 (see the TODO on the catch-all handler about responding with a 413
+ * instead), and reclassifying them as malformed input would be a separate
+ * behavior change, so they are rethrown rather than answered with a 400.
  */
 function isBodySizeLimitError(err: unknown): boolean {
   const { ApiError } = require('../api-utils') as typeof import('../api-utils')
-  return err instanceof ApiError
+  return err instanceof ApiError && err.statusCode === 413
+}
+
+/**
+ * Renders a decoder failure as a single log line. The Flight decoder quotes the
+ * offending input in its message (as does `JSON.parse`), so the message
+ * contains bytes taken straight from the request body. `JSON.stringify` escapes
+ * newlines and other control characters so that a crafted body can't forge log
+ * lines or emit terminal escape sequences, and the length cap keeps a flood of
+ * scanner traffic from filling the log. The stack is dropped because it only
+ * ever points into the decoder.
+ */
+function describeDecodeFailureForLogs(err: unknown): string {
+  const description =
+    err instanceof Error ? `${err.name}: ${err.message}` : String(err)
+
+  return `Failed to decode a Server Action request: ${JSON.stringify(
+    limitUntrustedValueForLogs(description)
+  )}`
 }
 
 const $ACTION_ = '$ACTION_'

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -18,10 +18,30 @@ export interface ServerModuleMap {
   }
 }
 
+/**
+ * Marks a not-found error so that callers decoding an action payload can tell
+ * it apart from other decoding failures. A well-formed ID that isn't in this
+ * build means client/server skew, which a client can recover from by reloading
+ * to pick up the current build. That is not true of a payload we simply
+ * couldn't parse, nor of an ID that never had the right shape to begin with
+ * (see `getInvalidServerReferenceIdError`), so those stay unmarked.
+ */
+const ACTION_NOT_FOUND = Symbol.for('next.action-not-found')
+
+export function isActionNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === 'object' && error !== null && ACTION_NOT_FOUND in error
+  )
+}
+
 export function getActionNotFoundError(actionId: string | null): Error {
-  return new Error(
+  const error = new Error(
     `Failed to find Server Action${actionId ? ` "${actionId}"` : ''}. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
   )
+
+  Object.defineProperty(error, ACTION_NOT_FOUND, { value: true })
+
+  return error
 }
 
 export function getInvalidServerReferenceIdError(id: string): Error {

--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -35,8 +35,12 @@ export function isActionNotFoundError(error: unknown): boolean {
 }
 
 export function getActionNotFoundError(actionId: string | null): Error {
+  // `actionId` is client-provided. It has passed the length gate, which bounds
+  // it but does not constrain its bytes, so it is escaped for the same reason
+  // as in `getInvalidServerReferenceIdError`. `JSON.stringify` supplies the
+  // surrounding quotes and renders a well-formed id unchanged.
   const error = new Error(
-    `Failed to find Server Action${actionId ? ` "${actionId}"` : ''}. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
+    `Failed to find Server Action${actionId ? ` ${JSON.stringify(actionId)}` : ''}. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
   )
 
   Object.defineProperty(error, ACTION_NOT_FOUND, { value: true })
@@ -46,12 +50,11 @@ export function getActionNotFoundError(actionId: string | null): Error {
 
 export function getInvalidServerReferenceIdError(id: string): Error {
   // `id` is arbitrary client-provided input. Unlike the not-found case, it has
-  // not passed the length gate and can reach this error via a malformed server
-  // reference in an action payload, so it may be of any length and contain
-  // control characters. `JSON.stringify` escapes newlines and quotes so it
-  // can't forge log lines, and truncating overly long ids prevents log
-  // flooding. Ids at or below the cap are logged in full so that we only add an
-  // ellipsis to ids that are meaningfully longer than the truncated length.
+  // not passed the length gate, so it may be of any length. `JSON.stringify`
+  // escapes newlines and quotes so it can't forge log lines, and truncating
+  // overly long ids prevents log flooding. Ids at or below the cap are logged
+  // in full so that we only add an ellipsis to ids that are meaningfully
+  // longer than the truncated length.
   const encoded = JSON.stringify(
     id.length > MAX_LOGGED_SERVER_REFERENCE_ID_LENGTH
       ? id.slice(0, TRUNCATED_SERVER_REFERENCE_ID_LENGTH) + '…'

--- a/test/e2e/app-dir/actions-invalid-requests/actions-invalid-requests.test.ts
+++ b/test/e2e/app-dir/actions-invalid-requests/actions-invalid-requests.test.ts
@@ -248,15 +248,17 @@ describe('server actions - invalid requests', () => {
     const submitForm = async (
       browser: Awaited<ReturnType<typeof next.browser>>
     ) => {
-      expect(await browser.elementByCss('#submitted').text()).toBe('no')
+      expect(await browser.elementByCss('#state').text()).toBe('not-submitted')
 
       await browser
         .elementByCss('form#action-form button[type="submit"]')
         .click()
 
-      // The action sets a cookie that the page reads back on re-render.
+      // The action redirects, so landing on /submitted is what proves the
+      // action body actually ran on the server.
       await retry(async () => {
-        expect(await browser.elementByCss('#submitted').text()).toBe('yes')
+        expect(await browser.elementByCss('#state').text()).toBe('submitted')
+        expect(await browser.url()).toEndWith('/submitted')
       })
 
       // Neither rejection path should have been taken.

--- a/test/e2e/app-dir/actions-invalid-requests/actions-invalid-requests.test.ts
+++ b/test/e2e/app-dir/actions-invalid-requests/actions-invalid-requests.test.ts
@@ -211,6 +211,37 @@ describe('server actions - invalid requests', () => {
     })
   })
 
+  describe('hostile action id', () => {
+    // An id only has to be 42 characters long to pass validation; its bytes are
+    // never checked. Sent as a multipart field name it can carry anything, so an
+    // unescaped id would put control characters, including terminal escape
+    // sequences, into the log of whatever ingests stdout.
+    it('should escape control characters in the logged action id', async () => {
+      const esc = String.fromCharCode(27)
+      const hostileActionId = '0'.repeat(20) + esc + '0'.repeat(21)
+      expect(hostileActionId).toHaveLength(42)
+
+      const { headers, body } = multipartBody({
+        [`$ACTION_ID_${hostileActionId}`]: '',
+      })
+      const res = await next.fetch('/', { method: 'POST', headers, body })
+
+      expect(res.status).toBe(404)
+
+      if (!isNextDeploy) {
+        await retry(async () =>
+          expect(getLogs()).toContain('Failed to find Server Action')
+        )
+        const logs = getLogs()
+        // The escaped form is what should reach the log. Asserting the raw id is
+        // absent is what makes this fail without the escaping; the log is full
+        // of ANSI colour codes, so a bare search for ESC would prove nothing.
+        expect(logs).toContain(JSON.stringify(hostileActionId))
+        expect(logs).not.toContain(hostileActionId)
+      }
+    })
+  })
+
   describe('regressions', () => {
     // The same form drives both cases: without JS the browser posts it as an
     // MPA action, with JS React submits it as a fetch action.

--- a/test/e2e/app-dir/actions-invalid-requests/actions-invalid-requests.test.ts
+++ b/test/e2e/app-dir/actions-invalid-requests/actions-invalid-requests.test.ts
@@ -96,9 +96,11 @@ describe('server actions - invalid requests', () => {
       expect(res.headers.get('x-nextjs-action-not-found')).toBe('1')
 
       if (!isNextDeploy) {
+        // The log names the unresolvable id, which is what makes a skew report
+        // actionable.
         await retry(async () =>
           expect(getLogs()).toContain(
-            'Failed to find Server Action. This request might be from an older or newer deployment.'
+            `Failed to find Server Action "${missingActionId}". This request might be from an older or newer deployment.`
           )
         )
       }

--- a/test/e2e/app-dir/actions-invalid-requests/actions-invalid-requests.test.ts
+++ b/test/e2e/app-dir/actions-invalid-requests/actions-invalid-requests.test.ts
@@ -131,9 +131,43 @@ describe('server actions - invalid requests', () => {
 
         if (!isNextDeploy) {
           expect(getLogs()).not.toContain('⨯ SyntaxError')
+          expect(getLogs()).toContain(
+            'Failed to decode a Server Action request'
+          )
         }
       }
     )
+
+    // The decoder quotes the offending input in its message, so the log line
+    // carries bytes from the request body. They have to be escaped, or a
+    // crafted body can forge log lines.
+    it('should not let a crafted body forge a log line', async () => {
+      const actionId = await getValidActionId()
+      const forged = '\n  ⨯ Error: forged by the request body\n'
+      const res = await next.fetch('/', {
+        method: 'POST',
+        headers: {
+          accept: 'text/x-component',
+          'content-type': 'text/plain;charset=UTF-8',
+          'next-action': actionId,
+          origin: next.url,
+        },
+        body: forged + '[',
+      })
+
+      expect(res.status).toBe(400)
+
+      if (!isNextDeploy) {
+        const logs = getLogs()
+        expect(logs).toContain('Failed to decode a Server Action request')
+        // The decoder echoes the start of the body, so an unescaped message
+        // would break here and leave a line of the attacker's choosing. The
+        // escaped form keeps those bytes on the warning's own line.
+        expect(
+          logs.split('\n').some((line) => line.startsWith('  ⨯ Error'))
+        ).toBe(false)
+      }
+    })
 
     it('should 400 rather than 500 for a fetch action with an unparseable multipart body', async () => {
       const actionId = await getValidActionId()
@@ -176,33 +210,35 @@ describe('server actions - invalid requests', () => {
   })
 
   describe('regressions', () => {
-    it('should still execute a genuine MPA form submission', async () => {
-      const browser = await next.browser('/', { disableJavaScript: true })
+    // The same form drives both cases: without JS the browser posts it as an
+    // MPA action, with JS React submits it as a fetch action.
+    const submitForm = async (
+      browser: Awaited<ReturnType<typeof next.browser>>
+    ) => {
       expect(await browser.elementByCss('#submitted').text()).toBe('no')
 
-      await browser.elementByCss('form#mpa-form button[type="submit"]').click()
+      await browser
+        .elementByCss('form#action-form button[type="submit"]')
+        .click()
 
       // The action sets a cookie that the page reads back on re-render.
       await retry(async () => {
         expect(await browser.elementByCss('#submitted').text()).toBe('yes')
       })
 
+      // Neither rejection path should have been taken.
       expect(getLogs()).not.toContain('Failed to find Server Action')
-      expect(getLogs()).not.toContain('Bad Request')
+      expect(getLogs()).not.toContain(
+        'Failed to decode a Server Action request'
+      )
+    }
+
+    it('should still execute a genuine MPA form submission', async () => {
+      await submitForm(await next.browser('/', { disableJavaScript: true }))
     })
 
     it('should still execute a genuine fetch action', async () => {
-      const browser = await next.browser('/')
-      expect(await browser.elementByCss('#submitted').text()).toBe('no')
-
-      await browser.elementByCss('form#mpa-form button[type="submit"]').click()
-
-      await retry(async () => {
-        expect(await browser.elementByCss('#submitted').text()).toBe('yes')
-      })
-
-      expect(getLogs()).not.toContain('Failed to find Server Action')
-      expect(getLogs()).not.toContain('Bad Request')
+      await submitForm(await next.browser('/'))
     })
   })
 })

--- a/test/e2e/app-dir/actions-invalid-requests/actions-invalid-requests.test.ts
+++ b/test/e2e/app-dir/actions-invalid-requests/actions-invalid-requests.test.ts
@@ -1,0 +1,208 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+// Invalid or malformed requests that reach the Server Action handler should be
+// answered with a 4xx status, not a 500. These are all client faults (skew,
+// hand-crafted requests, automated scanner traffic) and reporting them as
+// server errors both misleads users and pollutes production error monitoring.
+describe('server actions - invalid requests', () => {
+  const missingActionId = '0'.repeat(42)
+
+  const { next, isNextDeploy } = nextTestSetup({
+    files: __dirname,
+  })
+
+  let cliOutputPosition: number = 0
+  beforeEach(() => {
+    cliOutputPosition = next.cliOutput.length
+  })
+  const getLogs = () => next.cliOutput.slice(cliOutputPosition)
+
+  /**
+   * Reads a real, currently-valid action ID out of the rendered form, so that
+   * the malformed-body cases get past ID validation and actually reach the
+   * Flight decoder.
+   */
+  const getValidActionId = async () => {
+    const html = await next.render('/')
+    const match = html.match(/\$ACTION_ID_([0-9a-f]+)/)
+    if (!match) {
+      throw new Error('Could not find a server action ID in the rendered page')
+    }
+    return match[1]
+  }
+
+  const multipartBody = (fields: Record<string, string>) => {
+    const boundary = '----FormBoundaryTest'
+    const body =
+      Object.entries(fields)
+        .map(
+          ([name, value]) =>
+            `--${boundary}\r\nContent-Disposition: form-data; name="${name}"\r\n\r\n${value}\r\n`
+        )
+        .join('') + `--${boundary}--\r\n`
+
+    return {
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      body,
+    }
+  }
+
+  describe('multipart POST that is not a server action', () => {
+    // Deployed 404s are served as a static route which rejects POST with a 405.
+    if (!isNextDeploy) {
+      it('should 404 rather than 500 when POSTing form data to a nonexistent route', async () => {
+        const { headers, body } = multipartBody({ file: 'contents' })
+        const res = await next.fetch('/non-existent-route', {
+          method: 'POST',
+          headers,
+          body,
+        })
+
+        expect(res.status).toBe(404)
+        // Warnings are expected here; an error is not. Matching the error
+        // marker alone would also match the dev server's experiments banner.
+        expect(getLogs()).not.toContain('⨯ Error')
+      })
+    }
+
+    it('should 404 rather than 500 when POSTing form data to an existing page', async () => {
+      const { headers, body } = multipartBody({ file: 'contents' })
+      const res = await next.fetch('/', { method: 'POST', headers, body })
+
+      expect(res.status).toBe(404)
+      expect(res.headers.get('x-nextjs-action-not-found')).toBe('1')
+    })
+
+    it('should 404 rather than 500 for an empty multipart body', async () => {
+      const res = await next.fetch('/', {
+        method: 'POST',
+        headers: {
+          'content-type': 'multipart/form-data; boundary=----FormBoundaryTest',
+        },
+        body: '------FormBoundaryTest--\r\n',
+      })
+
+      expect(res.status).toBe(404)
+    })
+
+    it('should 404 rather than 500 for an unrecognized MPA action id', async () => {
+      const { headers, body } = multipartBody({
+        [`$ACTION_ID_${missingActionId}`]: '',
+      })
+      const res = await next.fetch('/', { method: 'POST', headers, body })
+
+      expect(res.status).toBe(404)
+      expect(res.headers.get('x-nextjs-action-not-found')).toBe('1')
+
+      if (!isNextDeploy) {
+        await retry(async () =>
+          expect(getLogs()).toContain(
+            'Failed to find Server Action. This request might be from an older or newer deployment.'
+          )
+        )
+      }
+    })
+  })
+
+  describe('malformed request body', () => {
+    // A valid Next-Action header with a body the Flight decoder can't parse
+    // used to throw a SyntaxError and surface as a 500.
+    it.each([
+      { description: 'truncated JSON', body: '[' },
+      { description: 'invalid JSON', body: '[zxc]' },
+      { description: 'a bare string', body: 'not-json-at-all' },
+    ])(
+      'should 400 rather than 500 for a fetch action with $description',
+      async ({ body }) => {
+        const actionId = await getValidActionId()
+        const res = await next.fetch('/', {
+          method: 'POST',
+          headers: {
+            accept: 'text/x-component',
+            'content-type': 'text/plain;charset=UTF-8',
+            'next-action': actionId,
+            origin: next.url,
+          },
+          body,
+        })
+
+        expect(res.status).toBe(400)
+
+        if (!isNextDeploy) {
+          expect(getLogs()).not.toContain('⨯ SyntaxError')
+        }
+      }
+    )
+
+    it('should 400 rather than 500 for a fetch action with an unparseable multipart body', async () => {
+      const actionId = await getValidActionId()
+      const res = await next.fetch('/', {
+        method: 'POST',
+        headers: {
+          accept: 'text/x-component',
+          'content-type': 'multipart/form-data; boundary=----FormBoundaryTest',
+          'next-action': actionId,
+          origin: next.url,
+        },
+        // Truncated: the closing boundary is missing.
+        body: '------FormBoundaryTest\r\nContent-Disposition: form-data;',
+      })
+
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('malformed origin header', () => {
+    it.each([
+      { description: 'an origin with no host', origin: 'http://' },
+      { description: 'a non-URL origin', origin: 'not-a-url' },
+      { description: 'an empty-scheme origin', origin: '://example.com' },
+    ])('should 400 rather than 500 for $description', async ({ origin }) => {
+      const { headers, body } = multipartBody({ file: 'contents' })
+      const res = await next.fetch('/', {
+        method: 'POST',
+        headers: { ...headers, origin },
+        body,
+      })
+
+      expect(res.status).toBe(400)
+
+      if (!isNextDeploy) {
+        expect(getLogs()).not.toContain('TypeError')
+        expect(getLogs()).not.toContain('Invalid URL')
+      }
+    })
+  })
+
+  describe('regressions', () => {
+    it('should still execute a genuine MPA form submission', async () => {
+      const browser = await next.browser('/', { disableJavaScript: true })
+      expect(await browser.elementByCss('#submitted').text()).toBe('no')
+
+      await browser.elementByCss('form#mpa-form button[type="submit"]').click()
+
+      // The action sets a cookie that the page reads back on re-render.
+      await retry(async () => {
+        expect(await browser.elementByCss('#submitted').text()).toBe('yes')
+      })
+
+      expect(getLogs()).not.toContain('Failed to find Server Action')
+      expect(getLogs()).not.toContain('Bad Request')
+    })
+
+    it('should still execute a genuine fetch action', async () => {
+      const browser = await next.browser('/')
+      expect(await browser.elementByCss('#submitted').text()).toBe('no')
+
+      await browser.elementByCss('form#mpa-form button[type="submit"]').click()
+
+      await retry(async () => {
+        expect(await browser.elementByCss('#submitted').text()).toBe('yes')
+      })
+
+      expect(getLogs()).not.toContain('Failed to find Server Action')
+      expect(getLogs()).not.toContain('Bad Request')
+    })
+  })
+})

--- a/test/e2e/app-dir/actions-invalid-requests/app/actions.ts
+++ b/test/e2e/app-dir/actions-invalid-requests/app/actions.ts
@@ -1,0 +1,8 @@
+'use server'
+
+import { cookies } from 'next/headers'
+
+export async function recordSubmission() {
+  const cookieStore = await cookies()
+  cookieStore.set('submitted', 'yes')
+}

--- a/test/e2e/app-dir/actions-invalid-requests/app/actions.ts
+++ b/test/e2e/app-dir/actions-invalid-requests/app/actions.ts
@@ -1,8 +1,10 @@
 'use server'
 
-import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
 
+// Redirecting is what the regression tests observe: reaching this line proves
+// the action body ran on the server, and it keeps the page free of any dynamic
+// read, so the page still prerenders under Cache Components.
 export async function recordSubmission() {
-  const cookieStore = await cookies()
-  cookieStore.set('submitted', 'yes')
+  redirect('/submitted')
 }

--- a/test/e2e/app-dir/actions-invalid-requests/app/layout.tsx
+++ b/test/e2e/app-dir/actions-invalid-requests/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/actions-invalid-requests/app/page.tsx
+++ b/test/e2e/app-dir/actions-invalid-requests/app/page.tsx
@@ -1,0 +1,18 @@
+import { cookies } from 'next/headers'
+import { recordSubmission } from './actions'
+
+// The app needs at least one registered Server Action for these requests to
+// reach the action handler at all -- an app with no actions bails out earlier.
+export default async function Page() {
+  const cookieStore = await cookies()
+  const submitted = cookieStore.get('submitted')?.value ?? 'no'
+
+  return (
+    <>
+      <p id="submitted">{submitted}</p>
+      <form id="mpa-form" action={recordSubmission}>
+        <button type="submit">Submit</button>
+      </form>
+    </>
+  )
+}

--- a/test/e2e/app-dir/actions-invalid-requests/app/page.tsx
+++ b/test/e2e/app-dir/actions-invalid-requests/app/page.tsx
@@ -10,7 +10,7 @@ export default async function Page() {
   return (
     <>
       <p id="submitted">{submitted}</p>
-      <form id="mpa-form" action={recordSubmission}>
+      <form id="action-form" action={recordSubmission}>
         <button type="submit">Submit</button>
       </form>
     </>

--- a/test/e2e/app-dir/actions-invalid-requests/app/page.tsx
+++ b/test/e2e/app-dir/actions-invalid-requests/app/page.tsx
@@ -1,15 +1,11 @@
-import { cookies } from 'next/headers'
 import { recordSubmission } from './actions'
 
 // The app needs at least one registered Server Action for these requests to
 // reach the action handler at all -- an app with no actions bails out earlier.
-export default async function Page() {
-  const cookieStore = await cookies()
-  const submitted = cookieStore.get('submitted')?.value ?? 'no'
-
+export default function Page() {
   return (
     <>
-      <p id="submitted">{submitted}</p>
+      <p id="state">not-submitted</p>
       <form id="action-form" action={recordSubmission}>
         <button type="submit">Submit</button>
       </form>

--- a/test/e2e/app-dir/actions-invalid-requests/app/submitted/page.tsx
+++ b/test/e2e/app-dir/actions-invalid-requests/app/submitted/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="state">submitted</p>
+}

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -6,7 +6,7 @@ import { outdent } from 'outdent'
 describe('unrecognized server actions', () => {
   const unrecognizedActionId = '0'.repeat(42)
 
-  const { next, isNextDeploy, isNextDev } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
@@ -184,38 +184,20 @@ describe('unrecognized server actions', () => {
         } else {
           // An MPA action, sent without JS.
 
-          // FIXME: When deployed, the request is logged as a 500, but returns a 405.
-          // We also don't seem to display the error page correctly
+          // FIXME: When deployed, the request returns a 405.
           if (!isNextDeploy) {
-            // FIXME: Currently, an unrecognized id in an MPA action results in a 500.
-            // This is not ideal, and ignores all nested `error.js` files, only showing the topmost one.
-            expect(response.status()).toBe(500)
-            if (isNextDev) {
-              expect(response.headers()['content-type']).toStartWith(
-                'text/html'
-              )
-            } else {
-              const responseText = await response.text()
-              expect(responseText).toBe('Internal Server Error')
-              expect(response.headers()['content-type']).toStartWith(
-                'text/plain'
-              )
-            }
+            // An unrecognized action id means client/server skew or manipulated
+            // input, so an MPA action is answered with a 404 like any other
+            // unrecognized action. This previously surfaced as a 500.
+            expect(response.status()).toBe(404)
+            expect(response.headers()['content-type']).toStartWith('text/plain')
+            expect(await response.text()).toBe('Server action not found.')
 
-            // In dev, the 500 page doesn't have any SSR'd html, so it won't show anything without JS.
-            if (!isNextDev) {
-              expect(await browser.elementByCss('body').text()).toContain(
-                'Internal Server Error'
+            await retry(async () =>
+              expect(getLogs()).toInclude(
+                'Failed to find Server Action. This request might be from an older or newer deployment'
               )
-            }
-
-            if (!isNextDeploy) {
-              await retry(async () =>
-                expect(getLogs()).toInclude(
-                  `Error: Failed to find Server Action "${unrecognizedActionId}". This request might be from an older or newer deployment`
-                )
-              )
-            }
+            )
           }
         }
       }

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -195,7 +195,7 @@ describe('unrecognized server actions', () => {
 
             await retry(async () =>
               expect(getLogs()).toInclude(
-                'Failed to find Server Action. This request might be from an older or newer deployment'
+                `Failed to find Server Action "${unrecognizedActionId}". This request might be from an older or newer deployment`
               )
             )
           }


### PR DESCRIPTION
Closes:

- #86945 HTTP 500 on malformed request body for server action (JSON parse SyntaxError) 
- #90090 500 error instead of 404 when answering a POST request with form data 
- #92703 Malformed Origin header in Next.js Server Actions returns HTTP 500 instead of 400 
- #95447 Server Actions: multipart/form-data POST to a non-action route returns 500 in production (next start) but 404 in development (next dev)

## Claude PR description

`serverModuleMap` is not a nullable map. `createServerModuleMap()` in `manifests-singleton.ts` returns a throwing Proxy: an id of the wrong shape throws `getInvalidServerReferenceIdError`, and a well-formed id absent from the build throws `getActionNotFoundError`. For a string id it returns `undefined` in exactly one case, when the id collides with a well-known property name such as `toString`. (It also falls through to `Reflect.get` for non-string keys, which is React's debug serialization probing the map with symbols rather than looking up a server reference.)

Two validation predicates were written against the wrong contract. `isInvalidStringActionDescriptor` (bound-args variant) and `isInvalidActionIdFieldName` (the `$ACTION_ID_<id>` form-field variant, the one the common repro hits) both do `const entry = serverModuleMap[actionId]` and then test `entry == null`. The subscript throws before that test is ever reached, so the throw escaped the validation helper entirely and landed in the generic action-error handler, which treats any error arriving there as a failure inside user action code and answers 500.

Two details worth having:

- That `entry == null` branch is dead code in both predicates. They gate on `mightBeServerReferenceId`, which is `id.length === 42` and nothing else, while the only `undefined`-returning path is the well-known-property list whose longest member (`propertyIsEnumerable`) is 20 characters. The same branch is genuinely live in `getActionModIdOrError`, which has no length gate, and that function's author documented the proxy's behavior correctly. So the correct handling already existed in the file, one function away from the two that got it wrong.
- Two further failure classes threw into the same catch-all: `new URL(origin)` on a malformed `origin` header (#92703), and the React Flight decoder calls (`decodeReply`, `decodeReplyFromBusboy`, `decodeAction`, `decodeFormState`) on a body they can't parse (#86945).

Separately, `getActionNotFoundError` interpolated the client-supplied id straight into its message. The id only has to be 42 characters to pass validation and its bytes are never checked, so it is now escaped with `JSON.stringify` for the same reason the decode-failure message already was.