### PR TITLE
Deopt optimistic routes with unresolved active params

### DIFF
--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -774,8 +774,12 @@ export function matchKnownRoute(
     resolvedParams,
     search,
     null, // Start with null partial vary path at the root
+    false, // The root is always part of the active route.
     acc
   )
+  if (reifiedTree === null) {
+    return null
+  }
 
   // The metadata tree is a flat page node without the intermediate layout
   // structure. Clone it with the updated metadata vary path collected during
@@ -1015,9 +1019,11 @@ function reifyRouteTree(
   resolvedParams: ResolvedParams,
   search: NormalizedSearch,
   parentPartialVaryPath: PartialSegmentVaryPath | null,
+  parentIsInactive: boolean,
   acc: ReifyAccumulator
-): RouteTree<null> {
+): RouteTree<null> | null {
   const originalSegment = pattern.segment
+  const isInactive = parentIsInactive || pattern.refreshState !== null
 
   // This segment's param (if any) is a root param iff the segment is at or
   // above the root layout, which the server marks directly.
@@ -1045,8 +1051,15 @@ function reifyRouteTree(
         isRootParam
       )
     } else {
-      // Param not found in resolvedParams - keep original and inherit partial
-      // TODO: This should never happen. Bail out with null.
+      // Matching a URL only resolves params along the trie branch that led to
+      // the pattern. A whole route tree may also contain dynamic params in
+      // active parallel branches. Reusing their values from the pattern would
+      // create a tree that mixes params from two different URLs, so deopt to a
+      // server-resolved route tree instead.
+      if (!isInactive) {
+        return null
+      }
+      // Inactive parallel routes intentionally retain their previous state.
       partialVaryPath = parentPartialVaryPath
     }
   } else {
@@ -1060,16 +1073,18 @@ function reifyRouteTree(
   if (patternSlots !== null) {
     newSlots = new Map()
     for (const [key, childPattern] of patternSlots) {
-      newSlots.set(
-        key,
-        reifyRouteTree(
-          childPattern,
-          resolvedParams,
-          search,
-          partialVaryPath,
-          acc
-        )
+      const childTree = reifyRouteTree(
+        childPattern,
+        resolvedParams,
+        search,
+        partialVaryPath,
+        isInactive,
+        acc
       )
+      if (childTree === null) {
+        return null
+      }
+      newSlots.set(key, childTree)
     }
   }
 

--- a/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/@header/[...all]/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/@header/[...all]/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+
+async function Header({ params }: { params: Promise<{ all: string[] }> }) {
+  const { all } = await params
+  return <header id="header-slot">Header {all.join('/')}</header>
+}
+
+export default function HeaderPage({
+  params,
+}: {
+  params: Promise<{ all: string[] }>
+}) {
+  return (
+    <Suspense fallback={null}>
+      <Header params={params} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/@header/default.tsx
+++ b/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/@header/default.tsx
@@ -1,0 +1,3 @@
+export default function HeaderDefault() {
+  return null
+}

--- a/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/@secondary/[...all]/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/@secondary/[...all]/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+
+async function Secondary({ params }: { params: Promise<{ all: string[] }> }) {
+  const { all } = await params
+  return <aside id="secondary-slot">Secondary {all.join('/')}</aside>
+}
+
+export default function SecondaryPage({
+  params,
+}: {
+  params: Promise<{ all: string[] }>
+}) {
+  return (
+    <Suspense fallback={null}>
+      <Secondary params={params} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/@secondary/default.tsx
+++ b/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/@secondary/default.tsx
@@ -1,0 +1,3 @@
+export default function SecondaryDefault() {
+  return null
+}

--- a/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/dashboard/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/dashboard/page.tsx
@@ -1,0 +1,19 @@
+import { LinkAccordion } from '../../components/link-accordion'
+
+export default function DashboardPage() {
+  const projectIds = ['alpha', 'beta', 'gamma', 'delta', 'epsilon']
+
+  return (
+    <main>
+      <h1 id="dashboard-heading">Dashboard</h1>
+      {projectIds.map((id) => (
+        <section key={id}>
+          <LinkAccordion href={`/projects/${id}`} prefetch={true}>
+            Project {id}
+          </LinkAccordion>
+          <LinkAccordion href={`/projects/${id}/edit`}>Edit {id}</LinkAccordion>
+        </section>
+      ))}
+    </main>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/layout.tsx
+++ b/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/layout.tsx
@@ -1,0 +1,19 @@
+export default function RootLayout({
+  children,
+  header,
+  secondary,
+}: {
+  children: React.ReactNode
+  header: React.ReactNode
+  secondary: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>
+        {header}
+        {secondary}
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/page.tsx
@@ -1,0 +1,5 @@
+import Link from 'next/link'
+
+export default function HomePage() {
+  return <Link href="/dashboard">Dashboard</Link>
+}

--- a/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/projects/[projectId]/edit/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/projects/[projectId]/edit/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react'
+
+async function EditProject({
+  params,
+}: {
+  params: Promise<{ projectId: string }>
+}) {
+  const { projectId } = await params
+  return <h1 id="edit-heading">Edit project {projectId}</h1>
+}
+
+export default function EditProjectPage({
+  params,
+}: {
+  params: Promise<{ projectId: string }>
+}) {
+  return (
+    <Suspense fallback={null}>
+      <EditProject params={params} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/projects/[projectId]/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/app/projects/[projectId]/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+
+async function Project({ params }: { params: Promise<{ projectId: string }> }) {
+  const { projectId } = await params
+  return <h1 id="project-heading">Project {projectId}</h1>
+}
+
+export default function ProjectPage({
+  params,
+}: {
+  params: Promise<{ projectId: string }>
+}) {
+  return (
+    <Suspense fallback={null}>
+      <Project params={params} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/components/link-accordion.tsx
+++ b/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: LinkProps['href']
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/next.config.js
+++ b/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true,
+  experimental: {
+    optimisticRouting: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/optimistic-routing-parallel-catchall-prefetch-loop.test.ts
+++ b/test/e2e/app-dir/optimistic-routing-parallel-catchall-prefetch-loop/optimistic-routing-parallel-catchall-prefetch-loop.test.ts
@@ -1,0 +1,88 @@
+import { nextTestSetup } from 'e2e-utils'
+import { createRouterAct } from 'router-act'
+import type { Page, Request } from 'playwright'
+
+describe('optimistic-routing-parallel-catchall-prefetch-loop', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    // Known Routes prediction is only used in production builds.
+    test('skipped in dev mode', () => {})
+    return
+  }
+
+  const MAX_RSC_REQUESTS_PER_PATH = 25
+
+  it('does not reuse stale params from active parallel catch-all slots', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const rscRequestCounts = new Map<string, number>()
+    let excessRequests: string | null = null
+    let rejectOnExcess!: (error: Error) => void
+    const excessDetected = new Promise<never>((_, reject) => {
+      rejectOnExcess = reject
+    })
+    excessDetected.catch(() => {})
+
+    async function actExpectingToSettle<T>(
+      scope: () => Promise<T> | T,
+      config?: Parameters<typeof act>[1]
+    ): Promise<unknown> {
+      const actPromise = act(scope, config)
+      actPromise.catch(() => {})
+      return Promise.race([actPromise, excessDetected])
+    }
+
+    const browser = await next.browser('/dashboard', {
+      beforePageLoad(page: Page) {
+        act = createRouterAct(page)
+        page.on('request', (request: Request) => {
+          if (request.headers().rsc === undefined) {
+            return
+          }
+          const pathname = new URL(request.url()).pathname
+          const count = (rscRequestCounts.get(pathname) ?? 0) + 1
+          rscRequestCounts.set(pathname, count)
+          if (count > MAX_RSC_REQUESTS_PER_PATH && excessRequests === null) {
+            excessRequests =
+              `Observed more than ${MAX_RSC_REQUESTS_PER_PATH} RSC requests ` +
+              `for ${pathname}`
+            rejectOnExcess(
+              new Error(`Prefetch livelock detected: ${excessRequests}`)
+            )
+          }
+        })
+      },
+    })
+
+    expect(await browser.elementById('dashboard-heading').text()).toBe(
+      'Dashboard'
+    )
+
+    await actExpectingToSettle(async () => {
+      for (const id of ['alpha', 'beta', 'gamma', 'delta', 'epsilon']) {
+        for (const href of [`/projects/${id}`, `/projects/${id}/edit`]) {
+          await browser
+            .elementByCss(`input[data-link-accordion="${href}"]`)
+            .click()
+        }
+      }
+    })
+    expect(excessRequests).toBeNull()
+
+    await actExpectingToSettle(async () => {
+      await browser.elementByCss('a[href="/projects/beta/edit"]').click()
+    })
+    expect(await browser.elementById('edit-heading').text()).toBe(
+      'Edit project beta'
+    )
+    expect(await browser.elementById('header-slot').text()).toBe(
+      'Header projects/beta/edit'
+    )
+    expect(await browser.elementById('secondary-slot').text()).toBe(
+      'Secondary projects/beta/edit'
+    )
+    expect(excessRequests).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #98021. This is a follow-up to #97128, which addressed #97135. When an active parallel branch contains a dynamic parameter that is absent from `resolvedParams`, the client cannot safely predict the route tree and must fall back to the server-issued route tree. Previously, an unresolved param retained its value from the older pattern and produced a tree that mixed parameters from different URLs. `reifyRouteTree` now returns null in this case. `matchKnownRoute` then falls back to server route discovery. Inactive parallel routes marked by `refreshState` keep their prior state because that state is intentional. This also avoids unnecessary server requests.

Important technical facts:

- Known Routes matching resolves parameters only along the matched trie branch.
- Stored route patterns contain the entire route tree, including active parallel slots.
- An unresolved parameter in an active slot previously retained its value from the older pattern, producing a tree that mixed parameters from different URLs.
- `reifyRouteTree` now returns null in this case, falling back to server route discovery.
- Inactive parallel routes identified by `refreshState` continue preserving their prior state.

Impact evidence:

- Affected production route shape: the same seven-second browser measurement across ten target URLs produced 6,239 RSC requests before the fix and 17 afterward—a 99.7% reduction.
- Exact #98021 reproduction:
  - Unmodified canary: 5/5 broken scroll resets and two router requests per navigation.
  - Patched canary: 0/5 broken scroll resets and one router request per navigation.

Verification:

- The new regression fails on unmodified canary after one pathname exceeds the 25-request fail-fast limit.
- The regression passes in production with Turbopack and webpack.
- Existing #97135 and parallel-slot catch-all regressions pass with both bundlers.
- The `next` package type declarations, ESLint, Prettier, and `git diff --check` pass.

<!-- NEXT_JS_LLM -->

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
