### PR TITLE
Fix Route Handler response compression

### DIFF
--- a/packages/next/src/server/send-response.ts
+++ b/packages/next/src/server/send-response.ts
@@ -42,26 +42,27 @@ export async function sendResponse(
 
     // Copy over the response headers.
     response.headers?.forEach((value, name) => {
+      const lowercasedName = name.toLowerCase()
+
       // `x-middleware-set-cookie` is an internal header not needed for the response
-      if (name.toLowerCase() === 'x-middleware-set-cookie') {
+      if (lowercasedName === 'x-middleware-set-cookie') {
         return
       }
 
       // The append handling is special cased for `set-cookie`.
-      if (name.toLowerCase() === 'set-cookie') {
+      if (lowercasedName === 'set-cookie') {
         // TODO: (wyattjoh) replace with native response iteration when we can upgrade undici
         for (const cookie of splitCookiesString(value)) {
           res.appendHeader(name, cookie)
         }
       } else {
-        // only append the header if it is either not present in the outbound response
-        // or if the header supports multiple values
+        // Append headers that support multiple values. Otherwise, only set the
+        // header if it is not already present in the outbound response.
         const isHeaderPresent = typeof res.getHeader(name) !== 'undefined'
-        if (
-          headersWithMultipleValuesAllowed.includes(name.toLowerCase()) ||
-          !isHeaderPresent
-        ) {
+        if (headersWithMultipleValuesAllowed.includes(lowercasedName)) {
           res.appendHeader(name, value)
+        } else if (!isHeaderPresent) {
+          res.setHeader(name, value)
         }
       }
     })

--- a/test/e2e/app-dir/route-handler-compression/app/layout.tsx
+++ b/test/e2e/app-dir/route-handler-compression/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/route-handler-compression/app/page.tsx
+++ b/test/e2e/app-dir/route-handler-compression/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>{'page-content'.repeat(200)}</p>
+}

--- a/test/e2e/app-dir/route-handler-compression/app/route/route.ts
+++ b/test/e2e/app-dir/route-handler-compression/app/route/route.ts
@@ -1,0 +1,10 @@
+export const dynamic = 'force-dynamic'
+
+export function GET() {
+  return new Response('route-handler-content'.repeat(200), {
+    headers: {
+      'content-type': 'text/plain',
+      vary: 'custom',
+    },
+  })
+}

--- a/test/e2e/app-dir/route-handler-compression/app/sitemap.ts
+++ b/test/e2e/app-dir/route-handler-compression/app/sitemap.ts
@@ -1,0 +1,7 @@
+import type { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return Array.from({ length: 100 }, (_, index) => ({
+    url: `https://example.com/page-${index}`,
+  }))
+}

--- a/test/e2e/app-dir/route-handler-compression/next.config.js
+++ b/test/e2e/app-dir/route-handler-compression/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/route-handler-compression/route-handler-compression.test.ts
+++ b/test/e2e/app-dir/route-handler-compression/route-handler-compression.test.ts
@@ -1,0 +1,23 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('route-handler-compression', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it.each(['/', '/route', '/sitemap.xml'])(
+    'compresses the response for %s',
+    async (pathname) => {
+      const response = await next.fetch(pathname, {
+        headers: { 'accept-encoding': 'gzip' },
+      })
+
+      expect(response.headers.get('content-encoding')).toBe('gzip')
+
+      if (pathname === '/route') {
+        expect(response.headers.get('vary')).toContain('custom')
+        expect(response.headers.get('vary')).toContain('Accept-Encoding')
+      }
+    }
+  )
+})


### PR DESCRIPTION
## Summary

When running a self-hosted application with `next start`, I noticed that the built-in compression worked for regular page responses but not for Route Handlers or metadata routes such as `sitemap.xml`. Large API and sitemap responses were therefore sent without compression even when the client requested gzip.

The issue came from `sendResponse()` copying regular headers with `appendHeader()`. This stored single-value headers such as `Content-Type` as arrays, so the compression middleware could not recognize the response as compressible. This change uses `setHeader()` for normal single-value headers when the outbound response does not already contain them. Multi-value headers such as `Set-Cookie`, `Vary`, `WWW-Authenticate`, and `Proxy-Authenticate` continue to use append behavior.

I also added an end-to-end regression test covering a regular page, a dynamic Route Handler, and a generated sitemap. It checks that all three responses are gzip-compressed and that a Route Handler's existing custom `Vary` value is preserved alongside `Accept-Encoding`.

Fixes #98007

## Verification

- Docker: `pnpm --filter=next build`
- Docker: `pnpm test-start-turbo test/e2e/app-dir/route-handler-compression/route-handler-compression.test.ts`
- Docker: `pnpm test-start-webpack test/e2e/app-dir/route-handler-compression/route-handler-compression.test.ts`
- Focused Prettier and ESLint checks for the changed files

<!-- NEXT_JS_LLM -->
