### PR TITLE
Pair glob entries with resolved paths

### DIFF
--- a/crates/next-api/src/nft.rs
+++ b/crates/next-api/src/nft.rs
@@ -200,15 +200,12 @@ async fn get_glob_includes(
     stack.push_back(glob_result);
     while let Some(glob_result) = stack.pop_back() {
         // Process direct results (files and directories at this level).
-        for entry in glob_result.results.values() {
-            let (DirectoryEntry::File(file_path) | DirectoryEntry::Symlink(file_path)) = entry
-            else {
+        for (entry, realpath) in glob_result.results.values() {
+            let (DirectoryEntry::File(_) | DirectoryEntry::Symlink(_)) = entry else {
                 continue;
             };
 
-            // ReadGlobResult paths are logical by contract. Resolve each match here so the NFT
-            // includes both the physical file and every symlink needed to reach it.
-            let realpath = file_path.realpath_with_links().await?;
+            let realpath = realpath.await?;
             result.extend(realpath.symlinks.iter().cloned());
             if let Ok(resolved_path) = &realpath.path_result
                 && matches!(*resolved_path.get_type().await?, FileSystemEntryType::File)

--- a/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/examples/hash_glob.rs
@@ -72,8 +72,10 @@ async fn print_hash(dir_hash: Vc<RcStr>) -> Result<()> {
 async fn hash_glob_result(result: Vc<ReadGlobResult>) -> Result<Vc<RcStr>> {
     let result = result.await?;
     let mut hashes = BTreeMap::new();
-    for (name, entry) in result.results.iter() {
-        if let DirectoryEntry::File(path) = entry {
+    for (name, (entry, realpath)) in result.results.iter() {
+        if matches!(entry, DirectoryEntry::File(_))
+            && let Ok(path) = &realpath.await?.path_result
+        {
             hashes.insert(name, hash_file(path.clone()).owned().await?);
         }
     }
@@ -98,9 +100,6 @@ async fn hash_glob_result(result: Vc<ReadGlobResult>) -> Result<Vc<RcStr>> {
 
 #[turbo_tasks::function]
 async fn hash_file(file_path: FileSystemPath) -> Result<Vc<RcStr>> {
-    let Ok(file_path) = file_path.realpath().await? else {
-        return Ok(empty_string());
-    };
     let content = file_path.read().await?;
     Ok(match &*content {
         FileContent::Content(file) => hash_content(&mut file.read()),

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -6,13 +6,16 @@ use turbo_tasks::{Completion, ResolvedVc, TryJoinIterExt, Vc, turbobail};
 
 use crate::{
     DirectoryContent, DirectoryEntry, FileSystem, FileSystemEntryType, FileSystemPath, LinkContent,
-    glob::Glob,
+    RealPathWithLinksResult, glob::Glob,
 };
 
 #[turbo_tasks::value]
 #[derive(Default, Debug)]
 pub struct ReadGlobResult {
-    pub results: FxHashMap<RcStr, DirectoryEntry>,
+    /// Matched entries keyed by their logical path segment. Each logical entry is paired with its
+    /// resolved path and complete symlink chain.
+    pub results: FxHashMap<RcStr, (DirectoryEntry, ResolvedVc<RealPathWithLinksResult>)>,
+    /// Recursively traversed directories keyed by their logical path segment.
     pub inner: FxHashMap<RcStr, ResolvedVc<ReadGlobResult>>,
 }
 
@@ -58,13 +61,24 @@ async fn read_glob_internal(
     let dir = directory.read_dir().await?;
     let mut result = ReadGlobResult::default();
     let glob_value = glob.await?;
-    let handle_file = |result: &mut ReadGlobResult,
-                       entry_path: &RcStr,
-                       segment: &RcStr,
-                       entry: &DirectoryEntry| {
+    let handle_file = async |result: &mut ReadGlobResult,
+                             entry_path: &RcStr,
+                             segment: &RcStr,
+                             entry: &DirectoryEntry| {
         if glob_value.matches(entry_path) {
-            result.results.insert(segment.clone(), entry.clone());
+            let path = entry
+                .clone()
+                .path()
+                .expect("matched directory entries always have a path");
+            result.results.insert(
+                segment.clone(),
+                (
+                    entry.clone(),
+                    path.realpath_with_links().to_resolved().await?,
+                ),
+            );
         }
+        anyhow::Ok(())
     };
     let handle_dir = async |result: &mut ReadGlobResult,
                             entry_path: RcStr,
@@ -101,11 +115,11 @@ async fn read_glob_internal(
 
                 match entry {
                     DirectoryEntry::File(_) => {
-                        handle_file(&mut result, &entry_path, segment, &output_entry);
+                        handle_file(&mut result, &entry_path, segment, &output_entry).await?;
                     }
                     DirectoryEntry::Directory(path) => {
                         // Add the directory to `results` if it is a whole match of the glob
-                        handle_file(&mut result, &entry_path, segment, &output_entry);
+                        handle_file(&mut result, &entry_path, segment, &output_entry).await?;
                         // Recursively handle the directory
                         handle_dir(&mut result, entry_path, segment, path).await?;
                     }
@@ -115,7 +129,8 @@ async fn read_glob_internal(
                         if let LinkContent::Link { target } = &*link_content {
                             let Ok(realpath) = target.file_system_path().realpath().await? else {
                                 // Preserve unresolvable symlinks that match the glob.
-                                handle_file(&mut result, &entry_path, segment, &output_entry);
+                                handle_file(&mut result, &entry_path, segment, &output_entry)
+                                    .await?;
                                 continue;
                             };
                             if matches!(*realpath.get_type().await?, FileSystemEntryType::Directory)
@@ -124,12 +139,14 @@ async fn read_glob_internal(
                                 check_symlink_directory_recursion(path, &realpath)?;
 
                                 // Add the directory to `results` if it is a whole match of the glob
-                                handle_file(&mut result, &entry_path, segment, &output_entry);
+                                handle_file(&mut result, &entry_path, segment, &output_entry)
+                                    .await?;
                                 // Enumerate the resolved target while preserving logical paths in
                                 // the glob result.
                                 handle_dir(&mut result, entry_path, segment, &realpath).await?;
                             } else {
-                                handle_file(&mut result, &entry_path, segment, &output_entry);
+                                handle_file(&mut result, &entry_path, segment, &output_entry)
+                                    .await?;
                             }
                         }
                     }
@@ -297,6 +314,41 @@ pub mod tests {
         glob::{Glob, GlobOptions},
     };
 
+    fn entries(result: &ReadGlobResult) -> HashMap<RcStr, DirectoryEntry> {
+        result
+            .results
+            .iter()
+            .map(|(segment, (entry, _))| (segment.clone(), entry.clone()))
+            .collect()
+    }
+
+    fn entry<'a>(result: &'a ReadGlobResult, segment: &str) -> Option<&'a DirectoryEntry> {
+        result.results.get(segment).map(|(entry, _)| entry)
+    }
+
+    async fn assert_realpath(
+        result: &ReadGlobResult,
+        segment: &str,
+        path: &FileSystemPath,
+        symlinks: &[FileSystemPath],
+    ) -> anyhow::Result<()> {
+        let realpath = result.results.get(segment).unwrap().1.await?;
+        assert_eq!(realpath.path_result.as_ref().unwrap(), path);
+        assert_eq!(realpath.symlinks.as_ref(), symlinks);
+        Ok(())
+    }
+
+    async fn assert_realpath_error(
+        result: &ReadGlobResult,
+        segment: &str,
+        symlinks: &[FileSystemPath],
+    ) -> anyhow::Result<()> {
+        let realpath = result.results.get(segment).unwrap().1.await?;
+        assert!(realpath.path_result.is_err());
+        assert_eq!(realpath.symlinks.as_ref(), symlinks);
+        Ok(())
+    }
+
     fn symlink<P: AsRef<std::path::Path>, Q: AsRef<std::path::Path>>(
         target: Q,
         path: P,
@@ -330,20 +382,23 @@ pub mod tests {
             .unwrap();
         assert_eq!(read_dir.results.len(), 2);
         assert_eq!(
-            read_dir.results.get("foo"),
+            entry(&read_dir, "foo"),
             Some(&DirectoryEntry::File(fs.root().await?.join("foo")?))
         );
         assert_eq!(
-            read_dir.results.get("sub"),
+            entry(&read_dir, "sub"),
             Some(&DirectoryEntry::Directory(fs.root().await?.join("sub")?))
         );
+        assert_realpath(&read_dir, "foo", &root.join("foo")?, &[]).await?;
+        assert_realpath(&read_dir, "sub", &root.join("sub")?, &[]).await?;
         assert_eq!(read_dir.inner.len(), 1);
         let inner = &*read_dir.inner.get("sub").unwrap().await?;
         assert_eq!(inner.results.len(), 1);
         assert_eq!(
-            inner.results.get("bar"),
+            entry(inner, "bar"),
             Some(&DirectoryEntry::File(fs.root().await?.join("sub/bar")?))
         );
+        assert_realpath(inner, "bar", &root.join("sub/bar")?, &[]).await?;
         assert_eq!(inner.inner.len(), 0);
 
         let read_dir = root
@@ -355,9 +410,10 @@ pub mod tests {
         let inner = &*read_dir.inner.get("sub").unwrap().await?;
         assert_eq!(inner.results.len(), 1);
         assert_eq!(
-            inner.results.get("bar"),
+            entry(inner, "bar"),
             Some(&DirectoryEntry::File(fs.root().await?.join("sub/bar")?))
         );
+        assert_realpath(inner, "bar", &root.join("sub/bar")?, &[]).await?;
         assert_eq!(inner.inner.len(), 0);
 
         Ok(())
@@ -375,7 +431,7 @@ pub mod tests {
         assert_eq!(read_dir.results.len(), 0);
         let inner = &*read_dir.inner.get("sub").unwrap().await?;
         assert_eq!(
-            inner.results,
+            entries(inner),
             HashMap::from_iter([
                 (
                     "link-foo.js".into(),
@@ -391,6 +447,21 @@ pub mod tests {
                 ),
             ])
         );
+        assert_realpath(inner, "foo.js", &root.join("sub/foo.js")?, &[]).await?;
+        assert_realpath(
+            inner,
+            "link-foo.js",
+            &root.join("sub/foo.js")?,
+            &[root.join("sub/link-foo.js")?],
+        )
+        .await?;
+        assert_realpath(
+            inner,
+            "link-root.js",
+            &root.join("root.js")?,
+            &[root.join("sub/link-root.js")?],
+        )
+        .await?;
         assert_eq!(inner.inner.len(), 0);
 
         // A symlinked folder
@@ -403,7 +474,7 @@ pub mod tests {
         assert_eq!(inner_sub.results.len(), 0);
         let inner_sub_dir = &*inner_sub.inner.get("dir").unwrap().await?;
         assert_eq!(
-            inner_sub_dir.results,
+            entries(inner_sub_dir),
             HashMap::from_iter([
                 (
                     "index.js".into(),
@@ -415,6 +486,19 @@ pub mod tests {
                 ),
             ])
         );
+        assert_realpath(
+            inner_sub_dir,
+            "index.js",
+            &root.join("dir/index.js")?,
+            &[root.join("sub/dir")?],
+        )
+        .await?;
+        assert_realpath_error(
+            inner_sub_dir,
+            "dead.js",
+            &[root.join("sub/dir")?, root.join("dir/dead.js")?],
+        )
+        .await?;
         assert_eq!(inner_sub_dir.inner.len(), 0);
 
         // A folder behind a symlink-to-symlink chain
@@ -427,7 +511,7 @@ pub mod tests {
         assert_eq!(inner_sub.results.len(), 0);
         let inner_sub_dir = &*inner_sub.inner.get("dir-chain").unwrap().await?;
         assert_eq!(
-            inner_sub_dir.results,
+            entries(inner_sub_dir),
             HashMap::from_iter([
                 (
                     "index.js".into(),
@@ -439,6 +523,23 @@ pub mod tests {
                 ),
             ])
         );
+        assert_realpath(
+            inner_sub_dir,
+            "index.js",
+            &root.join("dir/index.js")?,
+            &[root.join("sub/dir-chain")?, root.join("dir-link")?],
+        )
+        .await?;
+        assert_realpath_error(
+            inner_sub_dir,
+            "dead.js",
+            &[
+                root.join("sub/dir-chain")?,
+                root.join("dir-link")?,
+                root.join("dir/dead.js")?,
+            ],
+        )
+        .await?;
         assert_eq!(inner_sub_dir.inner.len(), 0);
 
         Ok(())
@@ -457,7 +558,7 @@ pub mod tests {
         let inner_sub = &*read_dir.inner.get("sub").unwrap().await?;
         assert_eq!(inner_sub.inner.len(), 0);
         assert_eq!(
-            inner_sub.results,
+            entries(inner_sub),
             HashMap::from_iter([
                 (
                     "foo.js".into(),
@@ -664,9 +765,16 @@ pub mod tests {
             .read_strongly_consistent()
             .await?;
             assert_eq!(
-                initial.results.get("file.txt"),
+                entry(&initial, "file.txt"),
                 Some(&DirectoryEntry::File(logical_base.join("file.txt")?))
             );
+            assert_realpath(
+                &initial,
+                "file.txt",
+                &root.join("target/inner/path/file.txt")?,
+                &[root.join("path/to/symlink")?],
+            )
+            .await?;
 
             let wildcard = read_glob_from_operation(
                 disk_root.clone(),
@@ -681,9 +789,16 @@ pub mod tests {
             let inner_result = symlink_result.inner.get("inner").unwrap().await?;
             let final_result = inner_result.inner.get("path").unwrap().await?;
             assert_eq!(
-                final_result.results.get("file.txt"),
+                entry(&final_result, "file.txt"),
                 Some(&DirectoryEntry::File(logical_base.join("file.txt")?))
             );
+            assert_realpath(
+                &final_result,
+                "file.txt",
+                &root.join("target/inner/path/file.txt")?,
+                &[root.join("path/to/symlink")?],
+            )
+            .await?;
 
             let initial_tracking = track_glob_from_operation(
                 disk_root.clone(),

--- a/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
@@ -356,7 +356,7 @@ async fn flatten_read_glob(result: &ReadGlobResult) -> Result<Vec<(RcStr, FileSy
         prefix: &str,
         files: &mut Vec<(RcStr, FileSystemPath)>,
     ) {
-        for (segment, entry) in &node.results {
+        for (segment, (entry, _realpath)) in &node.results {
             let full_path = if prefix.is_empty() {
                 segment.to_string()
             } else {


### PR DESCRIPTION
### What?

Follow-up to #97902. Pair each logical `read_glob` match with its cached resolved-path metadata, including the complete symlink chain, and migrate all existing consumers to use the paired result.

### Why?

Glob results intentionally retain logical paths so callers can recover every symlink used to reach a match. Previously, callers that needed a physical path had to start their own realpath lookup. That duplicated work and made it easy for a new consumer to accidentally perform filesystem access through the logical path.

### How?

Resolution now happens once when a matched entry is added to `ReadGlobResult`, and the resulting Turbo Tasks handle is shared with consumers. The recursive glob tree and logical keys remain unchanged.

NFT tracing reuses the paired metadata to emit resolved files and traversed links. The hash-glob example reads the paired resolved path directly. `import.meta.glob` continues deriving user-visible requests from logical keys while destructuring the new result shape.

Symlink tests cover ordinary files, direct and chained directory links, leaf links, dangling links, and initial-base plus wildcard-discovered links. They assert both the unchanged logical entry and the resolved target/link chain.

The main trade-off is that every matched entry now resolves eagerly, including consumers that only need logical paths; resolution is cached and shared across consumers.

### Verification

- `cargo clippy -p turbo-tasks-fs -p turbopack-ecmascript -p next-api --all-targets -- -D warnings`
- `cargo test -p turbo-tasks-fs` — 128 passed
- `cargo test -p next-api` — 7 passed
- `cargo check -p turbo-tasks-fs --examples`
- import-meta-glob symlink execution test — passed
- node-file-trace focused cases — 9 passed
- `pnpm build-all`
- webpack-loader glob e2e — passed
- build-trace e2e — passed

<!-- NEXT_JS_LLM -->


<!-- fleet 1d32e12c-f4ec-4f22-862a-c85f0005805c -->