### PR TITLE
Fix stalled RSC poisoning BFCache and dropping later clicks

### DIFF
--- a/packages/next/src/client/components/render-tree.ts
+++ b/packages/next/src/client/components/render-tree.ts
@@ -33,7 +33,6 @@ import {
   type FulfilledRouteCacheEntry,
   convertReusedFlightRouterStateToRouteTree,
   readSegmentCacheEntryForNavigation,
-  waitForSegmentCacheEntry,
   markRouteEntryAsDynamicRewrite,
   invalidateRouteCacheEntries,
   spawnStaticStageCacheWrite,
@@ -993,11 +992,22 @@ function createCacheNodeForSegment(
         now,
         tree.varyPath
       )
-      if (bfcacheEntry !== null) {
+      if (
+        bfcacheEntry !== null &&
+        isReusableBFCacheEntryForRegularNavigation(
+          bfcacheEntry.rsc,
+          bfcacheEntry.head
+        )
+      ) {
         // A regular navigation that happens to read cached data is still a
         // fresh navigation, so we use the caller-supplied bfcacheId — the
         // BFCacheEntry's id is only restored on history-traversal
         // navigations.
+        //
+        // Skip entries whose rsc/head never settled. writeToBFCache runs
+        // during tree construction, so a stalled navigation parks a pending
+        // thenable there. Serving it with needsDynamicRequest: false drops
+        // later clicks until staleAt (issue #98066).
         return {
           cacheNode: createCacheNode(
             bfcacheEntry.rsc,
@@ -1123,24 +1133,14 @@ function createCacheNodeForSegment(
         break
       }
       case EntryStatus.Pending: {
-        // We haven't received data for this segment yet, but there's already
-        // an in-progress request. Since it's extremely likely to arrive
-        // before the dynamic data response, we might as well use it.
-        const promiseForFulfilledEntry = waitForSegmentCacheEntry(segmentEntry)
-        cachedRsc = promiseForFulfilledEntry.then((entry) =>
-          entry !== null ? entry.rsc : null
-        )
-        // Because the request is still pending, we typically don't know yet
-        // whether the response will be partial. We shouldn't skip this segment
-        // during the dynamic navigation request. Otherwise, we might need to
-        // do yet another request to fill in the remaining data, creating
-        // a waterfall.
-        //
-        // The one exception is if this segment is being fetched with via
-        // prefetch={true} (i.e. the "force stale" or "full" strategy). If so,
-        // we can assume the response will be full. This field is set to `false`
-        // for such segments.
-        isCachedRscPartial = segmentEntry.isPartial
+        // Do not adopt an in-flight prefetch thenable as prefetchRsc.
+        // layout-router's useDeferredValue renders that thenable first; if
+        // the prefetch never settles, a later dynamic response cannot
+        // commit and the route stays dead (issue #98066). Always treat the
+        // segment as partial so this navigation issues a dynamic request
+        // instead of skipping it (the Pending-Full isPartial:false
+        // convention would otherwise omit the request).
+        isCachedRscPartial = true
         break
       }
       case EntryStatus.Empty:
@@ -1230,10 +1230,10 @@ function createCacheNodeForSegment(
             break
           }
           case EntryStatus.Pending: {
-            cachedHead = waitForSegmentCacheEntry(metadataEntry).then(
-              (entry) => (entry !== null ? entry.rsc : null)
-            )
-            isCachedHeadPartial = metadataEntry.isPartial
+            // Same as the segment Pending case: don't park a never-settling
+            // prefetch thenable on the head, and don't skip the dynamic
+            // request (issue #98066).
+            isCachedHeadPartial = true
             break
           }
           case EntryStatus.Empty:
@@ -2225,6 +2225,31 @@ type DeferredRsc<T extends React.ReactNode = React.ReactNode> =
 // too. We can remove it once type Cache Node type is more settled.
 export function isDeferredRsc(value: any): value is DeferredRsc {
   return value && typeof value === 'object' && value.tag === DEFERRED
+}
+
+function isSettledRenderableRsc(rsc: React.ReactNode | null): boolean {
+  if (rsc == null) {
+    return false
+  }
+  if (isDeferredRsc(rsc)) {
+    return rsc.status === 'fulfilled' && rsc.value != null
+  }
+  // A non-deferred thenable (e.g. a pending prefetch `.then()` wrapper)
+  // has no renderable data until it fulfills.
+  if (typeof (rsc as { then?: unknown }).then === 'function') {
+    return (rsc as { status?: string }).status === 'fulfilled'
+  }
+  return true
+}
+
+function isReusableBFCacheEntryForRegularNavigation(
+  rsc: React.ReactNode | null,
+  head: React.ReactNode | null
+): boolean {
+  return (
+    isSettledRenderableRsc(rsc) &&
+    (head == null || isSettledRenderableRsc(head))
+  )
 }
 
 function createDeferredRsc<

--- a/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/app/other/page.tsx
+++ b/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/app/other/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function OtherPage() {
+  return (
+    <main>
+      <h1 id="other-heading">Other page</h1>
+      <Link href="/">Home</Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/app/other/page.tsx
+++ b/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/app/other/page.tsx
@@ -1,10 +1,10 @@
-import Link from 'next/link'
+import { LinkAccordion } from '../../components/link-accordion'
 
 export default function OtherPage() {
   return (
     <main>
-      <h1 id="other-heading">Other page</h1>
-      <Link href="/">Home</Link>
+      <h1 id="other-heading">Issue 98066 other page</h1>
+      <LinkAccordion href="/stalled-page">Stalled page</LinkAccordion>
     </main>
   )
 }

--- a/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/app/page.tsx
@@ -1,0 +1,17 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Page() {
+  return (
+    <>
+      <h1 id="home-heading">Home</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/stalled-page">Stalled page</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/other">Other page</LinkAccordion>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/app/stalled-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/app/stalled-page/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+import { connection } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export default async function StalledPage() {
+  await connection()
+  return (
+    <main>
+      <h1 id="stalled-page-heading">Stalled page</h1>
+      <Link href="/">Home</Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/app/stalled-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/app/stalled-page/page.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link'
 import { connection } from 'next/server'
+import { LinkAccordion } from '../../components/link-accordion'
 
 export const dynamic = 'force-dynamic'
 
@@ -7,8 +7,8 @@ export default async function StalledPage() {
   await connection()
   return (
     <main>
-      <h1 id="stalled-page-heading">Stalled page</h1>
-      <Link href="/">Home</Link>
+      <h1 id="stalled-page-heading">Issue 98066 stalled page</h1>
+      <LinkAccordion href="/other">Other page</LinkAccordion>
     </main>
   )
 }

--- a/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  prefetch,
+  children,
+}: {
+  href: LinkProps['href']
+  prefetch?: boolean
+  children: React.ReactNode
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/next.config.js
+++ b/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/next.config.js
@@ -1,0 +1,16 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  // Match the production fingerprint in https://github.com/vercel/next.js/issues/98066:
+  // a non-zero staleTimes.dynamic is what makes a stalled RSC navigation
+  // reuse the poisoned BFCache entry and drop later clicks with zero requests.
+  experimental: {
+    staleTimes: {
+      dynamic: 30,
+      static: 180,
+    },
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/poisoned-bfcache-stale-nav.test.ts
+++ b/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/poisoned-bfcache-stale-nav.test.ts
@@ -61,23 +61,43 @@ describe('segment cache (poisoned BFCache / staleTimes.dynamic)', () => {
     })
     expect(await browser.url()).not.toContain('/stalled-page')
 
-    // Network is fully restored. A later click must issue a request and
-    // commit — not reuse the poisoned BFCache entry with
-    // needsDynamicRequest: false (zero requests until staleAt).
+    // Hide the poisoned link so it cannot re-prefetch outside an act scope.
+    await browser
+      .elementByCss('input[data-link-accordion="/stalled-page"]')
+      .click()
+
+    // Network is fully restored. Other routes must keep working, and a later
+    // click to the poisoned route must issue a request and commit — not reuse
+    // the BFCache entry with needsDynamicRequest: false.
     await page.evaluate(() => {
       ;(window as any).__restoreFetch()
     })
 
-    await act(
-      async () => {
-        await browser.elementByCss('a[href="/stalled-page"]').click()
-      },
-      { includes: 'Stalled page' }
+    await act(async () => {
+      await browser.elementByCss('input[data-link-accordion="/other"]').click()
+      const link = await browser.elementByCss('a[href="/other"]')
+      await link.click()
+    })
+    expect(await browser.elementById('other-heading').text()).toBe(
+      'Issue 98066 other page'
     )
 
-    expect(await browser.elementById('stalled-page-heading').text()).toBe(
-      'Stalled page'
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/stalled-page"]')
+          .click()
+        const link = await browser.elementByCss('a[href="/stalled-page"]')
+        await link.click()
+      },
+      { includes: 'Issue 98066 stalled page' }
     )
+
+    await retry(async () => {
+      expect(await browser.elementById('stalled-page-heading').text()).toBe(
+        'Issue 98066 stalled page'
+      )
+    })
     expect(await browser.url()).toContain('/stalled-page')
   })
 })

--- a/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/poisoned-bfcache-stale-nav.test.ts
+++ b/test/e2e/app-dir/segment-cache/poisoned-bfcache-stale-nav/poisoned-bfcache-stale-nav.test.ts
@@ -1,0 +1,83 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('segment cache (poisoned BFCache / staleTimes.dynamic)', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    // Prefetch + BFCache reuse of dynamic data is a production client behavior.
+    it('disabled in development', () => {})
+    return
+  }
+
+  it('does not drop a later click after a stalled RSC navigation (issue 98066)', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Reveal the link so the /stalled-page route tree is prefetched — the
+    // same starting state as a visible <Link> in production (#98066).
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/stalled-page"]')
+        .click()
+      await browser.elementByCss('a[href="/stalled-page"]')
+    })
+
+    // Stall only RSC requests for /stalled-page, matching the issue author's
+    // harness. The route is not named /target because that path is gitignored
+    // (Cargo `target/` directories).
+    await page.evaluate(() => {
+      const originalFetch = window.fetch.bind(window)
+      ;(window as any).__restoreFetch = () => {
+        window.fetch = originalFetch
+      }
+      window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input instanceof Request ? input.url : input)
+        if (url.includes('_rsc') && url.includes('/stalled-page')) {
+          ;(window as any).__hungStalledRsc = true
+          return new Promise<Response>(() => {})
+        }
+        return originalFetch(input, init)
+      }
+    })
+
+    // Poisoning click: the dynamic request hangs, writeToBFCache parks the
+    // unsettled rsc promise, and the URL does not change.
+    await browser.elementByCss('a[href="/stalled-page"]').click()
+    await retry(async () => {
+      const hung = await page.evaluate(
+        () => (window as any).__hungStalledRsc === true
+      )
+      expect(hung).toBe(true)
+    })
+    expect(await browser.url()).not.toContain('/stalled-page')
+
+    // Network is fully restored. A later click must issue a request and
+    // commit — not reuse the poisoned BFCache entry with
+    // needsDynamicRequest: false (zero requests until staleAt).
+    await page.evaluate(() => {
+      ;(window as any).__restoreFetch()
+    })
+
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/stalled-page"]').click()
+      },
+      { includes: 'Stalled page' }
+    )
+
+    expect(await browser.elementById('stalled-page-heading').text()).toBe(
+      'Stalled page'
+    )
+    expect(await browser.url()).toContain('/stalled-page')
+  })
+})


### PR DESCRIPTION
fixes #98066

If a dynamic RSC request hangs, the client was caching that hung promise in BFCache. later clicks on the same route then did nothing until staleTimes.dynamic expired, because the cache said it already had the result.

We only reuse a BFCache entry when that RSC actually resolved. we do not park an in-flight prefetch thenable as prefetchRsc.

Without the fix the later click starts zero requests. with it the e2e test passes.