### PR TITLE
fix: track request phase after response closes

### DIFF
--- a/packages/next/src/server/after/after-context.test.ts
+++ b/packages/next/src/server/after/after-context.test.ts
@@ -47,6 +47,36 @@ describe('AfterContext', () => {
       )
     }
 
+  it('updates the phase of tracked work unit stores when the request closes', () => {
+    const { onClose, triggerOnClose } = createOnClose()
+    const afterContext = new AfterContext({
+      waitUntil: undefined,
+      onClose,
+      onTaskError: undefined,
+    })
+    const workUnitStore = createMockWorkUnitStore()
+
+    afterContext.trackWorkUnitStore(workUnitStore)
+    triggerOnClose()
+
+    expect(workUnitStore.phase).toBe('after')
+  })
+
+  it('updates the phase of work unit stores tracked after the request closes', () => {
+    const { onClose, triggerOnClose } = createOnClose()
+    const afterContext = new AfterContext({
+      waitUntil: undefined,
+      onClose,
+      onTaskError: undefined,
+    })
+    const workUnitStore = createMockWorkUnitStore()
+
+    triggerOnClose()
+    afterContext.trackWorkUnitStore(workUnitStore)
+
+    expect(workUnitStore.phase).toBe('after')
+  })
+
   it('runs after() callbacks from a run() callback that resolves', async () => {
     const waitUntilPromises: Promise<unknown>[] = []
     const waitUntil = jest.fn((promise) => waitUntilPromises.push(promise))

--- a/packages/next/src/server/after/after-context.ts
+++ b/packages/next/src/server/after/after-context.ts
@@ -40,8 +40,6 @@ export class AfterContext {
       onClose(() => {
         this.isRequestClosed = true
 
-        // TODO(after): it's not ideal that we'll only switch the `phase` of a WorkUnitStore
-        // if `after()` was called inside it. We should probably track this whenever a store is created
         for (const workUnitStore of this.workUnitStores) {
           workUnitStore.phase = 'after'
         }
@@ -49,6 +47,14 @@ export class AfterContext {
     } catch (err) {
       // If onClose is broken, report errors lazily, when after() is called.
       this.initialOnCloseError = { error: err }
+    }
+  }
+
+  public trackWorkUnitStore(workUnitStore: WorkUnitStore): void {
+    this.workUnitStores.add(workUnitStore)
+
+    if (this.isRequestClosed) {
+      workUnitStore.phase = 'after'
     }
   }
 
@@ -60,8 +66,7 @@ export class AfterContext {
       )
     }
 
-    // Save the workUnitStore so we can switch its phase later.
-    this.workUnitStores.add(workUnitStore)
+    this.trackWorkUnitStore(workUnitStore)
 
     if (isThenable(task)) {
       this.addThenable(task)

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3009,21 +3009,24 @@ async function renderAppPage(
   const fallbackParams = getRequestMeta(req, 'fallbackParams') || null
   const hmrRefreshHash = getRequestMeta(req, 'hmrRefreshHash')
 
-  const createRequestStore = createRequestStoreForRender.bind(
-    null,
-    req,
-    res,
-    url,
-    rootParams,
-    implicitTags,
-    renderOpts.onUpdateCookies,
-    renderOpts.previewProps,
-    isHmrRefresh,
-    serverComponentsHmrCache,
-    renderResumeDataCache,
-    fallbackParams,
-    hmrRefreshHash
-  )
+  const createRequestStore = () => {
+    const requestStore = createRequestStoreForRender(
+      req,
+      res,
+      url,
+      rootParams,
+      implicitTags,
+      renderOpts.onUpdateCookies,
+      renderOpts.previewProps,
+      isHmrRefresh,
+      serverComponentsHmrCache,
+      renderResumeDataCache,
+      fallbackParams,
+      hmrRefreshHash
+    )
+    workStore.afterContext.trackWorkUnitStore(requestStore)
+    return requestStore
+  }
   const requestStore = createRequestStore()
 
   if (

--- a/test/e2e/app-dir/next-after-app/app/nodejs/interrupted/request-api-after-close/page.js
+++ b/test/e2e/app-dir/next-after-app/app/nodejs/interrupted/request-api-after-close/page.js
@@ -1,0 +1,21 @@
+import { Suspense } from 'react'
+import { headers } from 'next/headers'
+import { cliLog } from '../../../../utils/log'
+
+export const dynamic = 'force-dynamic'
+
+export default function Page() {
+  return (
+    <Suspense fallback="Loading...">
+      <RequestApiAfterClose />
+    </Suspense>
+  )
+}
+
+async function RequestApiAfterClose() {
+  cliLog({ source: '[page] /interrupted/request-api-after-close (waiting)' })
+  await new Promise((resolve) => setTimeout(resolve, 1_000))
+
+  const requestHeaders = await headers()
+  return <p>{requestHeaders.get('host')}</p>
+}

--- a/test/e2e/app-dir/next-after-app/index.test.ts
+++ b/test/e2e/app-dir/next-after-app/index.test.ts
@@ -194,6 +194,30 @@ describe.each(runtimes)('after() in %s runtime', (runtimeValue) => {
         })
       })
     })
+    if (runtimeValue === 'nodejs') {
+      it('updates the request phase on disconnect without an after() call', async () => {
+        const abortController = new AbortController()
+        const res = await next.fetch(
+          pathPrefix + '/interrupted/request-api-after-close',
+          { signal: abortController.signal }
+        )
+        expect(res.status).toBe(200)
+
+        await retry(() => {
+          expect(getLogs()).toContainEqual({
+            source: '[page] /interrupted/request-api-after-close (waiting)',
+          })
+        })
+
+        abortController.abort()
+
+        await retry(() => {
+          expect(next.cliOutput.slice(currentCliOutputIndex)).toContain(
+            `Route ${pathPrefix}/interrupted/request-api-after-close used \`headers()\` inside \`after()\` while rendering.`
+          )
+        })
+      })
+    }
   })
 
   it('runs in middleware', async () => {


### PR DESCRIPTION
## **Closes Next.js issue #98067.**

Added AfterContext.trackWorkUnitStore() to track request stores even when after() is never called.

Request stores now switch to the after phase when the response closes.
Stores created after the response has already closed are transitioned immediately.
Added unit tests for both timing cases.
Added an E2E regression reproducing a client disconnect followed by headers().