### PR TITLE
Add revalidate: false option to cookie mutations in Server Actions (reworks #84313)

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -38,7 +38,7 @@ import {
   filterReqHeaders,
   actionsForbiddenHeaders,
 } from '../lib/server-ipc/utils'
-import { getModifiedCookieValues } from '../web/spec-extension/adapters/request-cookies'
+import { didMutatedCookiesRequestRevalidation } from '../web/spec-extension/adapters/request-cookies'
 
 import {
   JSON_CONTENT_TYPE_HEADER,
@@ -180,9 +180,11 @@ function addRevalidationHeader(
   )
     ? 1
     : 0
-  const isCookieRevalidated = getModifiedCookieValues(
+  // Only count cookie mutations that requested revalidation. Mutations
+  // performed with `revalidate: false` opt out of client cache invalidation.
+  const isCookieRevalidated = didMutatedCookiesRequestRevalidation(
     requestStore.mutableCookies
-  ).length
+  )
     ? 1
     : 0
 

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.test.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.test.ts
@@ -1,4 +1,9 @@
 import type { RequestStore } from '../../../app-render/work-unit-async-storage.external'
+import type { WorkStore } from '../../../app-render/work-async-storage.external'
+import {
+  ActionDidRevalidateDynamicOnly,
+  ActionDidRevalidateStaticAndDynamic,
+} from '../../../../shared/lib/action-revalidation-kind'
 import { RequestCookies, ResponseCookies } from '../cookies'
 import {
   ReadonlyRequestCookiesError,
@@ -165,6 +170,253 @@ describe('wrapWithMutableAccessCheck', () => {
         cookies.delete('foo')
       }).toThrow(EXPECTED_ERROR)
       expect(cookies.get('foo')?.value).toEqual('1')
+    })
+  })
+})
+
+describe('cookie mutation revalidation opt-out', () => {
+  let workAsyncStorage: typeof import('../../../app-render/work-async-storage.external').workAsyncStorage
+  let requestCookiesModule: typeof import('./request-cookies')
+
+  beforeAll(() => {
+    ;(globalThis as any).AsyncLocalStorage ??= (
+      require('node:async_hooks') as typeof import('node:async_hooks')
+    ).AsyncLocalStorage
+    jest.resetModules()
+    workAsyncStorage = (
+      require('../../../app-render/work-async-storage.external') as typeof import('../../../app-render/work-async-storage.external')
+    ).workAsyncStorage
+    requestCookiesModule =
+      require('./request-cookies') as typeof import('./request-cookies')
+  })
+
+  const createMockWorkStore = () =>
+    ({ pathWasRevalidated: undefined }) as unknown as WorkStore
+
+  const wrapCookies = (onUpdateCookies?: (cookies: string[]) => void) =>
+    requestCookiesModule.MutableRequestCookiesAdapter.wrap(
+      new RequestCookies(new Headers({})),
+      onUpdateCookies
+    )
+
+  it('marks the path as revalidated when set() is called', () => {
+    const workStore = createMockWorkStore()
+    workAsyncStorage.run(workStore, () => {
+      const cookies = wrapCookies()
+      cookies.set('foo', '1')
+
+      expect(workStore.pathWasRevalidated).toBe(
+        ActionDidRevalidateStaticAndDynamic
+      )
+      expect(
+        requestCookiesModule.didMutatedCookiesRequestRevalidation(cookies)
+      ).toBe(true)
+    })
+  })
+
+  it('does not mark the path as revalidated when set() is called with revalidate: false', () => {
+    const workStore = createMockWorkStore()
+    workAsyncStorage.run(workStore, () => {
+      const onUpdateCookies = jest.fn<void, [string[]]>()
+      const cookies = wrapCookies(onUpdateCookies)
+      cookies.set('foo', '1', { revalidate: false })
+
+      expect(workStore.pathWasRevalidated).toBeUndefined()
+      expect(
+        requestCookiesModule.didMutatedCookiesRequestRevalidation(cookies)
+      ).toBe(false)
+
+      // The cookie must still be set and emitted to the response.
+      expect(cookies.get('foo')?.value).toBe('1')
+      expect(onUpdateCookies).toHaveBeenCalledWith([
+        expect.stringContaining('foo=1'),
+      ])
+
+      // The cookie must still be recorded as modified, so that route
+      // handlers and redirects emit it via `appendMutableCookies`.
+      expect(requestCookiesModule.getModifiedCookieValues(cookies)).toEqual([
+        expect.objectContaining({ name: 'foo', value: '1' }),
+      ])
+
+      // The `revalidate` option must not be stored on the cookie.
+      expect(cookies.get('foo')).not.toHaveProperty('revalidate')
+    })
+  })
+
+  it('supports revalidate: false in the single options object form of set()', () => {
+    const workStore = createMockWorkStore()
+    workAsyncStorage.run(workStore, () => {
+      const cookies = wrapCookies()
+      cookies.set({ name: 'foo', value: '1', path: '/x', revalidate: false })
+
+      expect(workStore.pathWasRevalidated).toBeUndefined()
+      expect(cookies.get('foo')).toMatchObject({
+        name: 'foo',
+        value: '1',
+        path: '/x',
+      })
+      expect(cookies.get('foo')).not.toHaveProperty('revalidate')
+    })
+  })
+
+  it('marks the path as revalidated when delete() is called with a name', () => {
+    const workStore = createMockWorkStore()
+    workAsyncStorage.run(workStore, () => {
+      const cookies = wrapCookies()
+      cookies.delete('foo')
+
+      expect(workStore.pathWasRevalidated).toBe(
+        ActionDidRevalidateStaticAndDynamic
+      )
+      expect(
+        requestCookiesModule.didMutatedCookiesRequestRevalidation(cookies)
+      ).toBe(true)
+    })
+  })
+
+  it('does not mark the path as revalidated when delete() is called with revalidate: false', () => {
+    const workStore = createMockWorkStore()
+    workAsyncStorage.run(workStore, () => {
+      const onUpdateCookies = jest.fn<void, [string[]]>()
+      const cookies = wrapCookies(onUpdateCookies)
+      cookies.delete({ name: 'foo', revalidate: false })
+
+      expect(workStore.pathWasRevalidated).toBeUndefined()
+      expect(
+        requestCookiesModule.didMutatedCookiesRequestRevalidation(cookies)
+      ).toBe(false)
+
+      // The deletion must still be emitted to the response and recorded as a
+      // modified cookie.
+      expect(onUpdateCookies).toHaveBeenCalledWith([
+        expect.stringContaining('foo=;'),
+      ])
+      expect(requestCookiesModule.getModifiedCookieValues(cookies)).toEqual([
+        expect.objectContaining({ name: 'foo', value: '' }),
+      ])
+
+      // The `revalidate` option must not be stored on the expired cookie.
+      expect(cookies.get('foo')).not.toHaveProperty('revalidate')
+    })
+  })
+
+  it('preserves cookie objects whose properties are inherited accessors', () => {
+    const workStore = createMockWorkStore()
+    workAsyncStorage.run(workStore, () => {
+      const cookies = wrapCookies()
+
+      class AccessorCookie {
+        httpOnly = true
+        get name() {
+          return 'sid'
+        }
+        get value() {
+          return 'token'
+        }
+      }
+
+      // Without the `revalidate` option, the object is forwarded untouched.
+      cookies.set(new AccessorCookie())
+      expect(cookies.get('sid')).toMatchObject({
+        name: 'sid',
+        value: 'token',
+        httpOnly: true,
+      })
+      expect(workStore.pathWasRevalidated).toBe(
+        ActionDidRevalidateStaticAndDynamic
+      )
+
+      class AccessorCookieOptOut extends AccessorCookie {
+        revalidate = false
+      }
+
+      // With the option, `name` and `value` must survive the stripping even
+      // though they aren't own enumerable properties.
+      workStore.pathWasRevalidated = undefined
+      const otherCookies = wrapCookies()
+      otherCookies.set(new AccessorCookieOptOut())
+      expect(otherCookies.get('sid')).toMatchObject({
+        name: 'sid',
+        value: 'token',
+        httpOnly: true,
+      })
+      expect(otherCookies.get('sid')).not.toHaveProperty('revalidate')
+      expect(workStore.pathWasRevalidated).toBeUndefined()
+    })
+  })
+
+  it('does not undo a requested revalidation with a later opted-out mutation', () => {
+    const workStore = createMockWorkStore()
+    workAsyncStorage.run(workStore, () => {
+      const cookies = wrapCookies()
+      cookies.set('foo', '1')
+      cookies.set('bar', '2', { revalidate: false })
+
+      expect(workStore.pathWasRevalidated).toBe(
+        ActionDidRevalidateStaticAndDynamic
+      )
+      expect(
+        requestCookiesModule.didMutatedCookiesRequestRevalidation(cookies)
+      ).toBe(true)
+    })
+  })
+
+  it('requests revalidation when an opted-out mutation is followed by a normal one', () => {
+    const workStore = createMockWorkStore()
+    workAsyncStorage.run(workStore, () => {
+      const cookies = wrapCookies()
+      cookies.set('foo', '1', { revalidate: false })
+
+      expect(
+        requestCookiesModule.didMutatedCookiesRequestRevalidation(cookies)
+      ).toBe(false)
+
+      cookies.set('bar', '2')
+
+      expect(workStore.pathWasRevalidated).toBe(
+        ActionDidRevalidateStaticAndDynamic
+      )
+      expect(
+        requestCookiesModule.didMutatedCookiesRequestRevalidation(cookies)
+      ).toBe(true)
+    })
+  })
+
+  it('does not overwrite a revalidation kind set by another API', () => {
+    const workStore = createMockWorkStore()
+    workAsyncStorage.run(workStore, () => {
+      // Simulate a preceding refresh() call.
+      workStore.pathWasRevalidated = ActionDidRevalidateDynamicOnly
+
+      const cookies = wrapCookies()
+      cookies.set('foo', '1', { revalidate: false })
+
+      expect(workStore.pathWasRevalidated).toBe(ActionDidRevalidateDynamicOnly)
+    })
+  })
+
+  it('honors revalidate: false through the userspace mutable cookies proxy', () => {
+    const workStore = createMockWorkStore()
+    workAsyncStorage.run(workStore, () => {
+      const requestStore = {
+        type: 'request',
+        phase: 'action',
+        mutableCookies: wrapCookies(),
+      } as RequestStore
+      const cookies =
+        requestCookiesModule.createCookiesWithMutableAccessCheck(requestStore)
+
+      cookies.set('foo', '1', { revalidate: false })
+      cookies.delete({ name: 'bar', revalidate: false })
+
+      expect(workStore.pathWasRevalidated).toBeUndefined()
+      expect(cookies.get('foo')?.value).toBe('1')
+
+      cookies.set('baz', '2')
+
+      expect(workStore.pathWasRevalidated).toBe(
+        ActionDidRevalidateStaticAndDynamic
+      )
     })
   })
 })

