### PR TITLE
Fix static export RSC payload version skew

### DIFF
--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -39,6 +39,7 @@ import type { NormalizedSearch } from '../segment-cache/cache-key'
 import { getDeploymentId } from '../../../shared/lib/deployment-id'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
+import { getStaticExportRscPath } from '../../../shared/lib/static-export-rsc'
 import {
   stripIsPartialByte,
   bufferPrefetchResponseBody,
@@ -175,14 +176,13 @@ export async function fetchServerResponse(
     if (process.env.NODE_ENV === 'production') {
       if (process.env.__NEXT_CONFIG_OUTPUT === 'export') {
         // In "output: export" mode, we can't rely on headers to distinguish
-        // between HTML and RSC requests. Instead, we append an extra prefix
-        // to the request.
+        // between HTML and RSC requests. Instead, we request a build-specific
+        // .txt file so payloads from multiple deployments can coexist.
         url = new URL(url)
-        if (url.pathname.endsWith('/')) {
-          url.pathname += 'index.txt'
-        } else {
-          url.pathname += '.txt'
-        }
+        url.pathname = getStaticExportRscPath(
+          url.pathname,
+          getNavigationBuildId()
+        )
       }
     }
 

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -3775,8 +3775,10 @@ function addSegmentPathToUrlInOutputExportMode(
     const routeDir = staticUrl.pathname.endsWith('/')
       ? staticUrl.pathname.slice(0, -1)
       : staticUrl.pathname
-    const staticExportFilename =
-      convertSegmentPathToStaticExportFilename(segmentPath)
+    const staticExportFilename = convertSegmentPathToStaticExportFilename(
+      segmentPath,
+      getNavigationBuildId()
+    )
     staticUrl.pathname = `${routeDir}/${staticExportFilename}`
     return staticUrl
   }

--- a/packages/next/src/client/route-params.ts
+++ b/packages/next/src/client/route-params.ts
@@ -19,6 +19,8 @@ import type {
 } from './components/segment-cache/cache-key'
 import type { RSCResponse } from './components/router-reducer/fetch-server-response'
 import type { ParsedUrlQuery } from 'querystring'
+import { getNavigationBuildId } from './navigation-build-id'
+import { stripStaticExportRscPath } from '../shared/lib/static-export-rsc'
 
 export type RouteParamValue = string | Array<string> | null
 
@@ -225,15 +227,11 @@ export function urlToUrlWithoutFlightMarker(url: URL): URL {
       process.env.__NEXT_CONFIG_OUTPUT === 'export' &&
       urlWithoutFlightParameters.pathname.endsWith('.txt')
     ) {
-      const { pathname } = urlWithoutFlightParameters
-      // Undo the marker appended in `fetchServerResponse`, which is keyed on
-      // whether the requested pathname ended with a slash: `index.txt` for
-      // `/foo/`, `.txt` for `/foo`. Slicing off only `index.txt` keeps that
-      // slash, then `normalizePathTrailingSlash` applies the configured
-      // policy so we don't hand-roll a second one here.
-      const length = pathname.endsWith('/index.txt') ? 9 : 4
       urlWithoutFlightParameters.pathname = normalizePathTrailingSlash(
-        pathname.slice(0, -length)
+        stripStaticExportRscPath(
+          urlWithoutFlightParameters.pathname,
+          getNavigationBuildId()
+        )
       )
     }
   }

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -70,6 +70,7 @@ import { isInterceptionRouteRewrite } from '../lib/is-interception-route-rewrite
 import type { ActionManifest } from '../build/webpack/plugins/flight-client-entry-plugin'
 import { extractInfoFromServerReferenceId } from '../shared/lib/server-reference-info'
 import { convertSegmentPathToStaticExportFilename } from '../shared/lib/segment-cache/segment-value-encoding'
+import { getStaticExportRscFileSuffix } from '../shared/lib/static-export-rsc'
 import { getNextBuildDebuggerPortOffset } from '../lib/worker'
 import { getParams } from './helpers/get-params'
 import { isDynamicRoute } from '../shared/lib/router/utils/is-dynamic'
@@ -257,6 +258,7 @@ async function exportAppImpl(
   }
 
   const buildId = await fs.readFile(buildIdFile, 'utf8')
+  const navigationBuildId = nextConfig.deploymentId || buildId
 
   const pagesManifest =
     !options.pages &&
@@ -1003,7 +1005,7 @@ async function exportAppImpl(
               outDir,
               `${route}${
                 subFolders && route !== '/index' ? `${sep}index` : ''
-              }.txt`
+              }${getStaticExportRscFileSuffix(navigationBuildId)}`
             )
           : join(pagesDataDir, `${route}.json`)
 
@@ -1034,8 +1036,10 @@ async function exportAppImpl(
             segmentPaths.map(async (segmentFileSrc) => {
               const segmentPath =
                 '/' + segmentFileSrc.slice(0, -RSC_SEGMENT_SUFFIX.length)
-              const segmentFilename =
-                convertSegmentPathToStaticExportFilename(segmentPath)
+              const segmentFilename = convertSegmentPathToStaticExportFilename(
+                segmentPath,
+                navigationBuildId
+              )
               const segmentFileDest = join(segmentsDirDest, segmentFilename)
               await fs.mkdir(dirname(segmentFileDest), { recursive: true })
               await fs.copyFile(

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -420,10 +420,14 @@ function maybeAppendBuildIdToRSCPayload<T extends RSCPayload>(
   ctx: AppRenderContext,
   payload: T
 ): T {
-  if (!ctx.sharedContext.deploymentId) {
-    // When using the build id, we need to initialize the id on initial page load, so a build id
-    // header wouldn't be enough.
-    payload.b = ctx.sharedContext.buildId
+  if (
+    !ctx.sharedContext.deploymentId ||
+    ctx.renderOpts.nextConfigOutput === 'export'
+  ) {
+    // Static exports cannot attach a deployment id response header when their
+    // RSC payloads are served as files, so include the navigation id in the
+    // payload instead. This also initializes the id on the initial page load.
+    payload.b = ctx.sharedContext.deploymentId || ctx.sharedContext.buildId
   }
   return payload
 }

--- a/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
@@ -1,5 +1,6 @@
 import { PAGE_SEGMENT_KEY } from '../segment'
 import type { Segment as FlightRouterStateSegment } from '../app-router-types'
+import { getStaticExportRscFileSuffix } from '../static-export-rsc'
 
 // TypeScript trick to simulate opaque types, like in Flow.
 type Opaque<K, T> = T & { __brand: K }
@@ -88,7 +89,8 @@ function encodeToFilesystemAndURLSafeString(value: string) {
 }
 
 export function convertSegmentPathToStaticExportFilename(
-  segmentPath: string
+  segmentPath: string,
+  navigationBuildId: string
 ): string {
-  return `__next${segmentPath.replace(/\//g, '.')}.txt`
+  return `__next${segmentPath.replace(/\//g, '.')}${getStaticExportRscFileSuffix(navigationBuildId)}`
 }

--- a/packages/next/src/shared/lib/static-export-rsc.ts
+++ b/packages/next/src/shared/lib/static-export-rsc.ts
@@ -1,0 +1,32 @@
+export function getStaticExportRscFileSuffix(
+  navigationBuildId: string
+): string {
+  return `.${navigationBuildId}.txt`
+}
+
+export function getStaticExportRscPath(
+  pathname: string,
+  navigationBuildId: string
+): string {
+  const suffix = getStaticExportRscFileSuffix(navigationBuildId)
+  return pathname.endsWith('/')
+    ? `${pathname}index${suffix}`
+    : `${pathname}${suffix}`
+}
+
+export function stripStaticExportRscPath(
+  pathname: string,
+  navigationBuildId: string
+): string {
+  const suffix = getStaticExportRscFileSuffix(navigationBuildId)
+  if (!pathname.endsWith(suffix)) {
+    return pathname
+  }
+
+  const indexSuffix = `/index${suffix}`
+  const length = pathname.endsWith(indexSuffix)
+    ? indexSuffix.length - 1
+    : suffix.length
+
+  return pathname.slice(0, -length)
+}

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -444,9 +444,19 @@ export function runTests({
 
       if (!isNextDev) {
         let outputDir = join(next.testDir, 'out')
-        const expected = trailingSlash
+        const buildId = (
+          await fs.readFile(join(next.testDir, '.next', 'BUILD_ID'), 'utf8')
+        ).trim()
+        const expectedWithoutBuildId = trailingSlash
           ? expectedWhenTrailingSlashTrue
           : expectedWhenTrailingSlashFalse
+        const expected = expectedWithoutBuildId.map((filename) =>
+          typeof filename === 'string' &&
+          filename.endsWith('.txt') &&
+          filename !== 'robots.txt'
+            ? filename.replace(/\.txt$/, `.${buildId}.txt`)
+            : filename
+        )
         const actualFiles = await getFiles(outputDir)
         expect(actualFiles).toEqual(expect.arrayContaining(expected))
         expect(actualFiles).toHaveLength(expected.length)

--- a/test/e2e/app-dir/static-export-skew-trailing-slash/app/layout.tsx
+++ b/test/e2e/app-dir/static-export-skew-trailing-slash/app/layout.tsx
@@ -1,8 +1,14 @@
-import { ReactNode } from 'react'
+'use client'
+
+import type { ReactNode } from 'react'
+
 export default function Root({ children }: { children: ReactNode }) {
   return (
     <html>
-      <body>{children}</body>
+      <body>
+        <input id="persistent-input" aria-label="Persistent input" />
+        {children}
+      </body>
     </html>
   )
 }

--- a/test/e2e/app-dir/static-export-skew-trailing-slash/next.config.js
+++ b/test/e2e/app-dir/static-export-skew-trailing-slash/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   output: 'export',
   trailingSlash: true,
   generateBuildId: async () => 'current-build-id',
+  deploymentId: 'current-deployment-id',
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/static-export-skew-trailing-slash/static-export-skew-trailing-slash.test.ts
+++ b/test/e2e/app-dir/static-export-skew-trailing-slash/static-export-skew-trailing-slash.test.ts
@@ -19,34 +19,69 @@ describe('static-export-skew-trailing-slash', () => {
 
   let port: number
   let server: Server
+  let targetFlightPath: string
+  let targetFlight: string
   const requests: string[] = []
 
   beforeAll(async () => {
     await next.build()
 
-    const targetFlightPath = join(next.testDir, 'out/target/index.txt')
-    const targetFlight = readFileSync(targetFlightPath, 'utf8')
-    const currentBuildId = '"b":"current-build-id"'
-    if (!targetFlight.includes(currentBuildId)) {
-      throw new Error('Could not find the current build ID in target RSC data')
-    }
-    writeFileSync(
-      targetFlightPath,
-      targetFlight.replace(currentBuildId, '"b":"foreign-build-id"')
+    targetFlightPath = join(
+      next.testDir,
+      'out/target/index.current-deployment-id.txt'
     )
+    targetFlight = readFileSync(targetFlightPath, 'utf8')
+    const currentNavigationId = '"b":"current-deployment-id"'
+    if (!targetFlight.includes(currentNavigationId)) {
+      throw new Error(
+        'Could not find the current deployment ID in target RSC data'
+      )
+    }
 
     port = await findPort()
     server = createExportServer(join(next.testDir, 'out'), requests)
     server.listen(port)
   })
 
+  beforeEach(() => {
+    requests.length = 0
+    writeFileSync(targetFlightPath, targetFlight)
+  })
+
   afterAll(() => {
     server?.close()
   })
 
-  it('preserves the trailing slash during an MPA fallback', async () => {
+  it('uses the current navigation RSC payload without an MPA navigation', async () => {
     const browser = await next.browser('/', { baseUrl: port })
 
+    await browser.elementById('persistent-input').type('draft value')
+    await browser.elementById('target-link').click()
+    await browser.waitForElementByCss('#target-page')
+
+    expect(await browser.elementById('persistent-input').getValue()).toBe(
+      'draft value'
+    )
+    expect(requests).toContain('/target/index.current-deployment-id.txt')
+    expect(
+      requests.filter(
+        (pathname) => pathname === '/target' || pathname === '/target/'
+      )
+    ).toEqual([])
+  })
+
+  it('preserves the trailing slash during an MPA fallback', async () => {
+    writeFileSync(
+      targetFlightPath,
+      targetFlight.replace(
+        '"b":"current-deployment-id"',
+        '"b":"foreign-deployment-id"'
+      )
+    )
+
+    const browser = await next.browser('/', { baseUrl: port })
+
+    await browser.elementById('persistent-input').type('draft value')
     await browser.elementById('target-link').click()
     await browser.waitForElementByCss('#target-page')
 
@@ -54,7 +89,8 @@ describe('static-export-skew-trailing-slash', () => {
       expect(new URL(await browser.url()).pathname).toBe('/target/')
     })
 
-    expect(requests).toContain('/target/index.txt')
+    expect(await browser.elementById('persistent-input').getValue()).toBe('')
+    expect(requests).toContain('/target/index.current-deployment-id.txt')
     expect(
       requests.filter(
         (pathname) => pathname === '/target' || pathname === '/target/'


### PR DESCRIPTION
## What

- Version static-export App Router RSC payload filenames.
- Apply the same versioning to segment-cache payloads.
- Use the deployment ID when configured; otherwise use the Build ID.

## Why

- Incremental deployments can overwrite unversioned `.txt` payloads.
- Existing browser sessions may then receive payloads from a newer deployment.
- This can trigger an MPA navigation and discard in-progress client state.

## How

- Keep export-side filenames and client-side request paths consistent.
- Preserve the existing MPA fallback for genuine version mismatches.
- Preserve trailing-slash behavior when constructing the fallback URL.

## Verification

- Turbopack static-export E2E
- Webpack static-export E2E
- Next.js package type checking and build

Refs #59986