### PR TITLE
[PPF] Pass in original searchParams for private-cache pages

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -2058,18 +2058,16 @@ export async function cache(
     args = [props, ...otherOuterArgs]
 
     fn = {
-      [name]: async (
-        {
-          params: _innerParams,
-          searchParams: innerSearchParams,
-        }: UseCachePageInnerProps,
-        ...otherInnerArgs: unknown[]
-      ) =>
+      [name]: async (_: UseCachePageInnerProps, ...otherInnerArgs: unknown[]) =>
         originalFn.apply(null, [
           {
-            params: outerParams,
+            params: props.params,
             searchParams:
-              innerSearchParams ??
+              // Preserve the original search params, if this cache can access them.
+              // Notably, in a runtime shell private caches can resolve, but search params
+              // will be hanging, and we need to preserve the original proxied promise object
+              // to trigger `dynamicAccessAbortSignal` when they're accessed.
+              props.searchParams ??
               // For public caches, search params are omitted from the cache
               // key (and the serialized args) to avoid mismatches between
               // prerendering and resuming a cached page that does not
@@ -2164,13 +2162,9 @@ export async function cache(
 
   switch (workUnitStore.type) {
     case 'prerender-runtime':
-    // We're currently only using `dynamicAccessAsyncStorage` for params,
-    // which are always available in a runtime prerender, so they will never hang,
-    // effectively making the tracking below a no-op.
-    // However, a runtime prerender shares a lot of the semantics with a static prerender,
-    // and might need to follow this codepath in the future
-    // if we start using `dynamicAccessAsyncStorage` for other APIs.
-    //
+    // A runtime prerender may be a runtime shell, which does not have access to
+    // params/searchParams, so we want to apply the same dynamic access logic
+    // as we do in static prerenders.
     // fallthrough
     case 'prerender':
       if (!isPageOrLayoutSegmentFunction) {

--- a/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/page.tsx
@@ -29,6 +29,21 @@ export default function Page() {
             /lazy-data-in-prefetch (prefetch=true)
           </LinkAccordion>
         </li>
+        <li>
+          <LinkAccordion href="/params-in-public-cache/1">
+            /params-in-public-cache/1
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/params-in-private-cache/1">
+            /params-in-private-cache/1
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/search-params-in-private-cache?foo=bar">
+            /search-params-in-private-cache?foo=bar
+          </LinkAccordion>
+        </li>
       </ul>
     </main>
   )

--- a/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/params-in-private-cache/[slug]/loading.tsx
+++ b/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/params-in-private-cache/[slug]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div id="page-loading">Loading page...</div>
+}

--- a/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/params-in-private-cache/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/params-in-private-cache/[slug]/page.tsx
@@ -1,0 +1,13 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  'use cache: private'
+  const { slug } = await params
+  return (
+    <main>
+      <p id="slug">{`Slug: ${slug}`}</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/params-in-public-cache/[slug]/loading.tsx
+++ b/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/params-in-public-cache/[slug]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div id="page-loading">Loading page...</div>
+}

--- a/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/params-in-public-cache/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/params-in-public-cache/[slug]/page.tsx
@@ -1,0 +1,13 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  'use cache'
+  const { slug } = await params
+  return (
+    <main>
+      <p id="slug">{`Slug: ${slug}`}</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/search-params-in-private-cache/loading.tsx
+++ b/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/search-params-in-private-cache/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div id="page-loading">Loading page...</div>
+}

--- a/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/search-params-in-private-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/app/search-params-in-private-cache/page.tsx
@@ -1,0 +1,12 @@
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[]>>
+}) {
+  'use cache: private'
+  return (
+    <main>
+      <p id="search">{`Search: ${JSON.stringify(await searchParams)}`}</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/next.config.ts
@@ -3,6 +3,11 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   cacheComponents: true,
   partialPrefetching: true,
+  experimental: {
+    // If a cache hangs, error quickly.
+    // (this is relevant for tests that validate caches with hanging inputs)
+    useCacheTimeout: 10,
+  },
 }
 
 export default nextConfig

--- a/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/runtime-prerender-cache-warming.test.ts
+++ b/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/runtime-prerender-cache-warming.test.ts
@@ -234,4 +234,156 @@ describe('runtime prerender cache warming', () => {
     // New in this request.
     expect(navigationLogs).toContain('cachedFn :: after navigation')
   })
+
+  describe('hanging props in cached pages in runtime shells', () => {
+    it('a public-cache page that awaits params becomes dynamic during a runtime shell prerender', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page, { includeAppShellRequests: true })
+
+      // Load the shell for the page.
+      // It contains a public cache that reads params, which are not available in a shell.
+      await act(async () => {
+        await browser
+          .elementByCss(
+            'input[data-link-accordion="/params-in-public-cache/1"]'
+          )
+          .click()
+      }, [
+        // The Shell should only the fallback for the page, not the page itself --
+        // The cache entry should be aborted as dynamic during cache filling,
+        // otherwise it would hang and time out.
+        {
+          includes: 'page-loading',
+          kind: 'runtime',
+        },
+        {
+          includes: 'Slug:',
+          block: 'reject',
+        },
+      ])
+
+      expectNoCacheFillTimeout(next.cliOutput)
+
+      // Navigate.
+      await act(async () => {
+        await browser
+          .elementByCss('a[href="/params-in-public-cache/1"]')
+          .click()
+        // The page is blocking, so we should show loading.tsx instead.
+        expect(await browser.elementByCss('#page-loading').text()).toEqual(
+          'Loading page...'
+        )
+      })
+
+      // After navigating, the full cache entry (including the param) should be visible.
+      expect(await browser.elementByCss('#slug').text()).toEqual('Slug: 1')
+    })
+
+    it('a private-cache page that awaits params becomes dynamic during a runtime shell prerender', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page, { includeAppShellRequests: true })
+
+      // Load the shell for the page.
+      // It contains a private cache that reads params, which are not available in a shell.
+      await act(async () => {
+        await browser
+          .elementByCss(
+            'input[data-link-accordion="/params-in-private-cache/1"]'
+          )
+          .click()
+      }, [
+        // The Shell should only the fallback for the page, not the page itself --
+        // The cache entry should be aborted as dynamic during cache filling,
+        // otherwise it would hang and time out.
+        {
+          includes: 'page-loading',
+          kind: 'runtime',
+        },
+        {
+          includes: 'Slug:',
+          block: 'reject',
+        },
+      ])
+
+      expectNoCacheFillTimeout(next.cliOutput)
+
+      // Navigate.
+      await act(async () => {
+        await browser
+          .elementByCss('a[href="/params-in-private-cache/1"]')
+          .click()
+        // The page is blocking, so we should show loading.tsx instead.
+        expect(await browser.elementByCss('#page-loading').text()).toEqual(
+          'Loading page...'
+        )
+      })
+
+      // After navigating, the full cache entry (including the param) should be visible.
+      expect(await browser.elementByCss('#slug').text()).toEqual('Slug: 1')
+    })
+
+    it('a private-cache page that awaits search params becomes dynamic during a runtime shell prerender', async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page, { includeAppShellRequests: true })
+
+      // Load the shell for the page.
+      // It contains a private cache that reads params, which are not available in a shell.
+      await act(async () => {
+        await browser
+          .elementByCss(
+            'input[data-link-accordion="/search-params-in-private-cache?foo=bar"]'
+          )
+          .click()
+      }, [
+        // The Shell should only the fallback for the page, not the page itself --
+        // The cache entry should be aborted as dynamic during cache filling,
+        // otherwise it would hang and time out.
+        {
+          includes: 'page-loading',
+          kind: 'runtime',
+        },
+        {
+          includes: 'Search:',
+          block: 'reject',
+        },
+      ])
+
+      expectNoCacheFillTimeout(next.cliOutput)
+
+      // Navigate.
+      await act(async () => {
+        await browser
+          .elementByCss('a[href="/search-params-in-private-cache?foo=bar"]')
+          .click()
+        // The page is blocking, so we should show loading.tsx instead.
+        expect(await browser.elementByCss('#page-loading').text()).toEqual(
+          'Loading page...'
+        )
+      })
+
+      // After navigating, the full cache entry (including the search params) should be visible.
+      expect(await browser.elementByCss('#search').text()).toEqual(
+        `Search: ${JSON.stringify({ foo: 'bar' })}`
+      )
+    })
+  })
 })
