### PR TITLE
fix(app-router): preserve hash scrolling for Suspense boundaries

### DIFF
--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -145,10 +145,22 @@ interface ScrollHandlerProps {
  */
 function InnerScrollHandler(props: ScrollHandlerProps) {
   const childrenRef = React.useRef<FragmentInstance>(null)
+  const observerRef = React.useRef<MutationObserver | null>(null)
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useLayoutEffect(
     () => {
       const { scrollRef: scrollHandlerRef, cacheNode } = props
+
+      // Disconnect any pending observer from a previous navigation commit
+      if (observerRef.current) {
+        observerRef.current.disconnect()
+        observerRef.current = null
+      }
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+        timeoutRef.current = null
+      }
 
       const scrollRef = scrollHandlerRef.forceScroll
         ? scrollHandlerRef.scrollRef
@@ -161,11 +173,61 @@ function InnerScrollHandler(props: ScrollHandlerProps) {
       if (hashFragment) {
         instance = getHashFragmentDomNode(hashFragment)
         if (instance === null) {
-          // A missing hash target is still a handled scroll intent. Do not
-          // fall back to the route Fragment or leave the intent pending.
-          scrollRef.current = false
-          scrollHandlerRef.onlyHashChange = false
-          scrollHandlerRef.hashFragment = null
+          // If the hash target is not yet in the DOM (e.g. within a Suspense boundary),
+          // observe the document for subtree mutations to scroll once mounted.
+          if (typeof MutationObserver !== 'undefined') {
+            const observer = new MutationObserver(() => {
+              if (!scrollRef.current) {
+                observer.disconnect()
+                return
+              }
+
+              const target = getHashFragmentDomNode(hashFragment)
+              if (target) {
+                observer.disconnect()
+                observerRef.current = null
+                if (timeoutRef.current) {
+                  clearTimeout(timeoutRef.current)
+                  timeoutRef.current = null
+                }
+
+                disableSmoothScrollDuringRouteTransition(
+                  () => {
+                    scrollRef.current = false
+                    target.scrollIntoView()
+                  },
+                  {
+                    dontForceLayout: true,
+                    onlyHashChange: scrollHandlerRef.onlyHashChange,
+                  }
+                )
+
+                scrollHandlerRef.onlyHashChange = false
+                scrollHandlerRef.hashFragment = null
+              }
+            })
+
+            observer.observe(document.body, {
+              childList: true,
+              subtree: true,
+            })
+            observerRef.current = observer
+
+            timeoutRef.current = setTimeout(() => {
+              observer.disconnect()
+              if (observerRef.current === observer) {
+                observerRef.current = null
+              }
+              if (timeoutRef.current) {
+                timeoutRef.current = null
+              }
+              if (scrollRef.current) {
+                scrollRef.current = false
+                scrollHandlerRef.onlyHashChange = false
+                scrollHandlerRef.hashFragment = null
+              }
+            }, 5000)
+          }
           return
         }
       } else {
@@ -271,6 +333,19 @@ function InnerScrollHandler(props: ScrollHandlerProps) {
     // but be prepared for lots of manual testing.
     undefined
   )
+
+  useLayoutEffect(() => {
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect()
+        observerRef.current = null
+      }
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+        timeoutRef.current = null
+      }
+    }
+  }, [])
 
   return <Fragment ref={childrenRef}>{props.children}</Fragment>
 }

--- a/test/e2e/app-dir/suspense-hash-scroll/app/layout.tsx
+++ b/test/e2e/app-dir/suspense-hash-scroll/app/layout.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, padding: 0 }}>
+        <header
+          style={{
+            position: 'sticky',
+            top: 0,
+            background: '#eee',
+            padding: '10px',
+            zIndex: 100,
+          }}
+        >
+          <Link id="link-home" href="/">
+            Home
+          </Link>
+        </header>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/suspense-hash-scroll/app/nested-suspense/page.tsx
+++ b/test/e2e/app-dir/suspense-hash-scroll/app/nested-suspense/page.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from 'react'
+
+async function LevelTwo() {
+  await new Promise((resolve) => setTimeout(resolve, 150))
+  return (
+    <div style={{ marginTop: '800px', height: '600px' }}>
+      <h2 id="nested-target">Nested Target Heading</h2>
+    </div>
+  )
+}
+
+async function LevelOne() {
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  return (
+    <div style={{ marginTop: '500px' }}>
+      <Suspense fallback={<p>Loading inner level...</p>}>
+        <LevelTwo />
+      </Suspense>
+    </div>
+  )
+}
+
+export default function NestedSuspensePage() {
+  return (
+    <main style={{ padding: '20px' }}>
+      <h1>Nested Suspense Page</h1>
+      <div style={{ height: '600px', background: '#ececec' }}>
+        <p>Outer spacer</p>
+      </div>
+      <Suspense fallback={<p>Loading outer level...</p>}>
+        <LevelOne />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/suspense-hash-scroll/app/page.tsx
+++ b/test/e2e/app-dir/suspense-hash-scroll/app/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link'
+
+export default function HomePage() {
+  return (
+    <main style={{ minHeight: '200vh', padding: '20px' }}>
+      <h1>Home Page</h1>
+      <ul>
+        <li>
+          <Link id="link-products-no-suspense" href="/products#category-42">
+            /products#category-42 (No Suspense)
+          </Link>
+        </li>
+        <li>
+          <Link
+            id="link-products-with-suspense"
+            href="/products-with-suspense#category-42"
+          >
+            /products-with-suspense#category-42 (With Suspense)
+          </Link>
+        </li>
+        <li>
+          <Link id="link-nested-suspense" href="/nested-suspense#nested-target">
+            /nested-suspense#nested-target (Nested Suspense)
+          </Link>
+        </li>
+        <li>
+          <Link id="link-nonexistent-hash" href="/products#nonexistent">
+            /products#nonexistent (Missing Hash)
+          </Link>
+        </li>
+        <li>
+          <Link id="link-home" href="/">
+            Home
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/suspense-hash-scroll/app/products-with-suspense/page.tsx
+++ b/test/e2e/app-dir/suspense-hash-scroll/app/products-with-suspense/page.tsx
@@ -1,0 +1,40 @@
+import { Suspense } from 'react'
+
+async function AsyncCategories() {
+  // Simulate network delay to trigger Suspense boundary
+  await new Promise((resolve) => setTimeout(resolve, 300))
+
+  return (
+    <div>
+      {Array.from({ length: 60 }, (_, i) => (
+        <h2
+          key={i}
+          id={`category-${i}`}
+          style={{ height: '60px', margin: '20px 0' }}
+        >
+          Category {i}
+        </h2>
+      ))}
+    </div>
+  )
+}
+
+export default function ProductsWithSuspensePage() {
+  return (
+    <main style={{ padding: '20px' }}>
+      <h1>Products (With Suspense)</h1>
+      <div style={{ height: '1200px', background: '#f5f5f5' }}>
+        <p>Spacer section before categories</p>
+      </div>
+      <Suspense
+        fallback={
+          <div id="suspense-fallback" style={{ height: '600px' }}>
+            <p>Loading categories...</p>
+          </div>
+        }
+      >
+        <AsyncCategories />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/suspense-hash-scroll/app/products/page.tsx
+++ b/test/e2e/app-dir/suspense-hash-scroll/app/products/page.tsx
@@ -1,0 +1,21 @@
+export default function ProductsPage() {
+  return (
+    <main style={{ padding: '20px' }}>
+      <h1 id="products-page-title">Products (No Suspense)</h1>
+      <div style={{ height: '1200px', background: '#f5f5f5' }}>
+        <p>Spacer section before categories</p>
+      </div>
+      <div>
+        {Array.from({ length: 60 }, (_, i) => (
+          <h2
+            key={i}
+            id={`category-${i}`}
+            style={{ height: '60px', margin: '20px 0' }}
+          >
+            Category {i}
+          </h2>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/suspense-hash-scroll/index.test.ts
+++ b/test/e2e/app-dir/suspense-hash-scroll/index.test.ts
@@ -1,0 +1,88 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+
+describe('app-dir - suspense hash scroll', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should scroll to target element within Suspense boundary after it resolves', async () => {
+    const browser = await next.browser('/')
+
+    // Navigate to page with Suspense containing anchor target #category-42
+    await browser.elementByCss('#link-products-with-suspense').click()
+
+    // Wait for the Suspense boundary to resolve and mount the target element
+    await retry(async () => {
+      const scrollY = await browser.eval('window.scrollY')
+      const targetTop = await browser.eval(
+        'document.getElementById("category-42") ? document.getElementById("category-42").getBoundingClientRect().top : null'
+      )
+      expect(scrollY).toBeGreaterThan(100)
+      expect(targetTop).not.toBeNull()
+      expect(Math.abs(targetTop)).toBeLessThan(150)
+    }, 6000)
+  })
+
+  it('should scroll immediately to target element when not in Suspense boundary', async () => {
+    const browser = await next.browser('/')
+
+    // Navigate to page without Suspense containing anchor target #category-42
+    await browser.elementByCss('#link-products-no-suspense').click()
+
+    await retry(async () => {
+      const scrollY = await browser.eval('window.scrollY')
+      const targetTop = await browser.eval(
+        'document.getElementById("category-42") ? document.getElementById("category-42").getBoundingClientRect().top : null'
+      )
+      expect(scrollY).toBeGreaterThan(100)
+      expect(targetTop).not.toBeNull()
+      expect(Math.abs(targetTop)).toBeLessThan(150)
+    }, 6000)
+  })
+
+  it('should scroll to target inside nested Suspense boundaries', async () => {
+    const browser = await next.browser('/')
+
+    await browser.elementByCss('#link-nested-suspense').click()
+
+    await retry(async () => {
+      const scrollY = await browser.eval('window.scrollY')
+      const targetTop = await browser.eval(
+        'document.getElementById("nested-target") ? document.getElementById("nested-target").getBoundingClientRect().top : null'
+      )
+      expect(scrollY).toBeGreaterThan(100)
+      expect(targetTop).not.toBeNull()
+      expect(Math.abs(targetTop)).toBeLessThan(150)
+    }, 6000)
+  })
+
+  it('should gracefully handle non-existent hash without errant scroll-to-top or errors', async () => {
+    const browser = await next.browser('/')
+
+    // Navigate to page with non-existent hash
+    await browser.elementByCss('#link-nonexistent-hash').click()
+    await browser.waitForElementByCss('#products-page-title')
+
+    // Wait a brief moment to ensure observer safety timeout / no errant jump occurs
+    await waitFor(1000)
+
+    const scrollY = await browser.eval('window.scrollY')
+    expect(scrollY).toBe(0)
+  })
+
+  it('should cancel observer on rapid navigation and prevent stale scroll', async () => {
+    const browser = await next.browser('/')
+
+    // Rapidly click Suspense link then immediate home link
+    await browser.elementByCss('#link-products-with-suspense').click()
+    await browser.elementByCss('#link-home').click()
+
+    // Wait for the Suspense delay window
+    await waitFor(1000)
+
+    // Ensure we are on home and scroll position remained 0
+    const scrollY = await browser.eval('window.scrollY')
+    expect(scrollY).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #65960 by preserving hash scroll intent when the target element is rendered inside a React `Suspense` boundary.

Previously, `InnerScrollHandler` cleared the scroll intent if `getHashFragmentDomNode()` returned `null` during the initial fallback commit. As a result, pages never scrolled to the hash after the Suspense boundary resolved.

## Changes

* Preserve synchronous fast path for existing behavior.
* Add a scoped `MutationObserver` only when the hash target is temporarily unavailable.
* Disconnect the observer immediately after the target mounts.
* Add 5-second cleanup for non-existent hash targets.
* Clean up observers on unmount and subsequent navigations.

## Tests

Added E2E coverage for:

* Hash scrolling inside Suspense
* Non-Suspense control
* Nested Suspense
* Missing hash cleanup
* Rapid navigation cancellation
