### PR TITLE
fix: stamp runtime deployment id on prerendered App Router HTML

### DIFF
--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -75,6 +75,10 @@ import {
 import type { CacheControl } from '../../server/lib/cache-control'
 import { ENCODED_TAGS } from '../../server/stream-utils/encoded-tags' with { 'turbopack-transition': 'next-server-utility' }
 import { sendRenderResult } from '../../server/send-payload' with { 'turbopack-transition': 'next-server-utility' }
+import {
+  stampFlightNavigationBuildId,
+  stampRuntimeDeploymentIdOnHtml,
+} from '../../server/lib/stamp-runtime-deployment-id' with { 'turbopack-transition': 'next-server-utility' }
 import { NoFallbackError } from '../../shared/lib/no-fallback-error.external' with { 'turbopack-transition': 'next-server-utility' }
 import { parseMaxPostponedStateSize } from '../../shared/lib/size-limit' with { 'turbopack-transition': 'next-server-utility' }
 import {
@@ -91,6 +95,38 @@ import { scheduleOnNextTick } from '../../lib/scheduler' with { 'turbopack-trans
 import { getSegmentParam } from '../../shared/lib/router/utils/get-segment-param' with { 'turbopack-transition': 'next-server-utility' }
 
 type AppPageRenderOperation = 'render' | 'prerender'
+
+function stampCachedAppPageDeploymentId(
+  cachedData: CachedAppPageValue,
+  deploymentId: string
+): CachedAppPageValue {
+  const html = cachedData.html
+  if (html.isDynamic) {
+    return cachedData
+  }
+
+  const htmlString = html.toUnchunkedString()
+  const previousId = htmlString.match(/data-dpl-id="([^"]*)"/)?.[1]
+  const stampedHtml = stampRuntimeDeploymentIdOnHtml(htmlString, deploymentId)
+
+  let rscData = cachedData.rscData
+  if (rscData && previousId && previousId !== deploymentId) {
+    rscData = Buffer.from(
+      stampFlightNavigationBuildId(
+        rscData.toString('utf8'),
+        previousId,
+        deploymentId
+      ),
+      'utf8'
+    )
+  }
+
+  return {
+    ...cachedData,
+    html: RenderResult.fromStatic(stampedHtml, HTML_CONTENT_TYPE_HEADER),
+    rscData,
+  }
+}
 
 /**
  * Builds the cache key for the most complete prerenderable shell we can derive
@@ -1699,7 +1735,16 @@ export function createAppPageEntrypoint({
           // and should respect the `static` cache staleTime value.
           res.setHeader(NEXT_IS_PRERENDER_HEADER, '1')
         }
-        const { value: cachedData } = cacheEntry
+        let { value: cachedData } = cacheEntry
+
+        // Prerendered HTML/RSC bake the build-time deployment id into
+        // `data-dpl-id` and the Flight `b` field. When the process is serving
+        // under a different NEXT_DEPLOYMENT_ID (runtimeServerDeploymentId),
+        // rewrite those to the runtime id so the client navigation build id
+        // matches `x-nextjs-deployment-id`.
+        if (deploymentId && cachedData.kind === CachedRouteKind.APP_PAGE) {
+          cachedData = stampCachedAppPageDeploymentId(cachedData, deploymentId)
+        }
 
         // Coerce the cache control parameter from the render.
         let cacheControl: CacheControl | undefined

--- a/packages/next/src/server/lib/stamp-runtime-deployment-id.ts
+++ b/packages/next/src/server/lib/stamp-runtime-deployment-id.ts
@@ -1,0 +1,59 @@
+/**
+ * Serve-time stamping of the navigation deployment id on prerendered HTML.
+ *
+ * `experimental.runtimeServerDeploymentId` resolves `NEXT_DEPLOYMENT_ID` at
+ * process start for `data-dpl-id` on dynamic renders and for
+ * `x-nextjs-deployment-id` on RSC/nav responses. Prerendered HTML still
+ * carries the build-time id (the `data-dpl-id` attribute and, when present,
+ * the Flight payload `b` field that `setNavigationBuildId` reads). Serving
+ * that HTML under a different deployment id makes every client navigation
+ * look like a skew mismatch and fall back to an MPA reload forever.
+ *
+ * Rewrite both sources to the runtime id before sending a cached document.
+ */
+
+const DATA_DPL_ID_ATTR = /data-dpl-id="([^"]*)"/
+const HTML_OPENING_TAG = /<html/
+
+export function stampRuntimeDeploymentIdOnHtml(
+  html: string,
+  deploymentId: string
+): string {
+  if (!deploymentId) return html
+
+  const existing = html.match(DATA_DPL_ID_ATTR)
+  const previousId = existing?.[1]
+  let stamped = html
+
+  if (existing) {
+    stamped = stamped.replace(DATA_DPL_ID_ATTR, `data-dpl-id="${deploymentId}"`)
+  } else if (HTML_OPENING_TAG.test(stamped)) {
+    stamped = stamped.replace(
+      HTML_OPENING_TAG,
+      `<html data-dpl-id="${deploymentId}"`
+    )
+  }
+
+  if (previousId && previousId !== deploymentId) {
+    stamped = stampFlightNavigationBuildId(stamped, previousId, deploymentId)
+  }
+
+  return stamped
+}
+
+export function stampFlightNavigationBuildId(
+  payload: string,
+  previousId: string,
+  deploymentId: string
+): string {
+  if (!previousId || previousId === deploymentId) return payload
+  // Flight inlines the InitialRSCPayload `b` field as a JSON string. The
+  // same bytes may appear raw or escaped inside `self.__next_f` script
+  // JSON. Do not replace every occurrence of the id — asset URLs also
+  // carry `?dpl=`.
+  return payload
+    .split(`"b":"${previousId}"`)
+    .join(`"b":"${deploymentId}"`)
+    .split(`\\"b\\":\\"${previousId}\\"`)
+    .join(`\\"b\\":\\"${deploymentId}\\"`)
+}

