### PR TITLE
Add the `unstable_generateStaticVariants` page export

### DIFF
--- a/packages/next/src/build/segment-config/app/app-segments.ts
+++ b/packages/next/src/build/segment-config/app/app-segments.ts
@@ -18,8 +18,22 @@ import {
   type LoaderTree,
 } from '../../../server/lib/app-dir-module'
 import type { DynamicParamTypes } from '../../../shared/lib/app-router-types'
+import type { VariantAssignment } from '../../../server/request/variants'
+import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 
 type GenerateStaticParams = (options: { params?: Params }) => Promise<Params[]>
+
+/**
+ * Declares the static variant combinations of a route.
+ *
+ * It takes no arguments. Each combination it returns applies to every prerender
+ * of the route: to each combination of static params, and to each fallback
+ * shell. A fallback shell is prerendered where a param is not known, so a
+ * combination that depended on params could not apply to one.
+ */
+type GenerateStaticVariants = () =>
+  | Promise<readonly VariantAssignment[][]>
+  | readonly VariantAssignment[][]
 
 /**
  * Parses the app config and attaches it to the segment.
@@ -61,6 +75,14 @@ function attach(segment: AppSegment, userland: unknown, route: string) {
       )
     }
   }
+
+  if (
+    'unstable_generateStaticVariants' in userland &&
+    typeof userland.unstable_generateStaticVariants === 'function'
+  ) {
+    segment.unstable_generateStaticVariants =
+      userland.unstable_generateStaticVariants as GenerateStaticVariants
+  }
 }
 
 export type AppSegment = {
@@ -70,6 +92,7 @@ export type AppSegment = {
   filePath: string | undefined
   config: AppSegmentConfig | undefined
   generateStaticParams: GenerateStaticParams | undefined
+  unstable_generateStaticVariants: GenerateStaticVariants | undefined
   createEmptyParamsError?: () => Error
 }
 
@@ -104,11 +127,30 @@ async function collectAppPageSegments(routeModule: AppPageRouteModule) {
       filePath,
       config: undefined,
       generateStaticParams: undefined,
+      unstable_generateStaticVariants: undefined,
     }
 
     // Only server components can have app segment configurations
     if (!isClientComponent) {
       attach(segment, userland, routeModule.definition.pathname)
+    }
+
+    // The build rejects combinations declared anywhere but on the page of a
+    // route. Prerenders are produced per page, so combinations on a layout
+    // would multiply those of every page beneath it. A default page does not
+    // render the route, so it may not declare them either.
+    //
+    // Only the page carries this segment key, so the comparison finds it
+    // whatever the shape of the tree, and a parallel route is never mistaken
+    // for it.
+    if (segment.unstable_generateStaticVariants && name !== PAGE_SEGMENT_KEY) {
+      // A module that has exports has a file path. The segment name stands in
+      // for it otherwise.
+      const declaredIn = filePath ?? name
+
+      throw new Error(
+        `${declaredIn} exported \`unstable_generateStaticVariants\`, but only a page may declare variant combinations.`
+      )
     }
 
     // If this segment doesn't already exist, then add it to the segments array.
@@ -165,6 +207,7 @@ async function collectAppRouteSegments(
       filePath: undefined,
       config: undefined,
       generateStaticParams: undefined,
+      unstable_generateStaticVariants: undefined,
     } satisfies AppSegment
   })
 
@@ -176,6 +219,17 @@ async function collectAppRouteSegments(
 
   // Extract the segment config from the userland module.
   attach(segment, routeModule.userland, routeModule.definition.pathname)
+
+  // The build rejects combinations declared on a route handler. A route handler
+  // cannot read a variant yet, so its response cannot differ between
+  // combinations.
+  //
+  // TODO(variants): support variants in a route handler.
+  if (segment.unstable_generateStaticVariants) {
+    throw new Error(
+      `${routeModule.definition.pathname} exported \`unstable_generateStaticVariants\`, but variants in a route handler are not supported yet.`
+    )
+  }
 
   return segments
 }

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -68,6 +68,7 @@ import { collectSegments } from './segment-config/app/app-segments'
 import { createIncrementalCache } from '../export/helpers/create-incremental-cache'
 import { collectRootParamKeys } from './segment-config/app/collect-root-param-keys'
 import { buildAppStaticPaths } from './static-paths/app'
+import { collectStaticVariantCombinations } from './variants/combinations'
 import { buildPagesStaticPaths } from './static-paths/pages'
 import type {
   PrerenderRouteMatcher,
@@ -878,6 +879,16 @@ export async function isPageStatic({
         }
 
         const route = parseNormalizedAppRoute(page)
+
+        // The build reads the static variant combinations of every app route
+        // here, and rejects what it cannot use. Nothing prerenders against them
+        // yet, so the result is discarded. A page with no dynamic segments
+        // builds no static paths, and can still declare combinations, so this
+        // call does not belong with the static paths below.
+        //
+        // TODO(variants): prerender each route against the combinations it
+        // declared.
+        await collectStaticVariantCombinations(segments, page)
 
         // If the page is dynamic and we're not in edge runtime, then we need to
         // build the static paths. The edge runtime doesn't support static

--- a/packages/next/src/build/variants/combinations.ts
+++ b/packages/next/src/build/variants/combinations.ts
@@ -1,0 +1,152 @@
+import type { AppSegment } from '../segment-config/app/app-segments'
+
+import {
+  assertValidVariantValue,
+  getVariantKey,
+  isVariant,
+} from '../../server/request/variants'
+
+/**
+ * Normalizes one combination that `unstable_generateStaticVariants` returned
+ * into a record keyed by variant identity, and rejects a malformed one.
+ *
+ * The parameter is `unknown` because the value comes from user code. The types
+ * describe what a combination should be, and this function establishes that it
+ * is one.
+ */
+function normalizeVariantAssignments(
+  assignments: unknown,
+  route: string
+): Record<string, string> {
+  if (!Array.isArray(assignments)) {
+    throw new Error(
+      `\`unstable_generateStaticVariants\` for ${route} returned a combination that is not an array. Each combination is a list of \`[variant, value]\` tuples.`
+    )
+  }
+
+  const values: Record<string, string> = {}
+
+  for (const assignment of assignments) {
+    if (!Array.isArray(assignment) || assignment.length !== 2) {
+      throw new Error(
+        `\`unstable_generateStaticVariants\` for ${route} returned a combination containing something that is not a \`[variant, value]\` tuple.`
+      )
+    }
+
+    const [variant, value] = assignment
+
+    if (!isVariant(variant)) {
+      throw new Error(
+        `\`unstable_generateStaticVariants\` for ${route} assigned a value to something that is not a variant. Use the value exported from a \`'use variants'\` module, for example \`[theme, 'dark']\`.`
+      )
+    }
+
+    const key = getVariantKey(variant)
+
+    if (key in values) {
+      throw new Error(
+        `\`unstable_generateStaticVariants\` for ${route} assigned the variant \`${key}\` more than once in one combination. A variant takes one value per combination.`
+      )
+    }
+
+    values[key] = assertValidVariantValue(key, value, 'assignment')
+  }
+
+  return values
+}
+
+/**
+ * Calls `unstable_generateStaticVariants` for a route and returns the static
+ * variant combinations it declared, each normalized to a record keyed by
+ * variant identity. A route that declares none produces an empty list. A
+ * combination that cannot be used throws.
+ *
+ * At most one segment can carry the export, because `collectSegments` rejects
+ * it anywhere but on the page of a route.
+ */
+export async function collectStaticVariantCombinations(
+  segments: ReadonlyArray<
+    Readonly<Pick<AppSegment, 'unstable_generateStaticVariants'>>
+  >,
+  route: string
+): Promise<Array<Record<string, string>>> {
+  const generateStaticVariants = segments.find(
+    (segment) => typeof segment.unstable_generateStaticVariants === 'function'
+  )?.unstable_generateStaticVariants
+
+  if (!generateStaticVariants) {
+    return []
+  }
+
+  const returned: unknown = await generateStaticVariants()
+
+  if (!Array.isArray(returned)) {
+    throw new Error(
+      `\`unstable_generateStaticVariants\` for ${route} did not return an array. Return a list of combinations, each a list of \`[variant, value]\` tuples.`
+    )
+  }
+
+  const declared: readonly unknown[] = returned
+  const combinations: Array<Record<string, string>> = []
+
+  for (const assignments of declared) {
+    const values = normalizeVariantAssignments(assignments, route)
+
+    if (Object.keys(values).length === 0) {
+      throw new Error(
+        `\`unstable_generateStaticVariants\` for ${route} returned an empty combination. A combination assigns at least one variant.`
+      )
+    }
+
+    combinations.push(values)
+  }
+
+  assertUnambiguousVariantCombinations(combinations, route)
+
+  return combinations
+}
+
+/**
+ * Rejects two combinations that one request can match with no order between
+ * them.
+ *
+ * Two combinations are ordered when one assigns everything the other assigns
+ * and more. The larger one is the more specific, and that is how a page covers
+ * a route both broadly and narrowly.
+ *
+ * Two combinations that each assign a variant the other leaves out have no such
+ * order. One of two things is then true:
+ *
+ * - They disagree on a variant they share, so no request matches both.
+ * - They agree wherever they overlap, so one request matches both.
+ *
+ * This function rejects the second, because nothing decides between them.
+ */
+function assertUnambiguousVariantCombinations(
+  combinations: ReadonlyArray<Record<string, string>>,
+  route: string
+): void {
+  for (let i = 0; i < combinations.length; i++) {
+    for (let j = i + 1; j < combinations.length; j++) {
+      const a = combinations[i]
+      const b = combinations[j]
+      const aKeys = Object.keys(a)
+      const bKeys = Object.keys(b)
+
+      if (aKeys.every((key) => key in b) || bKeys.every((key) => key in a)) {
+        continue
+      }
+
+      // Neither combination assigns everything the other does, so the variants
+      // they share decide. Two combinations that share none leave `shared`
+      // empty, and `every` holds for an empty array, so this rejects them.
+      const shared = aKeys.filter((key) => key in b)
+
+      if (shared.every((key) => a[key] === b[key])) {
+        throw new Error(
+          `\`unstable_generateStaticVariants\` for ${route} declared two combinations that a single request can match, neither of which is more specific than the other: ${JSON.stringify(a)} and ${JSON.stringify(b)}. Give one of them the other's variants as well, so that it is the more specific match, or give them different values for a variant they share so that no request matches both.`
+        )
+      }
+    }
+  }
+}

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -71,6 +71,7 @@ checkFields<Diff<{
   }
   config?: {}
   generateStaticParams?: Function
