### PR TITLE
fix: respect pageExtensions in no-html-link-for-pages rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -37,6 +37,38 @@ const cachedGetUrlFromAppDirectory = memoize(getUrlFromAppDirectory)
 
 const url = 'https://nextjs.org/docs/messages/no-html-link-for-pages'
 
+function getPageExtensionsFromNextConfig(rootDirs: string[]): string[] | undefined {
+  const configFiles = [
+    'next.config.js',
+    'next.config.mjs',
+    'next.config.cjs',
+    'next.config.ts',
+    'next.config.mts',
+    'next.config.cts',
+  ]
+  for (const dir of rootDirs) {
+    for (const file of configFiles) {
+      const fullPath = path.join(dir, file)
+      if (!fs.existsSync(fullPath)) continue
+      try {
+        const content = fs.readFileSync(fullPath, 'utf8')
+        const match = content.match(/pageExtensions\s*:\s*\[([^\]]+)\]/)
+        if (match) {
+          const inside = match[1]
+          const exts: string[] = []
+          const re = /['"]([^'"]+)['"]/g
+          let m: RegExpExecArray | null
+          while ((m = re.exec(inside)) !== null) {
+            exts.push(m[1])
+          }
+          if (exts.length > 0) return exts
+        }
+      } catch {}
+    }
+  }
+  return undefined
+}
+
 export default defineRule({
   meta: {
     docs: {
@@ -60,7 +92,39 @@ export default defineRule({
               type: 'string',
             },
           },
+          {
+            type: 'object',
+            properties: {
+              pageExtensions: {
+                type: 'array',
+                items: { type: 'string' },
+                uniqueItems: true,
+              },
+              pagesDir: {
+                oneOf: [
+                  { type: 'string' },
+                  {
+                    type: 'array',
+                    uniqueItems: true,
+                    items: { type: 'string' },
+                  },
+                ],
+              },
+            },
+            additionalProperties: false,
+          },
         ],
+      },
+      {
+        type: 'object',
+        properties: {
+          pageExtensions: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
       },
     ],
   },
@@ -69,10 +133,61 @@ export default defineRule({
    * Creates an ESLint rule listener.
    */
   create(context) {
-    const ruleOptions: (string | string[])[] = context.options
-    const [customPagesDirectory] = ruleOptions
+    let customPagesDirectory: string | string[] | undefined
+    let pageExtensions: string[] | undefined
+
+    const firstOpt: any = context.options[0]
+    const secondOpt: any = context.options[1]
+
+    if (
+      firstOpt &&
+      typeof firstOpt === 'object' &&
+      !Array.isArray(firstOpt)
+    ) {
+      if (firstOpt.pagesDir) customPagesDirectory = firstOpt.pagesDir
+      if (Array.isArray(firstOpt.pageExtensions))
+        pageExtensions = firstOpt.pageExtensions
+    } else if (typeof firstOpt === 'string' || Array.isArray(firstOpt)) {
+      customPagesDirectory = firstOpt
+      if (secondOpt) {
+        if (
+          Array.isArray(secondOpt) &&
+          secondOpt.every((v: any) => typeof v === 'string')
+        ) {
+          pageExtensions = secondOpt
+        } else if (
+          secondOpt &&
+          typeof secondOpt === 'object' &&
+          Array.isArray(secondOpt.pageExtensions)
+        ) {
+          pageExtensions = secondOpt.pageExtensions
+          if (!customPagesDirectory && secondOpt.pagesDir)
+            customPagesDirectory = secondOpt.pagesDir
+        }
+      }
+    } else if (
+      secondOpt &&
+      typeof secondOpt === 'object' &&
+      Array.isArray(secondOpt.pageExtensions)
+    ) {
+      pageExtensions = secondOpt.pageExtensions
+    }
+
+    // check settings.next.pageExtensions
+    if (!pageExtensions) {
+      const nextSettings: any = (context.settings as any).next || {}
+      if (Array.isArray(nextSettings.pageExtensions)) {
+        pageExtensions = nextSettings.pageExtensions
+      }
+    }
 
     const rootDirs = getRootDirs(context)
+
+    if (!pageExtensions) {
+      pageExtensions = getPageExtensionsFromNextConfig(rootDirs)
+    }
+
+    pageExtensions = pageExtensions || ['tsx', 'ts', 'jsx', 'js']
 
     const pagesDirs = (
       customPagesDirectory
@@ -107,8 +222,16 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,28 +5,60 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
+function escapeStringRegexp(str: string) {
+  return str.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d')
+}
+
+function getPageExtensionsRegex(pageExtensions: string[]) {
+  const sorted = [...pageExtensions].sort((a, b) => b.length - a.length)
+  const escaped = sorted.map((ext) => escapeStringRegexp(ext))
+  return new RegExp(`\\.(${escaped.join('|')})$`)
+}
+
+function getIndexRegex(pageExtensions: string[]) {
+  const sorted = [...pageExtensions].sort((a, b) => b.length - a.length)
+  const escaped = sorted.map((ext) => escapeStringRegexp(ext))
+  return new RegExp(`^index\\.(${escaped.join('|')})$`)
+}
+
+function getPageRegex(pageExtensions: string[]) {
+  const sorted = [...pageExtensions].sort((a, b) => b.length - a.length)
+  const escaped = sorted.map((ext) => escapeStringRegexp(ext))
+  return new RegExp(`^page\\.(${escaped.join('|')})$`)
+}
+
+function getLayoutRegex(pageExtensions: string[]) {
+  const sorted = [...pageExtensions].sort((a, b) => b.length - a.length)
+  const escaped = sorted.map((ext) => escapeStringRegexp(ext))
+  return new RegExp(`^layout\\.(${escaped.join('|')})$`)
+}
+
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = ['tsx', 'ts', 'jsx', 'js']
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extRegex = getPageExtensionsRegex(pageExtensions)
+  const indexRegex = getIndexRegex(pageExtensions)
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    if (extRegex.test(dirent.name)) {
+      if (indexRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(indexRegex, '')}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions)
+        )
       }
     }
   })
