### PR TITLE
Stabilize the Server Action HMR test

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1045,13 +1045,12 @@ describe('app-dir action handling', () => {
 
           await next.patchFile(
             filePath,
-            origContent.replace('return value + 1', 'return value + 1000')
+            origContent.replace('return value + 1', 'return 1000')
           )
 
           await retry(async () => {
             await browser.elementByCss('#inc').click()
-            const val = Number(await browser.elementById('count').text())
-            expect(val).toBeGreaterThan(1000)
+            expect(await browser.elementById('count').text()).toBe('1000')
           })
         } finally {
           await next.patchFile(filePath, origContent)


### PR DESCRIPTION
## Summary

The Server Action HMR test could fail when webpack dev HMR reset the client counter state while still applying the updated action correctly. That produced `1000` instead of a value greater than `1000`, coupling the action-update assertion to state preservation.

Update the action to return a fixed sentinel and assert that exact value. This keeps the test focused on whether the browser invokes the updated Server Action; runtime behavior and HMR state-preservation coverage are unchanged.

## Verification

- React 18 + webpack development suite: 80 passed, 3 skipped

<!-- NEXT_JS_LLM -->