### PR TITLE
fix(cli): use cross-spawn and handle errors in next upgrade

### DIFF
--- a/packages/next/src/cli/next-upgrade.test.ts
+++ b/packages/next/src/cli/next-upgrade.test.ts
@@ -1,0 +1,119 @@
+import { EventEmitter } from 'events'
+import * as Log from '../build/output/log'
+
+const mockSpawn = jest.fn()
+
+jest.mock('next/dist/compiled/cross-spawn', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockSpawn(...args),
+}))
+
+jest.mock('../build/output/log', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+}))
+
+const { spawnNextUpgrade } =
+  require('./next-upgrade') as typeof import('./next-upgrade')
+
+class MockChildProcess extends EventEmitter {
+  pid = 1234
+}
+
+describe('spawnNextUpgrade', () => {
+  let child: MockChildProcess
+  let initialExitCode: number | undefined
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    child = new MockChildProcess()
+    mockSpawn.mockReturnValue(child)
+    initialExitCode = process.exitCode
+  })
+
+  afterEach(() => {
+    process.exitCode = initialExitCode
+  })
+
+  it('spawns upgrade process with cross-spawn and default options', () => {
+    spawnNextUpgrade(undefined, {
+      revision: 'canary',
+      verbose: false,
+    })
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1)
+    const [command, args, options] = mockSpawn.mock.calls[0]
+
+    expect(command).toBe('npx')
+    expect(args).toEqual([
+      '--yes',
+      '@next/codemod@canary',
+      'upgrade',
+      'canary',
+    ])
+    expect(options).toMatchObject({
+      stdio: 'inherit',
+    })
+  })
+
+  it('passes --verbose flag when verbose option is true', () => {
+    spawnNextUpgrade(undefined, {
+      revision: 'latest',
+      verbose: true,
+    })
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1)
+    const [, args] = mockSpawn.mock.calls[0]
+    expect(args).toContain('--verbose')
+    expect(args).toEqual([
+      '--yes',
+      '@next/codemod@canary',
+      'upgrade',
+      'latest',
+      '--verbose',
+    ])
+  })
+
+  it('passes specific revision to codemod upgrade', () => {
+    spawnNextUpgrade(undefined, {
+      revision: '15.0.0',
+      verbose: false,
+    })
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1)
+    const [, args] = mockSpawn.mock.calls[0]
+    expect(args).toEqual([
+      '--yes',
+      '@next/codemod@canary',
+      'upgrade',
+      '15.0.0',
+    ])
+  })
+
+  it('sets process.exitCode on close event', () => {
+    spawnNextUpgrade(undefined, {
+      revision: 'canary',
+      verbose: false,
+    })
+
+    child.emit('close', 0)
+    expect(process.exitCode).toBe(0)
+
+    child.emit('close', 2)
+    expect(process.exitCode).toBe(2)
+  })
+
+  it('handles child process error event gracefully without throwing', () => {
+    spawnNextUpgrade(undefined, {
+      revision: 'canary',
+      verbose: false,
+    })
+
+    const testError = new Error('spawn npx ENOENT')
+    child.emit('error', testError)
+
+    expect(Log.error).toHaveBeenCalledWith('spawn npx ENOENT')
+    expect(process.exitCode).toBe(1)
+  })
+})

--- a/packages/next/src/cli/next-upgrade.ts
+++ b/packages/next/src/cli/next-upgrade.ts
@@ -1,4 +1,5 @@
-import { spawn } from 'child_process'
+import spawn from 'next/dist/compiled/cross-spawn'
+import * as Log from '../build/output/log'
 import { getProjectDir } from '../lib/get-project-dir'
 import { getNpxCommand } from '../lib/helpers/get-npx-command'
 
@@ -37,5 +38,10 @@ export function spawnNextUpgrade(
 
   upgradeProcess.on('close', (code) => {
     process.exitCode = code ?? 0
+  })
+
+  upgradeProcess.on('error', (err) => {
+    Log.error(err.message || 'Failed to start upgrade process')
+    process.exitCode = 1
   })
 }


### PR DESCRIPTION
### What?

Switches \packages/next/src/cli/next-upgrade.ts\ from native \child_process.spawn\ to \
ext/dist/compiled/cross-spawn\ and adds an \'error'\ event listener to the spawned child process.

Fixes #97980.

### Why?

On Windows, package manager CLI executables (\
px\, \pnpm\, \yarn\) are \.cmd\ / \.ps1\ scripts rather than native PE binaries. Calling \child_process.spawn('npx', ...)\ without \shell: true\ fails immediately with \Error: spawn npx ENOENT\ on Windows.

Furthermore, \spawnNextUpgrade\ previously did not attach an \'error'\ handler to the returned \ChildProcess\, causing any spawn failure to be emitted as an unhandled \'error'\ event and crash the Node.js process with an uncaught exception.

### How?

1. Use \import spawn from 'next/dist/compiled/cross-spawn'\ (matching the pattern used by \
ext test\, \
ext info\, and \unTypeScriptCli\).
2. Register an \upgradeProcess.on('error', ...)\ handler that logs the error via \Log.error\ and sets \process.exitCode = 1\.
3. Add comprehensive unit tests in \packages/next/src/cli/next-upgrade.test.ts\ covering spawn arguments, \--verbose\ flag handling, revision options, exit code propagation, and error event handling.