+  unstable_generateStaticVariants?: Function
   instant?: InstantConfigForTypeCheckInternal
   prefetch?: Prefetch
   unstable_dynamicStaleTime?: number

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -20,6 +20,7 @@ import { isAppPageRouteModule } from '../route-modules/checks'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { collectRootParamKeys } from '../../build/segment-config/app/collect-root-param-keys'
 import { buildAppStaticPaths } from '../../build/static-paths/app'
+import { collectStaticVariantCombinations } from '../../build/variants/combinations'
 import { buildPagesStaticPaths } from '../../build/static-paths/pages'
 import { createIncrementalCache } from '../../export/helpers/create-incremental-cache'
 import { parseNormalizedAppRoute } from '../../shared/lib/router/routes/app'
@@ -118,6 +119,15 @@ export async function loadStaticPaths({
       // above that the page type is 'app'.
       routeModule as AppPageRouteModule | AppRouteRouteModule
     )
+
+    // The dev server reads the static variant combinations of a route here, and
+    // rejects what it cannot use. Nothing prerenders against them yet, so the
+    // result is discarded.
+    //
+    // The dev server builds static paths only for a dynamic route. A route
+    // without dynamic segments is therefore checked by a production build
+    // alone.
+    await collectStaticVariantCombinations(segments, pathname)
 
     const route = parseNormalizedAppRoute(pathname)
     if (route.dynamicSegments.length === 0) {

--- a/packages/next/src/server/request/variants.ts
+++ b/packages/next/src/server/request/variants.ts
@@ -53,17 +53,41 @@ export function getVariantDecide(
   return value[VARIANT_DECIDE]
 }
 
+export function isVariant(value: unknown): value is Variant<string> {
+  return typeof value === 'function' && VARIANT_KEY in value
+}
+
 /**
- * Asserts that the value a `decide` function returned is a string.
+ * Where a variant value came from. A `decide` function returns one, and a
+ * combination assigns one. Each origin gets its own wording, so that an error
+ * names the code that supplied the value.
+ */
+type VariantValueOrigin = 'decide' | 'assignment'
+
+/**
+ * Asserts that a variant value is a string, and returns it.
  *
  * Any string is allowed, whatever characters it holds, because the transport
  * encodes it. A value that is not a string is the one thing to reject: it would
  * serialize into something that does not round-trip.
  */
-export function assertValidVariantValue(key: string, value: unknown): string {
+export function assertValidVariantValue(
+  key: string,
+  value: unknown,
+  origin: VariantValueOrigin
+): string {
   if (typeof value !== 'string') {
+    // Each origin has its own literal message. A computed prefix would give the
+    // two of them one error code, and neither wording would appear in the
+    // source.
+    if (origin === 'decide') {
+      throw new Error(
+        `The variant \`${key}\` resolved to a ${typeof value} value. Variant values must be strings.`
+      )
+    }
+
     throw new Error(
-      `The variant \`${key}\` resolved to a ${typeof value} value. Variant values must be strings.`
+      `The variant \`${key}\` was assigned a ${typeof value} value. Variant values must be strings.`
     )
   }
 
@@ -118,6 +142,19 @@ export function unstable_variant<T extends string = string>(
     [VARIANT_DECIDE]: { value: decide },
   }) as Variant<T>
 }
+
+/**
+ * Assigns one value to one variant.
+ *
+ * The tuple holds the variant itself, and not its name. An object key would be
+ * a local identifier at the call site: under `import { theme as t }` the
+ * framework could not map it back to the identity of the variant. A tuple is
+ * exact, and a rename does not change it.
+ */
+export type VariantAssignment<T extends string = string> = readonly [
+  Variant<T>,
+  T,
+]
 
 /**
  * Resolves a variant value at the render stage that the value belongs to.

--- a/packages/next/src/server/variants/wrap-proxy.ts
+++ b/packages/next/src/server/variants/wrap-proxy.ts
@@ -110,7 +110,7 @@ async function resolveVariants(
     const key = getVariantKey(variant)
     const value = await getVariantDecide(variant)(request)
 
-    values[key] = assertValidVariantValue(key, value)
+    values[key] = assertValidVariantValue(key, value, 'decide')
   }
 
   return encodeVariants(values)

--- a/packages/next/variants.d.ts
+++ b/packages/next/variants.d.ts
@@ -1,1 +1,5 @@
-export { unstable_variant, type Variant } from './dist/server/request/variants'
+export {
+  unstable_variant,
+  type Variant,
+  type VariantAssignment,
+} from './dist/server/request/variants'

--- a/test/e2e/app-dir/variants/fixtures/default/app/declared/page.tsx
+++ b/test/e2e/app-dir/variants/fixtures/default/app/declared/page.tsx
@@ -1,0 +1,30 @@
+import { Suspense } from 'react'
+
+import { country, locale, theme } from '../../variants'
+import { VariantValues } from '../variant-values'
+
+// Three combinations that are all accepted. The second assigns everything the
+// first does and one variant more, so the two are ordered. The third assigns a
+// variant that neither of the others does, and gives `theme` a different value,
+// so no request matches it together with either.
+export function unstable_generateStaticVariants() {
+  return [
+    [[theme, 'dark']],
+    [
+      [theme, 'dark'],
+      [locale, 'en'],
+    ],
+    [
+      [theme, 'light'],
+      [country, 'us'],
+    ],
+  ]
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p id="pending">pending</p>}>
+      <VariantValues />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/variants/fixtures/default/proxy.ts
+++ b/test/e2e/app-dir/variants/fixtures/default/proxy.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import { wrapProxy } from 'next/dist/server/variants/wrap-proxy'
-import { locale, theme } from './variants'
+import { country, locale, theme } from './variants'
 
 // This table names the variants of each route by hand.
 //
@@ -15,6 +15,10 @@ import { locale, theme } from './variants'
 const variantsByRoute = {
   '/': [locale, theme],
   '/rewrite-target': [locale, theme],
+  // This route declares static combinations that assign `country`, so a request
+  // to it resolves that variant as well, even though the route reads only the
+  // other two.
+  '/declared': [country, locale, theme],
   // The `config.matcher` below omits this route on purpose. See the route.
   '/unmatched-by-proxy': [locale, theme],
 }
@@ -46,5 +50,5 @@ export const proxy = wrapProxy(variantsByRoute, (request: NextRequest) => {
 })
 
 export const config = {
-  matcher: ['/', '/rewrite-source', '/external'],
+  matcher: ['/', '/declared', '/rewrite-source', '/external'],
 }

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/ambiguous-crossing/[slug]/page.tsx
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/ambiguous-crossing/[slug]/page.tsx
@@ -1,0 +1,20 @@
+import { country, locale, theme } from '../../../../variants'
+
+// Each combination assigns a variant the other leaves out, and they agree on
+// the one they share.
+export function unstable_generateStaticVariants() {
+  return [
+    [
+      [theme, 'dark'],
+      [locale, 'en'],
+    ],
+    [
+      [theme, 'dark'],
+      [country, 'us'],
+    ],
+  ]
+}
+
+export default function Page() {
+  return <p id="page">page</p>
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/ambiguous-disjoint/[slug]/page.tsx
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/ambiguous-disjoint/[slug]/page.tsx
@@ -1,0 +1,11 @@
+import { locale, theme } from '../../../../variants'
+
+// The two combinations share no variant, so there is nothing they can disagree
+// on, and a request that resolves both `theme` and `locale` matches each.
+export function unstable_generateStaticVariants() {
+  return [[[theme, 'dark']], [[locale, 'en']]]
+}
+
+export default function Page() {
+  return <p id="page">page</p>
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/assigned-twice/[slug]/page.tsx
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/assigned-twice/[slug]/page.tsx
@@ -1,0 +1,14 @@
+import { theme } from '../../../../variants'
+
+export function unstable_generateStaticVariants() {
+  return [
+    [
+      [theme, 'dark'],
+      [theme, 'light'],
+    ],
+  ]
+}
+
+export default function Page() {
+  return <p id="page">page</p>
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/combination-not-an-array/[slug]/page.tsx
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/combination-not-an-array/[slug]/page.tsx
@@ -1,0 +1,7 @@
+export function unstable_generateStaticVariants() {
+  return ['dark']
+}
+
+export default function Page() {
+  return <p id="page">page</p>
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/empty-combination/[slug]/page.tsx
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/empty-combination/[slug]/page.tsx
@@ -1,0 +1,7 @@
+export function unstable_generateStaticVariants() {
+  return [[]]
+}
+
+export default function Page() {
+  return <p id="page">page</p>
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/no-dynamic-segments/page.tsx
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/no-dynamic-segments/page.tsx
@@ -1,0 +1,7 @@
+export function unstable_generateStaticVariants() {
+  return 'dark'
+}
+
+export default function Page() {
+  return <p id="page">page</p>
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/non-string-value/[slug]/page.tsx
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/non-string-value/[slug]/page.tsx
@@ -1,0 +1,9 @@
+import { theme } from '../../../../variants'
+
+export function unstable_generateStaticVariants() {
+  return [[[theme, 1]]]
+}
+
+export default function Page() {
+  return <p id="page">page</p>
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/not-a-tuple/[slug]/page.tsx
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/not-a-tuple/[slug]/page.tsx
@@ -1,0 +1,9 @@
+import { theme } from '../../../../variants'
+
+export function unstable_generateStaticVariants() {
+  return [[[theme, 'dark', 'light']]]
+}
+
+export default function Page() {
+  return <p id="page">page</p>
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/not-a-variant/[slug]/page.tsx
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/not-a-variant/[slug]/page.tsx
@@ -1,0 +1,9 @@
+// The first element of the tuple is the name of a variant, and not the variant
+// itself.
+export function unstable_generateStaticVariants() {
+  return [[['theme', 'dark']]]
+}
+
+export default function Page() {
+  return <p id="page">page</p>
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/not-an-array/[slug]/page.tsx
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/not-an-array/[slug]/page.tsx
@@ -1,0 +1,7 @@
+export function unstable_generateStaticVariants() {
+  return 'dark'
+}
+
+export default function Page() {
+  return <p id="page">page</p>
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/on-layout/[slug]/page.tsx
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/on-layout/[slug]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="page">page</p>
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/on-layout/layout.tsx
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/on-layout/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react'
+
+import { theme } from '../../../variants'
+
+export function unstable_generateStaticVariants() {
+  return [[[theme, 'dark']]]
+}
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return children
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/on-route/[slug]/route.ts
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/case/on-route/[slug]/route.ts
@@ -1,0 +1,9 @@
+import { theme } from '../../../../variants'
+
+export function unstable_generateStaticVariants() {
+  return [[[theme, 'dark']]]
+}
+
+export function GET() {
+  return new Response('route')
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/layout.tsx
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/next.config.js
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    variants: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/variants/fixtures/invalid-combinations/variants.ts
+++ b/test/e2e/app-dir/variants/fixtures/invalid-combinations/variants.ts
@@ -12,15 +12,13 @@ export const theme = unstable_variant(
   'theme@variants.ts'
 )
 
-// A second variant. A resolved set then holds more than one pair, which
-// exercises the canonical ordering.
 export const locale = unstable_variant(
   (request) => (request.cookies.get('locale')?.value === 'de' ? 'de' : 'en'),
   'locale@variants.ts'
 )
 
-// A third variant, read by no route. It lets `/declared` declare two
-// combinations that each assign a variant the other leaves out.
+// A third variant, so that two combinations can each assign one that the other
+// leaves out while both assign `theme`.
 export const country = unstable_variant(
   (request) => (request.cookies.get('country')?.value === 'de' ? 'de' : 'us'),
   'country@variants.ts'

--- a/test/e2e/app-dir/variants/variants-invalid-combinations.test.ts
+++ b/test/e2e/app-dir/variants/variants-invalid-combinations.test.ts
@@ -1,0 +1,110 @@
+import { isNextDev, nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+// Each case names a route of the fixture and a distinctive part of the error
+// that its static variant combinations must produce. The dev server compiles a
+// route on request, so one server reports every one of them.
+const cases: ReadonlyArray<readonly [string, string]> = [
+  [
+    'not-an-array',
+    '`unstable_generateStaticVariants` for /case/not-an-array/[slug] did not return an array. Return a list of combinations',
+  ],
+  [
+    'combination-not-an-array',
+    '`unstable_generateStaticVariants` for /case/combination-not-an-array/[slug] returned a combination that is not an array.',
+  ],
+  [
+    'not-a-tuple',
+    '`unstable_generateStaticVariants` for /case/not-a-tuple/[slug] returned a combination containing something that is not a `[variant, value]` tuple.',
+  ],
+  [
+    'not-a-variant',
+    '`unstable_generateStaticVariants` for /case/not-a-variant/[slug] assigned a value to something that is not a variant.',
+  ],
+  [
+    'assigned-twice',
+    '`unstable_generateStaticVariants` for /case/assigned-twice/[slug] assigned the variant `theme@variants.ts` more than once in one combination.',
+  ],
+  [
+    'non-string-value',
+    'The variant `theme@variants.ts` was assigned a number value. Variant values must be strings.',
+  ],
+  [
+    'empty-combination',
+    '`unstable_generateStaticVariants` for /case/empty-combination/[slug] returned an empty combination.',
+  ],
+  [
+    'ambiguous-disjoint',
+    'neither of which is more specific than the other: {"theme@variants.ts":"dark"} and {"locale@variants.ts":"en"}',
+  ],
+  [
+    'ambiguous-crossing',
+    'neither of which is more specific than the other: {"theme@variants.ts":"dark","locale@variants.ts":"en"} and {"theme@variants.ts":"dark","country@variants.ts":"us"}',
+  ],
+  [
+    'on-layout',
+    'on-layout/layout.tsx exported `unstable_generateStaticVariants`, but only a page may declare variant combinations.',
+  ],
+  [
+    'on-route',
+    '/case/on-route/[slug] exported `unstable_generateStaticVariants`, but variants in a route handler are not supported yet.',
+  ],
+]
+
+// Variants are supported with Turbopack only, so a webpack build rejects the
+// config of this fixture before it reads any route.
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'static variant combinations that are rejected',
+  () => {
+    const { next, skipped } = nextTestSetup({
+      files: __dirname + '/fixtures/invalid-combinations',
+      // Every route of this fixture declares combinations that are rejected, so
+      // a build of all of them at once cannot succeed. Both modes below drive
+      // Next.js by hand instead.
+      skipStart: true,
+      skipDeployment: true,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    if (isNextDev) {
+      beforeAll(async () => {
+        await next.start()
+      })
+
+      it.each(cases)('should report %s', async (name, expected) => {
+        const response = await next.fetch(`/case/${name}/requested`)
+
+        expect(response.status).toBe(500)
+
+        await retry(async () => {
+          expect(next.cliOutput).toContain(expected)
+        })
+      })
+    } else {
+      it('should reject a combination on a route with no dynamic segments', async () => {
+        // The dev server reads the static variant combinations of a route when
+        // it builds the static paths of that route, and it builds them for a
+        // dynamic route on request. This route has no dynamic segments, so it
+        // builds no static paths at all, and only a build reads what it
+        // declared.
+        //
+        // `--debug-build-paths` restricts the build to this one route, so no
+        // other route of the fixture can fail first.
+        const { exitCode, cliOutput } = await next.build({
+          args: [
+            '--debug-build-paths',
+            'app/case/no-dynamic-segments/page.tsx',
+          ],
+        })
+
+        expect(exitCode).toBe(1)
+        expect(cliOutput).toContain(
+          '`unstable_generateStaticVariants` for /case/no-dynamic-segments did not return an array.'
+        )
+      })
+    }
+  }
+)

--- a/test/e2e/app-dir/variants/variants-invalid-combinations.test.ts
+++ b/test/e2e/app-dir/variants/variants-invalid-combinations.test.ts
@@ -53,58 +53,53 @@ const cases: ReadonlyArray<readonly [string, string]> = [
 
 // Variants are supported with Turbopack only, so a webpack build rejects the
 // config of this fixture before it reads any route.
-;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
-  'static variant combinations that are rejected',
-  () => {
-    const { next, skipped } = nextTestSetup({
-      files: __dirname + '/fixtures/invalid-combinations',
-      // Every route of this fixture declares combinations that are rejected, so
-      // a build of all of them at once cannot succeed. Both modes below drive
-      // Next.js by hand instead.
-      skipStart: true,
-      skipDeployment: true,
+// @force-gate turbopack
+describe('static variant combinations that are rejected', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname + '/fixtures/invalid-combinations',
+    // Every route of this fixture declares combinations that are rejected, so
+    // a build of all of them at once cannot succeed. Both modes below drive
+    // Next.js by hand instead.
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (isNextDev) {
+    beforeAll(async () => {
+      await next.start()
     })
 
-    if (skipped) {
-      return
-    }
+    it.each(cases)('should report %s', async (name, expected) => {
+      const response = await next.fetch(`/case/${name}/requested`)
 
-    if (isNextDev) {
-      beforeAll(async () => {
-        await next.start()
+      expect(response.status).toBe(500)
+
+      await retry(async () => {
+        expect(next.cliOutput).toContain(expected)
+      })
+    })
+  } else {
+    it('should reject a combination on a route with no dynamic segments', async () => {
+      // The dev server reads the static variant combinations of a route when
+      // it builds the static paths of that route, and it builds them for a
+      // dynamic route on request. This route has no dynamic segments, so it
+      // builds no static paths at all, and only a build reads what it
+      // declared.
+      //
+      // `--debug-build-paths` restricts the build to this one route, so no
+      // other route of the fixture can fail first.
+      const { exitCode, cliOutput } = await next.build({
+        args: ['--debug-build-paths', 'app/case/no-dynamic-segments/page.tsx'],
       })
 
-      it.each(cases)('should report %s', async (name, expected) => {
-        const response = await next.fetch(`/case/${name}/requested`)
-
-        expect(response.status).toBe(500)
-
-        await retry(async () => {
-          expect(next.cliOutput).toContain(expected)
-        })
-      })
-    } else {
-      it('should reject a combination on a route with no dynamic segments', async () => {
-        // The dev server reads the static variant combinations of a route when
-        // it builds the static paths of that route, and it builds them for a
-        // dynamic route on request. This route has no dynamic segments, so it
-        // builds no static paths at all, and only a build reads what it
-        // declared.
-        //
-        // `--debug-build-paths` restricts the build to this one route, so no
-        // other route of the fixture can fail first.
-        const { exitCode, cliOutput } = await next.build({
-          args: [
-            '--debug-build-paths',
-            'app/case/no-dynamic-segments/page.tsx',
-          ],
-        })
-
-        expect(exitCode).toBe(1)
-        expect(cliOutput).toContain(
-          '`unstable_generateStaticVariants` for /case/no-dynamic-segments did not return an array.'
-        )
-      })
-    }
+      expect(exitCode).toBe(1)
+      expect(cliOutput).toContain(
+        '`unstable_generateStaticVariants` for /case/no-dynamic-segments did not return an array.'
+      )
+    })
   }
-)
+})

--- a/test/e2e/app-dir/variants/variants.test.ts
+++ b/test/e2e/app-dir/variants/variants.test.ts
@@ -58,6 +58,18 @@ describe('variants', () => {
     expect($('#locale').text()).toBe('de')
   })
 
+  it('should resolve a variant per request on a route that declared static combinations', async () => {
+    const $ = await next.render$(url('/declared'), undefined, {
+      headers: { cookie: 'theme=dark' },
+    })
+
+    // This route declared static combinations, and resolves its variants for
+    // each request all the same, exactly as a route that declared none does.
+    // Nothing is prerendered against a combination yet.
+    expect($('#theme').text()).toBe('dark')
+    expect($('#locale').text()).toBe('en')
+  })
+
   it('should not expose the resolved values to the client', async () => {
     const response = await next.fetch(url('/'), {
       headers: { cookie: 'theme=dark' },

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -162,6 +162,7 @@ async function readNormalizedNFT(next, name) {
            "/node_modules/next/dist/build/swc/options.js",
            "/node_modules/next/dist/build/swc/types.js",
            "/node_modules/next/dist/build/utils.js",
+           "/node_modules/next/dist/build/variants/combinations.js",
            "/node_modules/next/dist/cli/next-test.js",
            "/node_modules/next/dist/client/*",
            "/node_modules/next/dist/compiled/@edge-runtime/cookies/index.js",


### PR DESCRIPTION
A page declares the variant combinations to prerender it against by exporting `unstable_generateStaticVariants`. Each combination is a list of `[variant, value]` tuples, and a combination does not have to assign every variant the page reads:

```tsx
// app/page.tsx
import { locale, theme } from '../variants'

export function unstable_generateStaticVariants() {
  return [
    [[theme, 'dark']],
    [
      [theme, 'light'],
      [locale, 'en'],
    ],
  ]
}
```

The name is prefixed because the shape is not settled. A page might instead declare its combinations through `generateStaticParams`, or through an API that does not exist yet, in which case this export goes away rather than changes. The prefix is dropped once the shape is settled.

Nothing prerenders against the combinations yet, so this change stops at reading the export and rejecting what cannot be used. Every route still resolves its variants for each request, and both callers discard the result. A later change adds the prerendering.

Only a page may declare combinations. Prerenders are produced per page, so combinations on a layout would multiply those of every page beneath it, and a default page does not render the route. A route handler is rejected for a different reason: it cannot read a variant yet, so its response cannot differ between combinations. Within one combination each variant takes a single value, and every value is a string.

Two combinations may assign different variants. One that assigns everything another assigns and more is the more specific of the two, which is how a page covers a route both broadly and narrowly. Two that each assign a variant the other leaves out have no such order. The build keeps such a pair when the two disagree on a variant they share, because no single request then matches both, and rejects it when they agree wherever they overlap.

An empty list is accepted. A list of combinations is often computed, and a configuration that yields none should build rather than fail.

A mistake is reported where the export is read, so that it names the route that made it. The build reads every app route, including one with no dynamic segments, because such a route builds no static paths and still declares combinations. The dev server reads a route where it builds the static paths of that route, which happens on the first request to a dynamic route.

---
Extracted from #96832