### PR TITLE
Fix no-JS useActionState hang for client-bound Server Functions

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-flight-loader/action-client-wrapper.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-loader/action-client-wrapper.ts
@@ -4,7 +4,89 @@
 export { callServer } from 'next/dist/client/app-call-server'
 export { findSourceMapURL } from 'next/dist/client/app-find-source-map-url'
 
-// A noop wrapper to let the Flight client create the server reference.
+import type { createServerReference as CreateServerReference } from 'react-server-dom-webpack/client'
+
+// A wrapper around the Flight client's createServerReference.
 // See also: https://github.com/facebook/react/pull/26632
+//
+// Client-side `.bind()` on a Server Function creates a new pending boundPromise
+// on every call. During a no-JS useActionState postback, Fizz's
+// $$IS_SIGNATURE_EQUAL suspends on that promise, retries the render, binds
+// again, and hangs. Compare the bound-arg count against the parent reference
+// instead, which is already resolved for createServerReference imports.
 // eslint-disable-next-line import/no-extraneous-dependencies
-export { createServerReference } from 'react-server-dom-webpack/client'
+import { createServerReference as createServerReferenceImpl } from 'react-server-dom-webpack/client'
+
+type ServerReferenceFn = ((...args: unknown[]) => Promise<unknown>) & {
+  $$FORM_ACTION?: (identifierPrefix: unknown) => unknown
+  $$IS_SIGNATURE_EQUAL?: (
+    referenceId: string,
+    numberOfBoundArgs: number
+  ) => boolean
+}
+
+function wrapServerReference(
+  target: ServerReferenceFn,
+  signatureParent: ServerReferenceFn,
+  extraBoundCount = 0
+): ServerReferenceFn {
+  const wrapper = function (this: unknown, ...args: unknown[]) {
+    return target.apply(this, args)
+  } as ServerReferenceFn
+
+  Object.defineProperties(wrapper, {
+    $$FORM_ACTION: {
+      value:
+        typeof target.$$FORM_ACTION === 'function'
+          ? target.$$FORM_ACTION.bind(target)
+          : undefined,
+    },
+    $$IS_SIGNATURE_EQUAL: {
+      value: function (
+        referenceId: string,
+        numberOfBoundArgs: number
+      ): boolean {
+        const isSignatureEqual = signatureParent.$$IS_SIGNATURE_EQUAL
+        if (typeof isSignatureEqual !== 'function') {
+          return false
+        }
+        return isSignatureEqual.call(
+          signatureParent,
+          referenceId,
+          numberOfBoundArgs - extraBoundCount
+        )
+      },
+    },
+    bind: {
+      value: function (...bindArgs: unknown[]) {
+        const bound = (
+          target.bind as (...args: unknown[]) => ServerReferenceFn
+        )(...bindArgs)
+        return wrapServerReference(
+          bound,
+          wrapper,
+          Math.max(0, bindArgs.length - 1)
+        )
+      },
+    },
+  })
+
+  return wrapper
+}
+
+export const createServerReference: typeof CreateServerReference = function (
+  id,
+  callServer,
+  encodeFormAction,
+  findSourceMapURL,
+  functionName
+) {
+  const action = createServerReferenceImpl(
+    id,
+    callServer,
+    encodeFormAction,
+    findSourceMapURL,
+    functionName
+  ) as ServerReferenceFn
+  return wrapServerReference(action, action)
+}

--- a/test/e2e/app-dir/client-bound-action-state/app/actions.ts
+++ b/test/e2e/app-dir/client-bound-action-state/app/actions.ts
@@ -1,0 +1,15 @@
+'use server'
+
+export type UpdateState = {
+  readonly message: string
+}
+
+export async function updateUser(
+  userId: string,
+  _previousState: UpdateState,
+  formData: FormData
+): Promise<UpdateState> {
+  const message = `Updated ${userId} to ${String(formData.get('name'))}`
+  console.log(`[client-bound-action-state] ${message}`)
+  return { message }
+}

