### PR TITLE
feat(dev-overlay): enhance user preferences select dropdown in devIndicator

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -10,6 +10,7 @@ import { NEXT_DEV_TOOLS_SCALE } from '../../../../shared'
 import LightIcon from '../../../../icons/light-icon'
 import DarkIcon from '../../../../icons/dark-icon'
 import SystemIcon from '../../../../icons/system-icon'
+import * as React from 'react'
 import { ShortcutRecorder } from './shortcut-recorder'
 import { useRestartServer } from '../../error-overlay-toolbar/use-restart-server'
 import { saveDevToolsConfig } from '../../../../utils/save-devtools-config'
@@ -230,16 +231,146 @@ export function UserPreferencesBody({
 function Select({
   children,
   prefix,
-  ...props
+  value,
+  onChange,
+  id,
+  name,
 }: {
   prefix?: React.ReactNode
-} & Omit<React.HTMLProps<HTMLSelectElement>, 'prefix'>) {
+  value: string | number
+  onChange: (e: any) => void
+  id?: string
+  name?: string
+  children: React.ReactNode
+}) {
+  const [isOpen, setIsOpen] = React.useState(false)
+  const [focusedIndex, setFocusedIndex] = React.useState(-1)
+  const containerRef = React.useRef<HTMLDivElement>(null)
+
+  const options = React.Children.toArray(children)
+    .filter(
+      (child): child is React.ReactElement =>
+        React.isValidElement(child) && child.type === 'option'
+    )
+    .map((child) => {
+      const props = child.props as {
+        value: string | number
+        children: React.ReactNode
+      }
+      return {
+        value: props.value,
+        label: props.children,
+      }
+    })
+
+  const selectedOption =
+    options.find((opt) => opt.value === value) || options[0]
+
+  React.useEffect(() => {
+    const handleOutsideClick = (e: MouseEvent) => {
+      const path = e.composedPath()
+      if (containerRef.current && !path.includes(containerRef.current)) {
+        setIsOpen(false)
+      }
+    }
+
+    if (isOpen) {
+      window.addEventListener('click', handleOutsideClick)
+    }
+    return () => window.removeEventListener('click', handleOutsideClick)
+  }, [isOpen])
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      if (!isOpen) {
+        setIsOpen(true)
+        setFocusedIndex(options.findIndex((opt) => opt.value === value))
+        e.preventDefault()
+      } else if (focusedIndex !== -1) {
+        selectValue(options[focusedIndex].value)
+        e.preventDefault()
+      }
+    } else if (e.key === 'Escape') {
+      setIsOpen(false)
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      if (!isOpen) {
+        setIsOpen(true)
+        setFocusedIndex(options.findIndex((opt) => opt.value === value))
+      } else {
+        setFocusedIndex((prev) => (prev < options.length - 1 ? prev + 1 : prev))
+      }
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      if (!isOpen) {
+        setIsOpen(true)
+        setFocusedIndex(options.findIndex((opt) => opt.value === value))
+      } else {
+        setFocusedIndex((prev) => (prev > 0 ? prev - 1 : prev))
+      }
+    }
+  }
+
+  const selectValue = (newValue: string | number | undefined) => {
+    if (newValue === undefined) return
+    const mockEvent = {
+      target: { value: newValue, name, id },
+    }
+    onChange(mockEvent)
+    setIsOpen(false)
+  }
+
   return (
-    <div className="select-button">
-      {prefix}
-      <select {...props}>{children}</select>
-      <ChevronDownIcon />
+    <div
+      className="select-container"
+      ref={containerRef}
+      onKeyDown={handleKeyDown}
+    >
+      <button
+        type="button"
+        className="select-button"
+        onClick={() => setIsOpen(!isOpen)}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        id={id}
+        name={name}
+      >
+        {prefix}
+        <span className="select-value">{selectedOption?.label}</span>
+        <ChevronDownIcon />
+      </button>
+
+      {isOpen && (
+        <ul className="select-dropdown" role="listbox">
+          {options.map((opt, index) => (
+            <li
+              key={String(opt.value)}
+              role="option"
+              aria-selected={opt.value === value}
+              className={`select-option ${focusedIndex === index ? 'focused' : ''}`}
+              onClick={() => selectValue(opt.value)}
+              onMouseEnter={() => setFocusedIndex(index)}
+            >
+              {opt.label}
+              {opt.value === value && <CheckIcon />}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
+  )
+}
+
+function CheckIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z"
+        fill="currentColor"
+      />
+    </svg>
   )
 }
 
@@ -327,20 +458,62 @@ export const DEV_TOOLS_INFO_USER_PREFERENCES_STYLES = css`
     }
   }
 
+  .select-container {
+    position: relative;
+  }
+
   .select-button {
-    &:focus-within {
+    &:focus-visible {
       outline: var(--focus-ring);
       outline-offset: -1px;
     }
 
-    select {
-      all: unset;
-    }
+    cursor: pointer;
+    min-width: 140px;
+    justify-content: space-between;
+  }
 
-    option {
-      color: var(--color-gray-1000);
-      background: var(--color-background-100);
-    }
+  .select-value {
+    flex: 1;
+    text-align: left;
+  }
+
+  .select-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    min-width: 100%;
+    margin: 0;
+    padding: 4px;
+    list-style: none;
+    background: var(--color-background-100);
+    border: 1px solid var(--color-gray-400);
+    border-radius: var(--rounded-lg);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    z-index: 100;
+    max-height: 200px;
+    overflow-y: auto;
+  }
+
+  .select-option {
+    padding: 6px 8px;
+    border-radius: var(--rounded-md);
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: var(--size-14);
+    color: var(--color-gray-1000);
+    transition: background-color 150ms var(--timing-swift);
+  }
+
+  .select-option:hover,
+  .select-option.focused {
+    background: var(--color-gray-400);
+  }
+
+  .select-option[aria-selected='true'] {
+    font-weight: 500;
   }
 
   .preference-section button:disabled {

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/user-preferences.tsx
@@ -291,7 +291,13 @@ function Select({
         e.preventDefault()
       }
     } else if (e.key === 'Escape') {
-      setIsOpen(false)
+      if (isOpen) {
+        // Only close the dropdown, and prevent the Escape from bubbling to the
+        // panel's document-level keydown handler, which would otherwise also
+        // close the entire Preferences panel.
+        e.stopPropagation()
+        setIsOpen(false)
+      }
     } else if (e.key === 'ArrowDown') {
       e.preventDefault()
       if (!isOpen) {


### PR DESCRIPTION


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
### What?

Previously, the `devIndicator` dropdown used native styling that didn't quite match the Next.js aesthetic; furthermore, it overflowed the screen on mobile devices. Additionally, clicking the `v` icon next to the dropdown failed to trigger it, forcing developers to click directly on the dropdown text itself to reveal the options.


This PR replaces the native `<select>` HTML element in the DevTools indicator (`user-preferences.tsx`) with a custom, fully accessible React `Select` component.


Before the devIndicator dropdown update:


https://github.com/user-attachments/assets/36733c23-a43a-476e-984b-06aea02a6582



<img width="959" height="577" alt="Screenshot 2026-08-29 083722" src="https://github.com/user-attachments/assets/477e23f0-f3cf-479e-9701-7539c797ef32" />


<img width="573" height="467" alt="Screenshot 2026-08-29 080818" src="https://github.com/user-attachments/assets/4502e368-56bf-492b-8845-799c8f8232c8" />


Here is the updated devIndicator dropdown:

https://github.com/user-attachments/assets/c0c80c9f-ff93-4a28-aa91-83250189befd


https://github.com/user-attachments/assets/bd6373d5-41df-450e-adad-0c72f9e898b5


<img width="554" height="458" alt="Screenshot 2026-08-29 081152" src="https://github.com/user-attachments/assets/41029403-214b-475e-9671-3798d84e4a8c" />
<img width="436" height="452" alt="Screenshot 2026-08-29 081126" src="https://github.com/user-attachments/assets/33789204-9e34-477d-ba06-583edc401b9c" />


### Why?

1. **Accessibility:** The native `<select>` dropdown requires a direct mouse click to open. With this custom component, the dropdown can now be toggled and navigated entirely via keyboard (`Enter`, `Space`, `ArrowUp`, `ArrowDown`, `Escape`), greatly improving accessibility for developers who rely on keyboard navigation.
2. **UX & UI Consistency:** The previous native dropdown inherited the browser's default ugly styling, which broke the premium aesthetic of the Next.js DevTools overlay. The new custom dropdown aligns perfectly with the overarching design system of the dev overlay.


### How?
- Implemented a lightweight, custom `Select` component in `user-preferences.tsx` using `React.useState`.
- Added comprehensive `onKeyDown` listeners to support standard WAI-ARIA keyboard navigation patterns.
- Re-used existing CSS variables (`--color-background-100`, `--color-gray-400`, etc.) to ensure styling consistency.
- No heavy third-party libraries were added.

### Testing
I tested this using the internal `examples/hello-world` test fixture. Keyboard navigation and state changes (`theme`, `position`, `size`) work flawlessly.