+
+function expectNoCacheFillTimeout(cliOutput: string) {
+  expect(cliOutput).not.toContain('Filling a cache during prerender timed out')
+}


### PR DESCRIPTION
The handing for page components marked with `use cache: private` was assuming that searchParams can never hang in `prerender-runtime`, so it passed the serialized `innerSearchParams` to the page, which we expected to just be a resolved promise. This *used to* be correct when runtime prerenders always had search params available, because the serialized search params were always equivalent to `outerSearchParams`.

However, for `partialPrefetching` we started using `prerender-runtime` for runtime shells, where search params are not available, and if a private cache awaits them, it needs to abort filling and become dynamic, same as when it awaits params. So we need to trigger `dynamicAccessAbortController` when `searchParams` is awaited:

```tsx
export default async function Page({ searchParams }) {
  'use cache: private'
  // this should trigger `dynamicAccessAbortController.abort()`, so we need the original instrumented
  // searchParams object instead of the serialized one
  await searchParams
}
```

This is fixed by using the outer searchParams object in the `isPageSegmentFunction` codepath of `use-cache-wrapper` -- we're preserving the instrumented promise, so the cache prerender will abort as expected.
(before this fix, a shell prefetch of such a page would get a deserialized hanging promise for `searchParams` and hang until it times out)

2 of the 3 newly added tests ("params in a public cache" and "params in a private cache") were already passing, because `params` was already being preserved, but i'm adding them here to prevent regressions. The "search params in a private cache" one was failing due to the cache timing out, and is now passing. I'm not covering "search params in public cache" because that's an error and is already tested elsewhere.