### PR TITLE
Turbopack: drop rust analyzer skip annotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,6 +3169,8 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
  "serde",
 ]

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -286,7 +286,6 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
         }
         quote! {
             // Register this `impl Trait for Concrete` into the link-time `TRAIT_IMPLS_SLICE`.
-            #[cfg(not(rust_analyzer))]
             turbo_tasks::macro_helpers::scattered_collect::declarative::scatter! {
                 #[scatter(turbo_tasks::macro_helpers::TRAIT_IMPLS_SLICE)]
                 const _: turbo_tasks::macro_helpers::TraitImplRecord = {


### PR DESCRIPTION
For some reason, rust-analyzer was reporting this incorrectly:

<img width="1340" height="658" alt="image" src="https://github.com/user-attachments/assets/6ba97a91-dc21-4bce-8d56-a9839005a040" />
