### PR TITLE
test: document deploy test exclusions

### DIFF
--- a/test/e2e/404-page-custom-error/404-page-custom-error.test.ts
+++ b/test/e2e/404-page-custom-error/404-page-custom-error.test.ts
@@ -10,6 +10,8 @@ const shouldSkip =
   () => {
     const { next } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely inspects local build artifacts that deploy tests do not expose.
       skipDeployment: true,
     })
 

--- a/test/e2e/404-page-router/index.test.ts
+++ b/test/e2e/404-page-router/index.test.ts
@@ -49,6 +49,8 @@ describe('404-page-router', () => {
     (options) => {
       const isDev = (global as any).isNextDev
 
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It currently avoids creating five deployments rather than documenting an incompatibility.
       if ((global as any).isNextDeploy) {
         // TODO: investigate condensing these tests to avoid
         // 5 separate deploys for this one test

--- a/test/e2e/404-page-ssg/404-page-ssg.test.ts
+++ b/test/e2e/404-page-ssg/404-page-ssg.test.ts
@@ -4,6 +4,7 @@ describe('404 Page Support SSG', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
     skipDeployment: true,
   })

--- a/test/e2e/404-page/404-page.test.ts
+++ b/test/e2e/404-page/404-page.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('404 Page Support', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 
@@ -137,6 +139,8 @@ describe('404 Page Support', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/500-page/500-page-build.test.ts
+++ b/test/e2e/500-page/500-page-build.test.ts
@@ -7,6 +7,8 @@ import { isNextDev, nextTestSetup } from 'e2e-utils'
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/500-page/500-page.test.ts
+++ b/test/e2e/500-page/500-page.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('500 Page Support', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/api-body-parser/api-body-parser.test.ts
+++ b/test/e2e/api-body-parser/api-body-parser.test.ts
@@ -4,6 +4,7 @@ describe('API body parser', () => {
   describe('without custom server', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // Deploy mode exclusion: This suite controls a local server or proxy process.
       // Uses a custom HTTP/proxy server in front of Next.js; not applicable in deploy mode.
       skipDeployment: true,
     })
@@ -31,6 +32,7 @@ describe('API body parser', () => {
       dependencies: {
         express: '4',
       },
+      // Deploy mode exclusion: This suite controls a local server or proxy process.
       // Uses a custom HTTP/proxy server in front of Next.js; not applicable in deploy mode.
       skipDeployment: true,
     })

--- a/test/e2e/api-catch-all/api-catch-all.test.ts
+++ b/test/e2e/api-catch-all/api-catch-all.test.ts
@@ -4,6 +4,7 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
   () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
       // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
       skipDeployment: true,
     })

--- a/test/e2e/api-resolver-query-writeable/api-resolver-query-writeable.test.ts
+++ b/test/e2e/api-resolver-query-writeable/api-resolver-query-writeable.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('api-resolver-query-writeable', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     startCommand: 'node server.js',
     serverReadyPattern: /Next mode: (production|development)/,

--- a/test/e2e/api-support/api-support.test.ts
+++ b/test/e2e/api-support/api-support.test.ts
@@ -15,6 +15,8 @@ describe('API routes', () => {
       cors: 'latest',
       'node-fetch': '2.6.7',
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     disableAutoSkewProtection: true,
   })
@@ -603,6 +605,8 @@ describe('API routes output export error', () => {
       'node-fetch': '2.6.7',
     },
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     disableAutoSkewProtection: true,
   })

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
@@ -5,6 +5,8 @@ import { join } from 'path'
 describe('app-dir action allowed origins', () => {
   const { next, skipped } = nextTestSetup({
     files: join(__dirname, 'safe-origins'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     dependencies: {
       'server-only': 'latest',

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-disallowed-origins.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-disallowed-origins.test.ts
@@ -5,6 +5,8 @@ import { join } from 'path'
 describe('app-dir action disallowed origins', () => {
   const { next, skipped } = nextTestSetup({
     files: join(__dirname, 'unsafe-origins'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     dependencies: {
       'server-only': 'latest',

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-opaque-origin.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-opaque-origin.test.ts
@@ -5,6 +5,8 @@ import { join } from 'path'
 describe('app-dir action allowed from opaque origins', () => {
   const { next, skipped } = nextTestSetup({
     files: join(__dirname, 'opaque-origin'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     env: {
       NEXT_TEST_ALLOW_OPAQUE_ORIGIN: '1',
@@ -31,6 +33,8 @@ describe('app-dir action allowed from opaque origins', () => {
 describe('app-dir action disallowed from opaque origins', () => {
   const { isNextDev, next, skipped } = nextTestSetup({
     files: join(__dirname, 'opaque-origin'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     env: {
       NEXT_TEST_ALLOW_OPAQUE_ORIGIN: '',

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -18,8 +18,8 @@ describe('unrecognized server actions', () => {
     return next.cliOutput.slice(cliOutputPosition)
   }
 
-  // This is disabled when deployed because the 404 page will be served as a static route
-  // which will not support POST requests, and will return a 405 instead.
+  // Deploy mode exclusion: Deployed 404 pages are static routes, so POST
+  // requests return 405 instead of this suite's local 404 behavior.
   if (!isNextDeploy) {
     it('should 404 when POSTing a non-server-action request to a nonexistent page', async () => {
       const res = await next.fetch('/non-existent-route', {

--- a/test/e2e/app-dir/actions-unused-args/actions-unused-args.test.ts
+++ b/test/e2e/app-dir/actions-unused-args/actions-unused-args.test.ts
@@ -4,6 +4,7 @@ import { retry } from '../../../lib/next-test-utils'
 describe('actions-unused-args', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     // No access to runtime logs when deployed.
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/actions/app-action-export.test.ts
+++ b/test/e2e/app-dir/actions/app-action-export.test.ts
@@ -4,6 +4,8 @@ describe('app-dir action handling - next export', () => {
   const { next, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     dependencies: {
       nanoid: '4.0.1',

--- a/test/e2e/app-dir/app-a11y/index.test.ts
+++ b/test/e2e/app-dir/app-a11y/index.test.ts
@@ -5,6 +5,8 @@ describe('app a11y features', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     packageJson: {},
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/app-basepath-custom-server/index.test.ts
+++ b/test/e2e/app-dir/app-basepath-custom-server/index.test.ts
@@ -5,6 +5,8 @@ import { join } from 'path'
 describe('custom-app-server-action-redirect', () => {
   const { next, skipped } = nextTestSetup({
     files: join(__dirname, 'custom-server'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     startCommand: 'node server.js',
     serverReadyPattern: /Next mode: (production|development)/,

--- a/test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
@@ -234,6 +234,8 @@ describe('app dir client cache semantics (experimental staleTimes)', () => {
       })
     })
 
+    // Deploy mode exclusion: This nested suite reads telemetry events from the
+    // local Next.js CLI output.
     if (!isNextDeploy) {
       describe('telemetry', () => {
         it('should send staleTimes feature usage event', async () => {
@@ -368,6 +370,8 @@ describe('app dir client cache semantics (experimental staleTimes)', () => {
       })
     })
 
+    // Deploy mode exclusion: This nested suite reads telemetry events from the
+    // local Next.js CLI output.
     if (!isNextDeploy) {
       describe('telemetry', () => {
         it('should send staleTimes feature usage event', async () => {

--- a/test/e2e/app-dir/app-client-cache/client-cache.original.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.original.test.ts
@@ -15,6 +15,7 @@ describe('app dir client cache semantics (30s/5min)', () => {
     nextConfig: {
       experimental: { staleTimes: { dynamic: 30, static: 180 } },
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/app-compilation/index.test.ts
+++ b/test/e2e/app-dir/app-compilation/index.test.ts
@@ -4,6 +4,7 @@ import { waitForNoRedbox, retry } from 'next-test-utils'
 describe('app dir', () => {
   const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite only defines assertions for local dev or start modes.
     // This is skipped when deployed because there are no assertions outside of next start/next dev
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/app-config-crossorigin/index.test.ts
+++ b/test/e2e/app-dir/app-config-crossorigin/index.test.ts
@@ -7,6 +7,8 @@ if (!isNextStart) {
   describe('app dir - crossOrigin config', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // No deploy-specific incompatibility is documented.
       skipDeployment: true,
     })
 
@@ -42,6 +44,7 @@ if (!isNextStart) {
     describe('default output', () => {
       const { next } = nextTestSetup({
         files: path.join(__dirname, 'default'),
+        // Deploy mode exclusion: This branch only runs in next start mode.
         skipDeployment: true,
       })
 
@@ -73,6 +76,8 @@ if (!isNextStart) {
             NEXT_TEST_OUTPUT_EXPORT: '1',
           },
           skipStart: true,
+          // Deploy mode exclusion: This test builds and starts the exported app
+          // through a local custom server.
           skipDeployment: true,
           startCommand: 'node server.mjs',
           serverReadyPattern: /- Local:/,

--- a/test/e2e/app-dir/app-css-pageextensions/index.test.ts
+++ b/test/e2e/app-dir/app-css-pageextensions/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app dir - css with pageextensions', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     dependencies: {
       '@picocss/pico': '1.5.7',

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -4,6 +4,8 @@ import { check } from 'next-test-utils'
 describe('app dir - css', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
     dependencies: {
       '@picocss/pico': '1.5.7',

--- a/test/e2e/app-dir/app-custom-cache-handler-errors/app-custom-cache-handler-errors.test.ts
+++ b/test/e2e/app-dir/app-custom-cache-handler-errors/app-custom-cache-handler-errors.test.ts
@@ -5,6 +5,8 @@ import stripAnsi from 'strip-ansi'
 describe('app-custom-cache-handler-errors - get throws', () => {
   const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     env: { CACHE_HANDLER_THROW_ON: 'get' },
   })
@@ -99,6 +101,8 @@ describe('app-custom-cache-handler-errors - get throws', () => {
 describe('app-custom-cache-handler-errors - set throws', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     env: { CACHE_HANDLER_THROW_ON: 'set' },
   })

--- a/test/e2e/app-dir/app-custom-cache-handler/index.test.ts
+++ b/test/e2e/app-dir/app-custom-cache-handler/index.test.ts
@@ -33,6 +33,8 @@ function runTests(
 describe('app-dir - custom-cache-handler - cjs', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     env: {
       CUSTOM_CACHE_HANDLER: 'cache-handler.js',
@@ -49,6 +51,8 @@ describe('app-dir - custom-cache-handler - cjs', () => {
 describe('app-dir - custom-cache-handler - cjs-default-export', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     env: {
       CUSTOM_CACHE_HANDLER: 'cache-handler-cjs-default-export.js',
@@ -72,6 +76,8 @@ describe('app-dir - custom-cache-handler - esm', () => {
         'export default '
       ),
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     packageJson: {
       type: 'module',
@@ -95,6 +101,8 @@ describe('app-dir - custom-cache-handler - esm import.meta.resolve', () => {
       'cache-handler-esm.js': new FileRef(__dirname + '/cache-handler-esm.js'),
       'next.config.js': importMetaResolveNextConfig,
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     packageJson: {
       type: 'module',

--- a/test/e2e/app-dir/app-edge-root-layout/index.test.ts
+++ b/test/e2e/app-dir/app-edge-root-layout/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app-dir edge runtime root layout', () => {
   const { next, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely inspects local build artifacts that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/app-edge/app-edge-invalid-reexport.test.ts
+++ b/test/e2e/app-dir/app-edge/app-edge-invalid-reexport.test.ts
@@ -10,6 +10,8 @@ describe('app-dir edge SSR invalid reexport', () => {
         "export { default, runtime, preferredRegion } from '../basic/page'",
     },
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/app-edge/app-edge.test.ts
+++ b/test/e2e/app-dir/app-edge/app-edge.test.ts
@@ -4,6 +4,8 @@ import { check } from 'next-test-utils'
 describe('app-dir edge SSR', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -32,6 +32,8 @@ describe('app dir - external dependency', () => {
     installCommand: 'pnpm i',
     startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
     buildCommand: 'pnpm build',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
+++ b/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
@@ -5,6 +5,8 @@ describe('app-invalid-revalidate', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
@@ -8,6 +8,8 @@ describe('app dir - prefetching (custom staleTime)', () => {
     files: {
       app: new FileRef(join(__dirname, 'app')),
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     nextConfig: {
       experimental: {

--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -393,7 +393,8 @@ describe('app dir - prefetching', () => {
     })
   })
 
-  // These tests are skipped when deployed as they rely on runtime logs
+  // Deploy mode exclusion: This nested suite asserts runtime logs from the
+  // local Next.js process.
   if (!isNextDeploy) {
     describe('dynamic rendering', () => {
       describe.each(['/force-dynamic', '/revalidate-0'])('%s', (basePath) => {

--- a/test/e2e/app-dir/app-rendering/rendering.test.ts
+++ b/test/e2e/app-dir/app-rendering/rendering.test.ts
@@ -5,6 +5,8 @@ import cheerio from 'cheerio'
 describe('app dir rendering', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/app-root-params-getters/generate-static-params-error.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/generate-static-params-error.test.ts
@@ -5,6 +5,8 @@ describe('app-root-param-getters - generateStaticParams error', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'generate-static-params-error'),
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/app-dir/app-root-params-getters/typecheck.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/typecheck.test.ts
@@ -13,6 +13,8 @@ describe.each([{ fixture: 'simple' }, { fixture: 'multiple-roots' }])(
   ({ fixture }) => {
     const { next, skipped } = nextTestSetup({
       files: join(__dirname, 'fixtures', fixture),
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely controls the local Next.js build or server lifecycle.
       skipDeployment: true,
     })
 

--- a/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
@@ -294,6 +294,7 @@ describe('app-root-param-getters - cache - at build', () => {
 describe('app-root-param-getters - cache dedup with root params', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'use-cache-dedup'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // In deploy mode, concurrent requests could hit different lambdas.
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/app-routes/app-custom-route-base-path.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-route-base-path.test.ts
@@ -1,2 +1,4 @@
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 process.env.BASE_PATH = '/docs'
 require('./app-custom-routes.test')

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -689,7 +689,8 @@ describe('app-custom-routes', () => {
     })
   }
 
-  // This test is skipped in deploy mode because `next.cliOutput` will only contain build-time logs.
+  // Deploy mode exclusion: This nested suite asserts local CLI output that
+  // deployments do not expose.
   if (!isNextDeploy) {
     describe('no response returned', () => {
       it('should print an error when no response is returned', async () => {

--- a/test/e2e/app-dir/app-static/app-static-custom-handler.test.ts
+++ b/test/e2e/app-dir/app-static/app-static-custom-handler.test.ts
@@ -1,2 +1,4 @@
+// Deploy mode exclusion: This suite installs a process-local custom cache
+// handler, while a hosting platform supplies its own cache infrastructure.
 process.env.CUSTOM_CACHE_HANDLER = '1'
 require('./app-static.test')

--- a/test/e2e/app-dir/app-validation/validation.test.ts
+++ b/test/e2e/app-dir/app-validation/validation.test.ts
@@ -7,6 +7,8 @@ import {
 describe('app dir - validation', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/async-component-preload/async-component-preload.test.ts
+++ b/test/e2e/app-dir/async-component-preload/async-component-preload.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('async-component-preload', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/back-button-download-bug/back-button-download-bug.test.ts
+++ b/test/e2e/app-dir/back-button-download-bug/back-button-download-bug.test.ts
@@ -5,6 +5,8 @@ describe.skip('app-dir back button download bug', () => {
   describe('app-dir back button download bug', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // No deploy-specific incompatibility is documented.
       skipDeployment: true,
     })
 

--- a/test/e2e/app-dir/binary/rsc-binary.test.ts
+++ b/test/e2e/app-dir/binary/rsc-binary.test.ts
@@ -4,6 +4,8 @@ import { check } from 'next-test-utils'
 describe('RSC binary serialization', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     dependencies: {
       'server-only': 'latest',

--- a/test/e2e/app-dir/bun-externals/bun-externals.test.ts
+++ b/test/e2e/app-dir/bun-externals/bun-externals.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app-dir - bun externals', () => {
   const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely inspects local build artifacts that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components-console/cache-components.console.test.ts
+++ b/test/e2e/app-dir/cache-components-console/cache-components.console.test.ts
@@ -9,6 +9,8 @@ describe.skip('cache-components - Console Dimming - Validation', () => {
       FORCE_COLOR: '1',
     },
     files: __dirname + '/fixtures/default',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: !isNextDev,
   })
@@ -208,6 +210,8 @@ describe.skip('cache-components - Logging after Abort', () => {
         FORCE_COLOR: '1',
       },
       files: __dirname + '/fixtures/default',
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       skipStart: !isNextDev,
     })
@@ -386,6 +390,8 @@ describe.skip('cache-components - Logging after Abort', () => {
         FORCE_COLOR: '1',
       },
       files: __dirname + '/fixtures/default',
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       skipStart: !isNextDev,
     })
@@ -555,6 +561,8 @@ describe.skip('cache-components - Logging after Abort', () => {
         FORCE_COLOR: '1',
       },
       files: __dirname + '/fixtures/hide-logs-after-abort',
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       skipStart: !isNextDev,
     })
@@ -656,6 +664,8 @@ describe.skip('cache-components - Logging after Abort', () => {
         FORCE_COLOR: '1',
       },
       files: __dirname + '/fixtures/hide-logs-after-abort',
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       skipStart: !isNextDev,
     })

--- a/test/e2e/app-dir/cache-components-create-component-tree/cache-components-create-component-tree.test.ts
+++ b/test/e2e/app-dir/cache-components-create-component-tree/cache-components-create-component-tree.test.ts
@@ -5,6 +5,8 @@ describe('hello-world', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: !isNextDev,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
+++ b/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
@@ -161,6 +161,8 @@ describe('async imports in cacheComponents', () => {
 describe('async imports in cacheComponents - external packages', () => {
   const { next, isNextStart, skipped } = nextTestSetup({
     files: path.join(__dirname, 'external'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
@@ -5,6 +5,8 @@ describe('Cache Components Errors - Client Hook Abort Reasons', () => {
   const { next, isTurbopack, isNextStart, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/client-hook-abort-reasons',
     skipStart: !isNextDev,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components-errors/client.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/client.test.ts
@@ -5,6 +5,8 @@ describe('Cache Components Errors - Client Components', () => {
   const { next, isTurbopack, isNextStart, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/client',
     skipStart: !isNextDev,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components-errors/console-patch.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/console-patch.test.ts
@@ -5,6 +5,8 @@ import { retry } from 'next-test-utils'
 describe('Cache Components Errors', () => {
   const { next, isTurbopack, isNextStart, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/console-patch',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: !isNextDev,
     env: {

--- a/test/e2e/app-dir/cache-components-errors/http-access-fallback-prerender.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/http-access-fallback-prerender.test.ts
@@ -6,6 +6,8 @@ describe('Cache Components HTTP Access Fallback Prerender', () => {
   const { next, isNextStart, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/http-access-fallback-prerender',
     skipStart: !isNextDev,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components-errors/module-scope.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/module-scope.test.ts
@@ -4,6 +4,8 @@ describe('Lazy Module Init', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/lazy-module-init',
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components-errors/prospective-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/prospective-errors.test.ts
@@ -6,6 +6,7 @@ describe(`Cache Components Prospective Render Errors - Debug Build`, () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/prospective-render-errors',
     env: { NEXT_DEBUG_BUILD: 'true' },
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     // Accessing cliOutput is only available on the deployment
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/cache-components-prerender-matrix/cache-components-prerender-matrix.test.ts
+++ b/test/e2e/app-dir/cache-components-prerender-matrix/cache-components-prerender-matrix.test.ts
@@ -452,6 +452,8 @@ function createDocumentFetcher(next: NextInstance) {
 describe('cache-components-prerender-matrix', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: !isAdapterTest,
   })
 

--- a/test/e2e/app-dir/cache-components-request-apis/cache-components-request-apis.test.ts
+++ b/test/e2e/app-dir/cache-components-request-apis/cache-components-request-apis.test.ts
@@ -82,6 +82,8 @@ describe(`Request Promises`, () => {
     const { next, isNextDev, skipped } = nextTestSetup({
       files: __dirname + '/fixtures/reject-hanging-promises-dynamic',
       skipStart: true,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
 

--- a/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
@@ -9,6 +9,8 @@ describe('cache-components-route-handler-errors', () => {
   const { next, skipped, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
@@ -29,6 +29,8 @@ function filterToErrorHeaders(output: string): string {
     const { next, skipped, isNextDev } = nextTestSetup({
       files: __dirname + '/fixtures/edge-deduplication',
       skipStart: true,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely expects a local build failure instead of a successful deployment.
       skipDeployment: true,
     })
 

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
@@ -10,6 +10,8 @@ describe('cache-components-segment-configs', () => {
   const { next, skipped, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname + '/fixtures/default',
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components/cache-components.connection.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.connection.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('cache-components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components/cache-components.cookies.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.cookies.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('cache-components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components/cache-components.date.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.date.test.ts
@@ -4,6 +4,8 @@ import expect from 'expect'
 describe('cache-components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components/cache-components.draft-mode.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.draft-mode.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('cache-components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components/cache-components.headers.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.headers.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('cache-components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components/cache-components.node-crypto.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.node-crypto.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('cache-components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components/cache-components.params.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.params.test.ts
@@ -4,6 +4,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('cache-components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components/cache-components.random.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.random.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('cache-components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components/cache-components.routes.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.routes.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('cache-components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components/cache-components.search.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.search.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('cache-components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components/cache-components.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.test.ts
@@ -8,6 +8,8 @@ import { fetchViaHTTP, findPort } from 'next-test-utils'
 describe('cache-components', () => {
   const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/cache-components/cache-components.web-crypto.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.web-crypto.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('cache-components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/client-reference-chunking/client-reference-chunking.test.ts
+++ b/test/e2e/app-dir/client-reference-chunking/client-reference-chunking.test.ts
@@ -4,6 +4,8 @@ import { getClientReferenceManifest } from 'next-test-utils'
 describe('client-reference-chunking', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/client-reference-side-effects/client-reference-side-effects.test.ts
+++ b/test/e2e/app-dir/client-reference-side-effects/client-reference-side-effects.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('client-reference-side-effects', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
+++ b/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
@@ -7,6 +7,8 @@ describe('conflicting-page-segments', () => {
     // we skip start & deploy because the build will fail and we won't be able to catch it
     // start is re-triggered but caught in the assertions below.
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
@@ -9,6 +9,7 @@ import stripAnsi from 'strip-ansi'
   () => {
     const isDev = (global as any).isNextDev
 
+    // Deploy mode exclusion: This suite creates and patches project files, which cannot be changed after deployment.
     if ((global as any).isNextDeploy) {
       it('should skip next deploy for now', () => {})
       return
@@ -232,6 +233,8 @@ import stripAnsi from 'strip-ansi'
         app: new FileRef(path.join(__dirname, 'app')),
         'next.config.js': new FileRef(path.join(__dirname, 'next.config.js')),
       },
+      // Deploy mode exclusion: This suite intentionally fails a local build
+      // and inspects its output and fixture files.
       skipDeployment: true,
       skipStart: true,
     })

--- a/test/e2e/app-dir/css-order/css-order.test.ts
+++ b/test/e2e/app-dir/css-order/css-order.test.ts
@@ -339,6 +339,8 @@ const options = (value: CssChunkingValue) => ({
   dependencies: {
     sass: 'latest',
   },
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
   skipDeployment: true,
 })
 

--- a/test/e2e/app-dir/css-server-chunks/css-server-chunks.test.ts
+++ b/test/e2e/app-dir/css-server-chunks/css-server-chunks.test.ts
@@ -6,6 +6,8 @@ import path from 'node:path'
 describe('css-server-chunks', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely reads files from the isolated local fixture.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
+++ b/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
@@ -5,6 +5,8 @@ describe('custom-cache-control', () => {
     files: __dirname,
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // The hosting platform applies cache headers outside the Next.js server, so deploy mode needs separate expectations.
   if (isNextDeploy) {
     // customizing these headers won't apply on environments
     // where headers are applied outside of the Next.js server

--- a/test/e2e/app-dir/dedupe-rsc-error-log/dedupe-rsc-error-log.test.ts
+++ b/test/e2e/app-dir/dedupe-rsc-error-log/dedupe-rsc-error-log.test.ts
@@ -12,6 +12,7 @@ async function expectContainOnce(next: any, search: string) {
 describe('dedupe-rsc-error-log', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     // Runtime logs aren't available when deployed
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/draft-mode-middleware/draft-mode-middleware.test.ts
+++ b/test/e2e/app-dir/draft-mode-middleware/draft-mode-middleware.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('app-dir - draft-mode-middleware', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/duplicate-layout-components/duplicate-layout-components.test.ts
+++ b/test/e2e/app-dir/duplicate-layout-components/duplicate-layout-components.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app dir - duplicate layout components', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/dynamic-css/index.test.ts
+++ b/test/e2e/app-dir/dynamic-css/index.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('app dir - dynamic css', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
+++ b/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
@@ -5,6 +5,8 @@ process.env.__TEST_SENTINEL = 'at buildtime'
 describe('dynamic-data', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/main',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 
@@ -163,6 +165,8 @@ describe('dynamic-data with dynamic = "error"', () => {
     return
   }
 
+  // Deploy mode exclusion: This suite intentionally tests dev-server errors
+  // or a failed local build, so it cannot produce a deployment.
   if (isNextDeploy) {
     it.skip('should not run in next deploy.', () => {})
     return
@@ -292,6 +296,8 @@ describe('dynamic-data inside cache scope', () => {
     return
   }
 
+  // Deploy mode exclusion: This suite intentionally tests dev-server errors
+  // or a failed local build, so it cannot produce a deployment.
   if (isNextDeploy) {
     it.skip('should not run in next deploy..', () => {})
     return

--- a/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
+++ b/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
@@ -7,6 +7,8 @@ describe('dynamic-href', () => {
     skipped,
   } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/dynamic-import-tree-shaking/dynamic-import-tree-shaking.test.ts
+++ b/test/e2e/app-dir/dynamic-import-tree-shaking/dynamic-import-tree-shaking.test.ts
@@ -5,6 +5,8 @@ import path from 'path'
 describe('dynamic-import-tree-shaking', () => {
   const { next, skipped, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely inspects local build artifacts that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/app-dir/dynamic-in-generate-params/index.test.ts
+++ b/test/e2e/app-dir/dynamic-in-generate-params/index.test.ts
@@ -14,6 +14,8 @@ function assertSitemapResponse(res: Response) {
 describe('app-dir - dynamic in generate params', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/dynamic/dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic/dynamic.test.ts
@@ -5,6 +5,8 @@ import path from 'path'
 describe('app dir - next/dynamic', () => {
   const { next, isNextStart, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/emotion-js/index.test.ts
+++ b/test/e2e/app-dir/emotion-js/index.test.ts
@@ -4,6 +4,8 @@ import { check } from 'next-test-utils'
 describe('app dir - emotion-js', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     dependencies: {
       '@emotion/react': 'latest',

--- a/test/e2e/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
+++ b/test/e2e/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
@@ -4,6 +4,8 @@ describe('empty-generate-static-params', () => {
   const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
+++ b/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
@@ -10,6 +10,8 @@ describe('app-dir - error-on-next-codemod-comment', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -5,6 +5,8 @@ import stripAnsi from 'strip-ansi'
 describe('app-dir - errors', () => {
   const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/explicit-parallel-route-children-viewport-known-limitation/explicit-parallel-route-children-viewport-known-limitation.test.ts
+++ b/test/e2e/app-dir/explicit-parallel-route-children-viewport-known-limitation/explicit-parallel-route-children-viewport-known-limitation.test.ts
@@ -11,9 +11,9 @@ describe('explicit parallel route children viewport limitation', () => {
     // startup only in that mode so we can add the declaration to the isolated
     // fixture first.
     skipStart: isCacheComponentsEnabled,
-    // A deployed fixture cannot be patched before startup. The ordinary deploy
-    // run remains covered; Cache Components behavior is exercised in the local
-    // dev and production test runs.
+    // Deploy mode exclusion: A deployed fixture cannot be patched before
+    // startup. The ordinary deploy run remains covered; Cache Components
+    // behavior is exercised in the local dev and production test runs.
     skipDeployment: isCacheComponentsEnabled,
   })
 

--- a/test/e2e/app-dir/forbidden/default/forbidden-default.test.ts
+++ b/test/e2e/app-dir/forbidden/default/forbidden-default.test.ts
@@ -8,6 +8,8 @@ import {
 describe('app dir - forbidden with default forbidden boundary', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/global-error/catch-all/index.test.ts
+++ b/test/e2e/app-dir/global-error/catch-all/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app dir - global error - with catch-all route', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/global-error/layout-error/index.test.ts
+++ b/test/e2e/app-dir/global-error/layout-error/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app dir - global error - layout error', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/global-error/with-style-import/index.test.ts
+++ b/test/e2e/app-dir/global-error/with-style-import/index.test.ts
@@ -9,6 +9,8 @@ async function testDev(browser, errorRegex) {
 describe('app dir - global error - with style import', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/graceful-shutdown-next-after/custom-server/index.test.ts
+++ b/test/e2e/app-dir/graceful-shutdown-next-after/custom-server/index.test.ts
@@ -8,6 +8,7 @@ describe('after during server shutdown - custom server', () => {
     serverReadyPattern: /Custom server started/,
     forcedPort: 'random',
     skipStart: true,
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     skipDeployment: true, // the tests use cli logs and a custom server
     env: {
       NODE_ENV: isNextDev ? 'development' : 'production',

--- a/test/e2e/app-dir/graceful-shutdown-next-after/next-start/index.test.ts
+++ b/test/e2e/app-dir/graceful-shutdown-next-after/next-start/index.test.ts
@@ -4,6 +4,7 @@ import { retry } from 'next-test-utils'
 describe('after during server shutdown - next start', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     skipDeployment: true, // the tests use cli logs
     skipStart: true,
   })

--- a/test/e2e/app-dir/i18n-hybrid/i18n-hybrid.test.ts
+++ b/test/e2e/app-dir/i18n-hybrid/i18n-hybrid.test.ts
@@ -48,6 +48,10 @@ const urls = [
   })),
 ]
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('i18n-hybrid', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/import-meta-glob-text-type/import-meta-glob-text-type.test.ts
+++ b/test/e2e/app-dir/import-meta-glob-text-type/import-meta-glob-text-type.test.ts
@@ -9,6 +9,8 @@ const testFn =
 testFn('turbopack `text` / `raw` module types', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -1331,6 +1331,8 @@ describe('instant-navigation-testing-api - blocking routes (dev only)', () => {
 
   const { next } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'blocking'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
+++ b/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
@@ -10,6 +10,8 @@ describe('instant-validation-build', () => {
   const { next, skipped, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
+++ b/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
@@ -5,6 +5,8 @@ import type { ValidationEvent } from 'next/dist/server/app-render/dev-validation
 describe('instant validation causes', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',

--- a/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
+++ b/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('app dir - instant-validation-client', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/app-dir/instant-validation-level-default/instant-validation-level-default.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-default/instant-validation-level-default.test.ts
@@ -15,6 +15,8 @@ describe('instant validation - default level', () => {
   const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',

--- a/test/e2e/app-dir/instant-validation-level-error/instant-validation-level-error.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-error/instant-validation-level-error.test.ts
@@ -9,6 +9,8 @@ describe('instant validation - level error', () => {
   const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',

--- a/test/e2e/app-dir/instant-validation-level-manual-error/instant-validation-level-manual-error.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/instant-validation-level-manual-error.test.ts
@@ -9,6 +9,8 @@ describe('instant validation - level manual-error', () => {
   const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/instant-validation-level-manual-warning.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/instant-validation-level-manual-warning.test.ts
@@ -11,6 +11,8 @@ describe('instant validation - level manual-warning', () => {
   const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',

--- a/test/e2e/app-dir/instant-validation-level-warning/instant-validation-level-warning.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-warning/instant-validation-level-warning.test.ts
@@ -9,6 +9,8 @@ describe('instant validation - level warning', () => {
   const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',

--- a/test/e2e/app-dir/instant-validation-static-shells/instant-validation-static-shells.test.ts
+++ b/test/e2e/app-dir/instant-validation-static-shells/instant-validation-static-shells.test.ts
@@ -5,6 +5,8 @@ import { join } from 'node:path'
 describe('instant validation - opting out of static shells', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'valid'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return
@@ -34,6 +36,8 @@ describe('instant validation', () => {
     const { next, skipped, isNextDev } = nextTestSetup({
       files: join(__dirname, 'fixtures', 'invalid-blocking-page-below-static'),
       skipStart: true,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
     if (skipped) return

--- a/test/e2e/app-dir/instant-validation/parallel-slots.test.ts
+++ b/test/e2e/app-dir/instant-validation/parallel-slots.test.ts
@@ -11,6 +11,8 @@ describe('instant validation - parallel slot configs', () => {
   const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',

--- a/test/e2e/app-dir/instant-validation/server-errors.test.ts
+++ b/test/e2e/app-dir/instant-validation/server-errors.test.ts
@@ -10,6 +10,8 @@ describe('instant validation - server errors', () => {
   const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',

--- a/test/e2e/app-dir/instrumentation-order/instrumentation-order.test.ts
+++ b/test/e2e/app-dir/instrumentation-order/instrumentation-order.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('instrumentation-order', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
+++ b/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
@@ -4,6 +4,7 @@ import { check } from 'next-test-utils'
 describe('interception-middleware-rewrite', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // TODO: remove after deployment handling is updated
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/interception-routes-output-export/interception-routes-output-export.test.ts
+++ b/test/e2e/app-dir/interception-routes-output-export/interception-routes-output-export.test.ts
@@ -6,6 +6,7 @@ describe('interception-routes-output-export', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/io/io.test.ts
+++ b/test/e2e/app-dir/io/io.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('io with cache components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/cache-components',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 
@@ -60,6 +62,8 @@ describe('io with cache components', () => {
 describe('io without cache components', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/default',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
+++ b/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
@@ -12,6 +12,8 @@ async function testDev(browser, errorRegex) {
 describe('Error test if the loader file export a named function', () => {
   describe('in Development', () => {
     const { next, isNextDev } = nextTestSetup({
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely expects a local build failure instead of a successful deployment.
       skipDeployment: true,
       files: __dirname,
     })
@@ -31,6 +33,8 @@ describe('Error test if the loader file export a named function', () => {
 
   describe('in Build and Start', () => {
     const { next, isNextStart } = nextTestSetup({
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely expects a local build failure instead of a successful deployment.
       skipDeployment: true,
       skipStart: true,
       files: __dirname,

--- a/test/e2e/app-dir/log-file/log-file.test.ts
+++ b/test/e2e/app-dir/log-file/log-file.test.ts
@@ -6,6 +6,8 @@ import { retry } from 'next-test-utils'
 describe('log-file', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely reads files from the isolated local fixture.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -45,6 +45,8 @@ function parseLogsFromCli(cliOutput: string) {
 
 describe('app-dir - fetch logging', () => {
   const { next, isNextDev } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     files: __dirname,
   })
@@ -81,6 +83,8 @@ describe('app-dir - fetch logging', () => {
 
 describe('app-dir - logging', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     files: __dirname,
   })

--- a/test/e2e/app-dir/logging/fetch-warning.test.ts
+++ b/test/e2e/app-dir/logging/fetch-warning.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 
 describe('app-dir - fetch warnings', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     files: __dirname,
   })

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
 for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
+  // TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+  // It was excluded as a known deploy failure without a documented root cause.
   describe(`mdx ${type}`, () => {
     const { next } = nextTestSetup({
       files: __dirname,

--- a/test/e2e/app-dir/metadata-invalid-image-file/metadata-invalid-image-file.test.ts
+++ b/test/e2e/app-dir/metadata-invalid-image-file/metadata-invalid-image-file.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('metadata-invalid-image-file', () => {
   const { next, isTurbopack, isNextDev, skipped, isRspack } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/app-dir/metadata-json-manifest/index.test.ts
+++ b/test/e2e/app-dir/metadata-json-manifest/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app-dir metadata-json-manifest', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/metadata-suspense/index.test.ts
+++ b/test/e2e/app-dir/metadata-suspense/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app dir - metadata dynamic routes suspense', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/metadata-warnings/metadata-warnings-missing-metadatabase.test.ts
+++ b/test/e2e/app-dir/metadata-warnings/metadata-warnings-missing-metadatabase.test.ts
@@ -6,6 +6,8 @@ const METADATA_BASE_WARN_STRING =
 describe('app dir - metadata missing metadataBase', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/metadata-warnings/metadata-warnings-with-metadatabase.test.ts
+++ b/test/e2e/app-dir/metadata-warnings/metadata-warnings-with-metadatabase.test.ts
@@ -6,6 +6,8 @@ const METADATA_BASE_WARN_STRING =
 describe('app dir - metadata missing metadataBase', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     overrideFiles: {
       'app/layout.js': `

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -16,6 +16,8 @@ import path from 'path'
 // Turbopack: /favicon.ico?favicon.<hash>.ico
 const FAVICON_REGEX = /\/favicon.ico\?\w+/
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('app dir - metadata', () => {
   const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/middleware-matching/index.test.ts
+++ b/test/e2e/app-dir/middleware-matching/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app dir - middleware with custom matcher', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/middleware-rsc-external-rewrite/middleware-rsc-external-rewrite.test.ts
+++ b/test/e2e/app-dir/middleware-rsc-external-rewrite/middleware-rsc-external-rewrite.test.ts
@@ -3,6 +3,8 @@ import { isNextDeploy, isNextDev, nextTestSetup } from 'e2e-utils'
 import { startExternalServer } from './external-server.mjs'
 
 describe('middleware RSC external rewrite', () => {
+  // Deploy mode exclusion: This suite starts an external test server on a
+  // local port, which the deployed application could not reach.
   if (isNextDev || isNextDeploy) {
     test('should not run during dev or deploy test runs', () => {})
     return

--- a/test/e2e/app-dir/missing-suspense-with-csr-bailout/missing-suspense-with-csr-bailout.test.ts
+++ b/test/e2e/app-dir/missing-suspense-with-csr-bailout/missing-suspense-with-csr-bailout.test.ts
@@ -4,6 +4,7 @@ describe('missing-suspense-with-csr-bailout', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // Deploy mode exclusion: This suite mutates fixture files, which cannot be changed after deployment.
     // This test is skipped when deployed because it's not possible to rename files after deployment.
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/modularizeimports/modularizeimports.test.ts
+++ b/test/e2e/app-dir/modularizeimports/modularizeimports.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('modularizeImports', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
@@ -22,6 +22,8 @@ describe('multiple-lockfiles - has-output-file-tracing-root', () => {
     },
     // So that ../package-lock.json doesn't leave the isolated testDir
     subDir: 'test',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     // The workspace file would suppress the warning itself, so the test
     // wouldn't be exercising `outputFileTracingRoot`.

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
@@ -22,6 +22,8 @@ describe('multiple-lockfiles - has-turbo-root', () => {
     },
     // So that ../package-lock.json doesn't leave the isolated testDir
     subDir: 'test',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     // The workspace file would suppress the warning itself, so the test
     // wouldn't be exercising `turbopack.root`.

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
@@ -21,6 +21,8 @@ describe('multiple-lockfiles', () => {
     },
     // So that ../package-lock.json doesn't leave the isolated testDir
     subDir: 'test',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     // The workspace file would be treated as the root and suppress the
     // warning.

--- a/test/e2e/app-dir/next-after-app-api-usage/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-api-usage/index.test.ts
@@ -7,6 +7,7 @@ describe('nextjs APIs in after()', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     skipDeployment: true, // reading runtime logs is not supported in deploy tests
   })
 

--- a/test/e2e/app-dir/next-after-app-static/build-time-error/build-time-error.test.ts
+++ b/test/e2e/app-dir/next-after-app-static/build-time-error/build-time-error.test.ts
@@ -8,6 +8,7 @@ _describe('after() in static pages - thrown errors', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // Deploy mode exclusion: This suite intentionally exercises a failed local build, so it cannot produce a deployment.
     skipDeployment: true, // can't access build errors in deploy tests
   })
 

--- a/test/e2e/app-dir/next-after-app-static/build-time/build-time.test.ts
+++ b/test/e2e/app-dir/next-after-app-static/build-time/build-time.test.ts
@@ -9,6 +9,7 @@ const _describe = isNextDev ? describe.skip : describe
 _describe('after() in static pages', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     skipDeployment: true, // reading CLI logs to observe after
     skipStart: true,
   })

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params-error/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params-error/index.test.ts
@@ -9,6 +9,7 @@ describe('after() in generateStaticParams - thrown errors', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // Deploy mode exclusion: This suite intentionally exercises a failed local build, so it cannot produce a deployment.
     skipDeployment: true, // can't access build errors in deploy tests
   })
 

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params/index.test.ts
@@ -6,6 +6,7 @@ import { waitForNoRedbox, retry } from '../../../../lib/next-test-utils'
 describe('after() in generateStaticParams', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     skipDeployment: true, // reading CLI logs to observe after
     skipStart: true,
   })

--- a/test/e2e/app-dir/next-after-app/index.test.ts
+++ b/test/e2e/app-dir/next-after-app/index.test.ts
@@ -10,6 +10,7 @@ const runtimes = ['nodejs', 'edge']
 describe.each(runtimes)('after() in %s runtime', (runtimeValue) => {
   const { next, isNextDeploy, skipped } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     // `patchFile` and reading runtime logs are not supported in a deployed environment
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/next-condition/next-condition.test.ts
+++ b/test/e2e/app-dir/next-condition/next-condition.test.ts
@@ -9,6 +9,7 @@ describe('`next-js` Condition - Rendering', () => {
       'sym-linked-packages': new FileRef(__dirname + '/packages'),
     },
     dependencies: require('./fixtures/render/package.json').dependencies,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Deploy tests are broken with `config.serverExternalPackages`
     skipDeployment: true,
   })
@@ -632,6 +633,7 @@ describe('`next-js` Condition - middleware (legacy)', () => {
       'sym-linked-packages': new FileRef(__dirname + '/packages'),
     },
     dependencies: require('./fixtures/middleware/package.json').dependencies,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Deploy tests are broken with `config.serverExternalPackages`
     skipDeployment: true,
   })
@@ -677,6 +679,7 @@ describe('`next-js` Condition - proxy', () => {
       'sym-linked-packages': new FileRef(__dirname + '/packages'),
     },
     dependencies: require('./fixtures/proxy/package.json').dependencies,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Deploy tests are broken with `config.serverExternalPackages`
     skipDeployment: true,
   })
@@ -723,6 +726,7 @@ describe('`next-js` Condition - instrumentation', () => {
     },
     dependencies: require('./fixtures/instrumentation/package.json')
       .dependencies,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Deploy tests are broken with `config.serverExternalPackages`
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-cjs.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-cjs.test.ts
@@ -10,6 +10,8 @@ describe('next-config-ts-type-error-cjs', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-esm.test.ts
@@ -10,6 +10,8 @@ describe('next-config-ts-type-error-esm', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     packageJson: {
       type: 'module',

--- a/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-cjs.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-cjs.test.ts
@@ -10,6 +10,8 @@ describe('next-config-ts-type-error-cjs', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-esm.test.ts
@@ -10,6 +10,8 @@ describe('next-config-ts-type-error-esm', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     packageJson: {
       type: 'module',

--- a/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-cjs.test.ts
+++ b/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-cjs.test.ts
@@ -4,6 +4,8 @@ describe('next-config-ts-type-error-cjs', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-esm.test.ts
@@ -4,6 +4,8 @@ describe('next-config-ts-type-error-esm', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     packageJson: {
       type: 'module',

--- a/test/e2e/app-dir/next-font/next-font.test.ts
+++ b/test/e2e/app-dir/next-font/next-font.test.ts
@@ -33,6 +33,8 @@ describe('app dir - next/font', () => {
       dependencies: {
         '@next/font': 'canary',
       },
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely mutates files in the isolated local fixture after setup.
       skipDeployment: true,
     })
 

--- a/test/e2e/app-dir/next-image-legacy-src-with-query-without-local-patterns/next-image-legacy-src-with-query-without-local-patterns.test.ts
+++ b/test/e2e/app-dir/next-image-legacy-src-with-query-without-local-patterns/next-image-legacy-src-with-query-without-local-patterns.test.ts
@@ -4,6 +4,8 @@ describe('next-image-legacy-src-with-query-without-local-patterns', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/next-image-src-with-query-without-local-patterns/next-image-src-with-query-without-local-patterns.test.ts
+++ b/test/e2e/app-dir/next-image-src-with-query-without-local-patterns/next-image-src-with-query-without-local-patterns.test.ts
@@ -4,6 +4,8 @@ describe('next-image-src-with-query-without-local-patterns', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/next-image/next-image-https.test.ts
+++ b/test/e2e/app-dir/next-image/next-image-https.test.ts
@@ -4,6 +4,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe.skip('app dir - next-image (with https)', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     startCommand: `pnpm next dev --experimental-https`,
   })

--- a/test/e2e/app-dir/next-image/next-image-proxy.test.ts
+++ b/test/e2e/app-dir/next-image/next-image-proxy.test.ts
@@ -11,6 +11,7 @@ let proxyServer: https.Server
 describe('next-image-proxy', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite controls a local server or proxy process.
     // This test is skipped when deployed because it relies on a proxy server
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/no-double-tailwind-execution/no-double-tailwind-execution.test.ts
+++ b/test/e2e/app-dir/no-double-tailwind-execution/no-double-tailwind-execution.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('no-double-tailwind-execution', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     dependencies: {
       '@tailwindcss/postcss': '^4',

--- a/test/e2e/app-dir/node-extensions/node-extensions.random.test.ts
+++ b/test/e2e/app-dir/node-extensions/node-extensions.random.test.ts
@@ -5,6 +5,8 @@ describe('Node Extensions', () => {
     describe('Cache Components', () => {
       const { next, skipped } = nextTestSetup({
         files: __dirname + '/fixtures/random/cache-components',
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // No deploy-specific incompatibility is documented.
         skipDeployment: true,
       })
 

--- a/test/e2e/app-dir/node-worker-threads/node-worker-threads.test.ts
+++ b/test/e2e/app-dir/node-worker-threads/node-worker-threads.test.ts
@@ -3,6 +3,8 @@ import { isNextDev, nextTestSetup } from 'e2e-utils'
 describe('node-worker-threads', () => {
   const { next, skipped, isTurbopack } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     dependencies: {
       pino: '9.6.0',

--- a/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
+++ b/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
@@ -24,6 +24,8 @@ describe('non-root-project-monorepo', () => {
     buildCommand: 'pnpm build',
     startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
     installCommand: 'pnpm i',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
+++ b/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
@@ -7,6 +7,8 @@ import {
 describe('non-rsc-router-prefetch', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/not-found-default/index.test.ts
+++ b/test/e2e/app-dir/not-found-default/index.test.ts
@@ -4,6 +4,8 @@ import { waitForNoRedbox } from 'next-test-utils'
 describe('app dir - not found with default 404 page', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/not-found-with-layout-and-group-not-found/index.test.ts
+++ b/test/e2e/app-dir/not-found-with-layout-and-group-not-found/index.test.ts
@@ -4,6 +4,8 @@ import { waitForNoRedbox } from 'next-test-utils'
 describe('app dir - not found with nested layouts and custom not-found', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/not-found-with-nested-layouts/index.test.ts
+++ b/test/e2e/app-dir/not-found-with-nested-layouts/index.test.ts
@@ -4,6 +4,8 @@ import { waitForNoRedbox } from 'next-test-utils'
 describe('app dir - not found with nested layouts', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/not-found/basic/index.test.ts
+++ b/test/e2e/app-dir/not-found/basic/index.test.ts
@@ -4,6 +4,8 @@ import { check } from 'next-test-utils'
 describe('app dir - not-found - basic', () => {
   const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/not-found/conflict-route/index.test.ts
+++ b/test/e2e/app-dir/not-found/conflict-route/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app dir - not-found - conflict route', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/not-found/css-precedence/index.test.ts
+++ b/test/e2e/app-dir/not-found/css-precedence/index.test.ts
@@ -4,6 +4,8 @@ import { check } from 'next-test-utils'
 describe('not-found app dir css', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     dependencies: {
       sass: 'latest',

--- a/test/e2e/app-dir/not-found/default/default.test.ts
+++ b/test/e2e/app-dir/not-found/default/default.test.ts
@@ -5,6 +5,8 @@ const isPPREnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 describe('app dir - not-found - default', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely inspects local build artifacts that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts
+++ b/test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app dir - group routes with root not-found', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/not-found/group-route/index.test.ts
+++ b/test/e2e/app-dir/not-found/group-route/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app dir - not-found - group route', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/nx-handling/nx-handling.test.ts
+++ b/test/e2e/app-dir/nx-handling/nx-handling.test.ts
@@ -2,6 +2,8 @@ import { nextTestSetup, isNextDev } from 'e2e-utils'
 
 describe('nx-handling', () => {
   const { next } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     files: __dirname,
     installCommand: 'npm i',

--- a/test/e2e/app-dir/otel-parent-span-propagation/otel-parent-span-propagation.test.ts
+++ b/test/e2e/app-dir/otel-parent-span-propagation/otel-parent-span-propagation.test.ts
@@ -7,6 +7,8 @@ const COLLECTOR_PORT = 9876
 describe('otel-parent-span-propagation', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     dependencies: require('./package.json').dependencies,
     env: {

--- a/test/e2e/app-dir/pages-router-app-not-found/pages-router-app-not-found.test.ts
+++ b/test/e2e/app-dir/pages-router-app-not-found/pages-router-app-not-found.test.ts
@@ -5,6 +5,7 @@ const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
 describe('pages-router-app-not-found', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // The legacy builder incorrectly replaces this response with the Pages
     // Router error page. The adapter preserves the App Router not-found page.
     skipDeployment: !isAdapterTest,

--- a/test/e2e/app-dir/parallel-routes-and-interception-nested-dynamic-routes/parallel-routes-and-interception-nested-dynamic-routes.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception-nested-dynamic-routes/parallel-routes-and-interception-nested-dynamic-routes.test.ts
@@ -3,6 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 describe('parallel-routes-and-interception-nested-dynamic-routes', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // TODO: re-enable when resolved related thread
     // https://vercel.slack.com/archives/C07UCHRBWGK/p1759165345308879
     skipDeployment: true,

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -1058,6 +1058,7 @@ describe.each([true, false])(
 
 describe('parallel-routes-and-interception-conflicting-pages', () => {
   const { next, skipped } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // This is skipped when deployed as it appears to cause an issue when tracing Next.js files
     // TODO: Investigate why this causes an issue when deployed
     skipDeployment: true,

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
@@ -6,6 +6,8 @@ describe('parallel-routes-leaf-segments-build-error', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'build-error'),
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
@@ -4,6 +4,7 @@ import { retry } from 'next-test-utils'
 describe('parallel-routes-and-interception', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // TODO: remove after deployment handling is updated
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/partial-fallback-root-blocking/partial-fallback-root-blocking.test.ts
+++ b/test/e2e/app-dir/partial-fallback-root-blocking/partial-fallback-root-blocking.test.ts
@@ -7,6 +7,7 @@ const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
 describe('partial-fallback-root-blocking', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // The latest changes to support this behavior on deployed infra are available in the adapter,
     // and are not being backported to the CLI
     skipDeployment: !isAdapterTest,

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
@@ -37,6 +37,7 @@ describe('partial-fallback-shell-upgrade', () => {
     // Deployed shell upgrades require `partialFallback` metadata, which the
     // adapter only emits when Partial Prefetching is enabled in the fixture.
     files: path.join(__dirname, 'fixtures', 'default'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // The latest changes to support this behavior on deployed infra are available in the adapter,
     // and are not being backported to the CLI
     skipDeployment: !isAdapterTest,
@@ -174,6 +175,7 @@ describe('partial-fallback-shell-upgrade', () => {
 describe('partial-fallback-shell-upgrade - partialPrefetching disabled', () => {
   const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'partial-prefetching-disabled'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // The latest changes to support this behavior on deployed infra are available in the adapter,
     // and are not being backported to the CLI
     skipDeployment: !isAdapterTest,

--- a/test/e2e/app-dir/pnpm-workspace-root/pnpm-workspace-root.test.ts
+++ b/test/e2e/app-dir/pnpm-workspace-root/pnpm-workspace-root.test.ts
@@ -44,6 +44,8 @@ describe('pnpm-workspace-root', () => {
     },
     // So that parent files don't leave the isolated testDir
     subDir: 'test',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/ppr-metadata-blocking/ppr-metadata-blocking-ppr-fallback.test.ts
+++ b/test/e2e/app-dir/ppr-metadata-blocking/ppr-metadata-blocking-ppr-fallback.test.ts
@@ -8,6 +8,7 @@ function countSubstring(str: string, substr: string): number {
 describe.skip('ppr-metadata-blocking-ppr-fallback', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Need to skip deployment because the test uses the private env cannot be used in deployment
     skipDeployment: true,
     env: {

--- a/test/e2e/app-dir/ppr-missing-root-params/ppr-missing-root-params.test.ts
+++ b/test/e2e/app-dir/ppr-missing-root-params/ppr-missing-root-params.test.ts
@@ -5,6 +5,8 @@ describe('ppr-missing-root-params (single)', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: path.join(__dirname, 'fixtures/single'),
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return
@@ -30,6 +32,8 @@ describe('ppr-missing-root-params (multiple)', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: path.join(__dirname, 'fixtures/multiple'),
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return
@@ -55,6 +59,8 @@ describe('ppr-missing-root-params (nested)', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: path.join(__dirname, 'fixtures/nested'),
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/app-dir/ppr-navigations/avoid-popstate-flash/avoid-popstate-flash.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/avoid-popstate-flash/avoid-popstate-flash.test.ts
@@ -4,6 +4,7 @@ import { createTestDataServer } from 'test-data-service/writer'
 import { createTestLog } from 'test-log'
 
 describe('avoid-popstate-flash', () => {
+  // Deploy mode exclusion: This suite depends on a test-data service running on a local port.
   if ((global as any).isNextDev || (global as any).isNextDeploy) {
     // this is skipped in dev because PPR is not enabled in dev
     // and in deploy we can't rely on this test data service existing

--- a/test/e2e/app-dir/ppr-navigations/stale-prefetch-entry/stale-prefetch-entry.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/stale-prefetch-entry/stale-prefetch-entry.test.ts
@@ -4,6 +4,7 @@ import { createTestDataServer } from 'test-data-service/writer'
 import { createTestLog } from 'test-log'
 
 describe('stale-prefetch-entry', () => {
+  // Deploy mode exclusion: This suite depends on a test-data service running on a local port.
   if ((global as any).isNextDev || (global as any).isNextDeploy) {
     // this is skipped in dev because PPR is not enabled in dev
     // and in deploy we can't rely on this test data service existing

--- a/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
+++ b/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
@@ -10,6 +10,7 @@ import { retry } from 'next-test-utils'
 describe('PPR - partial hydration', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // the file-patching strategy we use for synchronizing the test doesn't work
     // on deployments
     skipDeployment: true,

--- a/test/e2e/app-dir/ppr-unstable-cache/ppr-unstable-cache.test.ts
+++ b/test/e2e/app-dir/ppr-unstable-cache/ppr-unstable-cache.test.ts
@@ -3,6 +3,7 @@ import { findPort } from 'next-test-utils'
 import http from 'node:http'
 
 describe('ppr-unstable-cache', () => {
+  // Deploy mode exclusion: This suite starts a local HTTP data server on a dynamically allocated port.
   if (isNextDeploy) {
     it.skip('should not run in deploy mode', () => {})
     return

--- a/test/e2e/app-dir/proxy-missing-export/proxy-missing-export.test.ts
+++ b/test/e2e/app-dir/proxy-missing-export/proxy-missing-export.test.ts
@@ -18,6 +18,8 @@ Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`
 describe('proxy-missing-export', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/app-dir/proxy-runtime/proxy-runtime.test.ts
+++ b/test/e2e/app-dir/proxy-runtime/proxy-runtime.test.ts
@@ -4,6 +4,8 @@ import stripAnsi from 'strip-ansi'
 describe('proxy-runtime', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/app-dir/proxy-with-middleware/proxy-with-middleware.test.ts
+++ b/test/e2e/app-dir/proxy-with-middleware/proxy-with-middleware.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('proxy-with-middleware', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/app-dir/refresh/refresh.test.ts
+++ b/test/e2e/app-dir/refresh/refresh.test.ts
@@ -4,6 +4,7 @@ import { retry, waitForRedbox, getRedboxDescription } from 'next-test-utils'
 describe('app-dir refresh', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     // We do not have access to runtime logs when deployed
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/revalidate-dynamic/revalidate-dynamic.test.ts
+++ b/test/e2e/app-dir/revalidate-dynamic/revalidate-dynamic.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('app-dir revalidate-dynamic', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
+++ b/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
@@ -463,6 +463,7 @@ const cases: {
 describe('rewrite-headers', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // TODO: re-enable once changes in infrastructure are merged
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
+++ b/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
@@ -9,6 +9,8 @@ describe('redirects and rewrites', () => {
   })
 
   // TODO: investigate test failures on deploy
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // The source only records that these assertions fail after deployment; the root cause is unknown.
   if ((global as any).isNextDeploy) {
     it('should skip for deploy', () => {})
     return

--- a/test/e2e/app-dir/root-detection/git-repository-boundary.test.ts
+++ b/test/e2e/app-dir/root-detection/git-repository-boundary.test.ts
@@ -21,6 +21,8 @@ describe('root-detection - git repository boundary', () => {
     },
     // So that the files written above don't leave the isolated testDir
     subDir: 'repo/app',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     // The workspace file would stop the search before the Git boundary does,
     // so the test wouldn't be exercising the boundary.

--- a/test/e2e/app-dir/root-detection/git-worktree-boundary.test.ts
+++ b/test/e2e/app-dir/root-detection/git-worktree-boundary.test.ts
@@ -28,6 +28,8 @@ describe('root-detection - git worktree boundary', () => {
     },
     // So that the files written above don't leave the isolated testDir
     subDir: 'worktree/app',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     // The workspace file would stop the search before the worktree boundary
     // does, so the test wouldn't be exercising the boundary.

--- a/test/e2e/app-dir/root-detection/home-directory-boundary.test.ts
+++ b/test/e2e/app-dir/root-detection/home-directory-boundary.test.ts
@@ -54,6 +54,8 @@ describe.each(cases)(
       },
       // So that the files written above don't leave the isolated testDir
       subDir: 'project/app',
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       // The workspace file would stop the search before the home directory
       // boundary does, so the test wouldn't be exercising the boundary.

--- a/test/e2e/app-dir/root-detection/package-json-workspaces.test.ts
+++ b/test/e2e/app-dir/root-detection/package-json-workspaces.test.ts
@@ -28,6 +28,8 @@ describe('root-detection - package.json workspaces', () => {
     },
     // So that the files written above don't leave the isolated testDir
     subDir: 'test',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     // The workspace file would make the app directory a workspace root of its
     // own, so the test wouldn't be exercising the `workspaces` field.

--- a/test/e2e/app-dir/root-layout-render-once/index.test.ts
+++ b/test/e2e/app-dir/root-layout-render-once/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app-dir root layout render once', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/root-layout/root-layout.test.ts
+++ b/test/e2e/app-dir/root-layout/root-layout.test.ts
@@ -8,6 +8,8 @@ describe('app-dir root layout', () => {
     skipped,
   } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/root-suspense-dynamic/root-suspense-dynamic.test.ts
+++ b/test/e2e/app-dir/root-suspense-dynamic/root-suspense-dynamic.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('Root Suspense Dynamic Rendering', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname + '/fixtures/default',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -28,6 +28,8 @@ async function resolveStreamResponse(response: any, onData?: any) {
   return result
 }
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('app dir - rsc basics', () => {
   const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/rsc-webpack-loader/rsc-webpack-loader.test.ts
+++ b/test/e2e/app-dir/rsc-webpack-loader/rsc-webpack-loader.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // Skip as Turbopack doesn't support the `!=!` Webpack syntax
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'app dir - rsc webpack loader',
   () => {

--- a/test/e2e/app-dir/scss/compilation-and-prefixing/compilation-and-prefixing.test.ts
+++ b/test/e2e/app-dir/scss/compilation-and-prefixing/compilation-and-prefixing.test.ts
@@ -20,6 +20,7 @@ describe.each([
 ])('SCSS Support ($dependencies)', ({ dependencies, nextConfig }) => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite reads local build artifacts that deployments do not expose.
     // This test is skipped because it is reading files in the `.next` file which
     // isn't available/necessary in a deployment environment.
     skipDeployment: true,

--- a/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
@@ -7,6 +7,8 @@ describe('Invalid Global CSS with Custom App', () => {
   const { next, skipped, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: isNextStart,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     dependencies: { sass: '1.54.0' },
   })

--- a/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
@@ -7,6 +7,8 @@ describe('Invalid Global CSS', () => {
   const { next, skipped, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: isNextStart,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     dependencies: { sass: '1.54.0' },
   })

--- a/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
+++ b/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
@@ -10,6 +10,8 @@ import { waitForRedbox, getRedboxSource } from 'next-test-utils'
     const { next, skipped, isRspack } = nextTestSetup({
       files: __dirname,
       skipStart: isNextStart,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely expects a local build failure instead of a successful deployment.
       skipDeployment: true,
       dependencies: { sass: '1.54.0' },
     })

--- a/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
+++ b/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
@@ -7,6 +7,8 @@ describe('CSS Import from node_modules', () => {
   const { next, skipped, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: isNextStart,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     dependencies: { sass: '1.54.0' },
   })

--- a/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
@@ -7,6 +7,8 @@ describe('Valid and Invalid Global CSS with Custom App', () => {
   const { next, skipped, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: isNextStart,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     dependencies: { sass: '1.54.0' },
   })

--- a/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
+++ b/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
@@ -5,6 +5,8 @@ describe('SCSS Support', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   // Production only test

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
@@ -7,6 +7,8 @@ import { isNextDeploy, isNextDev, nextTestSetup } from 'e2e-utils'
 import { createFakeCDN } from './server.mjs'
 
 describe('segment cache (CDN cache busting)', () => {
+  // Deploy mode exclusion: This suite runs Next.js behind an in-process fake
+  // CDN on local ports.
   if (isNextDev || isNextDeploy) {
     test('should not run during dev or deploy test runs', () => {})
     return

--- a/test/e2e/app-dir/segment-cache/prefetch-fallback-retry/prefetch-fallback-retry.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-fallback-retry/prefetch-fallback-retry.test.ts
@@ -7,6 +7,8 @@ describe('segment cache prefetch fallback retry', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
+  // Deploy mode exclusion: This suite requires direct observation and control
+  // of local ISR cache state and background regeneration.
   if (isNextDev || isNextDeploy) {
     // Prefetching is disabled in dev, and the recovery test relies on
     // observing ISR cache state and background regeneration, which aren't

--- a/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
+++ b/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
@@ -6,6 +6,8 @@ import { createTestLog } from 'test-log'
 import { findPort } from 'next-test-utils'
 
 describe('segment cache (revalidation)', () => {
+  // Deploy mode exclusion: This suite starts and mutates a process-local test
+  // data server.
   if (isNextDev || isNextDeploy) {
     test('disabled in development / deployment', () => {})
     return

--- a/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/runtime-prerender-cache-warming.test.ts
+++ b/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/runtime-prerender-cache-warming.test.ts
@@ -7,7 +7,8 @@ const CACHE_MISS_WARNING = 'Unexpected cache miss after cache warming phase'
 describe('runtime prerender cache warming', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true, // reads CLI output
+    // Deploy mode exclusion: This suite asserts local server CLI output.
+    skipDeployment: true,
   })
   if (skipped) return
 

--- a/test/e2e/app-dir/segment-config-ts/segment-config-ts.test.ts
+++ b/test/e2e/app-dir/segment-config-ts/segment-config-ts.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('TypeScript type expressions in route segment config', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely inspects local build artifacts that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/self-importing-package/self-importing-package.test.ts
+++ b/test/e2e/app-dir/self-importing-package/self-importing-package.test.ts
@@ -4,6 +4,7 @@ import path from 'path'
 describe('self-importing-package', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // This test is skipped when deployed because the local tarball appears corrupted
     // It also doesn't seem particularly useful to test when deployed
     skipDeployment: true,

--- a/test/e2e/app-dir/server-action-logging/server-action-logging.test.ts
+++ b/test/e2e/app-dir/server-action-logging/server-action-logging.test.ts
@@ -4,6 +4,8 @@ import { nextTestSetup } from 'e2e-utils'
 
 describe('server-action-logging', () => {
   const { next, isNextStart, skipped } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     files: __dirname,
   })
@@ -190,6 +192,8 @@ describe('server-action-logging', () => {
 
 describe('server-action-logging when logging.serverFunctions is disabled', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     files: __dirname,
     env: {

--- a/test/e2e/app-dir/server-components-externals/index.test.ts
+++ b/test/e2e/app-dir/server-components-externals/index.test.ts
@@ -3,6 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 
 describe('app-dir - server components externals', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
+    // Deploy mode exclusion: This suite manually changes the local `node_modules` tree.
     // This test is skipped when deployed because it relies on manually patched `node_modules`
     skipDeployment: true,
     files: __dirname,

--- a/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
@@ -131,6 +131,8 @@ describe('app-dir - server source maps - fake frame source maps', () => {
   const { skipped, next, isNextDev, isTurbopack } = nextTestSetup({
     dependencies,
     files: path.join(__dirname, 'fixtures/default'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     // Expose the inspector on a random port.
     startArgs: ['--inspect=0'],

--- a/test/e2e/app-dir/server-source-maps/server-source-maps-edge.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps-edge.test.ts
@@ -10,6 +10,7 @@ function normalizeCliOutput(output: string) {
 describe('app-dir - server source maps edge runtime', () => {
   const { skipped, next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures/edge'),
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     // Deploy tests don't have access to runtime logs.
     // Manually verify that the runtime logs match.
     skipDeployment: true,

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -21,6 +21,7 @@ describe('app-dir - server source maps', () => {
   const { skipped, next, isNextDev, isTurbopack, isRspack } = nextTestSetup({
     dependencies,
     files: path.join(__dirname, 'fixtures/default'),
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     // Deploy tests don't have access to runtime logs.
     // Manually verify that the runtime logs match.
     skipDeployment: true,

--- a/test/e2e/app-dir/service-worker-multiple/service-worker-multiple.test.ts
+++ b/test/e2e/app-dir/service-worker-multiple/service-worker-multiple.test.ts
@@ -8,6 +8,7 @@ import { retry } from 'next-test-utils'
     const { next, skipped, isNextDev } = nextTestSetup({
       files: __dirname,
       skipStart: true,
+      // Deploy mode exclusion: This suite intentionally exercises a failed local build, so it cannot produce a deployment.
       // This test asserts a build failure.
       skipDeployment: true,
     })

--- a/test/e2e/app-dir/set-cookies/set-cookies.test.ts
+++ b/test/e2e/app-dir/set-cookies/set-cookies.test.ts
@@ -13,6 +13,7 @@ function getSetCookieHeaders(res: Response): ReadonlyArray<string> {
 describe('set-cookies', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // TODO: re-enable once this behavior is corrected on deploy
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/similar-pages-paths/similar-pages-paths.test.ts
+++ b/test/e2e/app-dir/similar-pages-paths/similar-pages-paths.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app-dir similar pages paths', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/static-shell-debugging/static-shell-debugging.test.ts
+++ b/test/e2e/app-dir/static-shell-debugging/static-shell-debugging.test.ts
@@ -10,6 +10,7 @@ describe.skip('static-shell-debugging', () => {
 
   const { next, skipped, isNextDev } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // This test skips deployment because env vars that are doubled underscore prefixed
     // are not supported. This is also intended to be used in development.
     skipDeployment: true,

--- a/test/e2e/app-dir/sub-shell-generation-middleware/sub-shell-generation-middleware.test.ts
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/sub-shell-generation-middleware.test.ts
@@ -8,6 +8,7 @@ const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
 describe('middleware-static-rewrite', () => {
   const { next, isNextDeploy, isNextDev } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // The latest changes to support this behavior on deployed infra are available in the adapter,
     // and are not being backported to the CLI
     skipDeployment: !isAdapterTest,

--- a/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
+++ b/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
@@ -6,6 +6,7 @@ const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
 describe('sub-shell-generation', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // The latest changes to support this behavior on deployed infra are available in the adapter,
     // and are not being backported to the CLI
     skipDeployment: !isAdapterTest,

--- a/test/e2e/app-dir/syntax-highlighter-crash/syntax-highlighter-crash.test.ts
+++ b/test/e2e/app-dir/syntax-highlighter-crash/syntax-highlighter-crash.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('syntax-highlighter-crash', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/third-parties/basic.test.ts
+++ b/test/e2e/app-dir/third-parties/basic.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('@next/third-parties basic usage', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
+++ b/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
@@ -7,6 +7,8 @@ describe('trace-build-file', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: !isNextDev,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely inspects local build artifacts that deploy tests do not expose.
     skipDeployment: true,
     env: {
       // Enable persistent caching even when the git working directory is

--- a/test/e2e/app-dir/turbopack-loader-content-type/turbopack-loader-content-type.test.ts
+++ b/test/e2e/app-dir/turbopack-loader-content-type/turbopack-loader-content-type.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('turbopack-loader-content-type', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/turbopack-postcss-multiple-configs/turbopack-postcss-multiple-configs.test.ts
+++ b/test/e2e/app-dir/turbopack-postcss-multiple-configs/turbopack-postcss-multiple-configs.test.ts
@@ -7,6 +7,8 @@ describe('turbopack-postcss-multiple-configs', () => {
     // (turbopackLocalPostcssConfig). Webpack does not support this feature and
     // does not accept function-valued PostCSS plugins, so skip non-Turbopack runs.
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
+++ b/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
@@ -8,6 +8,8 @@ const strictRouteTypes =
 describe('typed-routes-validator', () => {
   const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/app-dir/typed-routes/typed-links.test.ts
+++ b/test/e2e/app-dir/typed-routes/typed-links.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('typed-links', () => {
   const { next, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/typed-routes/typed-routes.test.ts
+++ b/test/e2e/app-dir/typed-routes/typed-routes.test.ts
@@ -15,6 +15,8 @@ type Routes = AppRoutes | PageRoutes | LayoutRoutes | RedirectRoutes | RewriteRo
 describe('typed-routes', () => {
   const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/typegen-bundler-env/typegen-bundler-env.test.ts
+++ b/test/e2e/app-dir/typegen-bundler-env/typegen-bundler-env.test.ts
@@ -14,6 +14,8 @@ const baseEnv = {
 describe('typegen bundler env', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/app-dir/typegen-error-diagnostic/typegen-error-diagnostic.test.ts
+++ b/test/e2e/app-dir/typegen-error-diagnostic/typegen-error-diagnostic.test.ts
@@ -4,6 +4,8 @@ import { runNextCommand } from 'next-test-utils'
 describe('typegen error diagnostic', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     // We drive `next typegen` manually; no server needed.
     skipStart: true,

--- a/test/e2e/app-dir/typeof-window/typeof-window.test.ts
+++ b/test/e2e/app-dir/typeof-window/typeof-window.test.ts
@@ -4,6 +4,7 @@ import path from 'path'
 describe('typeof-window', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // This test is skipped when deployed because the local tarball appears corrupted
     // It also doesn't seem particularly useful to test when deployed
     skipDeployment: true,

--- a/test/e2e/app-dir/types/types.test.ts
+++ b/test/e2e/app-dir/types/types.test.ts
@@ -4,6 +4,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('app-dir types', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/app-dir/unauthorized/default/unauthorized-default.test.ts
+++ b/test/e2e/app-dir/unauthorized/default/unauthorized-default.test.ts
@@ -8,6 +8,8 @@ import {
 describe('app dir - unauthorized with default unauthorized boundary', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/undefined-default-export/undefined-default-export.test.ts
+++ b/test/e2e/app-dir/undefined-default-export/undefined-default-export.test.ts
@@ -5,6 +5,8 @@ describe('Undefined default export', () => {
   const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname),
     skipStart: isNextStart,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/unhandled-rejection-logging/unhandled-rejection-logging.test.ts
+++ b/test/e2e/app-dir/unhandled-rejection-logging/unhandled-rejection-logging.test.ts
@@ -5,6 +5,8 @@ import stripAnsi from 'strip-ansi'
 describe('unhandled-rejection-logging', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/upward-distdir/upward-distdir.test.ts
+++ b/test/e2e/app-dir/upward-distdir/upward-distdir.test.ts
@@ -2,6 +2,8 @@ import { nextTestSetup, isNextDev } from 'e2e-utils'
 
 describe('upward-distdir', () => {
   const { next } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     files: __dirname,
     installCommand: 'pnpm install',

--- a/test/e2e/app-dir/use-cache-after-uncached-io/use-cache-after-uncached-io.test.ts
+++ b/test/e2e/app-dir/use-cache-after-uncached-io/use-cache-after-uncached-io.test.ts
@@ -7,6 +7,7 @@ import { retry } from '../../../lib/next-test-utils'
 describe('use cache called after tasky uncached IO', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     skipDeployment: true, // reads cli logs
   })
 

--- a/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
+++ b/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
@@ -10,6 +10,8 @@ import stripAnsi from 'strip-ansi'
 describe('use-cache-close-over-function', () => {
   const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })

--- a/test/e2e/app-dir/use-cache-configured-timeout/use-cache-configured-timeout.test.ts
+++ b/test/e2e/app-dir/use-cache-configured-timeout/use-cache-configured-timeout.test.ts
@@ -7,6 +7,8 @@ const expectedTimeoutErrorMessage =
 describe('use-cache-configured-timeout', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -6,6 +6,7 @@ const isoDateRegExp = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
 describe('use-cache-custom-handler', () => {
   const { next, skipped, isNextStart } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Skip deployment so we can test the custom cache handlers log output
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/use-cache-deadlock-probe/use-cache-deadlock-probe.test.ts
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/use-cache-deadlock-probe.test.ts
@@ -19,6 +19,8 @@ const expectedDeadlockMessage =
 describe.skip('use-cache-deadlock-probe', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     // Probe behavior is dev-only; skip the production server start, but
     // let dev mode auto-start.

--- a/test/e2e/app-dir/use-cache-default-handler-expire-zero/use-cache-default-handler-expire-zero.test.ts
+++ b/test/e2e/app-dir/use-cache-default-handler-expire-zero/use-cache-default-handler-expire-zero.test.ts
@@ -8,6 +8,8 @@ describe('use-cache-default-handler-expire-zero', () => {
     // assert on its `set()` decisions in the CLI output. That output is not
     // available on deploy, so skip the deploy variant.
     env: { NEXT_PRIVATE_DEBUG_CACHE: '1' },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -16,6 +16,8 @@ const expectedTimeoutErrorMessage =
 describe('use-cache-hanging-inputs', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })

--- a/test/e2e/app-dir/use-cache-hanging/use-cache-hanging.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging/use-cache-hanging.test.ts
@@ -8,6 +8,8 @@ const expectedTimeoutErrorMessage =
 describe('use-cache-hanging', () => {
   const { next, isNextDev, skipped, isTurbopack } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })

--- a/test/e2e/app-dir/use-cache-infinity-profile/use-cache-infinity-profile.test.ts
+++ b/test/e2e/app-dir/use-cache-infinity-profile/use-cache-infinity-profile.test.ts
@@ -6,6 +6,7 @@ const uuidRegExp =
 describe('use-cache-infinity-profile', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Deployment platforms provide their own cache handlers.
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/use-cache-og-image-top-level-await/use-cache-og-image-top-level-await.test.ts
+++ b/test/e2e/app-dir/use-cache-og-image-top-level-await/use-cache-og-image-top-level-await.test.ts
@@ -4,6 +4,7 @@ describe('use-cache-og-image-top-level-await', () => {
   const { next, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // The prerendered output can't be observed in a deployment, and without
     // it nothing distinguishes broken from fixed behavior.
     skipDeployment: true,

--- a/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
+++ b/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
@@ -6,6 +6,8 @@ import { AddressInfo, Server } from 'net'
 describe('use-cache-output-export', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })

--- a/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
+++ b/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
@@ -8,6 +8,8 @@ const getExpectedErrorMessage = (route: string) =>
 describe('use-cache-search-params', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -6,6 +6,8 @@ describe('use-cache-segment-configs', () => {
   const { next, skipped, isNextDev, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
+++ b/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('use-cache-swr', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -13,6 +13,8 @@ describe('use-cache-unknown-cache-kind', () => {
   const { next, isNextStart, isTurbopack, isRspack, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
+++ b/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
@@ -17,6 +17,8 @@ describe('use-cache-without-experimental-flag', () => {
   const { next, isNextStart, isTurbopack, skipped, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -23,6 +23,8 @@ describe('use-cache', () => {
   const { next, isNextDev, isNextDeploy, isNextStart, skipped } = nextTestSetup(
     {
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     }
   )

--- a/test/e2e/app-dir/webpack-loader-binary/webpack-loader-binary.test.ts
+++ b/test/e2e/app-dir/webpack-loader-binary/webpack-loader-binary.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('webpack-loader-ts-transform', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/webpack-loader-conditions/webpack-loader-conditions.test.ts
+++ b/test/e2e/app-dir/webpack-loader-conditions/webpack-loader-conditions.test.ts
@@ -6,6 +6,8 @@ import { nextTestSetup } from 'e2e-utils'
   () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // No deploy-specific incompatibility is documented.
       skipDeployment: true,
     })
 

--- a/test/e2e/app-dir/webpack-loader-errors/webpack-loader-errors.test.ts
+++ b/test/e2e/app-dir/webpack-loader-errors/webpack-loader-errors.test.ts
@@ -5,6 +5,8 @@ import stripAnsi from 'strip-ansi'
 describe('webpack-loader-errors', () => {
   const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/app-dir/webpack-loader-fs/webpack-loader-fs.test.ts
+++ b/test/e2e/app-dir/webpack-loader-fs/webpack-loader-fs.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('webpack-loader-fs', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/webpack-loader-import-module/webpack-loader-import-module.test.ts
+++ b/test/e2e/app-dir/webpack-loader-import-module/webpack-loader-import-module.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('webpack-loader-import-module', () => {
   const { next, skipped, isTurbopack } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
+++ b/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('webpack-loader-module-type', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/webpack-loader-resolve/webpack-loader-resolve.test.ts
+++ b/test/e2e/app-dir/webpack-loader-resolve/webpack-loader-resolve.test.ts
@@ -3,6 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 describe('webpack-loader-resolve', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // This test is skipped because it's only expected to run in turbopack, which isn't enabled for builds
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
+++ b/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('webpack-loader-resource-query', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/webpack-loader-ts-transform/webpack-loader-ts-transform.test.ts
+++ b/test/e2e/app-dir/webpack-loader-ts-transform/webpack-loader-ts-transform.test.ts
@@ -3,6 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 describe('webpack-loader-ts-transform', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // This test is skipped because it's only expected to run in turbopack, which isn't enabled for builds
     skipDeployment: true,
   })

--- a/test/e2e/app-dir/with-babel/with-babel.test.ts
+++ b/test/e2e/app-dir/with-babel/with-babel.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('with babel', () => {
   const { next, isNextStart, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely inspects local build artifacts that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/app-dir/x-forwarded-headers/x-forwarded-headers.test.ts
+++ b/test/e2e/app-dir/x-forwarded-headers/x-forwarded-headers.test.ts
@@ -3,6 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 describe('x-forwarded-headers', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: The assertions exercise behavior specific to the local Next.js server.
     // This test is skipped because it sends requests with manipulated host headers
     // which doesn't work in a deployed environment
     skipDeployment: true,

--- a/test/e2e/app-document/client.test.ts
+++ b/test/e2e/app-document/client.test.ts
@@ -4,6 +4,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('Document and App - Client side', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
 

--- a/test/e2e/basepath/basepath.test.ts
+++ b/test/e2e/basepath/basepath.test.ts
@@ -10,6 +10,8 @@ import {
   renderViaHTTP,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('basePath', () => {
   const basePath = '/docs'
 

--- a/test/e2e/build-indicator/test/index.test.ts
+++ b/test/e2e/build-indicator/test/index.test.ts
@@ -22,6 +22,7 @@ const installCheckVisible = (browser) => {
 
 describe('Build Activity Indicator', () => {
   // Use describe.skip so that this suite does not fail with "no tests" during deploy tests.
+  // Deploy mode exclusion: This nested suite intentionally fails a local build and asserts its CLI diagnostics.
   ;(isNextDeploy ? describe.skip : describe)('Invalid position config', () => {
     const { next } = nextTestSetup({
       files: join(__dirname, '..'),

--- a/test/e2e/cache-handlers-upstream-wiring/index.test.ts
+++ b/test/e2e/cache-handlers-upstream-wiring/index.test.ts
@@ -6,6 +6,8 @@ describe('cache-handlers-upstream-wiring', () => {
   describe('pages router non-edge', () => {
     const { next, skipped, isNextDev } = nextTestSetup({
       files: join(__dirname, 'fixtures/pages-router-non-edge'),
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
 
@@ -54,6 +56,8 @@ describe('cache-handlers-upstream-wiring', () => {
   describe('cacheComponents enabled, non-edge app router', () => {
     const { next, skipped, isNextDev } = nextTestSetup({
       files: join(__dirname, 'fixtures/non-edge-cache-components'),
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
 
@@ -103,6 +107,8 @@ describe('cache-handlers-upstream-wiring', () => {
     () => {
       const { next, skipped } = nextTestSetup({
         files: join(__dirname, 'fixtures/edge-without-cache-components'),
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely asserts local CLI or runtime output that deploy tests do not expose.
         skipDeployment: true,
       })
 

--- a/test/e2e/cancel-request/stream-cancel.test.ts
+++ b/test/e2e/cancel-request/stream-cancel.test.ts
@@ -2,6 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { sleep } from './sleep'
 import { get } from 'http'
 
+// Deploy mode exclusion: This suite aborts a raw client connection, but
+// a hosting proxy changes cancellation propagation before Next.js receives it.
 describe('streaming responses cancel inner stream after disconnect', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/catches-missing-getStaticProps/catches-missing-getStaticProps.test.ts
+++ b/test/e2e/catches-missing-getStaticProps/catches-missing-getStaticProps.test.ts
@@ -8,6 +8,8 @@ import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: isNextStart,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/cli/cli.test.ts
+++ b/test/e2e/cli/cli.test.ts
@@ -19,6 +19,8 @@ describe('CLI Usage', () => {
     files: join(__dirname, 'basic'),
     skipStart: true,
     dependencies: reactDependencies,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
 
@@ -1187,6 +1189,8 @@ describe('CLI Usage: duplicate sass dependencies', () => {
     files: join(__dirname, 'duplicate-sass'),
     skipStart: true,
     dependencies: reactDependencies,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/client-404/client-404.test.ts
+++ b/test/e2e/client-404/client-404.test.ts
@@ -7,6 +7,7 @@ import {
 describe('Client 404', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
     skipDeployment: true,
   })

--- a/test/e2e/client-max-body-size/index.test.ts
+++ b/test/e2e/client-max-body-size/index.test.ts
@@ -5,6 +5,7 @@ describe('client-max-body-size', () => {
   describe('default 10MB limit', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
       // Deployed environment has it's own configured limits.
       skipDeployment: true,
     })
@@ -80,6 +81,8 @@ describe('client-max-body-size', () => {
   describe('custom limit with string format', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       nextConfig: {
         experimental: {
@@ -139,6 +142,8 @@ describe('client-max-body-size', () => {
   describe('custom limit with number format', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       nextConfig: {
         experimental: {
@@ -198,6 +203,8 @@ describe('client-max-body-size', () => {
   describe('large custom limit', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       nextConfig: {
         experimental: {

--- a/test/e2e/config-schema-check/index.test.ts
+++ b/test/e2e/config-schema-check/index.test.ts
@@ -16,6 +16,8 @@ describe('next.config.js schema validating - defaultConfig', () => {
     }
     `,
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 
@@ -44,6 +46,8 @@ describe('next.config.js schema validating - invalid config', () => {
     }
     `,
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/conflicting-app-page-error/index.test.ts
+++ b/test/e2e/conflicting-app-page-error/index.test.ts
@@ -11,6 +11,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('Conflict between app file and pages file', () => {
   const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/conflicting-public-file-page/conflicting-public-file-page.test.ts
+++ b/test/e2e/conflicting-public-file-page/conflicting-public-file-page.test.ts
@@ -4,6 +4,8 @@ describe('Errors on conflict between public file and page file', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/cpu-profiling/cpu-profiling-build.test.ts
+++ b/test/e2e/cpu-profiling/cpu-profiling-build.test.ts
@@ -8,6 +8,8 @@ describe('CPU Profiling - next build', () => {
     buildCommand: 'pnpm next build --experimental-cpu-prof',
     dependencies: {},
     skipStart: true,
+    // Deploy mode exclusion: This suite invokes a local profiled build and
+    // inspects the generated profile files.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/cpu-profiling/cpu-profiling.test.ts
+++ b/test/e2e/cpu-profiling/cpu-profiling.test.ts
@@ -12,6 +12,7 @@ describe('CPU Profiling - next start', () => {
   })
 
   // CPU profiling only works with local `next start`, not dev or deploy modes
+  // Deploy mode exclusion: This suite controls a local `next start` process and inspects generated profile files.
   if (isNextDev || isNextDeploy || skipped) {
     it('skip for development/deploy mode', () => {})
     return

--- a/test/e2e/css-client-nav/css-client-nav.test.ts
+++ b/test/e2e/css-client-nav/css-client-nav.test.ts
@@ -9,6 +9,7 @@ describe('CSS Module client-side navigation', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // Deploy mode exclusion: This suite controls a local server or proxy process.
     // Calls `next.build()` and uses an in-test proxy in front of the Next
     // server; both rely on the local-process model and are not applicable to
     // deploy mode.

--- a/test/e2e/css-features/css-modules-ordering.test.ts
+++ b/test/e2e/css-features/css-modules-ordering.test.ts
@@ -22,6 +22,8 @@ describe('Basic CSS Modules Ordering', () => {
             useLightningcss: true,
           },
         },
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely asserts local CLI or runtime output that deploy tests do not expose.
         skipDeployment: true,
       })
 
@@ -92,6 +94,8 @@ describe('Basic CSS Modules Ordering', () => {
             useLightningcss: false,
           },
         },
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely asserts local CLI or runtime output that deploy tests do not expose.
         skipDeployment: true,
       })
 
@@ -163,6 +167,8 @@ describe('Ordering with Global CSS and Modules', () => {
           useLightningcss: true,
         },
       },
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
 
@@ -252,6 +258,8 @@ describe('Ordering with Global CSS and Modules', () => {
           useLightningcss: false,
         },
       },
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
 
@@ -347,6 +355,8 @@ describe('CSS Modules Composes Ordering', () => {
             useLightningcss: true,
           },
         },
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely asserts local CLI or runtime output that deploy tests do not expose.
         skipDeployment: true,
       })
 
@@ -507,6 +517,8 @@ describe('CSS Modules Composes Ordering', () => {
             useLightningcss: false,
           },
         },
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely asserts local CLI or runtime output that deploy tests do not expose.
         skipDeployment: true,
       })
 

--- a/test/e2e/custom-app-render/custom-app-render.test.ts
+++ b/test/e2e/custom-app-render/custom-app-render.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('custom-app-render', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     startCommand: 'node server.js',
     serverReadyPattern: /Next mode: (production|development)/,

--- a/test/e2e/custom-cache-handler-image/custom-cache-handler-image.test.ts
+++ b/test/e2e/custom-cache-handler-image/custom-cache-handler-image.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('custom-cache-handler-image', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     env: {
       // Set max cache entries to 2 to easily test eviction

--- a/test/e2e/custom-error/custom-error.test.ts
+++ b/test/e2e/custom-error/custom-error.test.ts
@@ -11,6 +11,8 @@ describe('Custom _error', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/custom-routes-i18n-index-redirect/custom-routes-i18n-index-redirect.test.ts
+++ b/test/e2e/custom-routes-i18n-index-redirect/custom-routes-i18n-index-redirect.test.ts
@@ -3,6 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 describe('Custom routes i18n with index redirect', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
     skipDeployment: true,
   })

--- a/test/e2e/custom-routes-i18n/custom-routes-i18n.test.ts
+++ b/test/e2e/custom-routes-i18n/custom-routes-i18n.test.ts
@@ -7,6 +7,8 @@ describe('Custom routes i18n', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/custom-routes/custom-routes.test.ts
+++ b/test/e2e/custom-routes/custom-routes.test.ts
@@ -18,6 +18,8 @@ describe('Custom routes', () => {
     files: __dirname,
     skipStart: true,
     disableAutoSkewProtection: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return
@@ -3478,6 +3480,8 @@ describe('Custom routes no-op rewrite', () => {
     env: {
       ADD_NOOP_REWRITE: 'true',
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return
@@ -3533,6 +3537,8 @@ describe('Custom routes solo types', () => {
     files: __dirname,
     skipStart: true,
     disableAutoSkewProtection: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return
@@ -3655,6 +3661,8 @@ describe('Custom routes solo types', () => {
   const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (isNextDeploy) return

--- a/test/e2e/custom-server/custom-server.test.ts
+++ b/test/e2e/custom-server/custom-server.test.ts
@@ -29,6 +29,8 @@ describe.each([
       serverReadyPattern: /- Local:/,
       env: { USE_HTTPS: useHttps, NODE_ENV: sharedNodeEnv },
       dependencies: sharedDeps,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       disableAutoSkewProtection: true,
     })
@@ -158,6 +160,8 @@ describe.each([
         NODE_ENV: sharedNodeEnv,
       },
       dependencies: sharedDeps,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       disableAutoSkewProtection: true,
     })
@@ -180,6 +184,8 @@ describe.each([
         NODE_ENV: sharedNodeEnv,
       },
       dependencies: sharedDeps,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       disableAutoSkewProtection: true,
     })
@@ -199,6 +205,8 @@ describe.each([
         serverReadyPattern: /- Local:/,
         env: { USE_HTTPS: useHttps, NODE_ENV: sharedNodeEnv },
         dependencies: sharedDeps,
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely asserts local CLI or runtime output that deploy tests do not expose.
         skipDeployment: true,
         disableAutoSkewProtection: true,
       })
@@ -244,6 +252,8 @@ describe.each([
       serverReadyPattern: /- Local:/,
       env: { USE_HTTPS: useHttps, NODE_ENV: sharedNodeEnv },
       dependencies: sharedDeps,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       disableAutoSkewProtection: true,
     })
@@ -281,6 +291,8 @@ describe.each([
         NODE_ENV: sharedNodeEnv,
       },
       dependencies: { ...sharedDeps, 'node-fetch': '2.6.7' },
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       disableAutoSkewProtection: true,
     })
@@ -299,6 +311,8 @@ describe.each([
       serverReadyPattern: /- Local:/,
       env: { USE_HTTPS: useHttps, NODE_ENV: sharedNodeEnv },
       dependencies: sharedDeps,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       disableAutoSkewProtection: true,
     })
@@ -326,6 +340,8 @@ describe.each([
       serverReadyPattern: /- Local:/,
       env: { USE_HTTPS: useHttps, NODE_ENV: sharedNodeEnv },
       dependencies: sharedDeps,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       disableAutoSkewProtection: true,
     })

--- a/test/e2e/data-fetching-errors/data-fetching-errors.test.ts
+++ b/test/e2e/data-fetching-errors/data-fetching-errors.test.ts
@@ -9,6 +9,8 @@ describe('GS(S)P Page Errors', () => {
   ;(isNextDev ? describe : describe.skip)('development mode', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely expects a local build failure instead of a successful deployment.
       skipDeployment: true,
     })
     if (skipped) return
@@ -107,6 +109,8 @@ describe('GS(S)P Page Errors', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
       skipStart: true,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely expects a local build failure instead of a successful deployment.
       skipDeployment: true,
     })
     if (skipped) return

--- a/test/e2e/deferred-entries/deferred-entries.test.ts
+++ b/test/e2e/deferred-entries/deferred-entries.test.ts
@@ -113,6 +113,8 @@ async function waitForCallbackTimestampToStabilize(
 describe('deferred-entries', () => {
   const { next, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: true,
     dependencies: {},

--- a/test/e2e/disable-js/disable-js.test.ts
+++ b/test/e2e/disable-js/disable-js.test.ts
@@ -4,6 +4,8 @@ import cheerio from 'cheerio'
 describe('disabled runtime JS', () => {
   const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/dist-dir/dist-dir.test.ts
+++ b/test/e2e/dist-dir/dist-dir.test.ts
@@ -4,6 +4,8 @@ import { BUILD_ID_FILE, BUILD_MANIFEST } from 'next/constants'
 describe('distDir', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return
@@ -31,6 +33,8 @@ if (isNextStart) {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
       skipStart: true,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
     if (skipped) return

--- a/test/e2e/draft-mode/draft-mode.test.ts
+++ b/test/e2e/draft-mode/draft-mode.test.ts
@@ -15,6 +15,8 @@ function getData(html: string) {
 describe('Test Draft Mode', () => {
   const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/dynamic-optional-routing/dynamic-optional-routing.test.ts
+++ b/test/e2e/dynamic-optional-routing/dynamic-optional-routing.test.ts
@@ -5,6 +5,8 @@ import { retry } from 'next-test-utils'
 describe('Dynamic Optional Routing', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return
@@ -220,6 +222,8 @@ describe('Dynamic Optional Routing - build validation', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/dynamic-routing-middleware/dynamic-routing-middleware.test.ts
+++ b/test/e2e/dynamic-routing-middleware/dynamic-routing-middleware.test.ts
@@ -7,6 +7,8 @@ describe('Dynamic Routing with Middleware', () => {
     files: join(__dirname, '../dynamic-routing'),
     skipStart: true,
     disableAutoSkewProtection: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/dynamic-routing/dynamic-routing.test.ts
+++ b/test/e2e/dynamic-routing/dynamic-routing.test.ts
@@ -5,6 +5,7 @@ describe('Dynamic Routing', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
+    // Deploy mode exclusion: The assertions exercise behavior specific to the local Next.js server.
     // Some assertions (`should not decode slashes`, `should serve file with
     // plus from public/static folder`) depend on local Next.js URL handling
     // and don't apply to Vercel's deploy infrastructure.

--- a/test/e2e/edge-compiler-module-exports-preference/index.test.ts
+++ b/test/e2e/edge-compiler-module-exports-preference/index.test.ts
@@ -2,6 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('Edge compiler module exports preference', () => {
+  // Deploy mode exclusion: This suite manually creates a package in the local `node_modules` directory.
   if ((global as any).isNextDeploy) {
     // this test is skipped when deployed because it manually creates a package in the node_modules directory
     // which is unsupported

--- a/test/e2e/edge-configurable-runtime/index.test.ts
+++ b/test/e2e/edge-configurable-runtime/index.test.ts
@@ -139,6 +139,7 @@ const apiPath = 'pages/api/edge.js'
       })
     })
   } else {
+    // Deploy mode exclusion: This suite mutates fixture files and asserts local build and CLI output.
     it.skip('no deploy tests', () => {})
   }
 })

--- a/test/e2e/edge-runtime-configurable-guards/edge-runtime-configurable-guards.test.ts
+++ b/test/e2e/edge-runtime-configurable-guards/edge-runtime-configurable-guards.test.ts
@@ -17,6 +17,8 @@ describe('Edge runtime configurable guards', () => {
   ;(isNextDev ? describe : describe.skip)('development mode', () => {
     const { next, isTurbopack, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely expects a local build failure instead of a successful deployment.
       skipDeployment: true,
     })
     if (skipped) return
@@ -346,6 +348,8 @@ describe('Edge runtime configurable guards', () => {
       files: __dirname,
       skipStart: true,
       env: shouldUseTurbopack() ? {} : { NEXT_TELEMETRY_DEBUG: '1' },
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely expects a local build failure instead of a successful deployment.
       skipDeployment: true,
     })
     if (skipped) return

--- a/test/e2e/edge-runtime-module-errors/edge-runtime-module-errors.test.ts
+++ b/test/e2e/edge-runtime-module-errors/edge-runtime-module-errors.test.ts
@@ -126,6 +126,8 @@ describe('Edge runtime module errors', () => {
       // pushes the initial server startup past the default 10s window on
       // loaded CI hardware.
       startServerTimeout: 30_000,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
     if (skipped) return
@@ -581,6 +583,8 @@ describe('Edge runtime module errors', () => {
       dependencies: {
         nanoid: 'latest',
       },
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
     if (skipped) return

--- a/test/e2e/edge-runtime-response-error/edge-runtime-response-error.test.ts
+++ b/test/e2e/edge-runtime-response-error/edge-runtime-response-error.test.ts
@@ -4,6 +4,7 @@ describe('Edge runtime response error', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
     skipDeployment: true,
   })

--- a/test/e2e/edge-runtime-streaming-error/edge-runtime-streaming-error.test.ts
+++ b/test/e2e/edge-runtime-streaming-error/edge-runtime-streaming-error.test.ts
@@ -6,6 +6,7 @@ describe('edge-runtime-streaming-error', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
     skipDeployment: true,
   })

--- a/test/e2e/edge-runtime-timer-this/edge-runtime-timer-this.test.ts
+++ b/test/e2e/edge-runtime-timer-this/edge-runtime-timer-this.test.ts
@@ -5,6 +5,7 @@ const enableCacheComponents = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 describe('edge-runtime-timer-this', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: The assertions exercise behavior specific to the local Next.js server.
     // This is testing the edge runtime sandbox, which is only used in `next start`.
     skipDeployment: true,
   })

--- a/test/e2e/edge-runtime-uses-edge-light-import-specifier-for-packages/edge-runtime-uses-edge-light-import-specifier-for-packages.test.ts
+++ b/test/e2e/edge-runtime-uses-edge-light-import-specifier-for-packages/edge-runtime-uses-edge-light-import-specifier-for-packages.test.ts
@@ -13,6 +13,8 @@ describe('edge-runtime uses edge-light import specifier for packages', () => {
     installCommand: 'pnpm i',
     startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
     buildCommand: 'pnpm build',
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
   })
 

--- a/test/e2e/edge-runtime-with-node.js-apis/edge-runtime-with-node.js-apis.test.ts
+++ b/test/e2e/edge-runtime-with-node.js-apis/edge-runtime-with-node.js-apis.test.ts
@@ -35,6 +35,7 @@ describe('Edge runtime with Node.js APIs', () => {
     // the automatic start so we can run the build manually and ignore the
     // non-zero exit code.
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
     skipDeployment: true,
   })

--- a/test/e2e/env-config/env-config.test.ts
+++ b/test/e2e/env-config/env-config.test.ts
@@ -9,6 +9,8 @@ describe('env-config', () => {
       PROCESS_ENV_KEY: 'processenvironment',
       ENV_FILE_PROCESS_ENV: 'env-cli',
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/externals-pages-bundle/externals-pages-bundle.test.ts
+++ b/test/e2e/externals-pages-bundle/externals-pages-bundle.test.ts
@@ -6,6 +6,8 @@ describe('externals-pages-bundle', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/fallback-false-rewrite/fallback-false-rewrite.test.ts
+++ b/test/e2e/fallback-false-rewrite/fallback-false-rewrite.test.ts
@@ -4,6 +4,7 @@ import cheerio from 'cheerio'
 describe('fallback: false rewrite', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
     skipDeployment: true,
   })

--- a/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
+++ b/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
@@ -5,6 +5,7 @@ import stripAnsi from 'strip-ansi'
 describe('fetch failures have good stack traces in edge runtime', () => {
   const { next, isNextStart, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     // don't have access to runtime logs on deploy
     skipDeployment: true,
   })

--- a/test/e2e/fetch-polyfill/fetch-polyfill.test.ts
+++ b/test/e2e/fetch-polyfill/fetch-polyfill.test.ts
@@ -14,6 +14,7 @@ describe('Fetch polyfill', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
     skipDeployment: true,
   })

--- a/test/e2e/file-serving/file-serving.test.ts
+++ b/test/e2e/file-serving/file-serving.test.ts
@@ -7,6 +7,7 @@ import { fetchViaHTTP } from 'next-test-utils'
 describe('file-serving', () => {
   const { next, isNextDeploy, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Vercel's edge rejects malformed URLs (mixed-encoding traversal,
     // backslash, double-encoded, etc.) before they reach the runtime, and
     // `safeFetch` for those paths uses `localhost:0` which doesn't apply in

--- a/test/e2e/filesystem-cache/build-cache-default.test.ts
+++ b/test/e2e/filesystem-cache/build-cache-default.test.ts
@@ -15,6 +15,8 @@ import path from 'path'
     const { next, skipped } = nextTestSetup({
       files: __dirname,
       skipStart: true,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely mutates files in the isolated local fixture after setup.
       skipDeployment: true,
     })
 

--- a/test/e2e/filesystem-cache/evict-after-snapshot.test.ts
+++ b/test/e2e/filesystem-cache/evict-after-snapshot.test.ts
@@ -16,6 +16,8 @@ import { retry, waitFor } from 'next-test-utils'
 
   const { skipped, next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
     packageJson: {
       scripts: {

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -49,6 +49,8 @@ for (const cacheEnabled of [false, true]) {
 
     const { skipped, next, isTurbopack } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely mutates files in the isolated local fixture after setup.
       skipDeployment: true,
       packageJson: {
         packageManager: 'npm@10.9.2',

--- a/test/e2e/filesystem-cache/warm-restart-task-stats.test.ts
+++ b/test/e2e/filesystem-cache/warm-restart-task-stats.test.ts
@@ -46,6 +46,8 @@ const STATS_RELATIVE_PATH = '.next/warm-restart-task-stats.json'
 
     const { skipped, next } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely inspects local build artifacts that deploy tests do not expose.
       skipDeployment: true,
       packageJson: {
         packageManager: 'npm@10.9.2',

--- a/test/e2e/geist-font/geist-font.test.ts
+++ b/test/e2e/geist-font/geist-font.test.ts
@@ -4,6 +4,7 @@ import { waitForNoRedbox } from 'next-test-utils'
 describe('geist-font', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // `geist@latest` has a peer dependency issue with the latest Next.js.
     // see: https://github.com/vercel/geist-font/pull/117
     skipDeployment: true,

--- a/test/e2e/getserversideprops-preview/getserversideprops-preview.test.ts
+++ b/test/e2e/getserversideprops-preview/getserversideprops-preview.test.ts
@@ -18,6 +18,7 @@ function getData(html: string) {
 describe('ServerSide Props Preview Mode', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
     skipDeployment: true,
   })

--- a/test/e2e/gip-identifier/gip-identifier.test.ts
+++ b/test/e2e/gip-identifier/gip-identifier.test.ts
@@ -5,6 +5,8 @@ import cheerio from 'cheerio'
 describe('gip identifiers', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/gssp-redirect-base-path/gssp-redirect-base-path.test.ts
+++ b/test/e2e/gssp-redirect-base-path/gssp-redirect-base-path.test.ts
@@ -10,6 +10,8 @@ describe('GS(S)P Redirect with basePath', () => {
       react: '19.3.0-canary-da9325b5-20260417',
       'react-dom': '19.3.0-canary-da9325b5-20260417',
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/gssp-redirect/gssp-redirect.test.ts
+++ b/test/e2e/gssp-redirect/gssp-redirect.test.ts
@@ -8,6 +8,8 @@ describe('GS(S)P Redirect Support', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/i18n-data-fetching-redirect/redirect-from-context.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/redirect-from-context.test.ts
@@ -4,6 +4,8 @@ import { check } from 'next-test-utils'
 
 describe('i18n-data-fetching-redirect', () => {
   // TODO: investigate tests failures on deploy
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // The source only records that these assertions fail after deployment; the root cause is unknown.
   if ((global as any).isNextDeploy) {
     it('should skip temporarily', () => {})
     return

--- a/test/e2e/i18n-data-fetching-redirect/redirect.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/redirect.test.ts
@@ -4,6 +4,8 @@ import { check } from 'next-test-utils'
 
 describe('i18n-data-fetching-redirect', () => {
   // TODO: investigate tests failures on deploy
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // The source only records that these assertions fail after deployment; the root cause is unknown.
   if ((global as any).isNextDeploy) {
     it('should skip temporarily', () => {})
     return

--- a/test/e2e/i18n-data-route/i18n-data-route.test.ts
+++ b/test/e2e/i18n-data-route/i18n-data-route.test.ts
@@ -15,6 +15,7 @@ function checkDataRoute(data: any, page: string) {
 describe('i18n-data-route', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // This test skips deployment because env vars that are doubled underscore prefixed
     // are not supported.
     skipDeployment: true,

--- a/test/e2e/i18n-disallow-multiple-locales/i18n-disallow-multiple-locales.test.ts
+++ b/test/e2e/i18n-disallow-multiple-locales/i18n-disallow-multiple-locales.test.ts
@@ -16,6 +16,7 @@ async function verify(res, locale) {
 describe('i18n-disallow-multiple-locales', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // TODO: re-enable after this behavior is corrected
     skipDeployment: true,
   })

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
@@ -8,6 +8,8 @@ const locales = ['', '/en', '/sv', '/nl']
 describe('i18n-ignore-rewrite-source-locale with basepath', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely reads files from the isolated local fixture.
     skipDeployment: true,
   })
 

--- a/test/e2e/i18n-support-base-path/i18n-support-base-path.test.ts
+++ b/test/e2e/i18n-support-base-path/i18n-support-base-path.test.ts
@@ -11,6 +11,8 @@ describe('i18n Support basePath', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/i18n-support-custom-error/i18n-support-custom-error.test.ts
+++ b/test/e2e/i18n-support-custom-error/i18n-support-custom-error.test.ts
@@ -4,6 +4,7 @@ import { retry } from 'next-test-utils'
 describe('Custom routes i18n custom error', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
     skipDeployment: true,
   })

--- a/test/e2e/i18n-support/i18n-support.test.ts
+++ b/test/e2e/i18n-support/i18n-support.test.ts
@@ -13,6 +13,8 @@ describe('i18n Support', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/image-optimizer/image-optimizer.test.ts
+++ b/test/e2e/image-optimizer/image-optimizer.test.ts
@@ -18,6 +18,8 @@ describe('Image Optimizer', () => {
     const { next, skipped } = nextTestSetup({
       files: join(__dirname, 'app'),
       skipStart: true,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
     if (skipped) return
@@ -272,6 +274,8 @@ describe('Image Optimizer', () => {
           qualities: [70, 75],
         },
       },
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
     if (skipped) return
@@ -288,6 +292,8 @@ describe('Image Optimizer', () => {
       const size = 96
       const { next, skipped } = nextTestSetup({
         files: join(__dirname, 'app'),
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely asserts local CLI or runtime output that deploy tests do not expose.
         skipDeployment: true,
       })
       if (skipped) return
@@ -380,6 +386,8 @@ describe('Image Optimizer', () => {
             path: 'https://example.com/act123/',
           },
         },
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely asserts local CLI or runtime output that deploy tests do not expose.
         skipDeployment: true,
       })
       if (skipped) return
@@ -404,6 +412,8 @@ describe('Image Optimizer', () => {
         nextConfig: {
           images: { unoptimized: true },
         },
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely asserts local CLI or runtime output that deploy tests do not expose.
         skipDeployment: true,
       })
       if (skipped) return
@@ -428,6 +438,8 @@ describe('Image Optimizer', () => {
         nextConfig: {
           experimental: { imgOptMaxInputPixels: 100 },
         },
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely asserts local CLI or runtime output that deploy tests do not expose.
         skipDeployment: true,
       })
       if (skipped) return
@@ -461,6 +473,8 @@ describe('Image Optimizer', () => {
             ]
           },
         },
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely asserts local CLI or runtime output that deploy tests do not expose.
         skipDeployment: true,
       })
       if (skipped) return
@@ -515,6 +529,8 @@ describe('Image Optimizer', () => {
             imageSizes: [],
           },
         },
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely asserts local CLI or runtime output that deploy tests do not expose.
         skipDeployment: true,
       })
       if (skipped) return

--- a/test/e2e/import-meta-env/import-meta-env.test.ts
+++ b/test/e2e/import-meta-env/import-meta-env.test.ts
@@ -8,6 +8,8 @@ const testFn =
 testFn('import.meta.env', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/import-meta-glob/import-meta-glob.test.ts
+++ b/test/e2e/import-meta-glob/import-meta-glob.test.ts
@@ -9,6 +9,8 @@ const testFn =
 testFn('import-meta-glob', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/index-index/index-index.test.ts
+++ b/test/e2e/index-index/index-index.test.ts
@@ -5,6 +5,7 @@ import { retry } from 'next-test-utils'
 describe('nested index.js', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Vercel's deploy infrastructure normalizes nested `/index/index/index`
     // paths differently from Next.js's local server, so the routing
     // assertions here are local-only.

--- a/test/e2e/instrumentation-hook-src/instrumentation-hook-src.test.ts
+++ b/test/e2e/instrumentation-hook-src/instrumentation-hook-src.test.ts
@@ -4,6 +4,8 @@ describe('instrumentation-hook-rsc', () => {
   describe('instrumentation', () => {
     const { next, isNextDev, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
 

--- a/test/e2e/instrumentation-hook/register-once/register-once.test.ts
+++ b/test/e2e/instrumentation-hook/register-once/register-once.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('instrumentation-hook - register-once', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/invalid-custom-routes/invalid-custom-routes.test.ts
+++ b/test/e2e/invalid-custom-routes/invalid-custom-routes.test.ts
@@ -5,6 +5,8 @@ describe('Errors on invalid custom routes', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/invalid-middleware-matchers/invalid-middleware-matchers.test.ts
+++ b/test/e2e/invalid-middleware-matchers/invalid-middleware-matchers.test.ts
@@ -5,6 +5,8 @@ describe('Errors on invalid custom middleware matchers', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/invalid-multi-match/invalid-multi-match.test.ts
+++ b/test/e2e/invalid-multi-match/invalid-multi-match.test.ts
@@ -4,6 +4,7 @@ describe('Custom routes invalid multi-match', () => {
   const { next, isNextDeploy, skipped } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
+    // Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
     // The test asserts on `next.cliOutput`, expecting the local
     // `next build` failure message ("To use a multi-match in the
     // destination..."). In deploy mode `next.cliOutput` contains the

--- a/test/e2e/jsconfig-baseurl/jsconfig-baseurl.test.ts
+++ b/test/e2e/jsconfig-baseurl/jsconfig-baseurl.test.ts
@@ -5,6 +5,8 @@ import { retry } from 'next-test-utils'
 describe('jsconfig.json baseurl', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/jsconfig-paths/jsconfig-paths.test.ts
+++ b/test/e2e/jsconfig-paths/jsconfig-paths.test.ts
@@ -5,6 +5,8 @@ import stripAnsi from 'next/dist/compiled/strip-ansi'
 describe('jsconfig paths', () => {
   const { next, isNextDeploy, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return
@@ -100,6 +102,8 @@ describe('jsconfig paths without baseurl', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/legacy-link-behavior/index.test.ts
+++ b/test/e2e/legacy-link-behavior/index.test.ts
@@ -8,6 +8,8 @@ import {
 describe('Link with legacyBehavior', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/legacy-link-behavior/validations.console.test.ts
+++ b/test/e2e/legacy-link-behavior/validations.console.test.ts
@@ -7,6 +7,8 @@ const partialPrefetching = !!process.env.__NEXT_PARTIAL_PREFETCHING
 describe('Validations for <Link legacyBehavior>', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/manual-client-base-path/index.test.ts
+++ b/test/e2e/manual-client-base-path/index.test.ts
@@ -6,6 +6,7 @@ import assert from 'assert'
 import { check, renderViaHTTP, waitFor } from 'next-test-utils'
 
 describe('manual-client-base-path', () => {
+  // Deploy mode exclusion: This suite runs an in-test HTTP proxy in front of the local Next.js server.
   if ((global as any).isNextDeploy) {
     it('should skip deploy', () => {})
     return

--- a/test/e2e/middleware-custom-matchers/test/index.test.ts
+++ b/test/e2e/middleware-custom-matchers/test/index.test.ts
@@ -8,6 +8,8 @@ const itif = (condition: boolean) => (condition ? it : it.skip)
 const isModeDeploy = process.env.NEXT_TEST_MODE === 'deploy'
 
 describe('Middleware custom matchers', () => {
+  // TODO(deploy-test-completion): Re-enable this suite for deployed Node.js middleware.
+  // No deploy-specific incompatibility is documented.
   if ((global as any).isNextDeploy && process.env.TEST_NODE_MIDDLEWARE) {
     return it('should skip deploy for now', () => {})
   }

--- a/test/e2e/middleware-matcher/index.test.ts
+++ b/test/e2e/middleware-matcher/index.test.ts
@@ -30,6 +30,8 @@ function normalizeMiddlewareManifest(value: unknown, key?: string): unknown {
   return value
 }
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('Middleware can set the matcher in its config', () => {
   const { next } = nextTestSetup({
     files: new FileRef(join(__dirname, 'app')),

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -16,6 +16,7 @@ describe('Middleware Rewrite', () => {
       'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
       'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // FIXME: Fails to deploy
     skipDeployment: isAdapterTest && isTurbopackTest,
   })

--- a/test/e2e/middleware-src-node/middleware-src-node.test.ts
+++ b/test/e2e/middleware-src-node/middleware-src-node.test.ts
@@ -8,6 +8,8 @@ describe('middleware-src-node', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/middleware-src/middleware-src.test.ts
+++ b/test/e2e/middleware-src/middleware-src.test.ts
@@ -8,6 +8,8 @@ describe('middleware-src', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/multi-zone/multi-zone.test.ts
+++ b/test/e2e/multi-zone/multi-zone.test.ts
@@ -5,6 +5,8 @@ import path from 'path'
 describe('multi-zone', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: path.join(__dirname, 'app'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
     buildCommand: 'pnpm build',
     startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',

--- a/test/e2e/new-link-behavior/material-ui.test.ts
+++ b/test/e2e/new-link-behavior/material-ui.test.ts
@@ -3,6 +3,8 @@ import path from 'path'
 
 const appDir = path.join(__dirname, 'material-ui')
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('New Link Behavior with material-ui', () => {
   const { next } = nextTestSetup({
     files: {

--- a/test/e2e/new-link-behavior/stitches.test.ts
+++ b/test/e2e/new-link-behavior/stitches.test.ts
@@ -3,6 +3,8 @@ import path from 'path'
 
 const appDir = path.join(__dirname, 'stitches')
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('New Link Behavior with stitches', () => {
   const { next } = nextTestSetup({
     files: {

--- a/test/e2e/next-analyze/next-analyze.test.ts
+++ b/test/e2e/next-analyze/next-analyze.test.ts
@@ -14,6 +14,8 @@ describe('next experimental-analyze', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely inspects local build artifacts that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/next-dynamic-css-asset-prefix/next-dynamic-css-asset-prefix.test.ts
+++ b/test/e2e/next-dynamic-css-asset-prefix/next-dynamic-css-asset-prefix.test.ts
@@ -10,6 +10,8 @@ describe('next/dynamic with assetPrefix', () => {
     dependencies: {
       sass: '1.54.0',
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/next-font/basepath.test.ts
+++ b/test/e2e/next-font/basepath.test.ts
@@ -8,6 +8,7 @@ const mockedGoogleFontResponses = require.resolve(
 )
 
 describe('next/font/google basepath', () => {
+  // Deploy mode exclusion: This suite passes an absolute local mocked-font-response path into the build.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return

--- a/test/e2e/next-font/google-fetch-error.test.ts
+++ b/test/e2e/next-font/google-fetch-error.test.ts
@@ -9,6 +9,7 @@ describe('next/font/google fetch error', () => {
   const isDev = (global as any).isNextDev
   const isTurbopack = !!process.env.IS_TURBOPACK_TEST
 
+  // Deploy mode exclusion: This suite intentionally fails the build, so there is no successful deployment to exercise.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return

--- a/test/e2e/next-font/index.test.ts
+++ b/test/e2e/next-font/index.test.ts
@@ -36,6 +36,7 @@ function hrefMatchesFontWithoutSizeAdjust(href: string) {
 }
 
 describe('next/font', () => {
+  // Deploy mode exclusion: This suite passes an absolute local mocked-font-response path into the build.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return

--- a/test/e2e/next-font/with-font-declarations-file.test.ts
+++ b/test/e2e/next-font/with-font-declarations-file.test.ts
@@ -10,6 +10,7 @@ const mockedGoogleFontResponses = require.resolve(
 const isDev = (global as any).isNextDev
 
 describe('next/font/google with-font-declarations-file', () => {
+  // Deploy mode exclusion: This suite passes an absolute local mocked-font-response path into the build.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return

--- a/test/e2e/next-font/with-proxy.test.ts
+++ b/test/e2e/next-font/with-proxy.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import spawn from 'cross-spawn'
 
 describe('next/font/google with proxy', () => {
+  // Deploy mode exclusion: This suite spawns a local proxy process.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy', () => {})
     return

--- a/test/e2e/next-font/without-preloaded-fonts.test.ts
+++ b/test/e2e/next-font/without-preloaded-fonts.test.ts
@@ -8,6 +8,7 @@ const mockedGoogleFontResponses = require.resolve(
 )
 
 describe('next/font/google without-preloaded-fonts without _app', () => {
+  // Deploy mode exclusion: This suite passes an absolute local mocked-font-response path into the build.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
@@ -54,6 +55,7 @@ describe('next/font/google without-preloaded-fonts without _app', () => {
 })
 
 describe('next/font/google no preloads with _app', () => {
+  // Deploy mode exclusion: This suite passes an absolute local mocked-font-response path into the build.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return

--- a/test/e2e/next-image-forward-ref/index.test.ts
+++ b/test/e2e/next-image-forward-ref/index.test.ts
@@ -2,6 +2,8 @@ import { FileRef, nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('next-image-forward-ref', () => {
   const appDir = path.join(__dirname, 'app')
 

--- a/test/e2e/next-image-legacy-src-with-query-without-local-patterns/next-image-legacy-src-with-query-without-local-patterns.test.ts
+++ b/test/e2e/next-image-legacy-src-with-query-without-local-patterns/next-image-legacy-src-with-query-without-local-patterns.test.ts
@@ -4,6 +4,8 @@ describe('next-image-legacy-src-with-query-without-local-patterns', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/next-image-legacy/base-path/base-path-static.test.ts
+++ b/test/e2e/next-image-legacy/base-path/base-path-static.test.ts
@@ -4,6 +4,8 @@ describe('Build Error Tests for basePath', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 
@@ -34,6 +36,8 @@ describe('Build Error Tests for basePath', () => {
 describe('Static Image Component Tests for basePath', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/next-image-legacy/base-path/base-path.test.ts
+++ b/test/e2e/next-image-legacy/base-path/base-path.test.ts
@@ -11,6 +11,7 @@ describe('Legacy Image Component basePath Tests', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
+    // Deploy mode exclusion: This suite reads local build artifacts that deployments do not expose.
     // Image URL assertions construct expected URLs via
     // `getDeploymentId(next.testDir, ...)`, which reads the local
     // `.next/required-server-files.json`. In deploy mode that file lives on

--- a/test/e2e/next-image-legacy/default/default-static.test.ts
+++ b/test/e2e/next-image-legacy/default/default-static.test.ts
@@ -11,6 +11,8 @@ describe('Build Error Tests', () => {
   const { next, isTurbopack, isRspack, isNextDeploy } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (isNextDeploy) return
@@ -46,6 +48,8 @@ describe('Build Error Tests', () => {
 describe('Static Image Component Tests', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/next-image-legacy/typescript/typescript.test.ts
+++ b/test/e2e/next-image-legacy/typescript/typescript.test.ts
@@ -6,6 +6,8 @@ describe('TypeScript Image Component', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/next-image-new/app-dir-localpatterns/app-dir-localpatterns.test.ts
+++ b/test/e2e/next-image-new/app-dir-localpatterns/app-dir-localpatterns.test.ts
@@ -8,6 +8,8 @@ import {
 describe('Image localPatterns config', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely inspects local build artifacts that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/next-image-new/app-dir-qualities/app-dir-qualities.test.ts
+++ b/test/e2e/next-image-new/app-dir-qualities/app-dir-qualities.test.ts
@@ -4,6 +4,8 @@ import { waitForNoRedbox } from 'next-test-utils'
 describe('Image qualities config', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely inspects local build artifacts that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/next-image-new/app-dir/app-dir-static.test.ts
+++ b/test/e2e/next-image-new/app-dir/app-dir-static.test.ts
@@ -11,6 +11,8 @@ import cheerio from 'cheerio'
     const { next, isTurbopack, isRspack } = nextTestSetup({
       files: __dirname,
       skipStart: true,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely expects a local build failure instead of a successful deployment.
       skipDeployment: true,
     })
 
@@ -50,6 +52,8 @@ import cheerio from 'cheerio'
   () => {
     const { next, isTurbopack, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely expects a local build failure instead of a successful deployment.
       skipDeployment: true,
     })
     if (skipped) return

--- a/test/e2e/next-image-new/app-dir/app-dir.test.ts
+++ b/test/e2e/next-image-new/app-dir/app-dir.test.ts
@@ -14,6 +14,8 @@ import { join } from 'path'
 describe('Image Component App Dir Tests', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely inspects local build artifacts that deploy tests do not expose.
     skipDeployment: true,
     disableAutoSkewProtection: true,
   })

--- a/test/e2e/next-image-new/base-path/base-path-static.test.ts
+++ b/test/e2e/next-image-new/base-path/base-path-static.test.ts
@@ -5,6 +5,8 @@ describe('Build Error Tests', () => {
   const { next, isTurbopack, isRspack, isNextDeploy } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (isNextDeploy) return
@@ -43,6 +45,8 @@ describe('Build Error Tests', () => {
 describe('Static Image Component Tests for basePath', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/next-image-new/base-path/base-path.test.ts
+++ b/test/e2e/next-image-new/base-path/base-path.test.ts
@@ -11,6 +11,7 @@ describe('Image Component basePath Tests', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
+    // Deploy mode exclusion: This suite reads local build artifacts that deployments do not expose.
     // Image URL assertions construct expected URLs via
     // `getDeploymentId(next.testDir, ...)`, which reads the local
     // `.next/required-server-files.json`. In deploy mode that file lives on

--- a/test/e2e/next-image-new/both-basepath-trailingslash/both-basepath-trailingslash.test.ts
+++ b/test/e2e/next-image-new/both-basepath-trailingslash/both-basepath-trailingslash.test.ts
@@ -5,6 +5,7 @@ describe('Image Component basePath + trailingSlash Tests', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
+    // Deploy mode exclusion: This suite reads local build artifacts that deployments do not expose.
     // Image URL assertions construct expected URLs via
     // `getDeploymentId(next.testDir, ...)`, which reads the local
     // `.next/required-server-files.json`. In deploy mode that file lives on

--- a/test/e2e/next-image-new/default/default-static.test.ts
+++ b/test/e2e/next-image-new/default/default-static.test.ts
@@ -5,6 +5,8 @@ describe('Build Error Tests', () => {
   const { next, isNextDeploy, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     disableAutoSkewProtection: true,
   })
@@ -40,6 +42,8 @@ describe('Build Error Tests', () => {
 describe('Static Image Component Tests', () => {
   const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
     disableAutoSkewProtection: true,
   })

--- a/test/e2e/next-image-new/default/default.test.ts
+++ b/test/e2e/next-image-new/default/default.test.ts
@@ -16,6 +16,7 @@ describe('Image Component Default Tests', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
+    // Deploy mode exclusion: This suite reads local build artifacts that deployments do not expose.
     // Image URL assertions assume local-relative `/_next/image?url=...`
     // paths and access to `.next/static` on disk; deploy mode rewrites URLs
     // through the Vercel hostname and has no on-disk `.next/`.

--- a/test/e2e/next-image-new/typescript/typescript.test.ts
+++ b/test/e2e/next-image-new/typescript/typescript.test.ts
@@ -10,6 +10,8 @@ describe('TypeScript Image Component Build Errors', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 
@@ -47,6 +49,8 @@ describe('TypeScript Image Component Dev', () => {
 
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 

--- a/test/e2e/next-image-new/unicode/unicode.test.ts
+++ b/test/e2e/next-image-new/unicode/unicode.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup, isNextDev } from 'e2e-utils'
 describe('Image Component Unicode Image URL', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely inspects local build artifacts that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/next-image-new/unoptimized/unoptimized.test.ts
+++ b/test/e2e/next-image-new/unoptimized/unoptimized.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('Unoptimized Image Tests', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely inspects local build artifacts that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/next-image-src-with-query-without-local-patterns/next-image-src-with-query-without-local-patterns.test.ts
+++ b/test/e2e/next-image-src-with-query-without-local-patterns/next-image-src-with-query-without-local-patterns.test.ts
@@ -4,6 +4,8 @@ describe('next-image-src-with-query-without-local-patterns', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/next-image-svgo-webpack/svgo-webpack.test.ts
+++ b/test/e2e/next-image-svgo-webpack/svgo-webpack.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('svgo-webpack loader', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     dependencies: {
       '@svgr/webpack': '8.1.0',

--- a/test/e2e/next-link-errors/next-link-errors.test.ts
+++ b/test/e2e/next-link-errors/next-link-errors.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('next-link', () => {
   const { skipped, next, isNextDev } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/next-phase/index.test.ts
+++ b/test/e2e/next-phase/index.test.ts
@@ -2,6 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 
 describe('next-phase', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // This test is skipped when deployed because it asserts against runtime
     // logs that cannot be queried in a deployed environment.
     skipDeployment: true,

--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('beforeInteractive in document Head', () => {
   const { next } = nextTestSetup({
     files: {

--- a/test/e2e/next-test/next-test.test.ts
+++ b/test/e2e/next-test/next-test.test.ts
@@ -32,6 +32,7 @@ describe.skip('next test', () => {
       '@playwright/test': '1.43.1',
     },
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // This doesn't need to be deployed as it's using `experimental-test` mode
     skipDeployment: true,
   })

--- a/test/e2e/node-cli-args/node-cli-args.test.ts
+++ b/test/e2e/node-cli-args/node-cli-args.test.ts
@@ -4,6 +4,8 @@ describe('node-cli-args', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     startCommand: `node --experimental-network-inspection ./node_modules/next/dist/bin/next ${process.env.NEXT_TEST_MODE === 'dev' ? 'dev' : 'start'}`,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/node-fetch-keep-alive/node-fetch-keep-alive.test.ts
+++ b/test/e2e/node-fetch-keep-alive/node-fetch-keep-alive.test.ts
@@ -7,6 +7,7 @@ describe('node-fetch-keep-alive', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
     skipDeployment: true,
   })

--- a/test/e2e/nullish-config/nullish-config.test.ts
+++ b/test/e2e/nullish-config/nullish-config.test.ts
@@ -4,6 +4,8 @@ describe('Nullish configs in next.config.js', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -7,6 +7,8 @@ import { join } from 'path'
 describe('og-api', () => {
   const { next, skipped } = nextTestSetup({
     files: new FileRef(join(__dirname, 'app')),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: process.env.TEST_OUTPUT_STANDALONE === 'true',
   })
 

--- a/test/e2e/on-request-error/basic/basic.test.ts
+++ b/test/e2e/on-request-error/basic/basic.test.ts
@@ -5,6 +5,8 @@ import { getOutputLogJson } from '../_testing/utils'
 describe('on-request-error - basic', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/on-request-error/client-abort/client-abort.test.ts
+++ b/test/e2e/on-request-error/client-abort/client-abort.test.ts
@@ -4,6 +4,8 @@ import { retry } from 'next-test-utils'
 describe('on-request-error - client-abort', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite asserts local server CLI output after
+    // aborting a response stream.
     skipDeployment: true,
   })
 

--- a/test/e2e/on-request-error/dynamic-routes/dynamic-routes.test.ts
+++ b/test/e2e/on-request-error/dynamic-routes/dynamic-routes.test.ts
@@ -5,6 +5,8 @@ import { getOutputLogJson } from '../_testing/utils'
 describe('on-request-error - dynamic-routes', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/on-request-error/isr/isr.test.ts
+++ b/test/e2e/on-request-error/isr/isr.test.ts
@@ -7,6 +7,8 @@ const outputLogPath = 'output-log.json'
 describe('on-request-error - isr', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
     skipDeployment: true,
   })
 

--- a/test/e2e/on-request-error/otel/otel.test.ts
+++ b/test/e2e/on-request-error/otel/otel.test.ts
@@ -5,6 +5,8 @@ import { getOutputLogJson } from '../_testing/utils'
 describe('on-request-error - otel', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     packageJson: {
       dependencies: {

--- a/test/e2e/on-request-error/server-action-error/server-action-error.test.ts
+++ b/test/e2e/on-request-error/server-action-error/server-action-error.test.ts
@@ -5,6 +5,8 @@ import { getOutputLogJson } from '../_testing/utils'
 describe('on-request-error - server-action-error', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
+++ b/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('on-request-error - skip-next-internal-error', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/opentelemetry/instrumentation/instrumentation-pages-app-only.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/instrumentation-pages-app-only.test.ts
@@ -38,6 +38,8 @@ for (const { app, src, pathname, text } of [
       env: {
         NEXT_PUBLIC_SIMPLE_INSTRUMENT: '1',
       },
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       packageJson: {
         scripts: {

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -33,6 +33,8 @@ function setup({ useDirectEntrypointHandler, useNodeMiddleware }) {
 
   let next = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     dependencies: require('./package.json').dependencies,
     ...(!useDirectEntrypointHandler
@@ -1540,6 +1542,8 @@ if (isNextStart) {
     let collector: Collector | undefined
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // Deploy mode exclusion: This suite starts a process-local telemetry
+      // collector and controls the server lifecycle.
       skipDeployment: true,
       skipStart: true,
       dependencies: require('./package.json').dependencies,
@@ -1615,6 +1619,8 @@ describe.each(
     let collector: Collector | undefined
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // Deploy mode exclusion: This suite starts a process-local telemetry
+      // collector and controls the server lifecycle.
       skipDeployment: true,
       skipStart: true,
       dependencies: require('./package.json').dependencies,
@@ -1845,6 +1851,8 @@ describe.each(
     let collector: Collector | undefined
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // Deploy mode exclusion: This suite starts a process-local telemetry
+      // collector and controls the server lifecycle.
       skipDeployment: true,
       skipStart: true,
       dependencies: require('./package.json').dependencies,
@@ -1944,6 +1952,8 @@ describe.each(
   () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely controls the local Next.js build or server lifecycle.
       skipDeployment: true,
       dependencies: require('./package.json').dependencies,
       env: {
@@ -2011,6 +2021,8 @@ describe.each(
 describe('opentelemetry with disabled fetch tracing', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     dependencies: require('./package.json').dependencies,
     env: {
@@ -2093,6 +2105,8 @@ describe('opentelemetry with disabled fetch tracing', () => {
 describe('opentelemetry with custom server', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely controls the local Next.js build or server lifecycle.
     skipDeployment: true,
     dependencies: require('./package.json').dependencies,
     startCommand: 'pnpm start',
@@ -2271,6 +2285,8 @@ if (isNextStart) {
   describe('opentelemetry with direct entrypoint handler', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely controls the local Next.js build or server lifecycle.
       skipDeployment: true,
       dependencies: require('./package.json').dependencies,
       startCommand: 'pnpm start-entrypoint',

--- a/test/e2e/pages-performance-mark/index.test.ts
+++ b/test/e2e/pages-performance-mark/index.test.ts
@@ -5,6 +5,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('pages performance mark', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/persistent-caching-migration/persistent-caching-migration.test.ts
+++ b/test/e2e/persistent-caching-migration/persistent-caching-migration.test.ts
@@ -27,6 +27,8 @@ describe('persistent-caching-migration', () => {
   },
 }`,
         },
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely expects a local build failure instead of a successful deployment.
         skipDeployment: true,
         skipStart: true,
       })

--- a/test/e2e/postcss-config-cjs/index.test.ts
+++ b/test/e2e/postcss-config-cjs/index.test.ts
@@ -1,6 +1,8 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('postcss-config-cjs', () => {
   const { next } = nextTestSetup({
     files: new FileRef(join(__dirname, 'app')),

--- a/test/e2e/prerender-fallback-encoding/prerender-fallback-encoding.test.ts
+++ b/test/e2e/prerender-fallback-encoding/prerender-fallback-encoding.test.ts
@@ -6,6 +6,7 @@ import { join } from 'path'
 describe('Fallback path encoding', () => {
   const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
     skipDeployment: true,
   })

--- a/test/e2e/react-compiler/react-compiler.test.ts
+++ b/test/e2e/react-compiler/react-compiler.test.ts
@@ -16,6 +16,8 @@ function normalizeCodeLocInfo(str) {
   )
 }
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe.each(['default', 'babelrc', 'rust'] as const)(
   'react-compiler %s',
   (variant) => {

--- a/test/e2e/react-current-version/react-current-version.test.ts
+++ b/test/e2e/react-current-version/react-current-version.test.ts
@@ -45,6 +45,8 @@ describe('react-current-version', () => {
       return
     }
 
+    // Deploy mode exclusion: This block asserts local build and server CLI
+    // output, which is produced before a deployment is available.
     if (isNextDeploy) {
       it('should skip in deploy mode', () => {})
       return

--- a/test/e2e/react-dnd-compile/react-dnd-compile.test.ts
+++ b/test/e2e/react-dnd-compile/react-dnd-compile.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('react-dnd-compile', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/relay-graphql-swc-multi-project/relay-graphql-swc-multi-project.test.ts
+++ b/test/e2e/relay-graphql-swc-multi-project/relay-graphql-swc-multi-project.test.ts
@@ -44,6 +44,7 @@ describe('Relay Compiler Transform - Multi Project Config', () => {
       startCommand: isNextDev
         ? 'pnpm run dev-project-a'
         : 'pnpm run start-project-a',
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
       // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
       skipDeployment: true,
     })
@@ -78,6 +79,7 @@ describe('Relay Compiler Transform - Multi Project Config', () => {
       startCommand: isNextDev
         ? 'pnpm run dev-project-b'
         : 'pnpm run start-project-b',
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
       // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
       skipDeployment: true,
     })

--- a/test/e2e/repeated-slashes/repeated-slashes.test.ts
+++ b/test/e2e/repeated-slashes/repeated-slashes.test.ts
@@ -421,6 +421,8 @@ describe('404 handling', () => {
     describe('server mode', () => {
       const { next, isNextDeploy } = nextTestSetup({
         files: path.join(__dirname, 'app'),
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely mutates files in the isolated local fixture after setup.
         skipDeployment: true,
       })
       if (isNextDeploy) return
@@ -431,6 +433,8 @@ describe('404 handling', () => {
       const { next, skipped } = nextTestSetup({
         files: path.join(__dirname, 'app'),
         skipStart: true,
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely mutates files in the isolated local fixture after setup.
         skipDeployment: true,
       })
       if (skipped) return
@@ -475,6 +479,8 @@ describe('404 handling', () => {
       const { next, skipped } = nextTestSetup({
         files: path.join(__dirname, 'app'),
         skipStart: true,
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely mutates files in the isolated local fixture after setup.
         skipDeployment: true,
       })
       if (skipped) return
@@ -505,6 +511,8 @@ describe('404 handling', () => {
       const { next, skipped } = nextTestSetup({
         files: path.join(__dirname, 'app'),
         skipStart: true,
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // It likely mutates files in the isolated local fixture after setup.
         skipDeployment: true,
       })
       if (skipped) return

--- a/test/e2e/rewrite-request-smuggling/rewrite-request-smuggling.test.ts
+++ b/test/e2e/rewrite-request-smuggling/rewrite-request-smuggling.test.ts
@@ -4,6 +4,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { findPort, retry } from 'next-test-utils'
 
 describe('rewrite-request-smuggling', () => {
+  // Deploy mode exclusion: This suite opens raw TCP connections to a local backend server.
   if ((global as any).isNextDeploy) {
     it('should skip deploy', () => {})
     return

--- a/test/e2e/rewrite-with-browser-history/rewrite-with-browser-history.test.ts
+++ b/test/e2e/rewrite-with-browser-history/rewrite-with-browser-history.test.ts
@@ -7,6 +7,7 @@ describe('rewrites persist with browser history actions', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
     skipDeployment: true,
   })

--- a/test/e2e/rewrites-hostname/rewrites-hostname.test.ts
+++ b/test/e2e/rewrites-hostname/rewrites-hostname.test.ts
@@ -5,6 +5,8 @@ import createTargetServer from './target-server'
 describe('rewrites hostname', () => {
   const { skipped, next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely depends on a local server, proxy, process, or dynamically allocated port.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/route-index/route-index.test.ts
+++ b/test/e2e/route-index/route-index.test.ts
@@ -3,6 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 describe('Route index handling', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Pages-router `/index` route resolution differs in Vercel's deploy
     // infrastructure; these assertions are local-only.
     skipDeployment: true,

--- a/test/e2e/route-indexes/route-indexes.test.ts
+++ b/test/e2e/route-indexes/route-indexes.test.ts
@@ -3,6 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 describe('Route indexes handling', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Pages-router `/index` route resolution differs in Vercel's deploy
     // infrastructure; these assertions are local-only.
     skipDeployment: true,

--- a/test/e2e/router-hash-navigation/router-hash-navigation.test.ts
+++ b/test/e2e/router-hash-navigation/router-hash-navigation.test.ts
@@ -7,6 +7,7 @@ describe('router hash navigation', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
     skipDeployment: true,
   })

--- a/test/e2e/script-loader/partytown-missing.test.ts
+++ b/test/e2e/script-loader/partytown-missing.test.ts
@@ -5,6 +5,7 @@ describe('script-loader - partytown-missing', () => {
   const { next, isNextDev } = nextTestSetup({
     files: join(__dirname, 'partytown-missing'),
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
     skipDeployment: true,
   })

--- a/test/e2e/scroll-back-restoration/scroll-back-restoration.test.ts
+++ b/test/e2e/scroll-back-restoration/scroll-back-restoration.test.ts
@@ -8,6 +8,7 @@ describe('Scroll Back Restoration Support', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
     skipDeployment: true,
   })

--- a/test/e2e/skip-trailing-slash-redirect/index.test.ts
+++ b/test/e2e/skip-trailing-slash-redirect/index.test.ts
@@ -11,6 +11,8 @@ import {
 import { join } from 'path'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('skip-trailing-slash-redirect', () => {
   const { next } = nextTestSetup({
     files: new FileRef(join(__dirname, 'app')),

--- a/test/e2e/socket-io/index.test.ts
+++ b/test/e2e/socket-io/index.test.ts
@@ -10,6 +10,7 @@ describe('socket-io', () => {
       'utf-8-validate': '6.0.3',
       bufferutil: '4.0.8',
     },
+    // Deploy mode exclusion: This suite controls a local server or proxy process.
     // the socket.io setup relies on patching next's `http.Server` instance,
     // which we can't do when deployed
     skipDeployment: true,

--- a/test/e2e/ssg-dynamic-routes-404-page/ssg-dynamic-routes-404-page.test.ts
+++ b/test/e2e/ssg-dynamic-routes-404-page/ssg-dynamic-routes-404-page.test.ts
@@ -7,6 +7,7 @@ describe('ssg-dynamic-routes-404-page', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
     // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
     skipDeployment: true,
   })

--- a/test/e2e/styled-jsx-dynamic/index.test.ts
+++ b/test/e2e/styled-jsx-dynamic/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('styled-jsx dynamic styles SSR', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/styled-jsx/index.test.ts
+++ b/test/e2e/styled-jsx/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('styled-jsx', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     dependencies: {
       'styled-jsx': '5.0.0', // styled-jsx on user side

--- a/test/e2e/swc-plugins-env/index.test.ts
+++ b/test/e2e/swc-plugins-env/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('swc-plugins-env', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/swc-plugins/index.test.ts
+++ b/test/e2e/swc-plugins/index.test.ts
@@ -4,6 +4,8 @@ describe('swcPlugins', () => {
   describe('supports swcPlugins', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely expects a local build failure instead of a successful deployment.
       skipDeployment: true,
       dependencies: {
         '@swc/plugin-react-remove-properties': '11.1.0',
@@ -20,6 +22,8 @@ describe('swcPlugins', () => {
   ;(isNextDev ? describe : describe.skip)('incompatible plugin version', () => {
     const { next, skipped, isTurbopack } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely expects a local build failure instead of a successful deployment.
       skipDeployment: true,
       dependencies: {
         '@swc/plugin-react-remove-properties': '7.0.2',
@@ -58,6 +62,8 @@ describe('swcPlugins', () => {
   ;(isNextDev ? describe : describe.skip)('invalid plugin name', () => {
     const { next, skipped, isTurbopack } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely expects a local build failure instead of a successful deployment.
       skipDeployment: true,
       overrideFiles: {
         'next.config.js': `

--- a/test/e2e/swc-warnings/index.test.ts
+++ b/test/e2e/swc-warnings/index.test.ts
@@ -2,6 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 // Tests Babel, not needed for Turbopack
+// Deploy mode exclusion: This suite asserts warning output from the local
+// Next.js CLI, which is not available from a deployed runtime.
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'swc warnings by default',
   () => {

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -31,6 +31,8 @@ async function testRoute(appPort, url, { isStatic, isEdge }) {
 describe('Switchable runtime', () => {
   let context
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // Prerenders used by this suite are not currently handled by deploy mode.
   if ((global as any).isNextDeploy) {
     // TODO-APP: re-enable after Prerenders are handled on deploy
     it('should skip for deploy temporarily', () => {})

--- a/test/e2e/telemetry/config.test.ts
+++ b/test/e2e/telemetry/config.test.ts
@@ -14,6 +14,8 @@ describe('config telemetry', () => {
   const { next, isNextStart, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/telemetry/page-features.test.ts
+++ b/test/e2e/telemetry/page-features.test.ts
@@ -8,6 +8,7 @@ describe('page features telemetry', () => {
   const { next, isTurbopack, isRspack, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // Deploy mode exclusion: The assertions exercise behavior specific to the local Next.js server.
     // Calls `next.build()` directly which is not supported on `NextDeployInstance`.
     skipDeployment: true,
   })

--- a/test/e2e/telemetry/telemetry.test.ts
+++ b/test/e2e/telemetry/telemetry.test.ts
@@ -13,6 +13,8 @@ import { findAllTelemetryEvents } from 'next-test-utils'
   const { next, isNextStart, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return

--- a/test/e2e/testmode/testmode.test.ts
+++ b/test/e2e/testmode/testmode.test.ts
@@ -4,6 +4,8 @@ import { createProxyServer } from 'next/experimental/testmode/proxy'
 describe('testmode', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     dependencies: require('./package.json').dependencies,
   })

--- a/test/e2e/third-parties/index.test.ts
+++ b/test/e2e/third-parties/index.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('@next/third-parties basic usage', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/trailing-slashes-rewrite/trailing-slashes-rewrite.test.ts
+++ b/test/e2e/trailing-slashes-rewrite/trailing-slashes-rewrite.test.ts
@@ -6,6 +6,7 @@ describe('Trailing Slash Rewrite Proxying', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // Deploy mode exclusion: This suite controls a local server or proxy process.
     // Spawns a custom proxy server in front of `next.start()`; deploy mode
     // doesn't run a local server.
     skipDeployment: true,

--- a/test/e2e/trailingslash-with-rewrite/index.test.ts
+++ b/test/e2e/trailingslash-with-rewrite/index.test.ts
@@ -3,6 +3,8 @@ import { FileRef, nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('trailingSlash:true with rewrites and getStaticProps', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
   if ((global as any).isNextDeploy) {
     it('should skip for deploy mode for now', () => {})
     return

--- a/test/e2e/transpile-packages-typescript-foreign/index.test.ts
+++ b/test/e2e/transpile-packages-typescript-foreign/index.test.ts
@@ -4,6 +4,8 @@ describe('transpile-packages-typescript-foreign', () => {
   describe('without transpilePackages', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       skipStart: true,
       dependencies: {
@@ -41,6 +43,8 @@ Module parse failed: Unexpected token`)
   describe('with transpilePackages', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
       dependencies: {
         pkg: `file:./pkg`,

--- a/test/e2e/transpile-packages/index.test.ts
+++ b/test/e2e/transpile-packages/index.test.ts
@@ -2,6 +2,8 @@ import path from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('transpile packages', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
   if ((global as any).isNextDeploy) {
     it('should skip for deploy mode for now', () => {})
     return

--- a/test/e2e/tsconfig-module-preserve/index.test.ts
+++ b/test/e2e/tsconfig-module-preserve/index.test.ts
@@ -17,6 +17,7 @@ describe('tsconfig module: preserve', () => {
         } 
       `,
     },
+    // Deploy mode exclusion: This suite reads local build artifacts that deployments do not expose.
     // This test is skipped because it relies on `next.readFile`
     skipDeployment: true,
     dependencies: {

--- a/test/e2e/turbopack-emit-collect/index.test.ts
+++ b/test/e2e/turbopack-emit-collect/index.test.ts
@@ -7,6 +7,8 @@ import { nextTestSetup } from 'e2e-utils'
   : describe.skip)('turbopack-emit-collect', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // Deploy mode exclusion: This suite restarts the local server to inspect
+    // process-global module state.
     skipDeployment: true,
   })
 

--- a/test/e2e/turbopack-import-with-type/index.test.ts
+++ b/test/e2e/turbopack-import-with-type/index.test.ts
@@ -10,6 +10,8 @@ throw new Error('please dont execute me')
   () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // No deploy-specific incompatibility is documented.
       skipDeployment: true,
     })
 

--- a/test/e2e/turbopack-loader-config/index.test.ts
+++ b/test/e2e/turbopack-loader-config/index.test.ts
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('turbopack-loader-config', () => {
   const { next, isTurbopack, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     // we can't set `nextConfig` inline because it contains regexes that fail to serialize, it needs
     // to be set in a separate module (`next.config.ts`)

--- a/test/e2e/turbopack-trace-server-query/turbopack-trace-server.test.ts
+++ b/test/e2e/turbopack-trace-server-query/turbopack-trace-server.test.ts
@@ -112,6 +112,8 @@ function runQueryTraceCli(
 // ─── test suite ──────────────────────────────────────────────────────────────
 
 describe('turbopack-trace-server', () => {
+  // Deploy mode exclusion: This suite reads a local trace file and spawns
+  // local MCP and CLI processes.
   if (isNextDeploy) {
     it('skipped for deploy mode', () => {})
     return
@@ -120,6 +122,8 @@ describe('turbopack-trace-server', () => {
   const { next, isTurbopack, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     env: { NEXT_TURBOPACK_TRACING: '1' },
+    // Deploy mode exclusion: The trace server requires local trace files and
+    // child processes.
     skipDeployment: true,
   })
 

--- a/test/e2e/turbopack-worker-asset-prefix/turbopack-worker-asset-prefix.test.ts
+++ b/test/e2e/turbopack-worker-asset-prefix/turbopack-worker-asset-prefix.test.ts
@@ -3,6 +3,7 @@ import { retry } from 'next-test-utils'
 
 // `experimental.turbopackWorkerAssetPrefix` is turbopack-only.
 const isTurbopack = !process.env.IS_WEBPACK_TEST && !process.env.NEXT_RSPACK
+// Deploy mode exclusion: This suite models cross-origin loading with `localhost` and `127.0.0.1` on a local port.
 const describeTurbopack =
   isTurbopack && !isNextDeploy ? describe : describe.skip
 

--- a/test/e2e/typescript-version-no-warning/typescript-version-no-warning.test.ts
+++ b/test/e2e/typescript-version-no-warning/typescript-version-no-warning.test.ts
@@ -4,6 +4,8 @@ describe('typescript-version-no-warning', () => {
   const { next, isNextDeploy, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
 

--- a/test/e2e/typescript-version-warning/typescript-version-warning.test.ts
+++ b/test/e2e/typescript-version-warning/typescript-version-warning.test.ts
@@ -4,6 +4,8 @@ describe('typescript-version-warning', () => {
   const { next, isNextDeploy, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     dependencies: {
       typescript: '4.0.6',

--- a/test/e2e/typescript-workspaces-paths/packages/www/test/index.test.ts
+++ b/test/e2e/typescript-workspaces-paths/packages/www/test/index.test.ts
@@ -47,6 +47,8 @@ describe('TypeScript Features', () => {
     })
 
     const { next, skipped } = nextTestSetup({
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely controls the local Next.js build or server lifecycle.
       skipDeployment: true,
       dependencies: testBaseUrl
         ? {

--- a/test/e2e/typescript/typescript.test.ts
+++ b/test/e2e/typescript/typescript.test.ts
@@ -6,6 +6,8 @@ describe('TypeScript Features', () => {
     dependencies: {
       sass: 'latest',
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
   })
   if (skipped) return
@@ -107,6 +109,8 @@ export default function EvilPage(): JSX.Element {
       dependencies: {
         sass: 'latest',
       },
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
     if (skipped) return

--- a/test/e2e/undefined-webpack-config/undefined-webpack-config.test.ts
+++ b/test/e2e/undefined-webpack-config/undefined-webpack-config.test.ts
@@ -11,6 +11,8 @@ const expectedErr =
     const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
       files: __dirname,
       skipStart: true,
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It likely asserts local CLI or runtime output that deploy tests do not expose.
       skipDeployment: true,
     })
     if (skipped) return

--- a/test/e2e/url-imports/url-imports.test.ts
+++ b/test/e2e/url-imports/url-imports.test.ts
@@ -34,6 +34,7 @@ import { join } from 'path'
             public: new FileRef(join(__dirname, 'public')),
           }
         : __dirname,
+      // Deploy mode exclusion: This suite controls a local server or proxy process.
       // The staticServer above doesn't work when deployed
       skipDeployment: true,
     })

--- a/test/e2e/url/url.test.ts
+++ b/test/e2e/url/url.test.ts
@@ -18,6 +18,8 @@ describe(`Handle new URL asset references`, () => {
       NEXT_DEPLOYMENT_ID: isNextStart ? 'test-deployment-id' : undefined,
       __NEXT_SUPPORTS_IMMUTABLE_ASSETS: isNextStart ? '1' : undefined,
     },
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/vary-header/test/index.test.ts
+++ b/test/e2e/vary-header/test/index.test.ts
@@ -5,6 +5,8 @@ import path from 'path'
 describe('Vary Header Tests', () => {
   const { next } = nextTestSetup({
     files: path.join(__dirname, '../app'),
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
   })
 

--- a/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
+++ b/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
@@ -78,6 +78,8 @@ function extractErrorBlock(output: string, errorTitle: string): string {
 describe('webpack-loader-parse-error (development)', () => {
   const { next, isTurbopack, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: true,
   })
@@ -201,6 +203,8 @@ describe('webpack-loader-parse-error (development)', () => {
 describe('webpack-loader-parse-error (production)', () => {
   const { next, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
     skipDeployment: true,
     skipStart: true,
   })

--- a/test/e2e/worker-react-refresh/worker-react-refresh.test.tsx
+++ b/test/e2e/worker-react-refresh/worker-react-refresh.test.tsx
@@ -3,6 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 describe('worker-react-refresh', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
     skipDeployment: true,
     dependencies: require('./package.json').dependencies,
   })


### PR DESCRIPTION
## Summary

Make suite-level deploy-test exclusions explicit and searchable across the e2e test suite.

- Add `Deploy mode exclusion:` comments for exclusions tied to local processes, local files or build artifacts, and deployed-platform differences.
- Add `TODO(deploy-test-completion):` comments with the observed or likely blocker for exclusions that should be revisited.
- Cover every current `skipDeployment` setting, hand-written suite guard, and manifest-excluded file without changing test execution.

This creates an actionable inventory for enabling valid suites while preserving exclusions whose current assertions are inherently local.

## Verification

- Confirmed every declarative skip, suite guard, and manifest exclusion has a rationale marker and that every TODO includes a reason.
- Confirmed the layer changes comments only.
- Prettier and ESLint passed for all affected test files.

<!-- NEXT_JS_LLM -->