--- a/test/e2e/app-dir/client-bound-action-state/app/bound-form.tsx
+++ b/test/e2e/app-dir/client-bound-action-state/app/bound-form.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useActionState } from 'react'
+import type { UpdateState } from './actions'
+
+const initialState: UpdateState = { message: '' }
+
+export function BoundForm({
+  action,
+}: {
+  action: (
+    previousState: UpdateState,
+    formData: FormData
+  ) => Promise<UpdateState>
+}) {
+  const [state, formAction] = useActionState(action, initialState)
+
+  return (
+    <form action={formAction} id="server-bound-form">
+      <input name="name" defaultValue="Ada" />
+      <button type="submit" id="server-bound-submit">
+        Update server-bound user
+      </button>
+      <output id="server-bound-state">{state.message}</output>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/client-bound-action-state/app/client-bound-form.tsx
+++ b/test/e2e/app-dir/client-bound-action-state/app/client-bound-form.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { useActionState } from 'react'
+import { updateUser, type UpdateState } from './actions'
+
+const initialState: UpdateState = { message: '' }
+
+export function ClientBoundForm({ userId }: { readonly userId: string }) {
+  const updateUserWithId = updateUser.bind(null, userId)
+  const [state, formAction] = useActionState(updateUserWithId, initialState)
+
+  return (
+    <form action={formAction} id="client-bound-form">
+      <input name="name" defaultValue="Ada" />
+      <button type="submit" id="client-bound-submit">
+        Update client-bound user
+      </button>
+      <output id="client-bound-state">{state.message}</output>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/client-bound-action-state/app/layout.tsx
+++ b/test/e2e/app-dir/client-bound-action-state/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/client-bound-action-state/app/page.tsx
+++ b/test/e2e/app-dir/client-bound-action-state/app/page.tsx
@@ -1,0 +1,5 @@
+import { ClientBoundForm } from './client-bound-form'
+
+export default function Page() {
+  return <ClientBoundForm userId="client-user" />
+}

--- a/test/e2e/app-dir/client-bound-action-state/app/server-bind/page.tsx
+++ b/test/e2e/app-dir/client-bound-action-state/app/server-bind/page.tsx
@@ -1,0 +1,7 @@
+import { updateUser } from '../actions'
+import { BoundForm } from '../bound-form'
+
+export default function Page() {
+  const updateUserWithId = updateUser.bind(null, 'server-user')
+  return <BoundForm action={updateUserWithId} />
+}

--- a/test/e2e/app-dir/client-bound-action-state/client-bound-action-state.test.ts
+++ b/test/e2e/app-dir/client-bound-action-state/client-bound-action-state.test.ts
@@ -1,0 +1,57 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('client-bound-action-state', () => {
+  const { next, isNextDeploy } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should return useActionState after a no-JS submit of a client-bound Server Function', async () => {
+    const browser = await next.browser('/', {
+      disableJavaScript: true,
+    })
+    const cliOutputLength = next.cliOutput.length
+
+    await browser.elementById('client-bound-submit').click()
+
+    if (!isNextDeploy) {
+      await retry(() => {
+        expect(next.cliOutput.slice(cliOutputLength)).toContain(
+          '[client-bound-action-state] Updated client-user to Ada'
+        )
+      })
+    }
+
+    await retry(async () => {
+      expect(await browser.elementById('client-bound-state').text()).toBe(
+        'Updated client-user to Ada'
+      )
+    })
+  })
+
+  it('should return useActionState after a no-JS submit of a server-bound Server Function', async () => {
+    const browser = await next.browser('/server-bind', {
+      disableJavaScript: true,
+    })
+
+    await browser.elementById('server-bound-submit').click()
+
+    await retry(async () => {
+      expect(await browser.elementById('server-bound-state').text()).toBe(
+        'Updated server-user to Ada'
+      )
+    })
+  })
+
+  it('should return useActionState after a client-bound submit with JS', async () => {
+    const browser = await next.browser('/')
+
+    await browser.elementById('client-bound-submit').click()
+
+    await retry(async () => {
+      expect(await browser.elementById('client-bound-state').text()).toBe(
+        'Updated client-user to Ada'
+      )
+    })
+  })
+})

--- a/test/e2e/app-dir/client-bound-action-state/next.config.js
+++ b/test/e2e/app-dir/client-bound-action-state/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
fixes #98045

action.bind() in a Client Component is how you pass extra Server Function args. with JS off the function runs but the form never finishes, so useActionState never shows the new state.

React bind() makes a new pending promise every time. useActionState suspends on it, retries, bind() again, and it loops until Map maximum size exceeded.

We wrap createServerReference so bind() still encodes for the form, and signature equal looks at the parent instead of that new promise.

the client-bound-action-state e2e passed on turbo dev and start.