### PR TITLE
chore: remove unused code from image optimizer

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -47,10 +47,6 @@ const CACHE_VERSION = 4
 const BLUR_IMG_SIZE = 8 // should match `next-image-loader`
 const BLUR_QUALITY = 70 // should match `next-image-loader`
 
-function isValidMime(contentType: string) {
-  return Boolean(getExtension(contentType))
-}
-
 async function initCacheEntries(
   cacheDir: string
 ): Promise<Array<{ key: string; size: number; expireAt: number }>> {
@@ -769,7 +765,6 @@ export async function imageOptimizer(
   )
 
   return imageOptimizerTransform(imageUpstream, paramsResult, nextConfig, {
-    isValidMime,
     previousOutput: previouslyCachedImage
       ? {
           buffer: previouslyCachedImage.buffer,

--- a/packages/next/src/server/image-optimizer/transform.ts
+++ b/packages/next/src/server/image-optimizer/transform.ts
@@ -62,7 +62,6 @@ export interface ImageOptimizerTransformLogger {
 }
 
 export interface ImageOptimizerTransformOptions {
-  isValidMime: (contentType: string) => boolean
   previousOutput?: {
     buffer: Buffer
     maxAge?: number
@@ -195,7 +194,7 @@ export async function imageOptimizerTransform(
   imageUpstream: ImageUpstream,
   paramsResult: ImageOptimizerTransformParams,
   nextConfig: ImageOptimizerTransformConfig,
-  opts: ImageOptimizerTransformOptions
+  opts: ImageOptimizerTransformOptions = {}
 ): Promise<ImageOptimizerResult> {
   const { href, quality, width, mimeType } = paramsResult
   const { buffer: upstreamBuffer, etag: upstreamEtag } = imageUpstream
@@ -256,14 +255,11 @@ export async function imageOptimizerTransform(
 
   if (mimeType) {
     contentType = mimeType
-  } else if (
-    opts.isValidMime(upstreamType) &&
-    upstreamType !== WEBP &&
-    upstreamType !== AVIF
-  ) {
-    contentType = upstreamType
-  } else {
+  } else if (upstreamType === WEBP || upstreamType === AVIF) {
+    // Downlevel WebP and AVIF when the client does not advertise support.
     contentType = JPEG
+  } else {
+    contentType = upstreamType
   }
 
   if (opts.previousOutput) {
@@ -301,21 +297,14 @@ export async function imageOptimizerTransform(
       upstreamEtag,
     }
   } catch (error) {
-    if (upstreamType) {
-      // If we fail to optimize, fallback to the original image
-      return {
-        buffer: upstreamBuffer,
-        contentType: upstreamType,
-        maxAge: nextConfig.images.minimumCacheTTL,
-        etag: upstreamEtag,
-        upstreamEtag,
-        error,
-      }
-    } else {
-      throw new ImageError(
-        400,
-        'Unable to optimize image and unable to fallback to upstream image'
-      )
+    // If we fail to optimize, fallback to the original image
+    return {
+      buffer: upstreamBuffer,
+      contentType: upstreamType,
+      maxAge: nextConfig.images.minimumCacheTTL,
+      etag: upstreamEtag,
+      upstreamEtag,
+      error,
     }
   }
 }

--- a/test/unit/image-optimizer/transform.test.ts
+++ b/test/unit/image-optimizer/transform.test.ts
@@ -1,10 +1,7 @@
 /* eslint-env jest */
 import { readFile } from 'fs-extra'
 import { join } from 'path'
-import {
-  imageOptimizerTransform,
-  type ImageOptimizerTransformOptions,
-} from 'next/dist/server/image-optimizer/transform'
+import { imageOptimizerTransform } from 'next/dist/server/image-optimizer/transform'
 import type {
   CachedRouteKind,
   IncrementalResponseCacheEntry,
@@ -12,8 +9,6 @@ import type {
 
 const getImage = (filename: string) =>
   readFile(join(__dirname, 'images', filename))
-
-const isValidMime = (contentType: string) => contentType === 'image/png'
 
 const config = {
   images: {
@@ -29,11 +24,7 @@ const config = {
   },
 }
 
-async function transform(
-  filename: string,
-  mimeType = 'image/webp',
-  options?: ImageOptimizerTransformOptions
-) {
+async function transform(filename: string, mimeType = 'image/webp') {
   const buffer = await getImage(filename)
   return imageOptimizerTransform(
     {
@@ -43,8 +34,7 @@ async function transform(
       etag: 'source-etag',
     },
     { href: `/${filename}`, width: 64, quality: 75, mimeType },
-    config,
-    { isValidMime, ...options }
+    config
   )
 }
 
@@ -110,6 +100,11 @@ describe('imageOptimizerTransform', () => {
     expect(result.contentType).toBe('image/webp')
   })
 
+  it('downlevels an avif source when no output format is requested', async () => {
+    const result = await transform('test.avif', '')
+    expect(result.contentType).toBe('image/jpeg')
+  })
+
   it('generates blur placeholders in development', async () => {
     const result = await transformInDevelopment('test.png')
     expect(result.contentType).toBe('image/svg+xml')
@@ -167,8 +162,7 @@ describe('imageOptimizerTransform', () => {
         {
           ...config,
           images: { ...config.images, dangerouslyAllowSVG: false },
-        },
-        { isValidMime }
+        }
       )
     ).rejects.toMatchObject({ statusCode: 400 })
   })
@@ -183,8 +177,7 @@ describe('imageOptimizerTransform', () => {
           etag: 'source-etag',
         },
         { href: '/bad', width: 64, quality: 75, mimeType: 'image/webp' },
-        config,
-        { isValidMime }
+        config
       )
     ).rejects.toMatchObject({ statusCode: 400 })
   })


### PR DESCRIPTION
This PR removes some unused code from the image optimizer.

- Remove redundant MIME validation
- Remove unreachable fallback error

These used to be necessary until PR https://github.com/vercel/next.js/pull/82118 removed the fallback.

Before 82118:

```js
upstreamType = detectContentType(upstreamBuffer) || imageUpstream.contentType?.toLowerCase().trim()
```

After 82118:

```js
upstreamType = detectContentType(upstreamBuffer)
```

Now there is never a case where upstreamType is invalid since its already been validated, there is no more fallback.