### PR TITLE
Fix Turbopack Emotion hydration mismatch with SWC plugins

### DIFF
--- a/test/development/turbopack-emotion-swc-plugin-hydration/next.config.js
+++ b/test/development/turbopack-emotion-swc-plugin-hydration/next.config.js
@@ -1,0 +1,15 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  output: 'standalone',
+  compiler: {
+    emotion: true,
+  },
+  experimental: {
+    swcPlugins: [
+      [
+        '@swc/plugin-react-remove-properties',
+        { properties: ['^data-custom-attribute$'] },
+      ],
+    ],
+  },
+}

--- a/test/development/turbopack-emotion-swc-plugin-hydration/pages/index.tsx
+++ b/test/development/turbopack-emotion-swc-plugin-hydration/pages/index.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled'
+import { useEffect } from 'react'
+
+const StyledButton = styled.button`
+  color: hotpink;
+`
+
+export default function Page({ message }: { message: string }) {
+  useEffect(() => {
+    document
+      .getElementById('styled-button')
+      ?.setAttribute('data-client-target', StyledButton.toString())
+  }, [])
+
+  return (
+    <StyledButton
+      id="styled-button"
+      data-custom-attribute="removed-by-swc-plugin"
+      data-server-target={StyledButton.toString()}
+    >
+      {message}
+    </StyledButton>
+  )
+}
+
+export function getServerSideProps() {
+  return { props: { message: 'rendered with SSR' } }
+}

--- a/test/development/turbopack-emotion-swc-plugin-hydration/turbopack-emotion-swc-plugin-hydration.test.ts
+++ b/test/development/turbopack-emotion-swc-plugin-hydration/turbopack-emotion-swc-plugin-hydration.test.ts
@@ -1,0 +1,30 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('Turbopack Emotion transform with SWC plugins', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    dependencies: {
+      '@emotion/react': '11.14.0',
+      '@emotion/styled': '11.14.1',
+      '@swc/plugin-react-remove-properties': '11.1.0',
+    },
+  })
+
+  it('uses the same Emotion target class during SSR and hydration', async () => {
+    const $ = await next.render$('/')
+    const serverTarget = $('#styled-button').attr('data-server-target')
+    expect(serverTarget).toBeTruthy()
+
+    const browser = await next.browser('/')
+    const button = browser.elementByCss('#styled-button')
+    const clientTarget = await retry(async () => {
+      const target = await button.getAttribute('data-client-target')
+      expect(target).toBeTruthy()
+      return target
+    })
+
+    expect(await button.getAttribute('data-custom-attribute')).toBeNull()
+    expect(clientTarget).toBe(serverTarget)
+  })
+})

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
@@ -1,14 +1,11 @@
 #![allow(unused)]
-use std::{
-    hash::{Hash, Hasher},
-    path::Path,
-};
+use std::path::Path;
 
 use anyhow::Result;
 use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use indexmap::IndexMap;