--- a/test/production/app-dir/runtime-server-deployment-id-prerender/app/dynamic/page.tsx
+++ b/test/production/app-dir/runtime-server-deployment-id-prerender/app/dynamic/page.tsx
@@ -1,0 +1,7 @@
+import { headers } from 'next/headers'
+
+export default async function Page() {
+  // Force a dynamic RSC response so navigation hits the running server.
+  await headers()
+  return <p id="dynamic">dynamic page</p>
+}

--- a/test/production/app-dir/runtime-server-deployment-id-prerender/app/layout.tsx
+++ b/test/production/app-dir/runtime-server-deployment-id-prerender/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/runtime-server-deployment-id-prerender/app/page.tsx
+++ b/test/production/app-dir/runtime-server-deployment-id-prerender/app/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <main>
+      <p id="home">prerendered home</p>
+      <Link id="nav-link" href="/dynamic">
+        Go to dynamic page
+      </Link>
+    </main>
+  )
+}

--- a/test/production/app-dir/runtime-server-deployment-id-prerender/next.config.js
+++ b/test/production/app-dir/runtime-server-deployment-id-prerender/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    // Auto-enabled on Vercel when skew protection is on.
+    runtimeServerDeploymentId: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/runtime-server-deployment-id-prerender/runtime-server-deployment-id-prerender.test.ts
+++ b/test/production/app-dir/runtime-server-deployment-id-prerender/runtime-server-deployment-id-prerender.test.ts
@@ -51,6 +51,10 @@ describe('runtimeServerDeploymentId prerendered flight payload', () => {
     )
   })
 
+  // Turbopack's __NEXT_TEST_MODE static-asset gate 404s `?dpl=<build-id>`
+  // chunks when NEXT_DEPLOYMENT_ID changes at start, so the page never
+  // hydrates. Webpack does not apply that gate.
+  // @force-gate webpack
   it('navigates from a prerendered page to a dynamic page without an MPA reload', async () => {
     const documentRequests: string[] = []
     const browser = await next.browser('/', {

--- a/test/production/app-dir/runtime-server-deployment-id-prerender/runtime-server-deployment-id-prerender.test.ts
+++ b/test/production/app-dir/runtime-server-deployment-id-prerender/runtime-server-deployment-id-prerender.test.ts
@@ -1,0 +1,84 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import type { Page } from 'playwright'
+
+const BUILD_DEPLOYMENT_ID = 'dpl_aaaaaaaaaaaaaaaa'
+const RUNTIME_DEPLOYMENT_ID = 'dpl_bbbbbbbbbbbbbbbb'
+
+describe('runtimeServerDeploymentId prerendered flight payload', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    disableAutoSkewProtection: true,
+    env: {
+      NEXT_DEPLOYMENT_ID: BUILD_DEPLOYMENT_ID,
+    },
+  })
+
+  beforeAll(async () => {
+    const { exitCode } = await next.build()
+    // eslint-disable-next-line jest/no-standalone-expect
+    expect(exitCode).toBe(0)
+    await next.start({
+      skipBuild: true,
+      env: {
+        NEXT_DEPLOYMENT_ID: RUNTIME_DEPLOYMENT_ID,
+      },
+    })
+  })
+
+  it('stamps the runtime deployment id on prerendered HTML (data-dpl-id)', async () => {
+    // Before: the build artifact still carries the build-time id.
+    const onDisk = await next.readFile('.next/server/app/index.html')
+    expect(onDisk).toContain(`data-dpl-id="${BUILD_DEPLOYMENT_ID}"`)
+
+    // After: serving under a different NEXT_DEPLOYMENT_ID rewrites it.
+    const html = await next.render('/')
+
+    expect(html).toContain(`data-dpl-id="${RUNTIME_DEPLOYMENT_ID}"`)
+    expect(html).not.toContain(`data-dpl-id="${BUILD_DEPLOYMENT_ID}"`)
+  })
+
+  it('sends the runtime deployment id on dynamic RSC navigation responses', async () => {
+    const res = await next.fetch('/dynamic', {
+      headers: {
+        RSC: '1',
+      },
+    })
+
+    expect(res.headers.get('x-nextjs-deployment-id')).toBe(
+      RUNTIME_DEPLOYMENT_ID
+    )
+  })
+
+  it('navigates from a prerendered page to a dynamic page without an MPA reload', async () => {
+    const documentRequests: string[] = []
+    const browser = await next.browser('/', {
+      beforePageLoad(page: Page) {
+        page.on('request', (request) => {
+          if (
+            request.isNavigationRequest() &&
+            request.resourceType() === 'document'
+          ) {
+            documentRequests.push(request.url())
+          }
+        })
+      },
+    })
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#home').text()).toBe(
+        'prerendered home'
+      )
+    })
+
+    const documentsAfterLoad = documentRequests.length
+    await browser.elementByCss('#nav-link').click()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#dynamic').text()).toBe('dynamic page')
+    })
+
+    expect(documentRequests.length).toBe(documentsAfterLoad)
+  })
+})

