### PR TITLE
Fix cacheComponents client navigation into a fully-dynamic redirect() route

### DIFF
--- a/packages/next/src/client/components/redirect-boundary.tsx
+++ b/packages/next/src/client/components/redirect-boundary.tsx
@@ -1,9 +1,36 @@
 'use client'
 import React, { useEffect } from 'react'
 import type { AppRouterInstance } from '../../shared/lib/app-router-context.shared-runtime'
+import { publicAppRouterInstance } from './app-router-instance'
 import { useRouter } from './navigation'
 import { getRedirectTypeFromError, getURLFromRedirectError } from './redirect'
 import { type RedirectType, isRedirectError } from './redirect-error'
+
+// Dedupes redirect() delivery when RedirectErrorBoundary remounts in a
+// discarded render (fully-dynamic cacheComponents navigations). See #97898.
+let lastScheduledRedirect: { url: string; at: number } | null = null
+
+function scheduleRedirect(url: string, redirectType: RedirectType) {
+  const now = Date.now()
+  if (
+    lastScheduledRedirect !== null &&
+    lastScheduledRedirect.url === url &&
+    now - lastScheduledRedirect.at < 1000
+  ) {
+    return
+  }
+  lastScheduledRedirect = { url, at: now }
+  // Do not wait for a commit — on ƒ routes the errored render never commits,
+  // so HandleRedirect's useEffect never runs. queueMicrotask is enough
+  // because getDerivedStateFromError already ran.
+  queueMicrotask(() => {
+    if (redirectType === 'push') {
+      publicAppRouterInstance.push(url, {})
+    } else {
+      publicAppRouterInstance.replace(url, {})
+    }
+  })
+}
 
 interface RedirectBoundaryProps {
   router: AppRouterInstance
@@ -54,6 +81,11 @@ export class RedirectErrorBoundary extends React.Component<
         // router.push.
         return { redirect: null, redirectType: null }
       }
+
+      // Schedule the navigation during the render phase. On fully-dynamic
+      // cacheComponents routes the boundary remounts and the render never
+      // commits, so HandleRedirect's effect would never fire. See #97898.
+      scheduleRedirect(url, redirectType)
 
       return { redirect: url, redirectType }
     }

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -44,6 +44,7 @@ import {
   bufferPrefetchResponseBody,
 } from '../segment-cache/cache'
 import { UnknownDynamicStaleTime } from '../segment-cache/bfcache'
+import { findRedirectHrefInTransportData } from './find-flight-redirect'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
@@ -268,6 +269,18 @@ export async function fetchServerResponse(
       // The server responded with an MPA navigation URL instead of a
       // SPA payload.
       return doMpaNavigation(flightResponse.n)
+    }
+
+    // Soft redirect() in a fully-dynamic segment arrives as NEXT_REDIRECT
+    // inside the Flight tree (RSC status stays 200). RedirectBoundary can
+    // catch that during render, but on a ƒ route there is no committable
+    // fallback, so HandleRedirect's effect never runs. Treat it like a hard
+    // redirect href and convert to MPA here. See issue #97898.
+    const softRedirectHref = findRedirectHrefInTransportData(
+      flightResponse.t ?? null
+    )
+    if (softRedirectHref !== null) {
+      return doMpaNavigation(softRedirectHref)
     }
 
     const staticStageResponse =