-use rustc_hash::{FxBuildHasher, FxHasher};
+use rustc_hash::FxBuildHasher;
 use serde::{Deserialize, Serialize};
 use swc_core::{
     atoms::Atom,
@@ -137,15 +134,10 @@ impl CustomTransformer for EmotionTransformer {
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         #[cfg(feature = "transform_emotion")]
         {
-            let hash = {
-                let mut hasher = FxHasher::default();
-                program.hash(&mut hasher);
-                hasher.finish()
-            };
             program.mutate(swc_emotion::emotion(
                 &self.config,
                 Path::new(ctx.file_name_str),
-                hash as u32,
+                ctx.source_hash as u32,
                 ctx.source_map.clone(),
                 ctx.comments.clone(),
             ));

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -568,6 +568,7 @@ async fn parse_file_content(
                 file_path_str: &fs_path.path,
                 file_name_str: fs_path.file_name(),
                 file_name_hash: file_path_hash,
+                source_hash: fm.src_hash(),
                 query_str: query,
                 file_path: fs_path.clone(),
                 source,

--- a/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -186,6 +186,8 @@ pub struct TransformContext<'a> {
     pub file_path_str: &'a str,
     pub file_name_str: &'a str,
     pub file_name_hash: u128,
+    /// Hash of the original source text, before any transforms are applied.
+    pub source_hash: u128,
     pub query_str: RcStr,
     pub file_path: FileSystemPath,
     pub source: ResolvedVc<Box<dyn Source>>,

--- a/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/turbopack_crates_turbopack-tests_tests_snapshot_1xzb8pohmqk06._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/emotion/emotion/output/turbopack_crates_turbopack-tests_tests_snapshot_1xzb8pohmqk06._.js
@@ -10,7 +10,7 @@ var __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbo
 ;
 ;
 const StyledButton = (0, /*#__PURE__*/ __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$emotion$2f$styled$2f$index$2e$js__$5b$test$5d$__$28$ecmascript$29$__["default"])("button", {
-    target: "egm8rku0"
+    target: "e1yqyh9b0"
 })("background:blue;");
 function ClassNameButton({ children }) {
     return /*#__PURE__*/ (0, __TURBOPACK__imported__module__$5b$project$5d2f$turbopack$2f$crates$2f$turbopack$2d$tests$2f$tests$2f$snapshot$2f$node_modules$2f40$emotion$2f$react$2f$jsx$2d$dev$2d$runtime$2e$js__$5b$test$5d$__$28$ecmascript$29$__["jsxDEV"])("button", {


### PR DESCRIPTION
### What?

This PR fixes an Emotion hydration mismatch in Turbopack when the Emotion compiler and a custom SWC plugin are enabled together.

The main changes are:

- Stop hashing the current, potentially transformed `Program` AST inside the Emotion transform.
- Capture `SourceFile::src_hash()` when the source is initially parsed, before any transforms run, and expose it through `TransformContext::source_hash`.
- Use this stable source hash when generating Emotion component targets.
- Add a Pages Router SSR regression test with the Emotion compiler and a custom SWC plugin enabled.
- Verify that the custom SWC plugin runs and that `StyledButton.toString()` produces the same Emotion target during SSR and client hydration.

The regression fixture also includes `output: 'standalone'` to mirror the configuration in which the issue was originally observed. The mismatch itself occurs in the Turbopack development compilation path and is not caused by standalone output.

### Why?

In the Pages Router Turbopack pipelines, Emotion and custom SWC plugins run in a different order for server and client compilations:

| Compilation target | Transform order             |
| ------------------ | --------------------------- |
| Server             | Emotion → custom SWC plugin |
| Client             | custom SWC plugin → Emotion |

Previously, the Emotion transform calculated its hash from the `Program` AST as it existed when the transform ran.

When a custom SWC plugin modifies the AST—for example, by expanding a Lingui macro—Emotion receives different inputs in the two compilation pipelines:

- On the server, Emotion sees the AST before the custom plugin runs.
- On the client, Emotion sees the AST after the custom plugin runs.
- The two AST hashes differ.
- Emotion generates different `target` values for the same styled component.

This causes the server-rendered HTML and the hydrated client output to contain different Emotion target classes, resulting in a React hydration mismatch. It can also make styles that depend on Emotion target selectors behave inconsistently.

This is not specific to Lingui. Any custom SWC plugin that mutates the AST before Emotion runs in one compilation pipeline can expose the same problem.

### How?

The source hash is now captured immediately after parsing, before any transforms are applied:

```text
original source
      ↓
stable source_hash
      ↓
server transforms ─┐
                   ├─→ same Emotion target
client transforms ─┘
```

Both compilation pipelines start from the same source text, so they now provide the same hash to Emotion regardless of subsequent transform ordering.

The Emotion target still changes when the source text changes, but remains stable when only the ordering of later transforms differs.

This also aligns the Turbopack implementation with the existing non-Turbopack Next.js SWC transform chain, which already passes `file.src_hash()` to the Emotion transform.

The regression test uses `@swc/plugin-react-remove-properties` instead of Lingui to demonstrate that the issue is caused by AST mutation in general rather than by Lingui specifically. It verifies both that the plugin removed the configured JSX property and that the server and client Emotion targets match.

### Tests

The new Turbopack regression test was verified to fail before the fix because the server and client generated different Emotion targets. It passes after the source hash is made independent of transform ordering.

The following checks pass:

- `pnpm build-all`
- `cargo fmt --all --check`
- `cargo check -p turbopack-ecmascript-plugins --features transform_emotion`
- `cargo test -p turbopack-tests --test snapshot emotion -- --nocapture`
- `pnpm test-dev-turbo test/development/turbopack-emotion-swc-plugin-hydration/turbopack-emotion-swc-plugin-hydration.test.ts`
- `pnpm test-dev-webpack test/development/turbopack-emotion-swc-plugin-hydration/turbopack-emotion-swc-plugin-hydration.test.ts`