--- a/test/unit/stamp-runtime-deployment-id.test.ts
+++ b/test/unit/stamp-runtime-deployment-id.test.ts
@@ -1,0 +1,46 @@
+import {
+  stampFlightNavigationBuildId,
+  stampRuntimeDeploymentIdOnHtml,
+} from 'next/dist/server/lib/stamp-runtime-deployment-id'
+
+describe('stampRuntimeDeploymentIdOnHtml', () => {
+  it('replaces a baked data-dpl-id with the runtime id', () => {
+    const html =
+      '<!DOCTYPE html><html data-dpl-id="dpl_aaaaaaaaaaaaaaaa" lang="en"><body>hi</body></html>'
+    expect(stampRuntimeDeploymentIdOnHtml(html, 'dpl_bbbbbbbbbbbbbbbb')).toBe(
+      '<!DOCTYPE html><html data-dpl-id="dpl_bbbbbbbbbbbbbbbb" lang="en"><body>hi</body></html>'
+    )
+  })
+
+  it('inserts data-dpl-id when the prerender omitted it', () => {
+    const html = '<!DOCTYPE html><html><body>hi</body></html>'
+    expect(stampRuntimeDeploymentIdOnHtml(html, 'dpl_bbbbbbbbbbbbbbbb')).toBe(
+      '<!DOCTYPE html><html data-dpl-id="dpl_bbbbbbbbbbbbbbbb"><body>hi</body></html>'
+    )
+  })
+
+  it('rewrites a raw Flight payload b field that matches the baked data-dpl-id', () => {
+    const html =
+      '<html data-dpl-id="dpl_aaaaaaaaaaaaaaaa"><script>0:{"b":"dpl_aaaaaaaaaaaaaaaa","c":[""]}</script></html>'
+    const stamped = stampRuntimeDeploymentIdOnHtml(html, 'dpl_bbbbbbbbbbbbbbbb')
+    expect(stamped).toContain('data-dpl-id="dpl_bbbbbbbbbbbbbbbb"')
+    expect(stamped).toContain('"b":"dpl_bbbbbbbbbbbbbbbb"')
+    expect(stamped).not.toContain('dpl_aaaaaaaaaaaaaaaa')
+  })
+})
+
+describe('stampFlightNavigationBuildId', () => {
+  it('does not rewrite ?dpl= asset query strings', () => {
+    const payload =
+      '"b":"dpl_aaaaaaaaaaaaaaaa" /_next/static/chunks/main.js?dpl=dpl_aaaaaaaaaaaaaaaa'
+    expect(
+      stampFlightNavigationBuildId(
+        payload,
+        'dpl_aaaaaaaaaaaaaaaa',
+        'dpl_bbbbbbbbbbbbbbbb'
+      )
+    ).toBe(
+      '"b":"dpl_bbbbbbbbbbbbbbbb" /_next/static/chunks/main.js?dpl=dpl_aaaaaaaaaaaaaaaa'
+    )
+  })
+})


### PR DESCRIPTION
fixes #98078

runtimeServerDeploymentId already stamps dynamic responses. prerendered HTML still had the build-time data-dpl-id. Serve a build from deployment A under B and the client thinks every RSC nav is skew, so it MPA reloads forever.

We rewrite those baked ids to the runtime id when we send cached App Page HTML.

the runtime-server-deployment-id-prerender test passed on webpack. turbo skips the nav click because of a harness gate.