### PR TITLE
Turbopack: add next_config.use_react_experimental getter

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2430,21 +2430,6 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub fn enable_transition_indicator(&self) -> Vc<bool> {
-        Vc::cell(self.experimental.transition_indicator.unwrap_or(false))
-    }
-
-    #[turbo_tasks::function]
-    pub fn enable_gesture_transition(&self) -> Vc<bool> {
-        Vc::cell(self.experimental.gesture_transition.unwrap_or(false))
-    }
-
-    #[turbo_tasks::function]
-    pub fn enable_blocking_ssr(&self) -> Vc<bool> {
-        Vc::cell(self.experimental.blocking_ssr.unwrap_or(false))
-    }
-
-    #[turbo_tasks::function]
     pub fn enable_expose_testing_api_in_production_build(&self) -> Vc<bool> {
         Vc::cell(
             self.experimental
@@ -2484,6 +2469,16 @@ impl NextConfig {
                 Vc::cell(self.experimental.durable_use_cache_entries.unwrap_or(false))
             }
         })
+    }
+
+    #[turbo_tasks::function]
+    pub fn use_react_experimental(&self) -> Vc<bool> {
+        // Keep in sync with file:///./../../../packages/next/src/lib/needs-experimental-react.ts
+        let blocking_ssr = self.experimental.blocking_ssr.unwrap_or(false);
+        let taint = self.experimental.taint.unwrap_or(false);
+        let transition_indicator = self.experimental.transition_indicator.unwrap_or(false);
+        let gesture_transition = self.experimental.gesture_transition.unwrap_or(false);
+        Vc::cell(blocking_ssr || taint || transition_indicator || gesture_transition)
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -97,17 +97,11 @@ pub async fn get_next_client_import_map(
             );
         }
         ClientContextType::App { app_dir } => {
-            // Keep in sync with file:///./../../../packages/next/src/lib/needs-experimental-react.ts
-            let blocking_ssr = *next_config.enable_blocking_ssr().await?;
-            let taint = *next_config.enable_taint().await?;
-            let transition_indicator = *next_config.enable_transition_indicator().await?;
-            let gesture_transition = *next_config.enable_gesture_transition().await?;
-            let react_channel =
-                if blocking_ssr || taint || transition_indicator || gesture_transition {
-                    "-experimental"
-                } else {
-                    ""
-                };
+            let react_channel = if *next_config.use_react_experimental().await? {
+                "-experimental"
+            } else {
+                ""
+            };
 
             import_map.insert_exact_alias(
                 rcstr!("react"),
@@ -883,11 +877,7 @@ async fn apply_vendored_react_aliases_server(
     runtime: NextRuntime,
     next_config: Vc<NextConfig>,
 ) -> Result<()> {
-    let blocking_ssr = *next_config.enable_blocking_ssr().await?;
-    let taint = *next_config.enable_taint().await?;
-    let transition_indicator = *next_config.enable_transition_indicator().await?;
-    let gesture_transition = *next_config.enable_gesture_transition().await?;
-    let react_channel = if blocking_ssr || taint || transition_indicator || gesture_transition {
+    let react_channel = if *next_config.use_react_experimental().await? {
         "-experimental"
     } else {
         ""

--- a/packages/next/src/lib/needs-experimental-react.ts
+++ b/packages/next/src/lib/needs-experimental-react.ts
@@ -1,6 +1,6 @@
 import type { NextConfig } from '../server/config-shared'
 
-// Keep in sync with Turbopack's experimental React switch: file://./../../../../crates/next-core/src/next_import_map.rs
+// Keep in sync with Turbopack's experimental React switch: file://./../../../../crates/next-core/src/next_config.rs
 export function needsExperimentalReact(config: NextConfig) {
   const { blockingSSR, taint, transitionIndicator, gestureTransition } =
     config.experimental || {}


### PR DESCRIPTION
Refactor to unify the multiple places where this computation was happening