### PR TITLE
test: add scoped deployment test exclusions

### DIFF
--- a/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
+++ b/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
@@ -158,15 +158,13 @@ describe('async imports in cacheComponents', () => {
   })
 })
 
+// This block intentionally exercises a failed build, so there is no deployment to test.
+// @force-gate !deploy
 describe('async imports in cacheComponents - external packages', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: path.join(__dirname, 'external'),
-    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-    // It likely asserts local CLI or runtime output that deploy tests do not expose.
-    skipDeployment: true,
     skipStart: true,
   })
-  if (skipped) return
 
   // This is currently expected to fail because we can only track `import()` in bundled code,
   // and packages marked as external aren't bundled.


### PR DESCRIPTION
## Summary

Use the existing `@force-gate !deploy` directive to exclude only the external-package block in the cache-components dynamic-import suite from deployment testing.

The adjacent rationale explains that this block intentionally verifies a failed build, so it cannot produce a deployment. Deploy-compatible sibling tests in the same Jest file remain runnable, and deployment CI reports the excluded block through Jest's native skip mechanism.

## Verification

- `pnpm exec jest --runInBand test/unit/gate/`
- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts`

<!-- NEXT_JS_LLM -->