--- a/packages/next/src/client/components/router-reducer/find-flight-redirect.test.ts
+++ b/packages/next/src/client/components/router-reducer/find-flight-redirect.test.ts
@@ -1,0 +1,61 @@
+import { findRedirectHrefInTransportData } from './find-flight-redirect'
+import { getRedirectError } from '../redirect'
+import type { PartialTransportData } from '../../../shared/lib/rsc-transport'
+
+function rejectedRedirect(url: string) {
+  const error = getRedirectError(url, 'replace')
+  const thenable = Promise.reject(error) as Promise<never> & {
+    status?: string
+    reason?: unknown
+  }
+  thenable.status = 'rejected'
+  thenable.reason = error
+  thenable.then(
+    () => {},
+    () => {}
+  )
+  return thenable
+}
+
+describe('findRedirectHrefInTransportData', () => {
+  it('returns null when there is no transport data', () => {
+    expect(findRedirectHrefInTransportData(null)).toBeNull()
+    expect(findRedirectHrefInTransportData(undefined)).toBeNull()
+  })
+
+  it('finds NEXT_REDIRECT on a rejected segment RSC thenable', () => {
+    const transportData: PartialTransportData = {
+      t: {
+        s: '',
+        d: {
+          r: rejectedRedirect('/target'),
+          p: false,
+          v: null,
+        },
+      },
+    }
+    expect(findRedirectHrefInTransportData(transportData)).toBe('/target')
+  })
+
+  it('walks child slots', () => {
+    const transportData: PartialTransportData = {
+      t: {
+        s: '',
+        c: new Map([
+          [
+            'children',
+            {
+              s: '__PAGE__',
+              d: {
+                r: rejectedRedirect('/dashboard'),
+                p: false,
+                v: null,
+              },
+            },
+          ],
+        ]),
+      },
+    }
+    expect(findRedirectHrefInTransportData(transportData)).toBe('/dashboard')
+  })
+})

