### PR TITLE
test: remove stale deploy manifest exclusions

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -104,7 +104,6 @@
       "test/e2e/app-dir/modularizeimports/modularizeimports.test.ts",
       "test/e2e/app-dir/third-parties/basic.test.ts",
       "test/e2e/app-dir/app-static/app-static-custom-handler.test.ts",
-      "test/e2e/app-dir/options-request/options-request.test.ts",
       "test/e2e/app-dir/revalidate-dynamic/revalidate-dynamic.test.ts",
       "test/e2e/app-dir/syntax-highlighter-crash/syntax-highlighter-crash.test.ts",
       "test/e2e/new-link-behavior/stitches.test.ts",
@@ -117,8 +116,7 @@
       "test/e2e/postcss-config-cjs/index.test.ts",
       "test/e2e/socket-io/index.test.ts",
       "test/e2e/middleware-matcher/index.test.ts",
-      "test/e2e/next-script/index.test.ts",
-      "test/production/standalone-mode/**/*"
+      "test/e2e/next-script/index.test.ts"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Remove two inert entries from the deploy-test manifest:

- the entry for `test/e2e/app-dir/options-request/options-request.test.ts`, which no longer exists
- the `test/production/standalone-mode/**/*` glob, which cannot match the manifest's e2e-only include rule

This leaves the hard exclusion list limited to live, selectable test suites so follow-up deploy-testing work starts from an accurate inventory.

## Verification

- Parsed `test/deploy-tests-manifest.json` and confirmed all 26 remaining exclusions resolve to files selected by the manifest's include rule.

<!-- NEXT_JS_LLM -->
