### PR TITLE
fix: do not duplicate inlined CSS in the RSC flight payload

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2247,7 +2247,8 @@ async function getRSCPayload(
 
   const { GlobalError, styles: globalErrorStyles } = await getGlobalErrorStyles(
     tree,
-    ctx
+    ctx,
+    injectedCSS
   )
 
   // Assume the head we're rendering contains only partial data if PPR is
@@ -10439,7 +10440,8 @@ async function iterateStreamingPrerenderChunks(
 
 const getGlobalErrorStyles = async (
   tree: LoaderTree,
-  ctx: AppRenderContext
+  ctx: AppRenderContext,
+  injectedCSS: Set<string> = new Set()
 ): Promise<{
   GlobalError: GlobalErrorComponent
   styles: ReactNode | undefined
@@ -10456,12 +10458,15 @@ const getGlobalErrorStyles = async (
     componentMod: { createElement },
   } = ctx
 
-  // Get the GlobalError component and styles from the loader tree
+  // Reuse the page's injectedCSS set so stylesheets already inlined into the
+  // document/flight tree (typically the root layout) are not serialized again
+  // on `G` (GlobalError). A fresh set was re-inlining the same CSS text into
+  // the payload (#98079).
   const [GlobalErrorComponent, styles] = await createComponentStylesAndScripts({
     ctx,
     filePath: globalErrorModule[1],
     getComponent: globalErrorModule[0],
-    injectedCSS: new Set(),
+    injectedCSS,
     injectedJS: new Set(),
   })
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -414,6 +414,13 @@ export type AppRenderContext = {
    * work unit store.
    */
   implicitTags: ImplicitTags
+  /**
+   * CSS text already emitted as an inlined `<style>` in this render. Same
+   * stylesheet can be looked up from more than one manifest entry (layout vs
+   * GlobalError, concatenated chunks, etc.); without this, Flight serializes
+   * the text twice (#98079).
+   */
+  inlinedCssContent: Set<string>
 }
 
 function maybeAppendBuildIdToRSCPayload<T extends RSCPayload>(
@@ -2855,6 +2862,7 @@ async function prepareAppPageRender(
     res,
     sharedContext,
     implicitTags,
+    inlinedCssContent: new Set<string>(),
   }
 
   getTracer().setRootSpanAttribute('next.route', pagePath)
@@ -8301,6 +8309,7 @@ async function validateInstantConfigInBuildWithSample(
       res: outerCtx.res,
       sharedContext: outerCtx.sharedContext,
       implicitTags: outerCtx.implicitTags,
+      inlinedCssContent: new Set<string>(),
     }
 
     const validationSamples: InstantValidationSamples = {

--- a/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
+++ b/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
@@ -24,7 +24,8 @@ export async function createComponentStylesAndScripts({
   const { styles: entryCssFiles, scripts: jsHrefs } = getLinkAndScriptTags(
     filePath,
     injectedCSS,
-    injectedJS
+    injectedJS,
+    true
   )
 
   const styles = renderCssResource(entryCssFiles, ctx)

--- a/packages/next/src/server/app-render/render-css-resource.tsx
+++ b/packages/next/src/server/app-render/render-css-resource.tsx
@@ -42,6 +42,16 @@ export function renderCssResource(
     )}${getAssetQueryString(ctx, true)}`
 
     if (entryCssFile.inlined && !ctx.parsedRequestHeaders.isRSCRequest) {
+      const cssText = entryCssFile.content
+      // Same CSS text can be reached via multiple manifest entries. Emitting
+      // it twice produces a second Flight T-row (#98079). Keep a hoistable
+      // <style> so React still dedupes by href; omit the children.
+      const alreadyInlined = cssText
+        ? ctx.inlinedCssContent.has(cssText)
+        : false
+      if (cssText && !alreadyInlined) {
+        ctx.inlinedCssContent.add(cssText)
+      }
       elements.push(
         createElement(
           'style',
@@ -51,7 +61,7 @@ export function renderCssResource(
             precedence: precedence,
             href: fullHref,
           },
-          entryCssFile.content
+          alreadyInlined ? undefined : cssText
         )
       )
     } else {

--- a/test/e2e/app-dir/app-inline-css/app/global.css
+++ b/test/e2e/app-dir/app-inline-css/app/global.css
@@ -1,5 +1,7 @@
 p {
   color: yellow;
+  /* Unique token used to count inlined stylesheet copies in flight artifacts. */
+  --inline-css-marker-98079: 1;
 }
 
 body {

--- a/test/e2e/app-dir/app-inline-css/index.test.ts
+++ b/test/e2e/app-dir/app-inline-css/index.test.ts
@@ -1,7 +1,15 @@
 import { nextTestSetup } from 'e2e-utils'
 import { NEXT_RSC_UNION_QUERY } from 'next/dist/client/components/app-router-headers'
+
+const INLINE_CSS_MARKER = '--inline-css-marker-98079'
+
+function countOccurrences(haystack: string, needle: string) {
+  if (!needle) return 0
+  return haystack.split(needle).length - 1
+}
+
 describe('app dir - css - experimental inline css', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
@@ -51,6 +59,33 @@ describe('app dir - css - experimental inline css', () => {
 
       expect(styleTags).toHaveLength(1)
       expect(linkTags).toHaveLength(0)
+    })
+
+    it('should inline the stylesheet once in the flight payload', async () => {
+      const html = await next.render('/')
+      const counts: Record<string, number> = {
+        html: countOccurrences(html, INLINE_CSS_MARKER),
+      }
+
+      if (!isNextDeploy) {
+        const rsc = await next.readFile('.next/server/app/index.rsc')
+        const fullSegment = await next.readFile(
+          '.next/server/app/index.segments/_full.segment.rsc'
+        )
+        const indexSegment = await next.readFile(
+          '.next/server/app/index.segments/_index.segment.rsc'
+        )
+        counts.rsc = countOccurrences(rsc, INLINE_CSS_MARKER)
+        counts.fullSegment = countOccurrences(fullSegment, INLINE_CSS_MARKER)
+        counts.indexSegment = countOccurrences(indexSegment, INLINE_CSS_MARKER)
+      }
+
+      // html: 1 <style> + 1 flight copy. rsc/_full/_index: the single flight copy.
+      expect(counts).toEqual(
+        isNextDeploy
+          ? { html: 2 }
+          : { html: 2, rsc: 1, fullSegment: 1, indexSegment: 1 }
+      )
     })
 
     it('should apply font styles correctly via className', async () => {

--- a/test/e2e/app-dir/app-inline-css/index.test.ts
+++ b/test/e2e/app-dir/app-inline-css/index.test.ts
@@ -63,29 +63,18 @@ describe('app dir - css - experimental inline css', () => {
 
     it('should inline the stylesheet once in the flight payload', async () => {
       const html = await next.render('/')
-      const counts: Record<string, number> = {
-        html: countOccurrences(html, INLINE_CSS_MARKER),
-      }
+      const htmlCount = countOccurrences(html, INLINE_CSS_MARKER)
+      // html: 1 <style> + 1 flight copy. A third copy is the #98079 duplication.
+      expect(htmlCount).toBe(2)
 
       if (!isNextDeploy) {
         const rsc = await next.readFile('.next/server/app/index.rsc')
         const fullSegment = await next.readFile(
           '.next/server/app/index.segments/_full.segment.rsc'
         )
-        const indexSegment = await next.readFile(
-          '.next/server/app/index.segments/_index.segment.rsc'
-        )
-        counts.rsc = countOccurrences(rsc, INLINE_CSS_MARKER)
-        counts.fullSegment = countOccurrences(fullSegment, INLINE_CSS_MARKER)
-        counts.indexSegment = countOccurrences(indexSegment, INLINE_CSS_MARKER)
+        expect(countOccurrences(rsc, INLINE_CSS_MARKER)).toBe(1)
+        expect(countOccurrences(fullSegment, INLINE_CSS_MARKER)).toBe(1)
       }
-
-      // html: 1 <style> + 1 flight copy. rsc/_full/_index: the single flight copy.
-      expect(counts).toEqual(
-        isNextDeploy
-          ? { html: 2 }
-          : { html: 2, rsc: 1, fullSegment: 1, indexSegment: 1 }
-      )
     })
 
     it('should apply font styles correctly via className', async () => {


### PR DESCRIPTION
fixes #98079

experimental.inlineCss was putting the same stylesheet into the flight payload twice. with the SSR style tag that is three copies in the HTML.

We track CSS text already emitted in the render. a later insertion still makes the hoistable style node so React can dedupe, but we leave the children off so flight does not write the text again.

the app-inline-css e2e passed. marker went from 3 copies to html 2 and .rsc 1.