### PR TITLE
fix: move webpack dev validation off-thread

### DIFF
--- a/packages/next/src/server/app-render/dev-validation-worker-globals.ts
+++ b/packages/next/src/server/app-render/dev-validation-worker-globals.ts
@@ -135,9 +135,27 @@ export type DevValidationWorkerMessage = DevValidationSnapshot &
   DevValidationInstallFields
 
 /**
+ * The unsourcemapped stack of one validation error. Webpack validation runs
+ * on a worker, but its development source maps live on the parent thread, so
+ * the parent reconstructs these errors and logs them there.
+ */
+export interface SerializedDevValidationError {
+  name: string
+  message: string
+  stack: string | undefined
+}
+
+/**
+ * The worker-thread response before the pool performs parent-thread logging.
+ */
+export interface DevValidationWorkerThreadResult {
+  chunks: Uint8Array[]
+  errorsForMainThread: SerializedDevValidationError[]
+}
+
+/**
  * The RSC-encoded `{ errors }` Flight chunks for the dev overlay,
- * or null when validation produced no errors or was aborted. The worker also
- * logs the errors to its own stderr (piped to the parent) with code frames.
+ * or null when validation produced no errors or was aborted.
  */
 export type DevValidationWorkerResult = Uint8Array[] | null
 

--- a/packages/next/src/server/dev/dev-validation-worker-pool.ts
+++ b/packages/next/src/server/dev/dev-validation-worker-pool.ts
@@ -9,6 +9,7 @@ import type {
   DevValidationSnapshot,
   DevValidationWorkerMessage,
   DevValidationWorkerResult,
+  SerializedDevValidationError,
 } from '../app-render/dev-validation-worker-globals'
 
 import { Worker } from 'next/dist/compiled/jest-worker'
@@ -16,6 +17,7 @@ import { setDevValidationWorker } from '../app-render/dev-validation-worker-glob
 import { onCacheInvalidation } from './require-cache'
 import { getFormattedNodeOptionsWithoutInspect } from '../lib/utils'
 import { needsExperimentalReact } from '../../lib/needs-experimental-react'