@@ -36,24 +68,32 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = ['tsx', 'ts', 'jsx', 'js']
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
+  const extRegex = getPageExtensionsRegex(pageExtensions)
+  const pageRegex = getPageRegex(pageExtensions)
+  const layoutRegex = getLayoutRegex(pageExtensions)
+  const indexRegex = getIndexRegex(pageExtensions)
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extRegex.test(dirent.name)) {
+      if (pageRegex.test(dirent.name) || indexRegex.test(dirent.name)) {
+        res.push(`${urlprefix}`)
+      } else if (!layoutRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
-      if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+      if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
+        res.push(
+          ...parseUrlForAppDir(urlprefix + dirent.name + '/', dirPath, pageExtensions)
+        )
       }
     }
   })
@@ -136,13 +176,14 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = ['tsx', 'ts', 'jsx', 'js']
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) => parseUrlForPages(urlPrefix, directory, pageExtensions))
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,17 +197,18 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = ['tsx', 'ts', 'jsx', 'js']
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) => parseUrlForAppDir(urlPrefix, directory, pageExtensions))
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
-          (url) => `^${normalizeAppPath(url)}$`
+          (url) => `^${normalizeURL(normalizeAppPath(url))}$`
         )
     )
   ).map((urlReg) => {


### PR DESCRIPTION
Fixes #53473

The @next/next/no-html-link-for-pages rule only handled .js/.jsx/.ts/.tsx and ignored custom pageExtensions (e.g. pageExtensions: [page.tsx] or mdx). With custom extensions, files like bout.page.tsx were not recognized as pages, so <a href=/about> was not flagged.

Changes:
- packages/eslint-plugin-next/src/utils/url.ts: make parseUrlForPages/parseUrlForAppDir accept pageExtensions, handle dotted extensions (sorted longest-first), correctly strip extensions and handle index/page files, fix recursive call in parseUrlForAppDir to recurse into itself, and normalize app URLs with trailing slash.
- packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts: resolve pageExtensions from rule options ({pageExtensions} or second arg), settings.next.pageExtensions, or by parsing 
ext.config.* in project roots, with fallback to default [tsx,ts,jsx,js]; pass extensions to URL helpers and update schema.

Verified via existing tests scenario and reproduction with pageExtensions: [page.tsx] where <a href=/about> is now correctly flagged.