--- a/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/request-cookies.ts
@@ -24,6 +24,55 @@ export class ReadonlyRequestCookiesError extends Error {
 // We use this to type some APIs but we don't construct instances directly
 export type { ResponseCookies }
 
+/**
+ * Next.js-specific options for cookie mutations, accepted by
+ * `cookies().set()` and `cookies().delete()` in addition to the standard
+ * cookie attributes.
+ */
+export type NextCookieMutationOptions = {
+  /**
+   * Whether mutating this cookie marks the current path as revalidated,
+   * causing the page to be re-rendered on the server and the client router
+   * caches to be invalidated after the Server Action completes. Defaults to
+   * `true`.
+   *
+   * Pass `revalidate: false` when the mutation doesn't affect rendered
+   * content (for example, when refreshing a session cookie) to skip the extra
+   * re-render. The cookie is still set on the response as usual.
+   *
+   * This option only has an effect in Server Actions. In Route Handlers and
+   * Middleware, cookie mutations never trigger revalidation, so the option is
+   * accepted but has no effect there. Note that cookies set by Middleware on
+   * the current request are merged into the Server Action's mutable cookies
+   * and always request revalidation, which cannot be opted out of with this
+   * option.
+   *
+   * @experimental
+   */
+  revalidate?: boolean
+}
+
+export type NextSetCookieOptions = ResponseCookie & NextCookieMutationOptions
+
+export type NextDeleteCookieOptions = Omit<
+  ResponseCookie,
+  'value' | 'expires'
+> &
+  NextCookieMutationOptions
+
+/**
+ * The cookie mutation methods of `ResponseCookies`, extended with
+ * Next.js-specific options.
+ */
+export interface NextCookieMutationMethods {
+  set(
+    ...args:
+      | [key: string, value: string, cookie?: Partial<NextSetCookieOptions>]
+      | [options: NextSetCookieOptions]
+  ): this
+  delete(...args: [key: string] | [options: NextDeleteCookieOptions]): this
+}
+
 // The `cookies()` API is a mix of request and response cookies. For `.get()` methods,
 // we want to return the request cookie if it exists. For mutative methods like `.set()`,
 // we want to return the response cookie.
@@ -31,7 +80,15 @@ export type ReadonlyRequestCookies = Omit<
   RequestCookies,
   'set' | 'clear' | 'delete'
 > &
-  Pick<ResponseCookies, 'set' | 'delete'>
+  NextCookieMutationMethods
+
+/**
+ * `ResponseCookies` with the mutation methods extended with Next.js-specific
+ * options. This is the runtime shape of the mutable cookies object created by
+ * `MutableRequestCookiesAdapter.wrap`.
+ */
+export type MutableRequestCookies = Omit<ResponseCookies, 'set' | 'delete'> &
+  NextCookieMutationMethods
 
 export class RequestCookiesAdapter {
   public static seal(cookies: RequestCookies): ReadonlyRequestCookies {
@@ -63,6 +120,9 @@ export class RequestCookiesAdapter {
 }
 
 const SYMBOL_MODIFY_COOKIE_VALUES = Symbol.for('next.mutated.cookies')
+const SYMBOL_MUTATED_COOKIES_REVALIDATE = Symbol.for(
+  'next.mutated.cookies.revalidate'
+)
 
 export function getModifiedCookieValues(
   cookies: ResponseCookies
@@ -77,9 +137,23 @@ export function getModifiedCookieValues(
   return modified
 }
 
+/**
+ * Whether any cookie mutation on this `MutableRequestCookiesAdapter`-wrapped
+ * cookies object requested path revalidation, i.e. was performed without
+ * `revalidate: false`. Returns `false` for cookies objects that were never
+ * mutated (or aren't wrapped).
+ */
+export function didMutatedCookiesRequestRevalidation(
+  cookies: ResponseCookies
+): boolean {
+  return (cookies as unknown as any)[SYMBOL_MUTATED_COOKIES_REVALIDATE] === true
+}
+
 type SetCookieArgs =
-  | [key: string, value: string, cookie?: Partial<ResponseCookie>]
-  | [options: ResponseCookie]
+  | [key: string, value: string, cookie?: Partial<NextSetCookieOptions>]
+  | [options: NextSetCookieOptions]
+
+type DeleteCookieArgs = [key: string] | [options: NextDeleteCookieOptions]
 
 export function appendMutableCookies(
   headers: Headers,
@@ -117,7 +191,7 @@ export class MutableRequestCookiesAdapter {
   public static wrap(
     cookies: RequestCookies,
     onUpdateCookies?: (cookies: string[]) => void
-  ): ResponseCookies {
+  ): MutableRequestCookies {
     const responseCookies = new ResponseCookies(new Headers())
     for (const cookie of cookies.getAll()) {
       responseCookies.set(cookie)
@@ -125,11 +199,18 @@ export class MutableRequestCookiesAdapter {
 
     let modifiedValues: ResponseCookie[] = []
     const modifiedCookies = new Set<string>()
-    const updateResponseCookies = () => {
-      // TODO-APP: change method of getting workStore
-      const workStore = workAsyncStorage.getStore()
-      if (workStore) {
-        workStore.pathWasRevalidated = ActionDidRevalidateStaticAndDynamic
+    let mutationsRequestedRevalidation = false
+    const updateResponseCookies = (shouldRevalidate: boolean) => {
+      if (shouldRevalidate) {
+        // Once any mutation requested revalidation, a later mutation with
+        // `revalidate: false` must not undo it.
+        mutationsRequestedRevalidation = true
+
+        // TODO-APP: change method of getting workStore
+        const workStore = workAsyncStorage.getStore()
+        if (workStore) {
+          workStore.pathWasRevalidated = ActionDidRevalidateStaticAndDynamic
+        }
       }
 
       const allCookies = responseCookies.getAll()
@@ -153,18 +234,37 @@ export class MutableRequestCookiesAdapter {
           case SYMBOL_MODIFY_COOKIE_VALUES:
             return modifiedValues
 
+          // A special symbol to check whether any cookie mutation requested
+          // path revalidation, i.e. was performed without `revalidate: false`.
+          case SYMBOL_MUTATED_COOKIES_REVALIDATE:
+            return mutationsRequestedRevalidation
+
           // TODO: Throw error if trying to set a cookie after the response
           // headers have been set.
           case 'delete':
-            return function (...args: [string] | [ResponseCookie]) {
+            return function (...args: DeleteCookieArgs) {
               modifiedCookies.add(
                 typeof args[0] === 'string' ? args[0] : args[0].name
               )
+              let shouldRevalidate = true
               try {
-                target.delete(...args)
+                if (typeof args[0] === 'string') {
+                  target.delete(args[0])
+                } else if ('revalidate' in args[0]) {
+                  const options = args[0]
+                  shouldRevalidate = options.revalidate !== false
+                  // Strip the Next.js-specific `revalidate` option so that it
+                  // isn't stored on the underlying cookie. `name` is read off
+                  // the original object because a rest-destructure only copies
+                  // own enumerable properties.
+                  const { revalidate, ...cookieOptions } = options
+                  target.delete({ ...cookieOptions, name: options.name })
+                } else {
+                  target.delete(args[0])
+                }
                 return wrappedCookies
               } finally {
-                updateResponseCookies()
+                updateResponseCookies(shouldRevalidate)
               }
             }
           case 'set':
@@ -172,11 +272,38 @@ export class MutableRequestCookiesAdapter {
               modifiedCookies.add(
                 typeof args[0] === 'string' ? args[0] : args[0].name
               )
+              let shouldRevalidate = true
               try {
-                target.set(...args)
+                if (args.length === 1) {
+                  const options = args[0]
+                  if ('revalidate' in options) {
+                    shouldRevalidate = options.revalidate !== false
+                    // Strip the Next.js-specific `revalidate` option so that
+                    // it isn't stored on the underlying cookie. `name` and
+                    // `value` are read off the original object because a
+                    // rest-destructure only copies own enumerable properties.
+                    const { revalidate, ...cookieOptions } = options
+                    target.set({
+                      ...cookieOptions,
+                      name: options.name,
+                      value: options.value,
+                    })
+                  } else {
+                    target.set(options)
+                  }
+                } else {
+                  const [name, value, options] = args
+                  if (options && 'revalidate' in options) {
+                    shouldRevalidate = options.revalidate !== false
+                    const { revalidate, ...cookieOptions } = options
+                    target.set(name, value, cookieOptions)
+                  } else {
+                    target.set(name, value, options)
+                  }
+                }
                 return wrappedCookies
               } finally {
-                updateResponseCookies()
+                updateResponseCookies(shouldRevalidate)
               }
             }
 
@@ -192,12 +319,15 @@ export class MutableRequestCookiesAdapter {
 
 export function createCookiesWithMutableAccessCheck(
   requestStore: RequestStore
-): ResponseCookies {
+): MutableRequestCookies {
   const wrappedCookies = new Proxy(requestStore.mutableCookies, {
     get(target, prop, receiver) {
       switch (prop) {
+        // The Next.js-specific `revalidate` option is handled by the
+        // `MutableRequestCookiesAdapter` proxy that `requestStore.mutableCookies`
+        // is wrapped with, so the arguments are forwarded untouched here.
         case 'delete':
-          return function (...args: [string] | [ResponseCookie]) {
+          return function (...args: DeleteCookieArgs) {
             ensureCookiesAreStillMutable(requestStore, 'cookies().delete')
             target.delete(...args)
             return wrappedCookies

--- a/test/e2e/app-dir/cookies-revalidate-opt-out/app/actions.ts
+++ b/test/e2e/app-dir/cookies-revalidate-opt-out/app/actions.ts
@@ -1,0 +1,50 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { revalidatePath } from 'next/cache'
+
+export async function setCookie(value: string) {
+  const cookieStore = await cookies()
+  cookieStore.set('test-cookie', value)
+  return value
+}
+
+export async function setCookieWithoutRevalidate(value: string) {
+  const cookieStore = await cookies()
+  cookieStore.set('test-cookie', value, { revalidate: false })
+  return value
+}
+
+export async function setCookieObjectFormWithoutRevalidate(value: string) {
+  const cookieStore = await cookies()
+  cookieStore.set({ name: 'test-cookie', value, revalidate: false })
+  return value
+}
+
+export async function deleteCookie(token: string) {
+  const cookieStore = await cookies()
+  cookieStore.delete('test-cookie')
+  return token
+}
+
+export async function deleteCookieWithoutRevalidate(token: string) {
+  const cookieStore = await cookies()
+  cookieStore.delete({ name: 'test-cookie', revalidate: false })
+  return token
+}
+
+export async function setCookiesMixed(value: string) {
+  const cookieStore = await cookies()
+  cookieStore.set('test-cookie', value, { revalidate: false })
+  cookieStore.set('other-cookie', value)
+  return value
+}
+
+export async function setCookieWithoutRevalidateAndRevalidatePath(
+  value: string
+) {
+  const cookieStore = await cookies()
+  cookieStore.set('test-cookie', value, { revalidate: false })
+  revalidatePath('/')
+  return value
+}

--- a/test/e2e/app-dir/cookies-revalidate-opt-out/app/buttons.tsx
+++ b/test/e2e/app-dir/cookies-revalidate-opt-out/app/buttons.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  setCookie,
+  setCookieWithoutRevalidate,
+  setCookieObjectFormWithoutRevalidate,
+  deleteCookie,
+  deleteCookieWithoutRevalidate,
+  setCookiesMixed,
+  setCookieWithoutRevalidateAndRevalidatePath,
+} from './actions'
+
+function randomValue() {
+  return `${Math.random()}`.replace('.', '')
+}
+
+export function Buttons() {
+  const [result, setResult] = useState('no-result')
+
+  const run = (name: string, action: () => Promise<string>) => async () => {
+    const returned = await action()
+    setResult(`${name}:${returned}`)
+  }
+
+  return (
+    <div>
+      <p id="action-result">{result}</p>
+      <button
+        id="set-cookie"
+        onClick={run('set-cookie', () => setCookie(randomValue()))}
+      >
+        set
+      </button>
+      <button
+        id="set-cookie-without-revalidate"
+        onClick={run('set-cookie-without-revalidate', () =>
+          setCookieWithoutRevalidate(randomValue())
+        )}
+      >
+        set without revalidate
+      </button>
+      <button
+        id="set-cookie-object-form"
+        onClick={run('set-cookie-object-form', () =>
+          setCookieObjectFormWithoutRevalidate(randomValue())
+        )}
+      >
+        set (object form) without revalidate
+      </button>
+      <button
+        id="delete-cookie"
+        onClick={run('delete-cookie', () => deleteCookie(randomValue()))}
+      >
+        delete
+      </button>
+      <button
+        id="delete-cookie-without-revalidate"
+        onClick={run('delete-cookie-without-revalidate', () =>
+          deleteCookieWithoutRevalidate(randomValue())
+        )}
+      >
+        delete without revalidate
+      </button>
+      <button
+        id="set-cookies-mixed"
+        onClick={run('set-cookies-mixed', () => setCookiesMixed(randomValue()))}
+      >
+        set mixed
+      </button>
+      <button
+        id="set-cookie-and-revalidate-path"
+        onClick={run('set-cookie-and-revalidate-path', () =>
+          setCookieWithoutRevalidateAndRevalidatePath(randomValue())
+        )}
+      >
+        set without revalidate + revalidatePath
+      </button>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/cookies-revalidate-opt-out/app/layout.tsx
+++ b/test/e2e/app-dir/cookies-revalidate-opt-out/app/layout.tsx
@@ -1,0 +1,11 @@
+import { Suspense, type ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cookies-revalidate-opt-out/app/page.tsx
+++ b/test/e2e/app-dir/cookies-revalidate-opt-out/app/page.tsx
@@ -1,0 +1,17 @@
+import { cookies } from 'next/headers'
+import { Buttons } from './buttons'
+
+export default async function Page() {
+  const cookieStore = await cookies()
+  // Note: a deleted cookie is still visible to a re-render within the same
+  // request as an empty-string value, so use truthiness instead of `??`.
+  const cookieValue = cookieStore.get('test-cookie')?.value || 'no-cookie'
+
+  return (
+    <main>
+      <p id="render-id">{Math.random()}</p>
+      <p id="rendered-cookie-value">{cookieValue}</p>
+      <Buttons />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cookies-revalidate-opt-out/app/route-handler/route.ts
+++ b/test/e2e/app-dir/cookies-revalidate-opt-out/app/route-handler/route.ts
@@ -1,0 +1,9 @@
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  const cookieStore = await cookies()
+  cookieStore.set('route-handler-cookie', 'route-value', { revalidate: false })
+  cookieStore.delete({ name: 'other-cookie', revalidate: false })
+  return NextResponse.json({ ok: true })
+}

--- a/test/e2e/app-dir/cookies-revalidate-opt-out/cookies-revalidate-opt-out.test.ts
+++ b/test/e2e/app-dir/cookies-revalidate-opt-out/cookies-revalidate-opt-out.test.ts
@@ -1,0 +1,269 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import type { Playwright } from 'next-webdriver'
+
+describe('cookies-revalidate-opt-out', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  function getBrowserCookie(browser: Playwright, name: string) {
+    return browser.eval<string | null>(
+      `document.cookie.match(/(?:^|; )${name}=([^;]+)/)?.[1] ?? null`
+    )
+  }
+
+  async function waitForActionResult(
+    browser: Playwright,
+    prefix: string,
+    previousResult = 'no-result'
+  ) {
+    let result = ''
+    await retry(async () => {
+      result = await browser.elementByCss('#action-result').text()
+      expect(result).toMatch(new RegExp(`^${prefix}:`))
+      expect(result).not.toBe(previousResult)
+    })
+    return result.slice(prefix.length + 1)
+  }
+
+  it('re-renders the page when a cookie is set in a server action', async () => {
+    const browser = await next.browser('/')
+    const initialRenderId = await browser.elementByCss('#render-id').text()
+
+    await browser.elementByCss('#set-cookie').click()
+    const value = await waitForActionResult(browser, 'set-cookie')
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#render-id').text()).not.toBe(
+        initialRenderId
+      )
+    })
+    expect(await browser.elementByCss('#rendered-cookie-value').text()).toBe(
+      value
+    )
+    expect(await getBrowserCookie(browser, 'test-cookie')).toBe(value)
+  })
+
+  it('does not re-render the page when a cookie is set with revalidate: false', async () => {
+    const browser = await next.browser('/')
+    const initialRenderId = await browser.elementByCss('#render-id').text()
+    const initialRenderedCookie = await browser
+      .elementByCss('#rendered-cookie-value')
+      .text()
+
+    await browser.elementByCss('#set-cookie-without-revalidate').click()
+    const value = await waitForActionResult(
+      browser,
+      'set-cookie-without-revalidate'
+    )
+
+    // The cookie must still reach the browser via the Set-Cookie header.
+    await retry(async () => {
+      expect(await getBrowserCookie(browser, 'test-cookie')).toBe(value)
+    })
+
+    // Run a second action roundtrip so that any erroneously scheduled refresh
+    // from the first action would have been applied by the time it completes.
+    await browser.elementByCss('#set-cookie-without-revalidate').click()
+    const secondValue = await waitForActionResult(
+      browser,
+      'set-cookie-without-revalidate',
+      `set-cookie-without-revalidate:${value}`
+    )
+    expect(secondValue).not.toBe(value)
+
+    // The page was not re-rendered: the server skipped rendering and the
+    // client router caches were not invalidated.
+    expect(await browser.elementByCss('#render-id').text()).toBe(
+      initialRenderId
+    )
+    expect(await browser.elementByCss('#rendered-cookie-value').text()).toBe(
+      initialRenderedCookie
+    )
+
+    // The cookie is visible to the server on the next request.
+    await browser.refresh()
+    await retry(async () => {
+      expect(await browser.elementByCss('#rendered-cookie-value').text()).toBe(
+        secondValue
+      )
+    })
+  })
+
+  it('does not re-render the page when a cookie is set with revalidate: false in the object form', async () => {
+    const browser = await next.browser('/')
+    const initialRenderId = await browser.elementByCss('#render-id').text()
+
+    await browser.elementByCss('#set-cookie-object-form').click()
+    const value = await waitForActionResult(browser, 'set-cookie-object-form')
+
+    await retry(async () => {
+      expect(await getBrowserCookie(browser, 'test-cookie')).toBe(value)
+    })
+
+    // Run a second action roundtrip so that any erroneously scheduled refresh
+    // from the first action would have been applied by the time it completes.
+    await browser.elementByCss('#set-cookie-object-form').click()
+    await waitForActionResult(
+      browser,
+      'set-cookie-object-form',
+      `set-cookie-object-form:${value}`
+    )
+
+    expect(await browser.elementByCss('#render-id').text()).toBe(
+      initialRenderId
+    )
+  })
+
+  it('re-renders the page when a cookie is deleted in a server action', async () => {
+    const browser = await next.browser('/')
+
+    // Set the cookie first so the page renders its value.
+    await browser.elementByCss('#set-cookie').click()
+    const value = await waitForActionResult(browser, 'set-cookie')
+    await retry(async () => {
+      expect(await browser.elementByCss('#rendered-cookie-value').text()).toBe(
+        value
+      )
+    })
+
+    await browser.elementByCss('#delete-cookie').click()
+    await waitForActionResult(browser, 'delete-cookie')
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#rendered-cookie-value').text()).toBe(
+        'no-cookie'
+      )
+    })
+    expect(await getBrowserCookie(browser, 'test-cookie')).toBe(null)
+  })
+
+  it('does not re-render the page when a cookie is deleted with revalidate: false', async () => {
+    const browser = await next.browser('/')
+
+    // Set the cookie first so the page renders its value.
+    await browser.elementByCss('#set-cookie').click()
+    const value = await waitForActionResult(browser, 'set-cookie')
+    let renderId = ''
+    await retry(async () => {
+      expect(await browser.elementByCss('#rendered-cookie-value').text()).toBe(
+        value
+      )
+      renderId = await browser.elementByCss('#render-id').text()
+    })
+
+    await browser.elementByCss('#delete-cookie-without-revalidate').click()
+    const token = await waitForActionResult(
+      browser,
+      'delete-cookie-without-revalidate'
+    )
+
+    // The deletion must still reach the browser via the Set-Cookie header.
+    await retry(async () => {
+      expect(await getBrowserCookie(browser, 'test-cookie')).toBe(null)
+    })
+
+    // Run a second action roundtrip so that any erroneously scheduled refresh
+    // from the first action would have been applied by the time it completes.
+    await browser.elementByCss('#delete-cookie-without-revalidate').click()
+    await waitForActionResult(
+      browser,
+      'delete-cookie-without-revalidate',
+      `delete-cookie-without-revalidate:${token}`
+    )
+
+    // But the page was not re-rendered, so it still shows the stale value.
+    expect(await browser.elementByCss('#render-id').text()).toBe(renderId)
+    expect(await browser.elementByCss('#rendered-cookie-value').text()).toBe(
+      value
+    )
+  })
+
+  it('re-renders the page when a revalidating mutation follows an opted-out one', async () => {
+    const browser = await next.browser('/')
+    const initialRenderId = await browser.elementByCss('#render-id').text()
+
+    await browser.elementByCss('#set-cookies-mixed').click()
+    const value = await waitForActionResult(browser, 'set-cookies-mixed')
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#render-id').text()).not.toBe(
+        initialRenderId
+      )
+    })
+    expect(await browser.elementByCss('#rendered-cookie-value').text()).toBe(
+      value
+    )
+  })
+
+  it('re-renders the page when revalidatePath is called alongside an opted-out cookie mutation', async () => {
+    const browser = await next.browser('/')
+    const initialRenderId = await browser.elementByCss('#render-id').text()
+
+    await browser.elementByCss('#set-cookie-and-revalidate-path').click()
+    const value = await waitForActionResult(
+      browser,
+      'set-cookie-and-revalidate-path'
+    )
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#render-id').text()).not.toBe(
+        initialRenderId
+      )
+    })
+    expect(await browser.elementByCss('#rendered-cookie-value').text()).toBe(
+      value
+    )
+  })
+
+  it('omits the x-action-revalidated header for opted-out mutations and sends it for plain ones', async () => {
+    const browser = await next.browser('/')
+
+    // Record the x-action-revalidated response header of action POSTs.
+    await browser.eval(`(() => {
+      window.__actionRevalidatedHeader = 'none'
+      const originalFetch = window.fetch.bind(window)
+      window.fetch = async (...args) => {
+        const response = await originalFetch(...args)
+        try {
+          const method = (
+            (args[1] && args[1].method) ||
+            'GET'
+          ).toUpperCase()
+          if (method === 'POST') {
+            window.__actionRevalidatedHeader =
+              response.headers.get('x-action-revalidated') ?? 'absent'
+          }
+        } catch {}
+        return response
+      }
+    })()`)
+
+    await browser.elementByCss('#set-cookie-without-revalidate').click()
+    const value = await waitForActionResult(
+      browser,
+      'set-cookie-without-revalidate'
+    )
+    expect(await browser.eval('window.__actionRevalidatedHeader')).toBe(
+      'absent'
+    )
+
+    await browser.elementByCss('#set-cookie').click()
+    await waitForActionResult(browser, 'set-cookie', `set-cookie:${value}`)
+    expect(await browser.eval('window.__actionRevalidatedHeader')).toBe('1')
+  })
+
+  it('accepts the revalidate option in a route handler and still emits Set-Cookie', async () => {
+    const res = await next.fetch('/route-handler', { method: 'POST' })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+
+    const setCookieHeader = res.headers.get('set-cookie') ?? ''
+    expect(setCookieHeader).toContain('route-handler-cookie=route-value')
+    expect(setCookieHeader).toContain('other-cookie=;')
+    // The Next.js-specific option must not leak into the header.
+    expect(setCookieHeader).not.toContain('revalidate')
+  })
+})

--- a/test/e2e/app-dir/cookies-revalidate-opt-out/next.config.js
+++ b/test/e2e/app-dir/cookies-revalidate-opt-out/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
Reworks #84313 by @cramforce. That PR has been open since September 2025, now conflicts with canary after the recent action refactors, and hasn't had maintainer movement despite people asking for news on it through 2026 (better-auth among them). I opened this as a fresh PR so the feature can be tracked and reviewed against current canary. Happy to close this one if the original gets picked up instead.

### What?

Adds an experimental `revalidate?: boolean` option to `cookies().set()` and `cookies().delete()`, on both call forms. Passing `{ revalidate: false }` opts that mutation out of marking the path as revalidated.

When a mutation opts out, the action response skips the page re-render and the `x-action-revalidated` header is not sent, so client router caches stay intact. The cookie still reaches the browser through `Set-Cookie` as usual.

### Why?

Original report: https://x.com/madarco/status/1972314852036374833

better-auth/better-auth#9363 names the option from #84313 as the root fix for their session cookie workaround. Their idempotency check can't handle cookie values that carry a timestamp, so every refresh triggers a full re-render.

There is no workaround today. The re-render is embedded in the action response on the server, so it can't be avoided with a proxy or by stripping headers on the way out.

### How?

All of the option handling lives in the inner `MutableRequestCookiesAdapter.wrap` proxy. It strips `revalidate` before the option can reach the cookie store, sets `pathWasRevalidated` conditionally, and keeps a monotonic latch (`Symbol.for('next.mutated.cookies.revalidate')`) recording whether any mutation in the request asked for revalidation.

`addRevalidationHeader` in `action-handler.ts` now consults that latch instead of `getModifiedCookieValues().length`. This resolves madarco's review comment on the original PR: without it, the client is still told to revalidate.

What's different from #84313:

* `delete()` is supported in both call forms (madarco's other review comment).
* The unused option extraction vercel[bot] flagged in `createCookiesWithMutableAccessCheck` is resolved by forwarding the option untouched into the inner proxy.
* Rebased onto the `ActionRevalidationKind` refactor (#86878). An opt-out never downgrades revalidation coming from `refresh()` or `revalidatePath()`.

Opted-out cookies stay in the modified cookies list, so route handlers, redirects, and middleware `Set-Cookie` emission are unchanged.

Known limitation, documented in the JSDoc: cookies set in middleware and merged into the action always revalidate.
