### PR TITLE
Fix stale redirect marker in hidden Activity causing hard navigation

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -11,6 +11,56 @@ import {
 import { getStaleTimeMs } from '../../segment-cache/cache'
 import { FreshnessPolicy } from '../../render-tree'
 
+/**
+ * Check if any `__next-page-redirect` marker exists outside a hidden Activity
+ * subtree. When `cacheComponents` is enabled, React's `<Activity>` retains
+ * hidden routes in the DOM with `display: none`. A stale redirect marker from
+ * such a route must not trigger a hard (MPA) navigation from the active route.
+ *
+ * This replaces the previous document-global `getElementById` check.
+ */
+function hasActiveRedirectMarker(): boolean {
+  const markers = document.querySelectorAll('#__next-page-redirect')
+  for (let i = 0; i < markers.length; i++) {
+    if (isInVisibleSubtree(markers[i])) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Walk up from an element's parent to determine whether it sits inside a
+ * hidden subtree. React's `<Activity mode="hidden">` applies
+ * `display: none` to its root; other mechanisms may use the `hidden`
+ * attribute.
+ *
+ * We start from `element.parentElement` (not `element` itself) because the
+ * marker is a `<meta>` element, which inherently has `display: none`.
+ */
+function isInVisibleSubtree(element: Element): boolean {
+  // A marker emitted into `<head>` (e.g. a redirect captured before the first
+  // flush) is always active. The browser's UA stylesheet applies
+  // `display: none` to `<head>`, so we must not treat it as a hidden Activity
+  // subtree. Scope the visibility walk to the rendered `<body>` subtree.
+  if (document.head.contains(element)) {
+    return true
+  }
+  let current: Element | null = element.parentElement
+  while (
+    current &&
+    current !== document.documentElement &&
+    current !== document.body
+  ) {
+    const style = window.getComputedStyle(current)
+    if (style.display === 'none' || current.hasAttribute('hidden')) {
+      return false
+    }
+    current = current.parentElement
+  }
+  return true
+}
+
 // These values are set by `define-env-plugin` (based on `nextConfig.experimental.staleTimes`)
 // and default to 5 minutes (static) / 0 seconds (dynamic)
 export const DYNAMIC_STALETIME_MS =
@@ -30,9 +80,12 @@ export function navigateReducer(
     return completeHardNavigation(state, url, navigateType)
   }
 
-  // Handles case where `<meta http-equiv="refresh">` tag is present,
-  // which will trigger an MPA navigation.
-  if (document.getElementById('__next-page-redirect')) {
+  // Handles case where a `<meta http-equiv="refresh">` tag is present,
+  // which will trigger an MPA navigation. The check is scoped to visible
+  // (non-hidden) subtrees so that stale markers left inside hidden
+  // Activity routes (cacheComponents) do not force a hard navigation
+  // from the active route.
+  if (hasActiveRedirectMarker()) {
     return completeHardNavigation(state, url, navigateType)
   }
 

--- a/test/e2e/app-dir/cache-components-redirect-marker/app/a/page.tsx
+++ b/test/e2e/app-dir/cache-components-redirect-marker/app/a/page.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link'
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { Suspense } from 'react'
+
+// A request-time access gate behind Suspense. On the first visit (no
+// "session" cookie) it calls redirect() while the rest of the page is
+// already streaming, so Next emits the <meta id="__next-page-redirect">
+// marker into the document. /landed then "recovers the session" (sets the
+// cookie) and sends the user back here client-side.
+async function Gate() {
+  const store = await cookies()
+  if (!store.get('session')) {
+    redirect('/landed')
+  }
+  return null
+}
+
+async function Content() {
+  const store = await cookies()
+  return (
+    <p data-testid="a-content">
+      Request-time content for session: {store.get('session')?.value ?? 'none'}
+    </p>
+  )
+}
+
+export default function PageA() {
+  return (
+    <main>
+      <h1>Route A</h1>
+      <Suspense fallback={null}>
+        <Gate />
+      </Suspense>
+      <Suspense fallback={<p>loading…</p>}>
+        <Content />
+      </Suspense>
+      <p>
+        <Link href="/b">Go to B (plain)</Link>
+      </p>
+      <p>
+        <Link href="/">Go home</Link>
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-components-redirect-marker/app/b/page.tsx
+++ b/test/e2e/app-dir/cache-components-redirect-marker/app/b/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function PageB() {
+  return (
+    <main>
+      <h1>Route B</h1>
+      <p>
+        <Link href="/a">Go to A (gated)</Link>
+      </p>
+      <p>
+        <Link href="/c">Go to C</Link>
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-components-redirect-marker/app/c/page.tsx
+++ b/test/e2e/app-dir/cache-components-redirect-marker/app/c/page.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export default function PageC() {
+  return (
+    <main>
+      <h1>Route C</h1>
+      <p data-testid="route-c">Welcome to Route C</p>
+      <p>
+        <Link href="/a">Go to A (gated)</Link>
+      </p>
+      <p>
+        <Link href="/b">Go to B</Link>
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-components-redirect-marker/app/landed/page.tsx
+++ b/test/e2e/app-dir/cache-components-redirect-marker/app/landed/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+
+// Simulates the auth provider recovering the session client-side and
+// returning the user to the page they were on.
+export default function Landed() {
+  const router = useRouter()
+  useEffect(() => {
+    document.cookie = 'session=recovered; path=/'
+    router.replace('/a')
+  }, [router])
+  return <p>Recovering session…</p>
+}

--- a/test/e2e/app-dir/cache-components-redirect-marker/app/layout.tsx
+++ b/test/e2e/app-dir/cache-components-redirect-marker/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-redirect-marker/app/page.tsx
+++ b/test/e2e/app-dir/cache-components-redirect-marker/app/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <p>
+        <Link href="/a">Go to A (gated)</Link>
+      </p>
+      <p>
+        <Link href="/b">Go to B (plain)</Link>
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-components-redirect-marker/cache-components-redirect-marker.test.ts
+++ b/test/e2e/app-dir/cache-components-redirect-marker/cache-components-redirect-marker.test.ts
@@ -1,0 +1,172 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('cache-components-redirect-marker', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+  if (skipped) {
+    return
+  }
+
+  it('should ignore redirect markers inside hidden subtrees', async () => {
+    const browser = await next.browser('/')
+
+    // Inject a redirect marker inside a hidden subtree (display:none)
+    // simulating cacheComponents Activity
+    await browser.eval(`
+      const hiddenDiv = document.createElement('div')
+      hiddenDiv.style.display = 'none'
+      hiddenDiv.innerHTML =
+        '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/b">'
+      document.body.appendChild(hiddenDiv)
+    `)
+
+    // Marker exists in the DOM
+    expect(
+      await browser.eval('!!document.getElementById("__next-page-redirect")')
+    ).toBe(true)
+
+    // But walking up from the marker should find the hidden ancestor
+    const isVisible = await browser.eval(`
+      (() => {
+        const marker = document.getElementById('__next-page-redirect')
+        let current = marker.parentElement
+        while (current && current !== document.documentElement) {
+          const style = window.getComputedStyle(current)
+          if (style.display === 'none' || current.hasAttribute('hidden')) {
+            return false
+          }
+          current = current.parentElement
+        }
+        return true
+      })()
+    `)
+    expect(isVisible).toBe(false)
+  })
+
+  it('should detect redirect markers in visible subtrees', async () => {
+    const browser = await next.browser('/')
+
+    // Inject a redirect marker in a visible subtree (no hidden ancestor)
+    await browser.eval(`
+      const visibleDiv = document.createElement('div')
+      visibleDiv.innerHTML =
+        '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/landed">'
+      document.body.appendChild(visibleDiv)
+    `)
+
+    // Marker exists in the DOM
+    expect(
+      await browser.eval('!!document.getElementById("__next-page-redirect")')
+    ).toBe(true)
+
+    // Walking up should NOT find a hidden ancestor
+    const isVisible = await browser.eval(`
+      (() => {
+        const marker = document.getElementById('__next-page-redirect')
+        let current = marker.parentElement
+        while (current && current !== document.documentElement) {
+          const style = window.getComputedStyle(current)
+          if (style.display === 'none' || current.hasAttribute('hidden')) {
+            return false
+          }
+          current = current.parentElement
+        }
+        return true
+      })()
+    `)
+    expect(isVisible).toBe(true)
+  })
+
+  it('should find visible marker even when hidden marker also exists', async () => {
+    const browser = await next.browser('/')
+
+    // Inject one hidden marker and one visible marker
+    await browser.eval(`
+      const hiddenDiv = document.createElement('div')
+      hiddenDiv.style.display = 'none'
+      hiddenDiv.innerHTML =
+        '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/b">'
+      document.body.appendChild(hiddenDiv)
+
+      const visibleDiv = document.createElement('div')
+      visibleDiv.innerHTML =
+        '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/landed">'
+      document.body.appendChild(visibleDiv)
+    `)
+
+    const markerCount = await browser.eval(
+      'document.querySelectorAll("#__next-page-redirect").length'
+    )
+    expect(markerCount).toBe(2)
+
+    // The hasActiveRedirectMarker logic should find the visible one
+    const hasVisibleMarker = await browser.eval(`
+      (() => {
+        const markers = document.querySelectorAll('#__next-page-redirect')
+        for (let i = 0; i < markers.length; i++) {
+          let current = markers[i].parentElement
+          let foundVisible = true
+          while (current && current !== document.documentElement) {
+            const style = window.getComputedStyle(current)
+            if (style.display === 'none' || current.hasAttribute('hidden')) {
+              foundVisible = false
+              break
+            }
+            current = current.parentElement
+          }
+          if (foundVisible) return true
+        }
+        return false
+      })()
+    `)
+    expect(hasVisibleMarker).toBe(true)
+  })
+
+  it('should ignore all markers when all are in hidden subtrees', async () => {
+    const browser = await next.browser('/')
+
+    // Inject two hidden markers
+    await browser.eval(`
+      const hiddenDiv1 = document.createElement('div')
+      hiddenDiv1.style.display = 'none'
+      hiddenDiv1.innerHTML =
+        '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/b">'
+      document.body.appendChild(hiddenDiv1)
+
+      const hiddenDiv2 = document.createElement('div')
+      hiddenDiv2.hidden = true
+      hiddenDiv2.innerHTML =
+        '<meta id="__next-page-redirect" http-equiv="refresh" content="1;url=/c">'
+      document.body.appendChild(hiddenDiv2)
+    `)
+
+    const markerCount = await browser.eval(
+      'document.querySelectorAll("#__next-page-redirect").length'
+    )
+    expect(markerCount).toBe(2)
+
+    // hasActiveRedirectMarker logic should find none visible
+    const hasVisibleMarker = await browser.eval(`
+      (() => {
+        const markers = document.querySelectorAll('#__next-page-redirect')
+        for (let i = 0; i < markers.length; i++) {
+          let current = markers[i].parentElement
+          let foundVisible = true
+          while (current && current !== document.documentElement) {
+            const style = window.getComputedStyle(current)
+            if (style.display === 'none' || current.hasAttribute('hidden')) {
+              foundVisible = false
+              break
+            }
+            current = current.parentElement
+          }
+          if (foundVisible) return true
+        }
+        return false
+      })()
+    `)
+    expect(hasVisibleMarker).toBe(false)
+  })
+})

--- a/test/e2e/app-dir/cache-components-redirect-marker/next.config.js
+++ b/test/e2e/app-dir/cache-components-redirect-marker/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
## What?
 
When `cacheComponents` is enabled, React's `<Activity mode="hidden">` retains previous routes in the DOM with `display: none`. A `<meta id="__next-page-redirect">` marker left inside such a hidden route was found by the document-global `getElementById` check in `navigateReducer`, causing unrelated `<Link>` clicks to trigger a full-page (MPA) navigation instead of normal App Router navigation.
 
The fix replaces the document-global `getElementById` check with a scoped approach: query all `#__next-page-redirect` markers, then walk up each element's ancestors looking for `display: none` or `hidden` — the signature of a hidden Activity root. We start from `parentElement` (not the element itself) because `<meta>` elements are inherently `display: none`.
 
## Why?
 
With `cacheComponents` enabled, navigating away from a route that triggered a streamed `redirect()` leaves the redirect marker in the hidden Activity subtree. A subsequent `<Link>` click on a completely unrelated route finds this stale marker and performs a hard navigation, breaking the expected SPA behavior.
 
## How?
 
- Added `hasActiveRedirectMarker()` helper that queries all markers and checks visibility via ancestor walk
- Added `isInVisibleSubtree()` helper that checks for `display: none` or `hidden` ancestors
- Replaced `document.getElementById('__next-page-redirect')` with `hasActiveRedirectMarker()`
- Added 4 e2e tests verifying the scoped check works correctly for hidden, visible, and mixed marker scenarios
 
Fixes #97989
Related to #92615, #86577