### PR TITLE
docs: Fix the documented contract for custom cache handlers

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/cacheHandlers.mdx
@@ -69,12 +69,86 @@ You can also define additional named handlers (e.g., `sessions`, `analytics`) an
 
 Note that `'use cache: private'` does not use cache handlers and cannot be customized.
 
-## API Reference
+## CacheEntry Type
 
-A cache handler must implement the `CacheHandler` interface with the following methods. The `CacheHandler` and `CacheEntry` types are exported from `next/cache`:
+A cache handler stores and returns `CacheEntry` objects. Both this type and `CacheHandler` are exported from `next/cache`:
 
 ```ts
 import type { CacheHandler, CacheEntry } from 'next/cache'
+```
+
+An entry has the following structure:
+
+```ts
+interface CacheEntry {
+  value: ReadableStream<Uint8Array>
+  tags: string[]
+  stale: number
+  timestamp: number
+  expire: number
+  revalidate: number
+}
+```
+
+| Property     | Type                         | Description                                                  |
+| ------------ | ---------------------------- | ------------------------------------------------------------ |
+| `value`      | `ReadableStream<Uint8Array>` | The cached data as a single-use stream.                      |
+| `tags`       | `string[]`                   | Cache tags (excluding soft tags).                            |
+| `stale`      | `number`                     | Duration in seconds for client-side staleness.               |
+| `timestamp`  | `number`                     | When the entry was created (timestamp in milliseconds).      |
+| `expire`     | `number`                     | How long the entry is allowed to be used (in seconds).       |
+| `revalidate` | `number`                     | How long until the entry should be revalidated (in seconds). |
+
+## The entry value stream
+
+Every handler writes entries through [`set()`](#set) and serves them through [`get()`](#get). Both methods work with the entry's serialized value, which arrives as a [`ReadableStream<Uint8Array>`](https://developer.mozilla.org/docs/Web/API/ReadableStream). Two properties of that stream constrain every implementation:
+
+- **It can be read only once.** Consume it in [`set()`](#set), and build a new stream over your stored data in every [`get()`](#get). A stream that was already read cannot serve a second reader: it delivers no data, or throws if the first reader still holds its lock.
+- **It belongs to the request that produced the entry.** Do not keep it once `set()` resolves. The stream holds a reference to that request, so keeping it holds the request's memory until your entry is evicted. The same applies to the `pendingEntry` promise. Next.js keeps its own copy of the value for the render, so your handler is free to consume the stream it receives.
+
+How you persist the data is up to you. Buffering the stream and piping it to your store as chunks arrive are both fine, as long as you consume it exactly once. Large entries are worth piping: a page can serialize to a lot of bytes, and an S3-like backend can accept them without your handler holding a second copy.
+
+Two more cases to plan for:
+
+- **Fan-out.** If a single entry has to reach two destinations, such as a local store and a remote one, use [`.tee()`](https://developer.mozilla.org/docs/Web/API/ReadableStream/tee) and consume both branches before `set()` resolves. Teeing is not a way to keep the value around. A stored branch does serve the next read, but it holds the source stream, its buffered chunks, and the request that produced them, and none of that appears in the size your store accounts for.
+- **Interrupted values.** The stream can error partway through rendering, which leaves you holding an incomplete value. Decide whether to keep it or discard it. Discarding is safer, because an incomplete value produces an incomplete page. This is separate from a partially written storage entry, which [Error Handling](#error-handling) covers.
+
+## API Reference
+
+A cache handler must implement the `CacheHandler` interface with the following five methods.
+
+### `set()`
+
+Store a cache entry for the given cache key.
+
+```ts
+set(cacheKey: string, pendingEntry: Promise<CacheEntry>): Promise<void>
+```
+
+| Parameter      | Type                  | Description                                 |
+| -------------- | --------------------- | ------------------------------------------- |
+| `cacheKey`     | `string`              | The unique key to store the entry under.    |
+| `pendingEntry` | `Promise<CacheEntry>` | A promise that resolves to the cache entry. |
+
+Returns `Promise<void>`.
+
+The entry may still be generating when `set()` is called, so await `pendingEntry` first. Then consume the value stream and persist what it delivers, as described in [The entry value stream](#the-entry-value-stream).
+
+The example below buffers, which is the simpler option and the right one for an in-memory store. A remote handler can pipe `entry.value` into an upload instead.
+
+```js
+const cacheHandler = {
+  async set(cacheKey, pendingEntry) {
+    // Wait for the entry to be ready
+    const entry = await pendingEntry
+
+    // Consume the stream, then keep the data rather than the stream
+    const value = new Uint8Array(await new Response(entry.value).arrayBuffer())
+
+    // Store in your cache system
+    cache.set(cacheKey, { ...entry, value })
+  },
+}
 ```
 
 ### `get()`
@@ -90,9 +164,29 @@ get(cacheKey: string, softTags: string[]): Promise<CacheEntry | undefined>
 | `cacheKey` | `string`   | The unique key for the cache entry.                                                         |
 | `softTags` | `string[]` | Implicit tags derived from the route path. See [Soft Tags](#soft-tags) for how to use them. |
 
-Returns a `CacheEntry` object if found, or `undefined` if not found or expired.
+Returns a `CacheEntry` object if one is stored, or `undefined` if not.
 
-Your `get` method should retrieve the cache entry from storage, check if it has expired based on the `revalidate` time, and return `undefined` for missing or expired entries.
+Your `get` method should retrieve the cache entry from storage and return `undefined` when there is nothing stored.
+
+You do not need to check how old the entry is. Next.js compares `timestamp` against the entry's own `expire` on every read and treats a too-old entry as a miss. It applies the same check to `revalidate` when the result is about to be written into another server cache, and it keeps entries a little longer on the dev server so reloads stay fast. Your own age check only duplicates the first of those.
+
+What the two timings mean for you is what Next.js does with the entry you return:
+
+- Past **`expire`**, the entry is discarded and the value is regenerated.
+- Past **`revalidate`** but within `expire`, the entry is served and a fresh one is generated in the background.
+
+Dropping entries earlier is a policy choice rather than a requirement. The [built-in handler](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/cache-handlers/default.ts) drops at `revalidate` because warming a replacement is wasted work when an in-memory entry is likely to be evicted before anything reads it. A shared store has no such problem and can serve until `expire`.
+
+Eviction is yours, though. Next.js never deletes from your store, so use a mechanism that reclaims entries nobody reads again: a TTL derived from `expire`, or a size-bounded LRU like the one in the built-in handler. Checking the age of an entry as you serve it is not eviction, because it only ever reaches the keys that are still being read.
+
+Invalidation is separate from both timings. When a tag tells you an entry is out of date, you have two options:
+
+- Return `undefined`. The entry counts as missing, and Next.js regenerates it now.
+- Return the entry with `revalidate: -1`. Next.js serves it and regenerates in the background, because a negative `revalidate` always lies in the past.
+
+See [Soft Tags](#soft-tags) and [Distributed Tag Coordination](#distributed-tag-coordination) for where those invalidations come from.
+
+Wrap your stored data in a new stream on every hit, never the stream you received in `set()`.
 
 ```js
 const cacheHandler = {
@@ -100,61 +194,32 @@ const cacheHandler = {
     const entry = cache.get(cacheKey)
     if (!entry) return undefined
 
-    // Check if expired
-    const now = Date.now()
-    if (now > entry.timestamp + entry.revalidate * 1000) {
-      return undefined
+    // No age check: Next.js compares `timestamp` against `expire` itself.
+    // `entry.value` holds the stored bytes, so wrap them in a fresh stream
+    return {
+      ...entry,
+      value: new ReadableStream({
+        start(controller) {
+          controller.enqueue(entry.value)
+          controller.close()
+        },
+      }),
     }
-
-    return entry
-  },
-}
-```
-
-### `set()`
-
-Store a cache entry for the given cache key.
-
-```ts
-set(cacheKey: string, pendingEntry: Promise<CacheEntry>): Promise<void>
-```
-
-| Parameter      | Type                  | Description                                 |
-| -------------- | --------------------- | ------------------------------------------- |
-| `cacheKey`     | `string`              | The unique key to store the entry under.    |
-| `pendingEntry` | `Promise<CacheEntry>` | A promise that resolves to the cache entry. |
-
-The entry may still be pending when this is called (i.e., its value stream may still be written to). Your handler should await the promise before processing the entry.
-
-Returns `Promise<void>`.
-
-Your `set` method must await the `pendingEntry` promise before storing it, since the cache entry may still be generating when this method is called. Once resolved, store the entry in your cache system.
-
-```js
-const cacheHandler = {
-  async set(cacheKey, pendingEntry) {
-    // Wait for the entry to be ready
-    const entry = await pendingEntry
-
-    // Store in your cache system
-    cache.set(cacheKey, entry)
   },
 }
 ```
 
 ### `refreshTags()`
 
-Called periodically before starting a new request to sync with external tag services.
+Called once per request, before the first cache read for this handler's kind, so the handler can sync tag state from an external service.
 
 ```ts
 refreshTags(): Promise<void>
 ```
 
-This is useful if you're coordinating cache invalidation across multiple instances or services. For in-memory caches, this can be a no-op.
-
 Returns `Promise<void>`.
 
-For in-memory caches, this can be a no-op. For distributed caches, use this to sync tag state from an external service or database before processing requests.
+For in-memory caches, this can be a no-op. For distributed caches, use it to read tag state from an external service or database, so this instance learns about invalidations made by the others before it serves anything from its own store. A request that reads nothing from this handler never calls it.
 
 ```js
 const cacheHandler = {
@@ -229,34 +294,79 @@ const cacheHandler = {
 }
 ```
 
-## CacheEntry Type
+## Soft Tags
 
-The `CacheEntry` object (exported from `next/cache`) has the following structure:
+Soft tags are implicit tags that Next.js automatically generates based on the route path. Every segment in the path gets a layout tag, plus the leaf route itself. For example, the route `/blog/hello` generates soft tags for `/layout`, `/blog/layout`, `/blog/hello/layout`, and `/blog/hello`. These tags are prefixed internally with `_N_T_`.
 
-```ts
-interface CacheEntry {
-  value: ReadableStream<Uint8Array>
-  tags: string[]
-  stale: number
-  timestamp: number
-  expire: number
-  revalidate: number
+Soft tags enable [`revalidatePath()`](/docs/app/api-reference/functions/revalidatePath) to work through the same tag-based cache system. When `revalidatePath('/blog/hello')` is called, it invalidates all cache entries associated with that path's soft tags.
+
+In the cache handler API, soft tags are passed to the [`get()`](#get) method as the `softTags` parameter. Your handler should check whether any soft tag has been invalidated (via `getExpiration()` or direct timestamp comparison) after the cache entry's `timestamp`.
+
+If an invalidation is more recent than the entry, report the entry as out of date using either option described in [`get()`](#get). The built-in handler uses both: it returns `undefined` for an expired tag, and `revalidate: -1` for a stale one.
+
+## Distributed Tag Coordination
+
+When running multiple Next.js instances, tag invalidation must be coordinated across instances. The default in-memory handler only tracks tags locally, so calling `revalidateTag()` on one instance does not affect others.
+
+To coordinate tags across instances:
+
+1. **`updateTags()`** is called when `revalidateTag()` is invoked. Your handler should write the invalidation timestamp to shared storage.
+2. **`refreshTags()`** runs once per request, before the first read from this handler. Your handler should read recent invalidation events from shared storage and update its local tag state.
+3. **`getExpiration()`** returns the most recent revalidation timestamp across all provided tags. The default implementation returns `Math.max(...timestamps, 0)`.
+
+Here's an example using Redis for distributed tag coordination:
+
+```js filename="cache-handlers/distributed-tags.js"
+const { createClient } = require('redis')
+
+const client = createClient({ url: process.env.REDIS_URL })
+client.connect()
+
+// Local cache of tag timestamps, synced via refreshTags
+const localTagTimestamps = new Map()
+
+module.exports = {
+  // ... get() and set() methods ...
+
+  async refreshTags() {
+    // Sync tag invalidation timestamps from Redis
+    // Using a dedicated set to track tag keys avoids scanning the keyspace
+    const tagKeys = await client.sMembers('revalidated-tags')
+    if (tagKeys.length > 0) {
+      const values = await client.mGet(tagKeys.map((k) => `tag:${k}`))
+      for (let i = 0; i < tagKeys.length; i++) {
+        localTagTimestamps.set(tagKeys[i], Number(values[i]))
+      }
+    }
+  },
+
+  async getExpiration(tags) {
+    const timestamps = tags.map((tag) => localTagTimestamps.get(tag) || 0)
+    return Math.max(...timestamps, 0)
+  },
+
+  async updateTags(tags, durations) {
+    const now = Date.now()
+    const pipeline = client.multi()
+    for (const tag of tags) {
+      pipeline.set(`tag:${tag}`, String(now))
+      pipeline.sAdd('revalidated-tags', tag)
+      localTagTimestamps.set(tag, now)
+    }
+    await pipeline.exec()
+  },
 }
 ```
 
-| Property     | Type                         | Description                                                  |
-| ------------ | ---------------------------- | ------------------------------------------------------------ |
-| `value`      | `ReadableStream<Uint8Array>` | The cached data as a stream.                                 |
-| `tags`       | `string[]`                   | Cache tags (excluding soft tags).                            |
-| `stale`      | `number`                     | Duration in seconds for client-side staleness.               |
-| `timestamp`  | `number`                     | When the entry was created (timestamp in milliseconds).      |
-| `expire`     | `number`                     | How long the entry is allowed to be used (in seconds).       |
-| `revalidate` | `number`                     | How long until the entry should be revalidated (in seconds). |
+For a full explanation of the tag architecture (including soft tags and multi-instance considerations), see [How Revalidation Works](/docs/app/guides/how-revalidation-works).
 
-> **Good to know**:
->
-> - The `value` is a [`ReadableStream`](https://developer.mozilla.org/docs/Web/API/ReadableStream). Use [`.tee()`](https://developer.mozilla.org/docs/Web/API/ReadableStream/tee) if you need to read and store the stream data.
-> - If the stream errors with partial data, your handler must decide whether to keep the partial cache or discard it.
+## Error Handling
+
+Cache operations should be implemented defensively:
+
+- **`set()` failure**: the response is still served to the user because `set()` is called asynchronously after the response stream is already flowing. The cache entry is lost, and the next request triggers a fresh render. Catch your own errors even so: a rejected `set()` joins the request's pending revalidation work, where it surfaces as a failed background task instead of a render error.
+- **`get()` failure**: your handler should catch internal errors and return `undefined` (the "cache miss" signal). The framework does not wrap `get()` in a try/catch, so an unhandled exception from `get()` will propagate as a render error.
+- **Partial writes**: if a cache entry is partially written and then read, the behavior is undefined. Use atomic writes or a write-then-rename pattern to avoid serving partial entries.
 
 ## Examples
 
@@ -265,8 +375,18 @@ interface CacheEntry {
 Here's a minimal implementation using a `Map` for storage. This example demonstrates the core concepts, but for a production-ready implementation with LRU eviction, error handling, and tag management, see the [default cache handler](https://github.com/vercel/next.js/blob/canary/packages/next/src/server/lib/cache-handlers/default.ts).
 
 ```js filename="cache-handlers/memory-handler.js"
+// Entries hold the serialized bytes, never the stream they arrived on
 const cache = new Map()
 const pendingSets = new Map()
+
+function streamFromBytes(bytes) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes)
+      controller.close()
+    },
+  })
+}
 
 module.exports = {
   async get(cacheKey, softTags) {
@@ -281,13 +401,11 @@ module.exports = {
       return undefined
     }
 
-    // Check if entry has expired
-    const now = Date.now()
-    if (now > entry.timestamp + entry.revalidate * 1000) {
-      return undefined
-    }
+    // No age check: Next.js compares `timestamp` against `expire` itself.
+    // This `Map` also has no eviction, which a real handler needs.
 
-    return entry
+    // Every hit gets its own stream over the stored bytes
+    return { ...entry, value: streamFromBytes(entry.value) }
   },
 
   async set(cacheKey, pendingEntry) {
@@ -302,8 +420,13 @@ module.exports = {
       // Wait for the entry to be ready
       const entry = await pendingEntry
 
-      // Store the entry in the cache
-      cache.set(cacheKey, entry)
+      // An in-memory store buffers the stream. Storing the stream itself, or
+      // a branch of it, keeps the request that produced the entry alive.
+      const value = new Uint8Array(
+        await new Response(entry.value).arrayBuffer()
+      )
+
+      cache.set(cacheKey, { ...entry, value })
     } finally {
       resolvePending()
       pendingSets.delete(cacheKey)
@@ -416,86 +539,6 @@ module.exports = {
   },
 }
 ```
-
-## Distributed Tag Coordination
-
-When running multiple Next.js instances, tag invalidation must be coordinated across instances. The default in-memory handler only tracks tags locally, so calling `revalidateTag()` on one instance does not affect others.
-
-To coordinate tags across instances:
-
-1. **`updateTags()`** is called when `revalidateTag()` is invoked. Your handler should write the invalidation timestamp to shared storage.
-2. **`refreshTags()`** is called before each request. Your handler should read recent invalidation events from shared storage and update its local tag state.
-3. **`getExpiration()`** returns the most recent revalidation timestamp across all provided tags. The default implementation returns `Math.max(...timestamps, 0)`.
-
-Here's an example using Redis for distributed tag coordination:
-
-```js filename="cache-handlers/distributed-tags.js"
-const { createClient } = require('redis')
-
-const client = createClient({ url: process.env.REDIS_URL })
-client.connect()
-
-// Local cache of tag timestamps, synced via refreshTags
-const localTagTimestamps = new Map()
-
-module.exports = {
-  // ... get() and set() methods ...
-
-  async refreshTags() {
-    // Sync tag invalidation timestamps from Redis
-    // Using a dedicated set to track tag keys avoids scanning the keyspace
-    const tagKeys = await client.sMembers('revalidated-tags')
-    if (tagKeys.length > 0) {
-      const values = await client.mGet(tagKeys.map((k) => `tag:${k}`))
-      for (let i = 0; i < tagKeys.length; i++) {
-        localTagTimestamps.set(tagKeys[i], Number(values[i]))
-      }
-    }
-  },
-
-  async getExpiration(tags) {
-    const timestamps = tags.map((tag) => localTagTimestamps.get(tag) || 0)
-    return Math.max(...timestamps, 0)
-  },
-
-  async updateTags(tags, durations) {
-    const now = Date.now()
-    const pipeline = client.multi()
-    for (const tag of tags) {
-      pipeline.set(`tag:${tag}`, String(now))
-      pipeline.sAdd('revalidated-tags', tag)
-      localTagTimestamps.set(tag, now)
-    }
-    await pipeline.exec()
-  },
-}
-```
-
-For a full explanation of the tag architecture (including soft tags and multi-instance considerations), see [How Revalidation Works](/docs/app/guides/how-revalidation-works).
-
-## Soft Tags
-
-Soft tags are implicit tags that Next.js automatically generates based on the route path. Every segment in the path gets a layout tag, plus the leaf route itself. For example, the route `/blog/hello` generates soft tags for `/layout`, `/blog/layout`, `/blog/hello/layout`, and `/blog/hello`. These tags are prefixed internally with `_N_T_`.
-
-Soft tags enable [`revalidatePath()`](/docs/app/api-reference/functions/revalidatePath) to work through the same tag-based cache system. When `revalidatePath('/blog/hello')` is called, it invalidates all cache entries associated with that path's soft tags.
-
-In the cache handler API, soft tags are passed to the [`get()`](#get) method as the `softTags` parameter. Your handler should check whether any soft tag has been invalidated (via `getExpiration()` or direct timestamp comparison) after the cache entry's `timestamp`. If a soft tag was invalidated more recently than the entry was created, the entry should be treated as stale.
-
-## Handling Streams
-
-The `CacheEntry.value` is a [`ReadableStream<Uint8Array>`](https://developer.mozilla.org/docs/Web/API/ReadableStream). When implementing a cache handler that stores entries externally, keep in mind:
-
-- **Use `.tee()`** if you need to both store and return the stream. One branch goes to storage, the other is returned to the caller.
-- **Memory implications**: large pages produce large cache entries. For S3-like storage backends, consider streaming directly to storage without buffering the entire entry in memory.
-- **Partial writes**: the stream may error partway through rendering. Your handler should decide whether to keep partial entries or discard them. Discarding is safer, as partial entries can produce incomplete pages.
-
-## Error Handling
-
-Cache operations should be implemented defensively:
-
-- **`set()` failure**: the response is still served to the user because `set()` is called asynchronously after the response stream is already flowing. The cache entry is lost, and the next request triggers a fresh render.
-- **`get()` failure**: your handler should catch internal errors and return `undefined` (the "cache miss" signal). The framework does not wrap `get()` in a try/catch, so an unhandled exception from `get()` will propagate as a render error.
-- **Partial writes**: if a cache entry is partially written and then read, the behavior is undefined. Use atomic writes or a write-then-rename pattern to avoid serving partial entries.
 
 ## Platform Support
 

--- a/packages/next/src/server/lib/cache-handlers/default.test.ts
+++ b/packages/next/src/server/lib/cache-handlers/default.test.ts
@@ -12,6 +12,20 @@ setFlagsFromString('--expose-gc')
 const forceGarbageCollection = runInNewContext('gc') as () => void
 
 describe('default use cache handler', () => {
+  /**
+   * These tests guard the handler against retaining the request that filled or
+   * read an entry. Whether a regression here fails depends on the
+   * `AsyncLocalStorage` implementation of the environment:
+   *
+   * - Node 20 and 22 attach the active store to every promise, so a retained
+   *   stream keeps the store reachable, and these tests fail on a regression.
+   * - Node 24 and later use `AsyncContextFrame`, and these tests pass with or
+   *   without the retention.
+   *
+   * CI runs Node 20.9, so the guard holds there. A regression is invisible to a
+   * developer who runs the suite on Node 24 or later.
+   */
+
   it('does not retain the async context that populated an entry', async () => {
     const handler = createDefaultCacheHandler(1024 * 1024)
     const requestStoreRef = await runInRequestContext(() =>

--- a/packages/next/src/server/lib/cache-handlers/types.ts
+++ b/packages/next/src/server/lib/cache-handlers/types.ts
@@ -5,9 +5,24 @@ export type Timestamp = number
 
 export interface CacheEntry {
   /**
-   * The ReadableStream can error and only have partial data so any cache
-   * handlers need to handle this case and decide to keep the partial cache
-   * around or not.
+   * The serialized value of the entry. A cache handler consumes this stream in
+   * `set` and persists what it delivers. A handler can buffer the stream, or it
+   * can pipe it to its storage as chunks arrive. Two rules apply either way:
+   *
+   * - A handler must return a new stream from every `get`.
+   * - A handler must not retain the stream after `set` resolves.
+   *
+   * A stream can be read one time only. A second reader of the same stream gets
+   * no data, or an error while the first reader holds the lock. A retained
+   * stream also keeps a reference to the async context of the request that
+   * created it, which keeps the state of that request reachable for as long as
+   * the entry lives.
+   *
+   * The same applies to the `pendingEntry` promise that `set` receives. A
+   * handler must not put that promise in a map that outlives the request.
+   *
+   * The stream can error and deliver partial data. Each handler decides whether
+   * it keeps the partial entry or discards it.
    */
   value: ReadableStream<Uint8Array>
 
@@ -30,11 +45,22 @@ export interface CacheEntry {
   /**
    * How long the entry is allowed to be used (should be longer than revalidate)
    * [duration in seconds]
+   *
+   * This is the hard limit. Next.js compares it against `timestamp` on every
+   * read and treats a too-old entry as a miss, so a handler does not need to
+   * check the age of an entry before it returns one. The dev server raises the
+   * limit to five minutes when `expire` is shorter, to keep reloads fast.
    */
   expire: number
 
   /**
    * How long until the entry should be revalidated [duration in seconds]
+   *
+   * An entry that is past `revalidate` but within `expire` is still served, and
+   * Next.js generates a fresh one in the background. A negative value always
+   * lies in the past, so it forces that background refresh on the next read.
+   * The built-in handler returns `-1` for an entry whose tag is stale, which
+   * serves the entry one more time and replaces it.
    */
   revalidate: number
 }
@@ -42,7 +68,10 @@ export interface CacheEntry {
 export interface CacheHandler {
   /**
    * Retrieve a cache entry for the given cache key, if available. Will return
-   * undefined if there's no valid entry, or if the given soft tags are stale.
+   * undefined if there's nothing stored, or if the given soft tags are stale.
+   *
+   * Each call returns a new `value` stream over the stored bytes. See
+   * `CacheEntry.value`.
    */
   get(cacheKey: string, softTags: string[]): Promise<undefined | CacheEntry>
 
@@ -53,12 +82,20 @@ export interface CacheHandler {
    * before the pending entry is complete, the cache handler must wait for the
    * `set` operation to finish, before returning the entry, instead of returning
    * undefined.
+   *
+   * The handler takes ownership of the entry's `value` stream, and consumes it
+   * exactly once. See `CacheEntry.value`.
+   *
+   * The handler also owns eviction. Next.js never removes an entry from the
+   * store, so the store needs a mechanism of its own, such as a time to live
+   * from `expire`, or a size-bounded LRU.
    */
   set(cacheKey: string, pendingEntry: Promise<CacheEntry>): Promise<void>
 
   /**
-   * This function may be called periodically, but always before starting a new
-   * request. If applicable, it should communicate with the tags service to
+   * This function is called once per request, before the first cache read for
+   * this handler's kind. A request that reads nothing from this handler does
+   * not call it. If applicable, it should communicate with the tags service to
    * refresh the local tags manifest accordingly.
    */
   refreshTags(): Promise<void>

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -87,6 +87,17 @@ export function streamFromString(str: string): ReadableStream<Uint8Array> {
   })
 }
 
+/**
+ * Creates a stream that delivers `chunk` and then closes.
+ *
+ * The stream is a default stream, and it has to stay one. A byte stream (`type:
+ * 'bytes'`) transfers the buffer of each chunk that it receives, which detaches
+ * `chunk`. A caller that keeps `chunk` to serve more than one read, such as an
+ * in-memory cache handler, loses the data on the first read.
+ *
+ * Every reader receives the same `chunk` instance. A reader that modifies it
+ * changes what later readers see.
+ */
 export function streamFromBuffer(chunk: Buffer): ReadableStream<Uint8Array> {
   return new ReadableStream({
     start(controller) {

--- a/packages/next/src/server/use-cache/tiered-cache-handler.ts
+++ b/packages/next/src/server/use-cache/tiered-cache-handler.ts
@@ -158,10 +158,12 @@ async function reconcileFrontFromBacking(
     if (backingEntry.timestamp > frontEntry.timestamp) {
       await front.set(cacheKey, Promise.resolve(backingEntry))
     } else {
-      // The front is already up to date, so the backing entry goes unused.
-      // Release its stream without awaiting: a teed stream's `cancel()` only
-      // settles once the sibling branch (retained by the backing handler) is
-      // also cancelled, so awaiting it here would hang the reconcile.
+      // The front is already up to date, so the backing entry goes unused. This
+      // code releases its stream and does not await the result. The backing
+      // handler is user-configured, and it can return one branch of a teed
+      // stream. `cancel()` on such a branch settles only after the sibling
+      // branch is cancelled too, and the handler retains that sibling, so an
+      // await here would hang the reconcile.
       void backingEntry.value.cancel()
     }
   } catch {


### PR DESCRIPTION
The documented in-memory handler stored the resolved entry and returned it from every `get`. A stored stream keeps the request that produced the entry reachable. The second cache hit also fails, because it reads a stream that another reader already consumed. The render then reports "Invalid state: ReadableStream is locked".

The "Handling Streams" section described a second, milder mistake. It told a handler to tee the stored stream in `get`. One branch goes back into the store, and the other serves the current read. That pattern serves every hit correctly. The built-in handler used it until #97941, so the page described the framework's own implementation. The stored branch retains the same request, and it also holds the source stream and its buffered chunks. The size a store accounts for covers none of that. The page now states that cost, because a reader who thinks of teeing would otherwise read the rule as inapplicable.

`get` told a handler to drop an entry once it is past `revalidate`. Next.js compares `timestamp` against `expire` on every read, and it treats a too-old entry as a miss. It applies the same check to `revalidate` when the result goes into another server cache. A handler therefore needs no age check at all. The built-in handler still drops at `revalidate`, as a deliberate policy for an in-memory cache, and the page now presents that as a policy instead of a rule.

Something still has to reclaim entries, so the page states that eviction belongs to the handler. Next.js never deletes from it. An age check at serve time is no substitute, because it only reaches the keys that a reader still asks for.

The page now follows an order in which no rule appears after the code that depends on it. The stream rules sit in one section ahead of the API reference. `CacheEntry Type` moves above the methods that reference it. `set` precedes `get`, because a handler writes an entry before it reads one. The tag and error sections move above the examples.

`types.ts` described `refreshTags` as periodic, and the page described it as a call before each request. Neither is accurate. It runs once per request, before the first cache read for its kind. A request that reads nothing from a handler never calls it.

Neither `types.ts` nor the page documented the `revalidate: -1` signal, which the built-in handler relies on. A negative value always lies in the past, so it serves an entry with a stale tag one more time while Next.js generates a fresh one.

`types.ts` now states these rules as well, so a handler author no longer has to read the built-in implementation to find them. It also covers the `pendingEntry` promise, which a handler must not retain either.

`streamFromBuffer` now records why it has to stay a default stream. A byte stream transfers the buffer of every chunk it receives. That would detach the buffer an in-memory handler serves many reads from. The comment in `tiered-cache-handler.ts` about cancelling a teed stream now says that the backing handler is user-configured, because the built-in one no longer returns such a branch.

The handler test from #97941 now records a limit of its own. It only fails on Node 20 and 22, whose `AsyncLocalStorage` attaches the active store to every promise. CI runs Node 20.9, so a regression fails there. A local run on a newer Node passes.

Nothing in this change affects runtime behavior.