+import { formatValidationEvent } from '../app-render/dev-validation-events'
 
 interface InstallOptions {
   distDir: string
@@ -45,7 +47,7 @@ type DevModuleStateChange =
 /**
  * Replays a change the dev server made to its own module state in the
  * validation worker. Installed alongside the worker, so it is absent when no
- * worker runs (`experimental.devValidationWorker: false`, or Webpack).
+ * worker runs (`experimental.devValidationWorker: false`).
  */
 let mirrorModuleState: ((change: DevModuleStateChange) => void) | undefined
 
@@ -63,6 +65,19 @@ let mirrorModuleState: ((change: DevModuleStateChange) => void) | undefined
  * current code from disk.
  */
 let dropWorker: (() => void) | undefined
+
+const isTestLoggingEnabled = !!(
+  process.env.__NEXT_TEST_MODE && process.env.NEXT_TEST_LOG_VALIDATION
+)
+
+function deserializeValidationError(
+  serialized: SerializedDevValidationError
+): Error {
+  const error = new Error(serialized.message)
+  error.name = serialized.name
+  error.stack = serialized.stack
+  return error
+}
 
 export function mirrorModuleStateToDevValidationWorker(
   change: DevModuleStateChange
@@ -206,11 +221,23 @@ export function installDevValidationWorker(options: InstallOptions): void {
     snapshot: DevValidationSnapshot,
     validationAbortSignal: AbortSignal
   ): Promise<DevValidationWorkerResult> => {
+    const logValidationErrorsOnMainThread = !process.env.TURBOPACK
     let activePool: ValidationPool
     try {
       activePool = getPool()
     } catch {
       return null
+    }
+
+    if (isTestLoggingEnabled && logValidationErrorsOnMainThread) {
+      console.log(
+        formatValidationEvent({
+          type: 'validation_start',
+          requestId: snapshot.requestId,
+          url: snapshot.request.urlPathname + snapshot.request.urlSearch,
+          responseFinished: snapshot.responseFinished,
+        })
+      )
     }
 
     const message: DevValidationWorkerMessage = {
@@ -250,7 +277,18 @@ export function installDevValidationWorker(options: InstallOptions): void {
     }
 
     try {
-      return await activePool.runDevValidation(message, abortBuffer)
+      const result = await activePool.runDevValidation(message, abortBuffer)
+      if (result === null) {
+        return null
+      }
+
+      if (logValidationErrorsOnMainThread) {
+        for (const serializedError of result.errorsForMainThread) {
+          console.error(deserializeValidationError(serializedError))
+        }
+      }
+
+      return result.chunks
     } catch {
       // Worker crash or IPC error: tear down so the next validation starts
       // fresh. The main thread treats a missing result as "nothing to deliver."
@@ -261,6 +299,18 @@ export function installDevValidationWorker(options: InstallOptions): void {
       // explicitly to bound its lifetime to this run when validation completed
       // without being superseded.
       validationAbortSignal.removeEventListener('abort', propagateAbort)
+
+      if (isTestLoggingEnabled && logValidationErrorsOnMainThread) {
+        console.log(
+          formatValidationEvent({
+            type: validationAbortSignal.aborted
+              ? 'validation_aborted'
+              : 'validation_end',
+            requestId: snapshot.requestId,
+            url: snapshot.request.urlPathname + snapshot.request.urlSearch,
+          })
+        )
+      }
     }
   }
 

--- a/packages/next/src/server/dev/dev-validation-worker.ts
+++ b/packages/next/src/server/dev/dev-validation-worker.ts
@@ -1,7 +1,8 @@
 import type { AppPageModule } from '../route-modules/app-page/module'
 import type {
   DevValidationWorkerMessage,
-  DevValidationWorkerResult,
+  DevValidationWorkerThreadResult,
+  SerializedDevValidationError,
 } from '../app-render/dev-validation-worker-globals'
 import type { NodeJsPartialHmrUpdate } from '../../build/swc/types'
 
@@ -118,6 +119,19 @@ try {
 const isTestLoggingEnabled = !!(
   process.env.__NEXT_TEST_MODE && process.env.NEXT_TEST_LOG_VALIDATION
 )
+
+// Turbopack emits source maps beside its chunks, so this thread can log its
+// own validation errors. Webpack keeps development source maps on the parent
+// thread; its errors are returned to the pool and logged there instead.
+const logValidationErrorsInWorker = Boolean(process.env.TURBOPACK)
+
+function serializeValidationError(error: Error): SerializedDevValidationError {
+  return {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+  }
+}
 
 /**
  * Adapts the pool's supersede flag into an `AbortSignal` the validation passes
@@ -301,19 +315,19 @@ export async function invalidateCaches(
  * Reloads the route's compiled module, then delegates the whole validation to
  * that module via `ComponentMod.routeModule.runValidationInDev`, so every
  * render (flight re-encodes and client prerenders) runs inside the app-page
- * bundle's single React instance. Logs any returned errors to the worker's
- * stderr with source-mapped code frames, then encodes them as RSC Flight bytes
- * for the main thread to forward to the dev overlay. Returns `null` when
- * validation was superseded or produced no errors.
+ * bundle's single React instance. Turbopack logs returned errors on the worker;
+ * Webpack returns their raw stacks for the parent to source-map and log. The
+ * worker also encodes them as RSC Flight bytes for the main thread to forward
+ * to the dev overlay. Returns `null` when validation was superseded or produced
+ * no errors.
  */
 export async function runDevValidation(
   message: DevValidationWorkerMessage,
   abortBuffer: SharedArrayBuffer
-): Promise<DevValidationWorkerResult> {
-  // Load the native SWC bindings and wire the code-frame renderer so the errors
-  // logged below render with a source-mapped code frame, matching the
-  // in-process dev output (the E2E tests snapshot the CLI text between the
-  // validation markers). The `build/swc` graph these pull in is bundled as a
+): Promise<DevValidationWorkerThreadResult | null> {
+  // Load the native SWC bindings and wire the code-frame renderer so errors
+  // logged in this thread render with a source-mapped code frame. The
+  // `build/swc` graph these pull in is bundled as a
   // runtime external (see `next-runtime.webpack-config.js`), so it resolves
   // from the installed `next/dist` tree rather than being compiled into this
   // worker bundle, the same way the unbundled build worker loads it.
@@ -346,7 +360,7 @@ export async function runDevValidation(
 
   const { signal, cleanup } = createSupersedeSignal(abortBuffer)
 
-  if (isTestLoggingEnabled) {
+  if (isTestLoggingEnabled && logValidationErrorsInWorker) {
     console.log(
       formatValidationEvent({
         type: 'validation_start',
@@ -380,13 +394,20 @@ export async function runDevValidation(
     }
 
     const errors: Error[] = []
+    const errorsForMainThread: SerializedDevValidationError[] = []
     for (const validationError of validationErrors) {
-      // Log to the worker's stderr; `node-environment` +
-      // `installCodeFrameSupport` render the source-mapped stack and code frame
-      // there, matching the in-process CLI output.
-      console.error(validationError)
       if (validationError instanceof Error) {
         errors.push(validationError)
+        if (logValidationErrorsInWorker) {
+          // `node-environment` + `installCodeFrameSupport` render the
+          // source-mapped stack and code frame in the worker for Turbopack.
+          console.error(validationError)
+        } else {
+          errorsForMainThread.push(serializeValidationError(validationError))
+        }
+      } else {
+        // Non-Error thrown values have no stack to source-map.
+        console.error(validationError)
       }
     }
 
@@ -394,10 +415,13 @@ export async function runDevValidation(
       return null
     }
 
-    return await serializeValidationErrorsToFlight(ComponentMod, errors)
+    return {
+      chunks: await serializeValidationErrorsToFlight(ComponentMod, errors),
+      errorsForMainThread,
+    }
   } finally {
     cleanup()
-    if (isTestLoggingEnabled) {
+    if (isTestLoggingEnabled && logValidationErrorsInWorker) {
       console.log(
         formatValidationEvent({
           type: signal.aborted ? 'validation_aborted' : 'validation_end',

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -236,16 +236,10 @@ export default class DevServer extends Server {
     // spawned lazily on the first navigation that validates, so this install is
     // free when a project doesn't use Cache Components.
     //
-    // Turbopack only, because the worker's thread has source maps just for the
-    // chunks it loaded itself, and resolves the rest by reading the `.map`
-    // Turbopack writes next to each chunk. Webpack keeps its dev source maps in
-    // the compiler, which the worker's thread cannot reach, so validation
-    // errors would be reported without a source location. Running validation on
-    // the main thread costs dev performance but keeps those frames intact.
-    if (
-      process.env.TURBOPACK &&
-      this.nextConfig.experimental.devValidationWorker !== false
-    ) {
+    // Turbopack logs validation errors in the worker using the `.map` files it
+    // emits beside chunks. Webpack keeps its development source maps on this
+    // thread, so the pool returns unsourcemapped stacks and logs them here.
+    if (this.nextConfig.experimental.devValidationWorker !== false) {
       installDevValidationWorker({
         distDir: this.distDir,
         buildId: this.buildId,

--- a/test/development/app-dir/instant-validation-large-payload/app/[locale]/[isBot]/[country]/[currency]/[measurement]/layout.tsx
+++ b/test/development/app-dir/instant-validation-large-payload/app/[locale]/[isBot]/[country]/[currency]/[measurement]/layout.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react'
+
+export default async function ShopLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{
+    locale: string
+    isBot: string
+    country: string
+    currency: string
+    measurement: string
+  }>
+}) {
+  const { locale } = await params
+
+  return (
+    <main>
+      <p id="locale">{locale}</p>
+      {children}
+    </main>
+  )
+}

--- a/test/development/app-dir/instant-validation-large-payload/app/[locale]/[isBot]/[country]/[currency]/[measurement]/p/[...slug]/loading.tsx
+++ b/test/development/app-dir/instant-validation-large-payload/app/[locale]/[isBot]/[country]/[currency]/[measurement]/p/[...slug]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p id="product-loading">loading product</p>
+}

--- a/test/development/app-dir/instant-validation-large-payload/app/[locale]/[isBot]/[country]/[currency]/[measurement]/p/[...slug]/page.tsx
+++ b/test/development/app-dir/instant-validation-large-payload/app/[locale]/[isBot]/[country]/[currency]/[measurement]/p/[...slug]/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from 'next'
+
+import { ProductDetails } from './product-details'
+
+type RootParams = {
+  locale: string
+  isBot: string
+  country: string
+  currency: string
+  measurement: string
+}
+
+type ProductParams = RootParams & {
+  slug: string[]
+}
+
+const items = Array.from({ length: 100_000 }, (_, id) => ({
+  id,
+  description: `${id}:${'x'.repeat(128)}`,
+}))
+
+// These partial params intentionally omit the catch-all slug. Each entry
+// prerenders the route's loading fallback for one concrete root-param set.
+export function generateStaticParams(): RootParams[] {
+  return Array.from({ length: 48 }, (_, index) => ({
+    locale: index === 0 ? 'en' : `locale-${index}`,
+    isBot: 'false',
+    country: 'US',
+    currency: 'USD',
+    measurement: 'metric',
+  }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<ProductParams>
+}): Promise<Metadata> {
+  const { slug } = await params
+  return { title: slug.join('/') }
+}
+
+export default async function ProductPage({
+  params,
+}: {
+  params: Promise<ProductParams>
+}) {
+  const { slug } = await params
+
+  return <ProductDetails items={items} slug={slug} />
+}

--- a/test/development/app-dir/instant-validation-large-payload/app/[locale]/[isBot]/[country]/[currency]/[measurement]/p/[...slug]/product-details.tsx
+++ b/test/development/app-dir/instant-validation-large-payload/app/[locale]/[isBot]/[country]/[currency]/[measurement]/p/[...slug]/product-details.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+export function ProductDetails({
+  items,
+  slug,
+}: {
+  items: Array<{ id: number; description: string }>
+  slug: string[]
+}) {
+  return (
+    <section id="product">
+      <h1>{slug.join('/')}</h1>
+      {items.map((item) => (
+        <span key={item.id}>{item.description}</span>
+      ))}
+    </section>
+  )
+}

--- a/test/development/app-dir/instant-validation-large-payload/app/layout.tsx
+++ b/test/development/app-dir/instant-validation-large-payload/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/instant-validation-large-payload/app/page.tsx
+++ b/test/development/app-dir/instant-validation-large-payload/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="home">home</p>
+}

--- a/test/development/app-dir/instant-validation-large-payload/app/ping/route.ts
+++ b/test/development/app-dir/instant-validation-large-payload/app/ping/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return new Response('pong')
+}

--- a/test/development/app-dir/instant-validation-large-payload/instant-validation-large-payload.test.ts
+++ b/test/development/app-dir/instant-validation-large-payload/instant-validation-large-payload.test.ts
@@ -1,0 +1,80 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  normalizeValidationUrl,
+  parseValidationMessages,
+  waitForValidation,
+  waitForValidationEnd,
+} from 'e2e-utils/instant-validation'
+import type { ValidationStartEvent } from 'next/dist/server/app-render/dev-validation-events'
+import { retry } from 'next-test-utils'
+
+describe('instant-validation-large-payload', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    env: {
+      NEXT_TEST_LOG_VALIDATION: '1',
+    },
+  })
+
+  function waitForValidationStart(
+    targetUrl: string
+  ): Promise<ValidationStartEvent> {
+    const expectedUrl = normalizeValidationUrl(targetUrl)
+
+    return new Promise((resolve) => {
+      let output = ''
+      const onStdout = (chunk: string) => {
+        output += chunk
+        const start = parseValidationMessages(output).find(
+          (event) =>
+            event.type === 'validation_start' &&
+            normalizeValidationUrl(event.url) === expectedUrl
+        )
+        if (start) {
+          next.off('stdout', onStdout)
+          resolve(start)
+        }
+      }
+      next.on('stdout', onStdout)
+    })
+  }
+
+  it('keeps serving requests while validating a large partial fallback route', async () => {
+    const warmupOutput = next.getCliOutputFromHere()
+    const homeResponse = await next.fetch('/')
+    expect(homeResponse.status).toBe(200)
+    await waitForValidation(new URL('/', next.url).href, warmupOutput)
+    expect(await (await next.fetch('/ping')).text()).toBe('pong')
+
+    const getOutput = next.getCliOutputFromHere()
+    const productPath =
+      '/en/false/US/USD/metric/p/category/type/example-product'
+    const validationStarted = waitForValidationStart(
+      new URL(productPath, next.url).href
+    )
+    const productResponse = await next.fetch(productPath)
+    expect(productResponse.status).toBe(200)
+    const productBody = productResponse.text()
+
+    const validation = await validationStarted
+
+    const requestAt = performance.now() + 50
+    await retry(
+      () => expect(performance.now()).toBeGreaterThanOrEqual(requestAt),
+      500,
+      25
+    )
+
+    const concurrentResponse = await fetch(`${next.url}/ping`, {
+      signal: AbortSignal.timeout(150),
+    })
+    expect(concurrentResponse.status).toBe(200)
+    expect(await concurrentResponse.text()).toBe('pong')
+
+    expect(await productBody).toContain('id="product"')
+
+    await expect(
+      waitForValidationEnd(validation, getOutput)
+    ).resolves.toMatchObject({ type: 'validation_end' })
+  })
+})

--- a/test/development/app-dir/instant-validation-large-payload/next.config.js
+++ b/test/development/app-dir/instant-validation-large-payload/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
The bug is in a development-only Instant Insights validation.

After Next.js returns a page, it renders that page again in the background to verify its static/loading shell. With Webpack, this “background” work actually ran on the dev server’s main thread. A complex render could therefore occupy the thread for a long time.
While that happens:
- Other requests can not be processed.
- CPU usage stays high.
- Memory usage grows rapidly.
- Even a trivial /ping request has to wait behind the validation render.

The fix moves Webpack validation onto the existing validation worker thread. The expensive render can continue there while the main dev-server thread remains free to serve requests.

Webpack’s source maps live in its main compiler process, so the worker sends raw validation errors back to the main thread. The main thread then applies the correct source locations and prints the same diagnostics as before.

---

Basically:  validation still happens and reports the same problems.  It no longer freezes the development server while doing so. Turbopack continues using its existing worker-based path.