### PR TITLE
Default GoogleTagManager script URL to gtag/js

### DIFF
--- a/docs/01-app/02-guides/third-party-libraries.mdx
+++ b/docs/01-app/02-guides/third-party-libraries.mdx
@@ -189,7 +189,7 @@ docs](https://developers.google.com/tag-platform/tag-manager/datalayer).
 | Name            | Type       | Description                                                              |
 | --------------- | ---------- | ------------------------------------------------------------------------ |
 | `gtmId`         | Required\* | Your GTM container ID. Usually starts with `GTM-`.                       |
-| `gtmScriptUrl`  | Optional\* | GTM script URL. Defaults to `https://www.googletagmanager.com/gtm.js`.   |
+| `gtmScriptUrl`  | Optional\* | GTM script URL. Defaults to `https://www.googletagmanager.com/gtag/js`. |
 | `dataLayer`     | Optional   | Data layer object to instantiate the container with.                     |
 | `dataLayerName` | Optional   | Name of the data layer. Defaults to `dataLayer`.                         |
 | `auth`          | Optional   | Value of authentication parameter (`gtm_auth`) for environment snippets. |

--- a/packages/third-parties/src/google/gtm.tsx
+++ b/packages/third-parties/src/google/gtm.tsx
@@ -21,7 +21,7 @@ export function GoogleTagManager(props: GTMParams) {
   currDataLayerName = dataLayerName
 
   const scriptUrl = new URL(
-    gtmScriptUrl || 'https://www.googletagmanager.com/gtm.js'
+    gtmScriptUrl || 'https://www.googletagmanager.com/gtag/js'
   )
   if (gtmId) {
     scriptUrl.searchParams.set('id', gtmId)

--- a/test/e2e/app-dir/third-parties/basic.test.ts
+++ b/test/e2e/app-dir/third-parties/basic.test.ts
@@ -35,7 +35,7 @@ describe('@next/third-parties basic usage', () => {
     await browser.waitForElementByCss('script#_next-gtm')
     await browser.elementByCss('script#_next-gtm-init')
     await browser.elementByCss(
-      'script[src^="https://www.googletagmanager.com/gtm.js?id=GTM-XYZ"]'
+      'script[src^="https://www.googletagmanager.com/gtag/js?id=GTM-XYZ"]'
     )
 
     const dataLayer = await browser.eval('window.dataLayer')

--- a/test/e2e/third-parties/index.test.ts
+++ b/test/e2e/third-parties/index.test.ts
@@ -39,7 +39,7 @@ describe('@next/third-parties basic usage', () => {
     expect(gtmInlineScript.length).toBe(1)
 
     const gtmScript = await browser.elementsByCss(
-      '[src^="https://www.googletagmanager.com/gtm.js?id=GTM-XYZ"]'
+      '[src^="https://www.googletagmanager.com/gtag/js?id=GTM-XYZ"]'
     )
 
     expect(gtmScript.length).toBe(1)

--- a/test/unit/third-parties-gtm-script-url.test.js
+++ b/test/unit/third-parties-gtm-script-url.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
-import { readFileSync } from 'fs'
-import { join } from 'path'
+const { readFileSync } = require('fs')
+const { join } = require('path')
 
 const gtmSource = readFileSync(
   join(__dirname, '../../packages/third-parties/src/google/gtm.tsx'),

--- a/test/unit/third-parties-gtm-script-url.test.ts
+++ b/test/unit/third-parties-gtm-script-url.test.ts
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const gtmSource = readFileSync(
+  join(__dirname, '../../packages/third-parties/src/google/gtm.tsx'),
+  'utf8'
+)
+
+describe('@next/third-parties GoogleTagManager default script URL', () => {
+  it('defaults gtmScriptUrl to googletagmanager.com/gtag/js', () => {
+    expect(gtmSource).toContain(
+      "gtmScriptUrl || 'https://www.googletagmanager.com/gtag/js'"
+    )
+    expect(gtmSource).not.toContain(
+      "gtmScriptUrl || 'https://www.googletagmanager.com/gtm.js'"
+    )
+  })
+})


### PR DESCRIPTION
## Summary

`GoogleTagManager` in `@next/third-parties` and the third-party libraries docs now default `gtmScriptUrl` to `https://www.googletagmanager.com/gtag/js`. Google is deprecating `https://www.googletagmanager.com/gtm.js` as the default GTM script URL.

Custom or server-side tagging can still pass `gtmScriptUrl` to load `gtm.js` (or any other URL).

Fixes #98017

## Verification

`test/unit/third-parties-gtm-script-url.test.js` locks the default URL. Existing app-dir and pages-dir e2e assertions now expect `gtag/js`.

Proof — same Jest test, old default then new default:

```
FAIL test/unit/third-parties-gtm-script-url.test.js
  @next/third-parties GoogleTagManager default script URL
    ✕ defaults gtmScriptUrl to googletagmanager.com/gtag/js

  Expected substring: "gtmScriptUrl || 'https://www.googletagmanager.com/gtag/js'"
  Received:           "gtmScriptUrl || 'https://www.googletagmanager.com/gtm.js'"
```

```
PASS test/unit/third-parties-gtm-script-url.test.js
  @next/third-parties GoogleTagManager default script URL
    ✓ defaults gtmScriptUrl to googletagmanager.com/gtag/js (1 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
```

- Not run: `pnpm test-dev-turbo test/e2e/app-dir/third-parties/basic.test.ts` (no local Next.js install in this environment)

<!-- NEXT_JS_LLM -->