--- a/packages/next/src/client/components/router-reducer/find-flight-redirect.ts
+++ b/packages/next/src/client/components/router-reducer/find-flight-redirect.ts
@@ -1,0 +1,98 @@
+import type {
+  PartialTransportData,
+  PartialTransportNode,
+} from '../../../shared/lib/rsc-transport'
+import { isThenable } from '../../../shared/lib/is-thenable'
+import { getURLFromRedirectError } from '../redirect'
+import { isRedirectError } from '../redirect-error'
+
+function noop() {}
+
+/**
+ * If `rsc` is a Flight-decoded Server Component that rejected with
+ * `NEXT_REDIRECT`, return the destination. Async server components that throw
+ * `redirect()` are encoded as rejected thenables; the digest is readable
+ * without rendering (and therefore without committing) the tree.
+ *
+ * Returns null when the value is still pending or is not a redirect — those
+ * cases stay on RedirectBoundary (e.g. a redirect behind a Suspense hole).
+ */
+function getRedirectHrefFromRsc(rsc: unknown): string | null {
+  if (rsc == null) {
+    return null
+  }
+
+  if (isRedirectError(rsc)) {
+    return getURLFromRedirectError(rsc)
+  }
+
+  if (isThenable(rsc)) {
+    const thenable = rsc as Promise<unknown> & {
+      status?: string
+      reason?: unknown
+    }
+    // Force Flight to attach `status`/`reason` when the row is already decoded.
+    thenable.then(noop, noop)
+    if (thenable.status === 'rejected') {
+      return getRedirectHrefFromRsc(thenable.reason)
+    }
+  }
+
+  return null
+}
+
+function findRedirectHrefInTransportNode(
+  node: PartialTransportNode | undefined
+): string | null {
+  if (node === undefined) {
+    return null
+  }
+
+  if (node.d !== undefined && node.d.r != null) {
+    const href = getRedirectHrefFromRsc(node.d.r)
+    if (href !== null) {
+      return href
+    }
+  }
+
+  const children = node.c
+  if (children !== undefined) {
+    for (const child of children.values()) {
+      const href = findRedirectHrefInTransportNode(child)
+      if (href !== null) {
+        return href
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Detect a soft `redirect()` that arrived in a navigation Flight payload.
+ *
+ * Fully-dynamic (ƒ) routes have no Suspense fallback, so RedirectBoundary can
+ * catch `NEXT_REDIRECT` but the errored render never commits — HandleRedirect's
+ * effect never runs, and the client spins. Convert the redirect into an MPA
+ * navigation at the fetch layer instead (same as a hard redirect href).
+ *
+ * See https://github.com/vercel/next.js/issues/97898
+ */
+export function findRedirectHrefInTransportData(
+  transportData: PartialTransportData | null | undefined
+): string | null {
+  if (transportData == null) {
+    return null
+  }
+
+  const fromTree = findRedirectHrefInTransportNode(transportData.t)
+  if (fromTree !== null) {
+    return fromTree
+  }
+
+  if (transportData.h?.r != null) {
+    return getRedirectHrefFromRsc(transportData.h.r)
+  }
+
+  return null
+}

--- a/test/e2e/app-dir/cache-components-dynamic-redirect/app/layout.tsx
+++ b/test/e2e/app-dir/cache-components-dynamic-redirect/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-dynamic-redirect/app/page.tsx
+++ b/test/e2e/app-dir/cache-components-dynamic-redirect/app/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <p id="home">home</p>
+      <Link id="to-redirect-blocking" href="/redirect-blocking">
+        /redirect-blocking
+      </Link>
+      <Link id="to-redirect-suspense" href="/redirect-suspense">
+        /redirect-suspense
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/cache-components-dynamic-redirect/app/redirect-blocking/page.tsx
+++ b/test/e2e/app-dir/cache-components-dynamic-redirect/app/redirect-blocking/page.tsx
@@ -1,0 +1,12 @@
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+// Fully-dynamic (ƒ) escape hatch. Client navigation into this route is the
+// regression in https://github.com/vercel/next.js/issues/97898.
+export const instant = false
+
+export default async function RedirectBlocking() {
+  const h = await headers()
+  h.get('cookie')
+  redirect('/redirect-result')
+}

--- a/test/e2e/app-dir/cache-components-dynamic-redirect/app/redirect-result/page.tsx
+++ b/test/e2e/app-dir/cache-components-dynamic-redirect/app/redirect-result/page.tsx
@@ -1,0 +1,3 @@
+export default function RedirectResult() {
+  return <p id="redirect-result">redirect-result</p>
+}

--- a/test/e2e/app-dir/cache-components-dynamic-redirect/app/redirect-suspense/page.tsx
+++ b/test/e2e/app-dir/cache-components-dynamic-redirect/app/redirect-suspense/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react'
+import { headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+async function Gate() {
+  const h = await headers()
+  h.get('cookie')
+  redirect('/redirect-result')
+}
+
+export default function RedirectSuspense() {
+  return (
+    <Suspense fallback={<p id="loading">loading…</p>}>
+      <Gate />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/cache-components-dynamic-redirect/app/redirect-suspense/page.tsx
+++ b/test/e2e/app-dir/cache-components-dynamic-redirect/app/redirect-suspense/page.tsx
@@ -6,6 +6,7 @@ async function Gate() {
   const h = await headers()
   h.get('cookie')
   redirect('/redirect-result')
+  return null
 }
 
 export default function RedirectSuspense() {

--- a/test/e2e/app-dir/cache-components-dynamic-redirect/cache-components-dynamic-redirect.test.ts
+++ b/test/e2e/app-dir/cache-components-dynamic-redirect/cache-components-dynamic-redirect.test.ts
@@ -1,0 +1,37 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('cache-components-dynamic-redirect', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('follows redirect() on client navigation into a fully-dynamic route', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('#home').text()).toBe('home')
+
+    await browser.elementByCss('#to-redirect-blocking').click()
+    expect(await browser.waitForElementByCss('#redirect-result').text()).toBe(
+      'redirect-result'
+    )
+    expect(await browser.url()).toContain('/redirect-result')
+  })
+
+  it('follows redirect() on client navigation into a Suspense-wrapped route', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('#home').text()).toBe('home')
+
+    await browser.elementByCss('#to-redirect-suspense').click()
+    expect(await browser.waitForElementByCss('#redirect-result').text()).toBe(
+      'redirect-result'
+    )
+    expect(await browser.url()).toContain('/redirect-result')
+  })
+
+  it('follows redirect() on a direct visit to a fully-dynamic route', async () => {
+    const browser = await next.browser('/redirect-blocking')
+    expect(await browser.waitForElementByCss('#redirect-result').text()).toBe(
+      'redirect-result'
+    )
+    expect(await browser.url()).toContain('/redirect-result')
+  })
+})

--- a/test/e2e/app-dir/cache-components-dynamic-redirect/next.config.js
+++ b/test/e2e/app-dir/cache-components-dynamic-redirect/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
fixes #97898

With cacheComponents, a Link into a fully-dynamic route that calls redirect() never changed the URL and spun RedirectBoundary. direct visits and Suspense-wrapped routes already worked.

We detect NEXT_REDIRECT in the Flight payload at fetch time and do an MPA navigation, same as a hard redirect href. we also schedule RedirectBoundary with queueMicrotask so a remounted boundary still fires if that walk misses it.

Without the fix the test times out waiting for the redirect. with it the e2e tests pass.