### PR TITLE
durableUseCacheEntries.unstableEnvVars and ignoredEnvVars

### DIFF
--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -235,8 +235,10 @@ impl Asset for ServerActionManifestAsset {
         let actions_value = self.actions.await?;
         let async_module_info = self.module_graph.async_module_info();
         let next_config = self.project.next_config();
-        let durable_use_cache_entries = next_config.enable_durable_use_cache_entries();
-        let durable_use_cache_entries_enabled = durable_use_cache_entries.await?.is_some();
+        let durable_use_cache_entries_enabled = *next_config
+            .enable_durable_use_cache_entries(self.project.next_mode())
+            .await?;
+        let durable_use_cache_entries_config = next_config.durable_use_cache_entries_config();
         let hash_salt = next_config.output_hash_salt();
 
         let loader_id = self.chunk_item.id().await?;
@@ -314,7 +316,7 @@ impl Asset for ServerActionManifestAsset {
                             *self.chunking_context,
                             hash_salt,
                             modules_to_ignore,
-                            durable_use_cache_entries,
+                            durable_use_cache_entries_config,
                         )
                         .await?,
                     )
@@ -427,7 +429,7 @@ async fn compute_subtree_content_hash(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     hash_salt: Vc<RcStr>,
     modules_to_ignore: Vc<Modules>,
-    durable_use_cache_entries: Vc<OptionDurableUseCacheEntriesConfig>,
+    durable_use_cache_entries_config: Vc<OptionDurableUseCacheEntriesConfig>,
 ) -> Result<Vc<OptionModulesInformation>> {
     let span = tracing::info_span!(
         "compute use-cache code hash",
@@ -437,8 +439,11 @@ async fn compute_subtree_content_hash(
         let module_graph_value = module_graph.await?;
         let async_module_info = module_graph.async_module_info();
 
-        let durable_use_cache_entries_value = durable_use_cache_entries.await?;
-        let durable_use_cache_entries_value = durable_use_cache_entries_value.as_ref().unwrap();
+        let durable_use_cache_entries_config = durable_use_cache_entries_config.await?;
+        let default_config = Default::default();
+        let durable_use_cache_entries_config = durable_use_cache_entries_config
+            .as_ref()
+            .unwrap_or(&default_config);
 
         let mut references_client_component = false;
 
@@ -526,7 +531,7 @@ async fn compute_subtree_content_hash(
             hashes.push(&data.ident_code_hash);
             if let Some(env) = &data.env_var_info {
                 runtime_env_vars.extend(env.runtime.iter().filter(|v| {
-                    !durable_use_cache_entries_value
+                    !durable_use_cache_entries_config
                         .ignored_env_vars
                         .contains(*v)
                 }));
@@ -534,7 +539,7 @@ async fn compute_subtree_content_hash(
         }
 
         if runtime_env_vars.iter().any(|v| {
-            durable_use_cache_entries_value
+            durable_use_cache_entries_config
                 .unstable_env_vars
                 .contains(*v)
         }) {

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -5,6 +5,7 @@ use bincode::{Decode, Encode};
 use next_core::{
     get_next_package,
     next_client_reference::{CssClientReferenceModule, EcmascriptClientReferenceModule},
+    next_config::OptionDurableUseCacheEntriesConfig,
     next_manifests::{
         ActionLayer, ActionManifestModuleId, ActionManifestWorkerEntry,
         ActionManifestWorkerEntryDurability, ServerReferenceManifest,
@@ -234,9 +235,8 @@ impl Asset for ServerActionManifestAsset {
         let actions_value = self.actions.await?;
         let async_module_info = self.module_graph.async_module_info();
         let next_config = self.project.next_config();
-        let durable_use_cache_entries = *next_config
-            .enable_durable_use_cache_entries(self.project.next_mode())
-            .await?;
+        let durable_use_cache_entries = next_config.enable_durable_use_cache_entries();
+        let durable_use_cache_entries_enabled = durable_use_cache_entries.await?.is_some();
         let hash_salt = next_config.output_hash_salt();
 
         let loader_id = self.chunk_item.id().await?;
@@ -288,7 +288,7 @@ impl Asset for ServerActionManifestAsset {
         struct ActionMetadata<'a> {
             exported_name: &'a str,
             filename: Cow<'a, str>,
-            data: Option<ReadRef<ModulesInformation>>,
+            data: Option<ReadRef<OptionModulesInformation>>,
         }
 
         let action_metadata: Vec<(&str, ActionMetadata<'_>)> = actions_value
@@ -303,7 +303,7 @@ impl Asset for ServerActionManifestAsset {
                     Cow::Owned(module.ident().await?.path.to_string())
                 };
 
-                let data = if durable_use_cache_entries
+                let data = if durable_use_cache_entries_enabled
                     && extract_type_from_server_reference_id(hash_id)
                         == ServerReferenceType::UseCache
                 {
@@ -314,6 +314,7 @@ impl Asset for ServerActionManifestAsset {
                             *self.chunking_context,
                             hash_salt,
                             modules_to_ignore,
+                            durable_use_cache_entries,
                         )
                         .await?,
                     )
@@ -351,10 +352,12 @@ impl Asset for ServerActionManifestAsset {
                     is_async: async_module_info
                         .is_async(self.chunk_item.module().to_resolved().await?)
                         .await?,
-                    durability: data.as_ref().map(|d| ActionManifestWorkerEntryDurability {
-                        code_hash: d.ident_code_hash.as_str(),
-                        runtime_env_vars: d.runtime_env_vars.as_slice(),
-                        references_client_component: d.references_client_component,
+                    durability: data.as_ref().and_then(|v| v.as_ref()).map(|d| {
+                        ActionManifestWorkerEntryDurability {
+                            code_hash: d.ident_code_hash.as_str(),
+                            runtime_env_vars: d.runtime_env_vars.as_slice(),
+                            references_client_component: d.references_client_component,
+                        }
                     }),
                 },
             );
@@ -403,8 +406,7 @@ pub async fn to_rsc_context(
 }
 
 /// Merged information about a module graph subgraph
-#[turbo_tasks::value]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Hash, TraceRawVcs, NonLocalValue, Encode, Decode)]
 struct ModulesInformation {
     /// The combined code hash of all modules in the subgraph
     pub ident_code_hash: RcStr,
@@ -414,6 +416,10 @@ struct ModulesInformation {
     pub references_client_component: bool,
 }
 
+#[turbo_tasks::value(transparent)]
+#[derive(Debug)]
+struct OptionModulesInformation(Option<ModulesInformation>);
+
 #[turbo_tasks::function]
 async fn compute_subtree_content_hash(
     module_graph: ResolvedVc<ModuleGraph>,
@@ -421,7 +427,8 @@ async fn compute_subtree_content_hash(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     hash_salt: Vc<RcStr>,
     modules_to_ignore: Vc<Modules>,
-) -> Result<Vc<ModulesInformation>> {
+    durable_use_cache_entries: Vc<OptionDurableUseCacheEntriesConfig>,
+) -> Result<Vc<OptionModulesInformation>> {
     let span = tracing::info_span!(
         "compute use-cache code hash",
         entry = display(entry.ident_string().await?)
@@ -429,6 +436,9 @@ async fn compute_subtree_content_hash(
     match async {
         let module_graph_value = module_graph.await?;
         let async_module_info = module_graph.async_module_info();
+
+        let durable_use_cache_entries_value = durable_use_cache_entries.await?;
+        let durable_use_cache_entries_value = durable_use_cache_entries_value.as_ref().unwrap();
 
         let mut references_client_component = false;
 
@@ -464,42 +474,6 @@ async fn compute_subtree_content_hash(
             /* include_traced */ true,
         )?;
 
-        static PRINT_USE_CACHE_SUBTREE: LazyLock<bool> = LazyLock::new(|| {
-            std::env::var_os("TURBOPACK_PRINT_USE_CACHE_SUBTREE")
-                .is_some_and(|v| v == "1" || v == "true")
-        });
-        if *PRINT_USE_CACHE_SUBTREE {
-            println!(
-                "Modules in subtree for {}:\n{}",
-                entry.ident().await?.path,
-                modules
-                    .iter()
-                    .map(async |m| {
-                        let data = module_hash(
-                            *module_graph,
-                            chunking_context,
-                            async_module_info,
-                            **m,
-                            hash_salt,
-                        )
-                        .await?;
-                        Ok(format!(
-                            "  '{}': {} with env: {}",
-                            m.ident_string().await?,
-                            data.ident_code_hash,
-                            data.env_var_info
-                                .as_ref()
-                                .map(|e| e.runtime.clone())
-                                .unwrap_or_default()
-                                .join(",")
-                        ))
-                    })
-                    .try_join()
-                    .await?
-                    .join("\n")
-            );
-        }
-
         let data = modules
             .into_iter()
             .map(async |m| {
@@ -518,26 +492,62 @@ async fn compute_subtree_content_hash(
             .try_join()
             .await?;
 
+        static PRINT_USE_CACHE_SUBTREE: LazyLock<bool> = LazyLock::new(|| {
+            std::env::var_os("TURBOPACK_PRINT_USE_CACHE_SUBTREE")
+                .is_some_and(|v| v == "1" || v == "true")
+        });
+        if *PRINT_USE_CACHE_SUBTREE {
+            println!(
+                "Modules in subtree for {}:\n{}",
+                entry.ident().await?.path,
+                data.iter()
+                    .map(async |(m, data)| {
+                        Ok(format!(
+                            "  '{}': {} with env: {}",
+                            m.ident_string().await?,
+                            data.ident_code_hash,
+                            data.env_var_info
+                                .as_ref()
+                                .map(|e| e.runtime.clone())
+                                .unwrap_or_default()
+                                .join(",")
+                        ))
+                    })
+                    .try_join()
+                    .await?
+                    .join("\n")
+            );
+        }
+
         let mut hashes = Vec::with_capacity(data.len());
         let mut runtime_env_vars = FxIndexSet::default();
 
         for (_m, data) in &data {
             hashes.push(&data.ident_code_hash);
             if let Some(env) = &data.env_var_info {
-                runtime_env_vars.extend(env.runtime.iter());
+                runtime_env_vars.extend(env.runtime.iter().filter(|v| {
+                    !durable_use_cache_entries_value
+                        .ignored_env_vars
+                        .contains(*v)
+                }));
             }
+        }
+
+        if runtime_env_vars.iter().any(|v| {
+            durable_use_cache_entries_value
+                .unstable_env_vars
+                .contains(*v)
+        }) {
+            return anyhow::Ok(Vc::cell(None));
         }
 
         let hash = deterministic_hash("", hashes, HashAlgorithm::Xxh3Hash128Hex).into();
 
-        anyhow::Ok(
-            ModulesInformation {
-                ident_code_hash: hash,
-                runtime_env_vars: runtime_env_vars.into_iter().cloned().collect(),
-                references_client_component,
-            }
-            .cell(),
-        )
+        anyhow::Ok(Vc::cell(Some(ModulesInformation {
+            ident_code_hash: hash,
+            runtime_env_vars: runtime_env_vars.into_iter().cloned().collect(),
+            references_client_component,
+        })))
     }
     .instrument(span)
     .await

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1348,7 +1348,8 @@ pub struct ExperimentalConfig {
     /// This field is kept for backwards compatibility during migration.
     cache_components: Option<bool>,
     use_cache: Option<bool>,
-    durable_use_cache_entries: Option<DurableUseCacheEntriesConfig>,
+    durable_use_cache_entries: Option<bool>,
+    durable_use_cache_entries_config: Option<DurableUseCacheEntriesConfig>,
     runtime_server_deployment_id: Option<bool>,
     expose_testing_api_in_production_build: Option<bool>,
 
@@ -2485,12 +2486,19 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn enable_durable_use_cache_entries(
-        &self,
-    ) -> Result<Vc<OptionDurableUseCacheEntriesConfig>> {
-        Ok(Vc::cell(
-            self.experimental.durable_use_cache_entries.clone(),
-        ))
+    pub async fn enable_durable_use_cache_entries(&self, mode: Vc<NextMode>) -> Result<Vc<bool>> {
+        Ok(match *mode.await? {
+            // TODO eventually also look into enabling this for better HMR
+            NextMode::Development => Vc::cell(false),
+            NextMode::Build => {
+                Vc::cell(self.experimental.durable_use_cache_entries.unwrap_or(false))
+            }
+        })
+    }
+
+    #[turbo_tasks::function]
+    pub fn durable_use_cache_entries_config(&self) -> Vc<OptionDurableUseCacheEntriesConfig> {
+        Vc::cell(self.experimental.durable_use_cache_entries_config.clone())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1228,6 +1228,30 @@ impl TurbopackChunking {
     }
 }
 
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(rename_all = "camelCase")]
+pub struct DurableUseCacheEntriesConfig {
+    #[serde(default)]
+    pub unstable_env_vars: FxHashSet<RcStr>,
+    #[serde(default)]
+    pub ignored_env_vars: FxHashSet<RcStr>,
+}
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionDurableUseCacheEntriesConfig(Option<DurableUseCacheEntriesConfig>);
+
 /// Compile a list of route-matching [`RegexComponents`] into an [`EsRegexSet`], which builds the
 /// combined [`regex::RegexSet`] up front so that matching a route doesn't have to.
 fn parse_route_regexes(patterns: &[RegexComponents]) -> Result<EsRegexSet> {
@@ -1324,7 +1348,7 @@ pub struct ExperimentalConfig {
     /// This field is kept for backwards compatibility during migration.
     cache_components: Option<bool>,
     use_cache: Option<bool>,
-    durable_use_cache_entries: Option<bool>,
+    durable_use_cache_entries: Option<DurableUseCacheEntriesConfig>,
     runtime_server_deployment_id: Option<bool>,
     expose_testing_api_in_production_build: Option<bool>,
 
@@ -2461,14 +2485,12 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
-    pub async fn enable_durable_use_cache_entries(&self, mode: Vc<NextMode>) -> Result<Vc<bool>> {
-        Ok(match *mode.await? {
-            // TODO eventually also look into enabling this for better HMR
-            NextMode::Development => Vc::cell(false),
-            NextMode::Build => {
-                Vc::cell(self.experimental.durable_use_cache_entries.unwrap_or(false))
-            }
-        })
+    pub async fn enable_durable_use_cache_entries(
+        &self,
+    ) -> Result<Vc<OptionDurableUseCacheEntriesConfig>> {
+        Ok(Vc::cell(
+            self.experimental.durable_use_cache_entries.clone(),
+        ))
     }
 
     #[turbo_tasks::function]

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -80,7 +80,10 @@ export async function exportAppRoute(
       // value is irrelevant here.
       // TODO: move validationLevel and other global config out of renderOpts
       validationLevel: 'warning',
-      experimental,
+      experimental: {
+        ...experimental,
+        durableUseCacheEntries: Boolean(experimental.durableUseCacheEntries),
+      },
       isBuildTimePrerendering: true,
       incrementalCache,
       waitUntil: afterRunner.context.waitUntil,

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -80,10 +80,7 @@ export async function exportAppRoute(
       // value is irrelevant here.
       // TODO: move validationLevel and other global config out of renderOpts
       validationLevel: 'warning',
-      experimental: {
-        ...experimental,
-        durableUseCacheEntries: Boolean(experimental.durableUseCacheEntries),
-      },
+      experimental,
       isBuildTimePrerendering: true,
       incrementalCache,
       waitUntil: afterRunner.context.waitUntil,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -468,7 +468,15 @@ export const experimentalSchema = {
   serverComponentsHmrCancellation: z.boolean().optional(),
   authInterrupts: z.boolean().optional(),
   useCache: z.boolean().optional(),
-  durableUseCacheEntries: z.boolean().optional(),
+  durableUseCacheEntries: z
+    .union([
+      z.boolean(),
+      z.object({
+        unstableEnvVars: z.array(z.string()).optional(),
+        ignoredEnvVars: z.array(z.string()).optional(),
+      }),
+    ])
+    .optional(),
   useCacheTimeout: z.number().positive().optional(),
   slowModuleDetection: z
     .object({

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -468,14 +468,12 @@ export const experimentalSchema = {
   serverComponentsHmrCancellation: z.boolean().optional(),
   authInterrupts: z.boolean().optional(),
   useCache: z.boolean().optional(),
-  durableUseCacheEntries: z
-    .union([
-      z.boolean(),
-      z.object({
-        unstableEnvVars: z.array(z.string()).optional(),
-        ignoredEnvVars: z.array(z.string()).optional(),
-      }),
-    ])
+  durableUseCacheEntries: z.boolean().optional(),
+  durableUseCacheEntriesConfig: z
+    .object({
+      unstableEnvVars: z.array(z.string()).optional(),
+      ignoredEnvVars: z.array(z.string()).optional(),
+    })
     .optional(),
   useCacheTimeout: z.number().positive().optional(),
   slowModuleDetection: z

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1394,17 +1394,17 @@ export interface ExperimentalConfig {
    * Enables durable `"use cache"` remote cache entries across deployments. Only implemented for
    * Turbopack.
    */
-  durableUseCacheEntries?:
-    | boolean
-    | {
-        // Env vars that are constantly changing (e.g. the deployment ID). If a cache entry depends on one of these, it will not be reused across deployments at all.
-        // NEXT_DEPLOYMENT_ID is automatically added to this list (and is the default), so it does not need to be specified.
-        unstableEnvVars?: string[]
-        // Env vars that do not change the cache entry, but might change often (e.g. passwords, LRU
-        // cache stale time, OIDC tokens). Note that a token include also a database name, in which
-        // case it should not be in this list.
-        ignoredEnvVars?: string[]
-      }
+  durableUseCacheEntries?: boolean
+
+  durableUseCacheEntriesConfig?: {
+    // Env vars that are constantly changing (e.g. the deployment ID). If a cache entry depends on one of these, it will not be reused across deployments at all.
+    // NEXT_DEPLOYMENT_ID is automatically added to this list (and is the default), so it does not need to be specified.
+    unstableEnvVars?: string[]
+    // Env vars that do not change the cache entry, but might change often (e.g. passwords, LRU
+    // cache stale time, OIDC tokens). Note that a token include also a database name, in which
+    // case it should not be in this list.
+    ignoredEnvVars?: string[]
+  }
 
   /**
    * Enables detection and reporting of slow modules during development builds.
@@ -2472,6 +2472,7 @@ export interface NextConfigRuntime {
     | 'reactBrowserBailout'
     | 'useCacheTimeout'
     | 'durableUseCacheEntries'
+    | 'durableUseCacheEntriesConfig'
     | 'clientTraceMetadata'
     | 'clientParamParsingOrigins'
     | 'allowedRevalidateHeaderKeys'
@@ -2541,6 +2542,7 @@ export function getNextConfigRuntime(
     reactBrowserBailout: ex.reactBrowserBailout,
     useCacheTimeout: ex.useCacheTimeout,
     durableUseCacheEntries: ex.durableUseCacheEntries,
+    durableUseCacheEntriesConfig: ex.durableUseCacheEntriesConfig,
     clientTraceMetadata: ex.clientTraceMetadata,
     clientParamParsingOrigins: ex.clientParamParsingOrigins,
     allowedRevalidateHeaderKeys: ex.allowedRevalidateHeaderKeys,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1394,7 +1394,17 @@ export interface ExperimentalConfig {
    * Enables durable `"use cache"` remote cache entries across deployments. Only implemented for
    * Turbopack.
    */
-  durableUseCacheEntries?: boolean
+  durableUseCacheEntries?:
+    | boolean
+    | {
+        // Env vars that are constantly changing (e.g. the deployment ID). If a cache entry depends on one of these, it will not be reused across deployments at all.
+        // NEXT_DEPLOYMENT_ID is automatically added to this list (and is the default), so it does not need to be specified.
+        unstableEnvVars?: string[]
+        // Env vars that do not change the cache entry, but might change often (e.g. passwords, LRU
+        // cache stale time, OIDC tokens). Note that a token include also a database name, in which
+        // case it should not be in this list.
+        ignoredEnvVars?: string[]
+      }
 
   /**
    * Enables detection and reporting of slow modules during development builds.

--- a/packages/next/src/server/config.test.ts
+++ b/packages/next/src/server/config.test.ts
@@ -301,11 +301,21 @@ describe('loadConfig', () => {
 
       const result = await loadConfig(PHASE_PRODUCTION_BUILD, __dirname, {
         customConfig: {
-          experimental: { durableUseCacheEntries: true },
+          experimental: {
+            durableUseCacheEntries: true,
+            durableUseCacheEntriesConfig: {
+              unstableEnvVars: ['CUSTOM_DEPLOYMENT_ID'],
+              ignoredEnvVars: ['IGNORED_TOKEN'],
+            },
+          },
         },
       })
 
       expect(result.experimental.durableUseCacheEntries).toBe(true)
+      expect(result.experimental.durableUseCacheEntriesConfig).toEqual({
+        unstableEnvVars: ['CUSTOM_DEPLOYMENT_ID', 'NEXT_DEPLOYMENT_ID'],
+        ignoredEnvVars: ['IGNORED_TOKEN'],
+      })
     })
   })
 })

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -528,25 +528,17 @@ function assignDefaultsAndValidate(
     }
   }
 
-  // Normalize experimental.durableUseCacheEntries to always be an object and to ensure NEXT_DEPLOYMENT_ID is ignored
-  if (result.experimental && 'durableUseCacheEntries' in result.experimental) {
-    if (result.experimental.durableUseCacheEntries) {
-      if (result.experimental.durableUseCacheEntries === true) {
-        result.experimental.durableUseCacheEntries = {}
-      }
-      result.experimental.durableUseCacheEntries.unstableEnvVars ??= []
-      if (
-        !result.experimental.durableUseCacheEntries.unstableEnvVars.includes(
-          'NEXT_DEPLOYMENT_ID'
-        )
-      ) {
-        result.experimental.durableUseCacheEntries.unstableEnvVars.push(
-          'NEXT_DEPLOYMENT_ID'
-        )
-      }
-    } else {
-      delete result.experimental.durableUseCacheEntries
-    }
+  // Ensure NEXT_DEPLOYMENT_ID prevents cache entries from being reused across deployments.
+  result.experimental.durableUseCacheEntriesConfig ??= {}
+  result.experimental.durableUseCacheEntriesConfig.unstableEnvVars ??= []
+  if (
+    !result.experimental.durableUseCacheEntriesConfig.unstableEnvVars.includes(
+      'NEXT_DEPLOYMENT_ID'
+    )
+  ) {
+    result.experimental.durableUseCacheEntriesConfig.unstableEnvVars.push(
+      'NEXT_DEPLOYMENT_ID'
+    )
   }
 
   if (

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -528,6 +528,27 @@ function assignDefaultsAndValidate(
     }
   }
 
+  // Normalize experimental.durableUseCacheEntries to always be an object and to ensure NEXT_DEPLOYMENT_ID is ignored
+  if (result.experimental && 'durableUseCacheEntries' in result.experimental) {
+    if (result.experimental.durableUseCacheEntries) {
+      if (result.experimental.durableUseCacheEntries === true) {
+        result.experimental.durableUseCacheEntries = {}
+      }
+      result.experimental.durableUseCacheEntries.unstableEnvVars ??= []
+      if (
+        !result.experimental.durableUseCacheEntries.unstableEnvVars.includes(
+          'NEXT_DEPLOYMENT_ID'
+        )
+      ) {
+        result.experimental.durableUseCacheEntries.unstableEnvVars.push(
+          'NEXT_DEPLOYMENT_ID'
+        )
+      }
+    } else {
+      delete result.experimental.durableUseCacheEntries
+    }
+  }
+
   if (
     result.experimental?.allowDevelopmentBuild &&
     process.env.NODE_ENV !== 'development'

--- a/test/production/app-dir/use-cache-code-hash/app/deopt-custom/foo.tsx
+++ b/test/production/app-dir/use-cache-code-hash/app/deopt-custom/foo.tsx
@@ -1,0 +1,3 @@
+export function foo() {
+  return 'foo-v1'
+}

--- a/test/production/app-dir/use-cache-code-hash/app/deopt-custom/logic.tsx
+++ b/test/production/app-dir/use-cache-code-hash/app/deopt-custom/logic.tsx
@@ -1,0 +1,5 @@
+export async function logic() {
+  'use cache'
+
+  return `${process.env.MY_DEPLOYMENT_ID}`
+}

--- a/test/production/app-dir/use-cache-code-hash/app/deopt-custom/page.tsx
+++ b/test/production/app-dir/use-cache-code-hash/app/deopt-custom/page.tsx
@@ -1,0 +1,6 @@
+import { logic } from './logic'
+
+export default async function Page() {
+  const value = await logic()
+  return <p>{value}</p>
+}

--- a/test/production/app-dir/use-cache-code-hash/app/deopt-next-deployment-id/foo.tsx
+++ b/test/production/app-dir/use-cache-code-hash/app/deopt-next-deployment-id/foo.tsx
@@ -1,0 +1,3 @@
+export function foo() {
+  return 'foo-v1'
+}

--- a/test/production/app-dir/use-cache-code-hash/app/deopt-next-deployment-id/logic.tsx
+++ b/test/production/app-dir/use-cache-code-hash/app/deopt-next-deployment-id/logic.tsx
@@ -1,0 +1,5 @@
+export async function logic() {
+  'use cache'
+
+  return `${process.env.NEXT_DEPLOYMENT_ID}`
+}

--- a/test/production/app-dir/use-cache-code-hash/app/deopt-next-deployment-id/page.tsx
+++ b/test/production/app-dir/use-cache-code-hash/app/deopt-next-deployment-id/page.tsx
@@ -1,0 +1,6 @@
+import { logic } from './logic'
+
+export default async function Page() {
+  const value = await logic()
+  return <p>{value}</p>
+}

--- a/test/production/app-dir/use-cache-code-hash/app/use-cache/logic.tsx
+++ b/test/production/app-dir/use-cache-code-hash/app/use-cache/logic.tsx
@@ -4,5 +4,9 @@ import { external } from 'external-dep'
 
 export async function logic() {
   'use cache'
+
+  // Should not be listed
+  globalThis.foo = process.env.MY_OIDC_TOKEN
+
   return `${foo()}:${external()}:${process.env.BUNDLED_NON_INLINED_ENVVAR}`
 }

--- a/test/production/app-dir/use-cache-code-hash/next.config.js
+++ b/test/production/app-dir/use-cache-code-hash/next.config.js
@@ -4,7 +4,11 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
-    durableUseCacheEntries: true,
+    durableUseCacheEntries: {
+      unstableEnvVars: ['MY_DEPLOYMENT_ID'],
+      ignoredEnvVars: ['MY_OIDC_TOKEN'],
+    },
+    runtimeServerDeploymentId: true,
   },
 }
 

--- a/test/production/app-dir/use-cache-code-hash/next.config.js
+++ b/test/production/app-dir/use-cache-code-hash/next.config.js
@@ -4,7 +4,8 @@
 const nextConfig = {
   cacheComponents: true,
   experimental: {
-    durableUseCacheEntries: {
+    durableUseCacheEntries: true,
+    durableUseCacheEntriesConfig: {
       unstableEnvVars: ['MY_DEPLOYMENT_ID'],
       ignoredEnvVars: ['MY_OIDC_TOKEN'],
     },

--- a/test/production/app-dir/use-cache-code-hash/use-cache-code-hash.test.ts
+++ b/test/production/app-dir/use-cache-code-hash/use-cache-code-hash.test.ts
@@ -29,6 +29,8 @@ async function getCodeHashes(
     }
   }
 
+  hashes.sort((a, b) => a.page.localeCompare(b.page))
+
   return hashes
 }
 
@@ -41,45 +43,61 @@ async function getCodeHashes(
         files: __dirname,
       })
 
-      it('emits codeHash only for use-cache functions', async () => {
+      it('emits codeHash only for eligible functions', async () => {
         const values = Object.values(await getCodeHashes(next))
-        expect(values.length).toBe(4)
+        expect(values.length).toBe(6)
 
         const valuesWithoutCodeHash = values.filter(
           (e) => typeof e.codeHash !== 'string'
         )
-        expect(valuesWithoutCodeHash.length).toBe(1)
-        expect(valuesWithoutCodeHash[0].page).toBe('app/use-server/page')
+        expect(valuesWithoutCodeHash.length).toBe(3)
+        expect(valuesWithoutCodeHash.map((v) => v.page)).toMatchInlineSnapshot(`
+         [
+           "app/deopt-custom/page",
+           "app/deopt-next-deployment-id/page",
+           "app/use-server/page",
+         ]
+        `)
       })
 
       it('lists non-inlined runtime env vars', async () => {
         const data = await getCodeHashes(next)
 
-        expect(data.find((e) => e.page === 'app/use-cache/page').runtimeEnvVars)
-          .toMatchInlineSnapshot(`
-         [
-           "BUNDLED_NON_INLINED_ENVVAR",
-           "NEXT_PRIVATE_DEBUG_CACHE",
-           "__NEXT_DEV_SERVER",
-           "NEXT_PRIVATE_DEBUG_RUNTIME_DATA",
-           "NEXT_OTEL_VERBOSE",
-           "NEXT_OTEL_PERFORMANCE_PREFIX",
-           "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
-           "EXTERNAL_ENV_VAR",
-         ]
-        `)
-
         expect(
-          data.find((e) => e.page === 'app/env-dynamic/page').runtimeEnvVars
+          Object.fromEntries(
+            data
+              .filter((d) => d.runtimeEnvVars)
+              .map((d) => [d.page, d.runtimeEnvVars])
+          )
         ).toMatchInlineSnapshot(`
-         [
-           "NEXT_PRIVATE_DEBUG_CACHE",
-           "__NEXT_DEV_SERVER",
-           "NEXT_PRIVATE_DEBUG_RUNTIME_DATA",
-           "NEXT_OTEL_VERBOSE",
-           "NEXT_OTEL_PERFORMANCE_PREFIX",
-           "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
-         ]
+         {
+           "app/env-dynamic/page": [
+             "NEXT_PRIVATE_DEBUG_CACHE",
+             "__NEXT_DEV_SERVER",
+             "NEXT_PRIVATE_DEBUG_RUNTIME_DATA",
+             "NEXT_OTEL_VERBOSE",
+             "NEXT_OTEL_PERFORMANCE_PREFIX",
+             "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
+           ],
+           "app/use-cache-client/page": [
+             "NEXT_PRIVATE_DEBUG_CACHE",
+             "__NEXT_DEV_SERVER",
+             "NEXT_PRIVATE_DEBUG_RUNTIME_DATA",
+             "NEXT_OTEL_VERBOSE",
+             "NEXT_OTEL_PERFORMANCE_PREFIX",
+             "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
+           ],
+           "app/use-cache/page": [
+             "BUNDLED_NON_INLINED_ENVVAR",
+             "NEXT_PRIVATE_DEBUG_CACHE",
+             "__NEXT_DEV_SERVER",
+             "NEXT_PRIVATE_DEBUG_RUNTIME_DATA",
+             "NEXT_OTEL_VERBOSE",
+             "NEXT_OTEL_PERFORMANCE_PREFIX",
+             "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
+             "EXTERNAL_ENV_VAR",
+           ],
+         }
         `)
       })
     })

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -271,7 +271,7 @@ impl From<String> for DefinableNameSegment {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum DefinableNameSegmentRef<'a> {
     Name(&'a str),
     Call(&'a str),
@@ -310,7 +310,7 @@ impl Equivalent<DefinableNameSegment> for DefinableNameSegmentRef<'_> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DefinableNameSegmentRefs<'a>(pub SmallVec<[DefinableNameSegmentRef<'a>; 4]>);
 
 // Hash can't be derived because it must match Vec<DefinableNameSegment>'s Hash.


### PR DESCRIPTION
```ts
type durableUseCacheEntries = {
	// Env vars that are constantly changing (e.g. the deployment ID).
	// If a cache entry depends on one of these, it will not be reused across deployments at all. 
    // NEXT_DEPLOYMENT_ID is automatically added to this list (and is the default), so it does not need to be specified.
	unstableEnvVars?: string[]
	// Env vars that do not change the cache entry, but might change often (e.g. passwords, LRU
	// cache stale time, OIDC tokens). Note that a token include also a database name, in which
	// case it should not be in this list.
	ignoredEnvVars?: string[]
}
```