### PR TITLE
Use intrusive locks for task storage

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/benches/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/mod.rs
@@ -6,11 +6,12 @@ use criterion::{Criterion, criterion_group, criterion_main};
 pub(crate) mod gc;
 pub(crate) mod overhead;
 pub(crate) mod scope_stress;
+pub(crate) mod storage_locking;
 pub(crate) mod stress;
 
 criterion_group!(
     name = turbo_tasks_backend_stress;
     config = Criterion::default();
-    targets = stress::fibonacci, scope_stress::scope_stress, overhead::overhead, gc::gc
+    targets = stress::fibonacci, scope_stress::scope_stress, overhead::overhead, gc::gc, storage_locking::storage_locking
 );
 criterion_main!(turbo_tasks_backend_stress);

--- a/turbopack/crates/turbo-tasks-backend/benches/storage_locking.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/storage_locking.rs
@@ -1,6 +1,7 @@
 use std::{cell::UnsafeCell, hash::BuildHasher, hint::black_box, sync::Arc, thread};
 
 use criterion::{BatchSize, Criterion, Throughput};
+use crossbeam_utils::CachePadded;
 use dashmap::DashMap;
 use parking_lot::{RawMutex, lock_api::RawMutex as RawMutexTrait};
 use rustc_hash::FxBuildHasher;
@@ -8,11 +9,9 @@ use rustc_hash::FxBuildHasher;
 const SHARDS: usize = 64;
 const TASKS: u32 = 4096;
 
-#[repr(C)]
 struct Payload {
     lock: RawMutex,
     value: UnsafeCell<u64>,
-    padding: [u64; 14],
 }
 
 impl Payload {
@@ -20,7 +19,6 @@ impl Payload {
         Self {
             lock: <RawMutex as RawMutexTrait>::INIT,
             value: UnsafeCell::new(value),
-            padding: [0; 14],
         }
     }
 
@@ -46,7 +44,8 @@ impl Drop for PayloadGuard<'_> {
     }
 }
 
-type Map = DashMap<u32, Box<Payload>, FxBuildHasher>;
+// Keep independently locked tasks on separate cache lines without hand-written layout padding.
+type Map = DashMap<u32, Box<CachePadded<Payload>>, FxBuildHasher>;
 
 fn empty_map() -> Map {
     DashMap::with_capacity_and_hasher_and_shard_amount(TASKS as usize, FxBuildHasher, SHARDS)
@@ -55,7 +54,7 @@ fn empty_map() -> Map {
 fn populated_map() -> Map {
     let map = empty_map();
     for id in 1..=TASKS {
-        map.insert(id, Box::new(Payload::new(id as u64)));
+        map.insert(id, Box::new(CachePadded::new(Payload::new(id as u64))));
     }
     map
 }
@@ -102,7 +101,7 @@ pub fn storage_locking(criterion: &mut Criterion) {
             key = key.wrapping_add(1);
             let mut task = map
                 .entry(current)
-                .or_insert_with(|| Box::new(Payload::new(0)));
+                .or_insert_with(|| Box::new(CachePadded::new(Payload::new(0))));
             *task.value.get_mut() = black_box(current as u64);
             drop(task);
             map.remove(&current);
@@ -116,7 +115,7 @@ pub fn storage_locking(criterion: &mut Criterion) {
             key = key.wrapping_add(1);
             let task = map
                 .entry(current)
-                .or_insert_with(|| Box::new(Payload::new(0)))
+                .or_insert_with(|| Box::new(CachePadded::new(Payload::new(0))))
                 .downgrade();
             task.with_mut(|value| *value = black_box(current as u64));
             drop(task);

--- a/turbopack/crates/turbo-tasks-backend/benches/storage_locking.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/storage_locking.rs
@@ -1,0 +1,238 @@
+use std::{cell::UnsafeCell, hash::BuildHasher, hint::black_box, sync::Arc, thread};
+
+use criterion::{BatchSize, Criterion, Throughput};
+use dashmap::DashMap;
+use parking_lot::{RawMutex, lock_api::RawMutex as RawMutexTrait};
+use rustc_hash::FxBuildHasher;
+
+const SHARDS: usize = 64;
+const TASKS: u32 = 4096;
+
+#[repr(C)]
+struct Payload {
+    lock: RawMutex,
+    value: UnsafeCell<u64>,
+    padding: [u64; 14],
+}
+
+impl Payload {
+    fn new(value: u64) -> Self {
+        Self {
+            lock: <RawMutex as RawMutexTrait>::INIT,
+            value: UnsafeCell::new(value),
+            padding: [0; 14],
+        }
+    }
+
+    fn with_mut<R>(&self, f: impl FnOnce(&mut u64) -> R) -> R {
+        self.lock.lock();
+        let guard = PayloadGuard(self);
+        // SAFETY: `guard` owns this payload's lock for the closure's lifetime.
+        let result = f(unsafe { &mut *self.value.get() });
+        drop(guard);
+        result
+    }
+}
+
+// SAFETY: `value` is accessed only while `lock` is held.
+unsafe impl Sync for Payload {}
+
+struct PayloadGuard<'a>(&'a Payload);
+
+impl Drop for PayloadGuard<'_> {
+    fn drop(&mut self) {
+        // SAFETY: This guard is created only after acquiring this payload's lock.
+        unsafe { self.0.lock.unlock() };
+    }
+}
+
+type Map = DashMap<u32, Box<Payload>, FxBuildHasher>;
+
+fn empty_map() -> Map {
+    DashMap::with_capacity_and_hasher_and_shard_amount(TASKS as usize, FxBuildHasher, SHARDS)
+}
+
+fn populated_map() -> Map {
+    let map = empty_map();
+    for id in 1..=TASKS {
+        map.insert(id, Box::new(Payload::new(id as u64)));
+    }
+    map
+}
+
+fn same_shard_keys(map: &Map, count: usize) -> Vec<u32> {
+    let mut keys = Vec::with_capacity(count);
+    let target = map.determine_shard(map.hash_usize(&1));
+    for key in 1.. {
+        if map.determine_shard(map.hash_usize(&key)) == target {
+            keys.push(key);
+            if keys.len() == count {
+                return keys;
+            }
+        }
+    }
+    unreachable!()
+}
+
+pub fn storage_locking(criterion: &mut Criterion) {
+    let map = populated_map();
+    let mut hit = criterion.benchmark_group("storage_locking_hit");
+    hit.throughput(Throughput::Elements(1));
+    hit.bench_function("dashmap_shard_write", |b| {
+        b.iter(|| {
+            let mut task = map.get_mut(black_box(&1)).unwrap();
+            task.value = UnsafeCell::new(black_box(1));
+        })
+    });
+    hit.bench_function("shard_read_intrusive", |b| {
+        b.iter(|| {
+            let task = map.get(black_box(&1)).unwrap();
+            task.with_mut(|value| *value = black_box(1));
+        })
+    });
+    hit.finish();
+
+    let mut insertion = criterion.benchmark_group("storage_locking_insert_roundtrip");
+    insertion.throughput(Throughput::Elements(1));
+    insertion.bench_function("dashmap_shard_write", |b| {
+        let map = empty_map();
+        let mut key = 1_u32;
+        b.iter(|| {
+            let current = key;
+            key = key.wrapping_add(1);
+            let mut task = map
+                .entry(current)
+                .or_insert_with(|| Box::new(Payload::new(0)));
+            *task.value.get_mut() = black_box(current as u64);
+            drop(task);
+            map.remove(&current);
+        })
+    });
+    insertion.bench_function("downgrade_then_intrusive", |b| {
+        let map = empty_map();
+        let mut key = 1_u32;
+        b.iter(|| {
+            let current = key;
+            key = key.wrapping_add(1);
+            let task = map
+                .entry(current)
+                .or_insert_with(|| Box::new(Payload::new(0)))
+                .downgrade();
+            task.with_mut(|value| *value = black_box(current as u64));
+            drop(task);
+            map.remove(&current);
+        })
+    });
+    insertion.finish();
+
+    let mut contention = criterion.benchmark_group("storage_locking_same_shard_parallel");
+    const THREADS: usize = 4;
+    const OPS: usize = 1000;
+    contention.throughput(Throughput::Elements((THREADS * OPS) as u64));
+    let keys = same_shard_keys(&map, THREADS);
+    contention.bench_function("dashmap_shard_write", |b| {
+        b.iter(|| {
+            thread::scope(|scope| {
+                for &key in &keys {
+                    let map = &map;
+                    scope.spawn(move || {
+                        for _ in 0..OPS {
+                            let mut task = map.get_mut(&key).unwrap();
+                            *task.value.get_mut() = black_box(key as u64);
+                        }
+                    });
+                }
+            });
+        })
+    });
+    contention.bench_function("shard_read_intrusive", |b| {
+        b.iter(|| {
+            thread::scope(|scope| {
+                for &key in &keys {
+                    let map = &map;
+                    scope.spawn(move || {
+                        for _ in 0..OPS {
+                            let task = map.get(&key).unwrap();
+                            task.with_mut(|value| *value = black_box(key as u64));
+                        }
+                    });
+                }
+            });
+        })
+    });
+    contention.finish();
+
+    let pair_keys = same_shard_keys(&map, 2);
+    let hash1 = map.hasher().hash_one(pair_keys[0]);
+    let hash2 = map.hasher().hash_one(pair_keys[1]);
+    let shard_index = map.determine_shard(hash1 as usize);
+    let mut pair = criterion.benchmark_group("storage_locking_same_shard_pair");
+    pair.throughput(Throughput::Elements(2));
+    pair.bench_function("dashmap_shard_write", |b| {
+        b.iter(|| {
+            let mut shard = map.shards()[shard_index].write();
+            let task1 = shard
+                .find_mut(hash1, |(key, _)| *key == pair_keys[0])
+                .unwrap();
+            *task1.1.value.get_mut() = black_box(1);
+            let task2 = shard
+                .find_mut(hash2, |(key, _)| *key == pair_keys[1])
+                .unwrap();
+            *task2.1.value.get_mut() = black_box(2);
+        })
+    });
+    pair.bench_function("shared_shard_read_intrusive", |b| {
+        b.iter(|| {
+            let shard = map.shards()[shard_index].read();
+            let task1 = shard.find(hash1, |(key, _)| *key == pair_keys[0]).unwrap();
+            let task2 = shard.find(hash2, |(key, _)| *key == pair_keys[1]).unwrap();
+            task1.1.with_mut(|value| *value = black_box(1));
+            task2.1.with_mut(|value| *value = black_box(2));
+        })
+    });
+    pair.finish();
+
+    let mut iteration = criterion.benchmark_group("storage_locking_iteration");
+    iteration.throughput(Throughput::Elements(TASKS as u64));
+    iteration.bench_function("shard_write", |b| {
+        b.iter(|| {
+            let mut sum = 0_u64;
+            for shard in map.shards() {
+                let shard = shard.write();
+                for (_, task) in shard.iter() {
+                    // SAFETY: The shard write lock excludes every map accessor in this baseline.
+                    sum = sum.wrapping_add(unsafe { *task.value.get() });
+                }
+            }
+            black_box(sum)
+        })
+    });
+    iteration.bench_function("shard_read_intrusive", |b| {
+        b.iter(|| {
+            let mut sum = 0_u64;
+            for shard in map.shards() {
+                let shard = shard.read();
+                for (_, task) in shard.iter() {
+                    sum = sum.wrapping_add(task.with_mut(|value| *value));
+                }
+            }
+            black_box(sum)
+        })
+    });
+    iteration.finish();
+
+    let mut removal = criterion.benchmark_group("storage_locking_structural_remove");
+    removal.throughput(Throughput::Elements(TASKS as u64));
+    removal.bench_function("dashmap_remove", |b| {
+        b.iter_batched(
+            || Arc::new(populated_map()),
+            |map| {
+                for key in 1..=TASKS {
+                    black_box(map.remove(&key));
+                }
+            },
+            BatchSize::LargeInput,
+        )
+    });
+    removal.finish();
+}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -250,7 +250,8 @@ impl TurboTasksBackend {
     }
 
     pub fn new(mut options: BackendOptions, backing_storage: TurboBackingStorage) -> Self {
-        let shard_amount = compute_shard_amount(options.num_workers, options.small_preallocation);
+        let resident_shard_amount =
+            compute_shard_amount(options.num_workers, options.small_preallocation);
         if !options.dependency_tracking {
             options.active_tracking = false;
         }
@@ -287,7 +288,7 @@ impl TurboTasksBackend {
                 TaskId::try_from(TRANSIENT_TASK_BIT).unwrap(),
                 TaskId::MAX,
             ),
-            storage: Storage::new(shard_amount, small_preallocation),
+            storage: Storage::new(resident_shard_amount, small_preallocation),
             snapshot_coord: SnapshotCoordinator::new(),
             snapshot_in_progress: Mutex::new(()),
             stopping: AtomicBool::new(false),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -19,7 +19,8 @@ use turbo_tasks::{FxDashMap, TaskId, backend::CachedTaskTypeArc, event::Event, p
 
 use crate::{
     backend::storage_schema::{
-        DropPartialOutcome, KeyEvictability, TaskStorage, UnevictableReason, ValueEvictability,
+        DropPartialOutcome, KeyEvictability, TaskSlot, TaskStorage, UnevictableReason,
+        ValueEvictability,
     },
     backing_storage::SnapshotItem,
     database::key_value_database::KeySpace,
@@ -175,9 +176,6 @@ pub struct Storage {
     ///
     /// Indexed by `map.determine_shard(map.hash_usize(&key))` and guaranteed by construction so
     /// that  `shard_modified_counts.len()==map.shards().len()`
-    ///
-    /// Should only be modified while holding either the task's intrusive lock and shard read
-    /// guard, or the corresponding DashMap shard write lock.
     shard_modified_counts: Box<[CachePadded<AtomicU64>]>,
     /// Stores snapshots of task state for tasks accessed during snapshot mode.
     /// - `Some(snapshot)`: Task was modified before snapshot mode and accessed again during it.
@@ -209,7 +207,7 @@ pub struct Storage {
     /// while `SnapshotShardIter::next` holds the map shard write lock; both then take a
     /// `snapshots` shard lock. `end_snapshot` must lock in the same order — see the shard-zipping
     /// pattern there.
-    map: FxDashMap<TaskId, Box<TaskStorage>>,
+    map: FxDashMap<TaskId, Box<TaskSlot>>,
     /// A shared event notified whenever any task finishes restoring (successfully or not).
     ///
     /// Threads waiting for another thread's in-progress restore subscribe to this event,
@@ -357,6 +355,7 @@ impl Storage {
             let work = if drain_entries {
                 let mut shard_guard = shard.write();
                 shard_guard.retain(|(key, task)| {
+                    let task = task.get_mut_exclusive();
                     let modified_task = task.flags.any_modified();
                     if modified_task {
                         debug_assert!(
@@ -489,7 +488,7 @@ impl Storage {
                 // write lock and would also obscure the pairing.
                 let hash = self.map.hasher().hash_one(key);
                 if let Some((_, task)) = map_guard.find_mut(hash, |(k, _)| *k == key) {
-                    self.promote_during_snapshot_flags(task, shard_idx);
+                    self.promote_during_snapshot_flags(task.get_mut_exclusive(), shard_idx);
                 }
             }
             // If we are saving a non-trivial amount of memory just clear it out.
@@ -515,7 +514,7 @@ impl Storage {
             let inner = match self.map.entry(key) {
                 dashmap::mapref::entry::Entry::Occupied(entry) => entry.into_ref(),
                 dashmap::mapref::entry::Entry::Vacant(entry) => {
-                    entry.insert(Box::new(TaskStorage::new()))
+                    entry.insert(Box::new(TaskSlot::new()))
                 }
             };
             StorageWriteGuard::new(self, inner.downgrade().into())
@@ -582,9 +581,13 @@ impl Storage {
         };
         // `get_disjoint` obtains all shard guards in shard-index order (sharing one guard for a
         // same-shard pair) before task locks are taken here in TaskId order.
-        let (lower, upper) = get_disjoint(&self.map, lower_key, upper_key, || {
-            Box::new(TaskStorage::new())
-        });
+        let (lower, upper) =
+            get_disjoint(
+                &self.map,
+                lower_key,
+                upper_key,
+                || Box::new(TaskSlot::new()),
+            );
         let lower = StorageWriteGuard::new(self, lower);
         let upper = StorageWriteGuard::new(self, upper);
         if reverse {
@@ -658,6 +661,7 @@ impl Storage {
                     }
                 };
             shard.retain(|(task_id, task)| {
+                let task = task.get_mut_exclusive();
                 if task_id.is_transient() {
                     evicted.unevictable_reasons[UnevictableReason::Transient.index()] += 1;
                     return true;
@@ -762,23 +766,25 @@ impl Storage {
 
 pub struct StorageWriteGuard<'a> {
     storage: &'a Storage,
-    inner: Ref<'a, TaskId, Box<TaskStorage>>,
-    task: *mut TaskStorage,
+    inner: Ref<'a, TaskId, Box<TaskSlot>>,
     // Match parking_lot's default guard behavior: task guards must not cross `.await`.
     _not_send: PhantomData<*const ()>,
 }
 
 impl<'a> StorageWriteGuard<'a> {
-    fn new(storage: &'a Storage, inner: Ref<'a, TaskId, Box<TaskStorage>>) -> Self {
-        let task = inner.value().as_ref() as *const TaskStorage as *mut TaskStorage;
-        // SAFETY: The DashMap read guard keeps the boxed task alive at this stable address.
-        unsafe { &*task }.lock();
+    fn new(storage: &'a Storage, inner: Ref<'a, TaskId, Box<TaskSlot>>) -> Self {
+        // The map guard keeps the opaque slot alive while its raw lock is acquired.
+        inner.value().lock();
         Self {
             storage,
             inner,
-            task,
             _not_send: PhantomData,
         }
+    }
+
+    fn task(&self) -> &TaskStorage {
+        // SAFETY: `new` acquired this slot's lock, and `inner` keeps it alive.
+        unsafe { self.inner.value().get() }
     }
 }
 
@@ -814,7 +820,7 @@ impl StorageWriteGuard<'_> {
             "track_modification called on transient task {:?}",
             self.inner.key()
         );
-        let flags = &self.inner.flags;
+        let flags = &self.flags;
         if flags.is_modified_during_snapshot(category) {
             // We can early return since `end_snapshot` is responsible for reconciling.
             return TrackOutcome::NoChange;
@@ -860,7 +866,7 @@ impl StorageWriteGuard<'_> {
                 if inserted_snapshot {
                     // Snapshot all non-transient fields, carrying the modified bits into
                     // the copy so the iterator knows which categories to persist.
-                    let mut snapshot = self.inner.clone_snapshot();
+                    let mut snapshot = self.clone_snapshot();
                     snapshot.flags.set_data_modified(flags.data_modified());
                     snapshot.flags.set_meta_modified(flags.meta_modified());
                     snapshot.flags.set_new_task(flags.new_task());
@@ -919,10 +925,10 @@ impl StorageWriteGuard<'_> {
             "discard_modifications_for_gc_new_task must run before the snapshot starts"
         );
         debug_assert!(
-            self.inner.flags.new_task(),
+            self.flags.new_task(),
             "only a never-persisted (new_task) collected task may be discarded this way"
         );
-        if self.inner.flags.any_modified() {
+        if self.flags.any_modified() {
             let shard_idx = self.storage.shard_index(self.inner.key());
             self.storage.shard_modified_counts[shard_idx].fetch_sub(1, Ordering::Relaxed);
         }
@@ -936,15 +942,14 @@ impl Deref for StorageWriteGuard<'_> {
     type Target = TaskStorage;
 
     fn deref(&self) -> &Self::Target {
-        // SAFETY: `new` locked this task, and `inner` keeps its Box alive until after `Drop`.
-        unsafe { &*self.task }
+        self.task()
     }
 }
 
 impl DerefMut for StorageWriteGuard<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        // SAFETY: The task's intrusive lock gives this guard exclusive payload access.
-        unsafe { &mut *self.task }
+        // SAFETY: This guard owns the slot's task lock, and `inner` keeps it alive.
+        unsafe { &mut *self.inner.value().as_ptr() }
     }
 }
 
@@ -953,7 +958,7 @@ impl Drop for StorageWriteGuard<'_> {
         // SAFETY: This guard acquired the lock in `new`, still owns it, and performs no task
         // access after unlocking. Rust drops `inner` only after this method returns, so the Box
         // remains alive through the unlock.
-        unsafe { (&*self.task).unlock() };
+        unsafe { self.inner.value().unlock() };
     }
 }
 
@@ -1045,7 +1050,7 @@ enum ShardWork {
     /// (modified-only) shard table out of the map. The iterator owns that table and drains it
     /// directly, freeing each task box as it is serialized. No second map lookup, no flag
     /// bookkeeping (the whole map is discarded right after this snapshot).
-    Drain(hash_table::IntoIter<(TaskId, Box<TaskStorage>)>),
+    Drain(hash_table::IntoIter<(TaskId, Box<TaskSlot>)>),
 }
 
 pub struct SnapshotShard<'l, P> {
@@ -1127,12 +1132,13 @@ where
             }
             ShardWork::Drain(entries) => {
                 // Shutdown only: the scan already moved this shard's modified entries out of the
-                // map, so we own each `Box<TaskStorage>` here. Serialize from a borrow of the owned
-                // box and let it drop at the end of this branch — freeing the task's memory as it
+                // map, so we own each `Box<TaskSlot>` here. Move out the storage, serialize it, and
+                // let it drop at the end of this branch — freeing the task's memory as it
                 // is persisted rather than after the whole batch is written. We skip the flag
                 // bookkeeping the normal path does, since the entire map is discarded right after
                 // this snapshot.
                 let (task_id, inner) = entries.next()?;
+                let inner = (*inner).into_inner();
                 Some(serialize_task(task_id, &inner))
                 // we don't need to update any bits because everything is getting dropped.
             }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -2,6 +2,7 @@ use std::{
     cell::Cell,
     fmt::{Display, Formatter},
     hash::{BuildHasher, Hash},
+    marker::PhantomData,
     ops::{Deref, DerefMut},
     sync::{
         Arc,
@@ -25,7 +26,7 @@ use crate::{
     utils::{
         dash_map_drop_contents::drop_contents,
         dash_map_entry::{TryLockAndRemove, try_lock_and_remove},
-        dash_map_multi::{RefMut, get_disjoint_mut},
+        dash_map_multi::{Ref, get_disjoint},
     },
 };
 
@@ -175,7 +176,8 @@ pub struct Storage {
     /// Indexed by `map.determine_shard(map.hash_usize(&key))` and guaranteed by construction so
     /// that  `shard_modified_counts.len()==map.shards().len()`
     ///
-    /// Should only be modified while holding the corresponding dashmap shard lock.
+    /// Should only be modified while holding either the task's intrusive lock and shard read
+    /// guard, or the corresponding DashMap shard write lock.
     shard_modified_counts: Box<[CachePadded<AtomicU64>]>,
     /// Stores snapshots of task state for tasks accessed during snapshot mode.
     /// - `Some(snapshot)`: Task was modified before snapshot mode and accessed again during it.
@@ -203,9 +205,10 @@ pub struct Storage {
     /// Acquiring locks in the opposite order should be defensive
     ///
     /// Lock Ordering vs. `snapshots`: `map` locks are acquired **before** `snapshots` locks.
-    /// `track_modification_internal` and `SnapshotShardIter::next` both hold a `map` shard write
-    /// lock (via `StorageWriteGuard` / `map.get_mut`) and then take a `snapshots` shard lock.
-    /// `end_snapshot` must lock in the same order — see the shard-zipping pattern there.
+    /// `track_modification_internal` holds a map shard read guard plus the task's intrusive lock,
+    /// while `SnapshotShardIter::next` holds the map shard write lock; both then take a
+    /// `snapshots` shard lock. `end_snapshot` must lock in the same order — see the shard-zipping
+    /// pattern there.
     map: FxDashMap<TaskId, Box<TaskStorage>>,
     /// A shared event notified whenever any task finishes restoring (successfully or not).
     ///
@@ -351,48 +354,47 @@ impl Storage {
             // - keep mode collects the modified `TaskId`s and looks them up again while iterating.
             // - drain mode erases the unmodified entries here and then moves the remaining
             //   (modified-only) table out of the map, so the iterator owns and drains it directly.
-            let work = {
+            let work = if drain_entries {
                 let mut shard_guard = shard.write();
-                if drain_entries {
-                    shard_guard.retain(|(key, task)| {
-                        let modified_task = task.flags.any_modified();
-                        if modified_task {
-                            debug_assert!(
-                                !key.is_transient(),
-                                "found a modified transient task: {key:?}"
-                            );
-                        }
-                        // Unmodified entries are not part of the snapshot. Remove and free them
-                        // now so the table we move out below holds only modified entries.
-                        modified_task
-                    });
-                    if shard_guard.is_empty() {
-                        // The shard held only unmodified entries, which we've now erased and freed.
-                        // No iterator is created for an empty shard.
-                        return None;
+                shard_guard.retain(|(key, task)| {
+                    let modified_task = task.flags.any_modified();
+                    if modified_task {
+                        debug_assert!(
+                            !key.is_transient(),
+                            "found a modified transient task: {key:?}"
+                        );
                     }
-                    // Move the modified-only table out of the map. Iterating it frees each task box
-                    // as it is serialized, and the shard's table allocation is released here.
-                    ShardWork::Drain(std::mem::take(&mut *shard_guard).into_iter())
-                } else {
-                    let mut modified = Vec::with_capacity(modified_count as usize);
-                    for (key, task) in shard_guard.iter() {
-                        // Only check modified flags — transient tasks never have modified flags set
-                        // (track_modification guards against it), so this naturally excludes them.
-                        // new_task always comes with modified flags (set_persistent_task_type calls
-                        // track_modification), so any_modified() is sufficient.
-                        if task.flags.any_modified() {
-                            debug_assert!(
-                                !key.is_transient(),
-                                "found a modified transient task: {key:?}"
-                            );
-                            modified.push(*key);
-                        }
-                    }
-                    // modified_count > 0 (we returned early otherwise), so this is never empty.
-                    debug_assert!(!modified.is_empty());
-                    ShardWork::Keep(modified)
+                    // Unmodified entries are not part of the snapshot. Remove and free them now so
+                    // the table we move out below holds only modified entries.
+                    modified_task
+                });
+                if shard_guard.is_empty() {
+                    // The shard held only unmodified entries, which we've now erased and freed.
+                    // No iterator is created for an empty shard.
+                    return None;
                 }
+                // Move the modified-only table out of the map. Iterating it frees each task box as
+                // it is serialized, and the shard's table allocation is released here.
+                ShardWork::Drain(std::mem::take(&mut *shard_guard).into_iter())
+            } else {
+                let shard_guard = shard.read();
+                let mut modified = Vec::with_capacity(modified_count as usize);
+                for (key, task) in shard_guard.iter() {
+                    // Only check modified flags — transient tasks never have modified flags set
+                    // (track_modification guards against it), so this naturally excludes them.
+                    // new_task always comes with modified flags (set_persistent_task_type calls
+                    // track_modification), so any_modified() is sufficient.
+                    if task.with_lock(|task| task.flags.any_modified()) {
+                        debug_assert!(
+                            !key.is_transient(),
+                            "found a modified transient task: {key:?}"
+                        );
+                        modified.push(*key);
+                    }
+                }
+                // modified_count > 0 (we returned early otherwise), so this is never empty.
+                debug_assert!(!modified.is_empty());
+                ShardWork::Keep(modified)
             };
 
             Some(SnapshotShard {
@@ -509,22 +511,27 @@ impl Storage {
     }
 
     pub fn access_mut(&self, key: TaskId) -> StorageWriteGuard<'_> {
-        let inner = match self.map.entry(key) {
-            dashmap::mapref::entry::Entry::Occupied(e) => e.into_ref(),
-            dashmap::mapref::entry::Entry::Vacant(e) => e.insert(Box::new(TaskStorage::new())),
-        };
-        StorageWriteGuard {
-            storage: self,
-            inner: inner.into(),
-        }
+        self.access_existing_mut(key).unwrap_or_else(|| {
+            let inner = match self.map.entry(key) {
+                dashmap::mapref::entry::Entry::Occupied(entry) => entry.into_ref(),
+                dashmap::mapref::entry::Entry::Vacant(entry) => {
+                    entry.insert(Box::new(TaskStorage::new()))
+                }
+            };
+            StorageWriteGuard::new(self, inner.downgrade().into())
+        })
     }
 
-    /// Read-only access to an already resident task. Returns `None` if the task isnt in memory
-    /// resident. The closure runs while a shard read lock is held, so it must be cheap and must
-    /// not re-enter the map.
+    fn access_existing_mut(&self, key: TaskId) -> Option<StorageWriteGuard<'_>> {
+        Some(StorageWriteGuard::new(self, self.map.get(&key)?.into()))
+    }
+
+    /// Read-only access to an already resident task. Returns `None` if the task isn't memory
+    /// resident. The closure runs while the task lock and shard read lock are held, so it must be
+    /// cheap and must not re-enter this task or the map.
     pub fn with_task<R>(&self, key: TaskId, f: impl FnOnce(&TaskStorage) -> R) -> Option<R> {
-        let task = self.map.get(&key)?;
-        Some(f(task.value()))
+        let task = StorageWriteGuard::new(self, self.map.get(&key)?.into());
+        Some(f(&task))
     }
 
     /// The number of **persistent** (non-transient) tasks resident in the map. Use this to assert
@@ -556,7 +563,7 @@ impl Storage {
     pub fn gc_scan_shard(&self, index: usize, mut on_candidate: impl FnMut(TaskId)) {
         let shard = self.map.shards()[index].read();
         for (task_id, task) in shard.iter() {
-            if !task_id.is_transient() && task.gc_maybe_collectible() {
+            if !task_id.is_transient() && task.with_lock(TaskStorage::gc_maybe_collectible) {
                 on_candidate(*task_id);
             }
         }
@@ -567,17 +574,24 @@ impl Storage {
         key1: TaskId,
         key2: TaskId,
     ) -> (StorageWriteGuard<'_>, StorageWriteGuard<'_>) {
-        let (a, b) = get_disjoint_mut(&self.map, key1, key2, || Box::new(TaskStorage::new()));
-        (
-            StorageWriteGuard {
-                storage: self,
-                inner: a,
-            },
-            StorageWriteGuard {
-                storage: self,
-                inner: b,
-            },
-        )
+        assert_ne!(key1, key2, "cannot mutably access the same task twice");
+        let (lower_key, upper_key, reverse) = if key1 < key2 {
+            (key1, key2, false)
+        } else {
+            (key2, key1, true)
+        };
+        // `get_disjoint` obtains all shard guards in shard-index order (sharing one guard for a
+        // same-shard pair) before task locks are taken here in TaskId order.
+        let (lower, upper) = get_disjoint(&self.map, lower_key, upper_key, || {
+            Box::new(TaskStorage::new())
+        });
+        let lower = StorageWriteGuard::new(self, lower);
+        let upper = StorageWriteGuard::new(self, upper);
+        if reverse {
+            (upper, lower)
+        } else {
+            (lower, upper)
+        }
     }
 
     pub fn drop_contents(&self) {
@@ -748,7 +762,24 @@ impl Storage {
 
 pub struct StorageWriteGuard<'a> {
     storage: &'a Storage,
-    inner: RefMut<'a, TaskId, Box<TaskStorage>>,
+    inner: Ref<'a, TaskId, Box<TaskStorage>>,
+    task: *mut TaskStorage,
+    // Match parking_lot's default guard behavior: task guards must not cross `.await`.
+    _not_send: PhantomData<*const ()>,
+}
+
+impl<'a> StorageWriteGuard<'a> {
+    fn new(storage: &'a Storage, inner: Ref<'a, TaskId, Box<TaskStorage>>) -> Self {
+        let task = inner.value().as_ref() as *const TaskStorage as *mut TaskStorage;
+        // SAFETY: The DashMap read guard keeps the boxed task alive at this stable address.
+        unsafe { &*task }.lock();
+        Self {
+            storage,
+            inner,
+            task,
+            _not_send: PhantomData,
+        }
+    }
 }
 
 impl StorageWriteGuard<'_> {
@@ -788,9 +819,10 @@ impl StorageWriteGuard<'_> {
             // We can early return since `end_snapshot` is responsible for reconciling.
             return TrackOutcome::NoChange;
         }
+        let modified = flags.is_modified(category);
         #[cfg(feature = "trace_task_modification")]
         let _span = (!modified).then(|| tracing::trace_span!("mark_modified", name).entered());
-        match (self.storage.snapshot_mode(), flags.is_modified(category)) {
+        match (self.storage.snapshot_mode(), modified) {
             (false, false) => {
                 // Not in snapshot mode and item is unmodified
                 let bumped = !flags.any_modified();
@@ -798,7 +830,7 @@ impl StorageWriteGuard<'_> {
                     let shard_idx = self.storage.shard_index(self.inner.key());
                     self.storage.shard_modified_counts[shard_idx].fetch_add(1, Ordering::Relaxed);
                 }
-                self.inner.flags.set_modified(category, true);
+                self.flags.set_modified(category, true);
                 TrackOutcome::Tracked { category, bumped }
             }
             (false, true) => {
@@ -815,9 +847,7 @@ impl StorageWriteGuard<'_> {
                 if inserted_snapshot {
                     self.storage.snapshots.insert(*self.inner.key(), None);
                 }
-                self.inner
-                    .flags
-                    .set_modified_during_snapshot(category, true);
+                self.flags.set_modified_during_snapshot(category, true);
                 TrackOutcome::TrackedDuringSnapshot {
                     category,
                     inserted_snapshot,
@@ -838,9 +868,7 @@ impl StorageWriteGuard<'_> {
                         .snapshots
                         .insert(*self.inner.key(), Some(Box::new(snapshot)));
                 }
-                self.inner
-                    .flags
-                    .set_modified_during_snapshot(category, true);
+                self.flags.set_modified_during_snapshot(category, true);
                 TrackOutcome::TrackedDuringSnapshot {
                     category,
                     inserted_snapshot,
@@ -855,18 +883,17 @@ impl StorageWriteGuard<'_> {
     /// # Correctness
     ///
     /// The `outcome` MUST be applied to the **same `StorageWriteGuard`** that produced it, with the
-    /// map shard write lock held continuously in between — i.e. `track_modification`, the mutation,
-    /// and `undo_track_modification` all run within one guard's lifetime. The guard holds its shard
-    /// write lock for its whole lifetime, so this guarantees no other thread observed the tracked
-    /// state, and that `bumped` / `inserted_snapshot` still describe reality (the counter and
-    /// `snapshots` entry are only mutated under that lock). Because those flags record whether
+    /// task's intrusive lock and map shard read guard held continuously in between — i.e.
+    /// `track_modification`, the mutation, and `undo_track_modification` all run within one guard's
+    /// lifetime. This guarantees no other thread observed the task's tracked state, and that
+    /// `bumped` / `inserted_snapshot` still describe reality. Because those flags record whether
     /// *this* call created the state, undo never clears a flag, counter, or snapshot entry that a
     /// prior modification owns.
     pub fn undo_track_modification(&mut self, outcome: TrackOutcome) {
         match outcome {
             TrackOutcome::NoChange => {}
             TrackOutcome::Tracked { category, bumped } => {
-                self.inner.flags.set_modified(category, false);
+                self.flags.set_modified(category, false);
                 if bumped {
                     let shard_idx = self.storage.shard_index(self.inner.key());
                     self.storage.shard_modified_counts[shard_idx].fetch_sub(1, Ordering::Relaxed);
@@ -876,9 +903,7 @@ impl StorageWriteGuard<'_> {
                 category,
                 inserted_snapshot,
             } => {
-                self.inner
-                    .flags
-                    .set_modified_during_snapshot(category, false);
+                self.flags.set_modified_during_snapshot(category, false);
                 if inserted_snapshot {
                     self.storage.snapshots.remove(self.inner.key());
                 }
@@ -901,9 +926,9 @@ impl StorageWriteGuard<'_> {
             let shard_idx = self.storage.shard_index(self.inner.key());
             self.storage.shard_modified_counts[shard_idx].fetch_sub(1, Ordering::Relaxed);
         }
-        self.inner.flags.set_meta_modified(false);
-        self.inner.flags.set_data_modified(false);
-        self.inner.flags.set_new_task(false);
+        self.flags.set_meta_modified(false);
+        self.flags.set_data_modified(false);
+        self.flags.set_new_task(false);
     }
 }
 
@@ -911,13 +936,24 @@ impl Deref for StorageWriteGuard<'_> {
     type Target = TaskStorage;
 
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        // SAFETY: `new` locked this task, and `inner` keeps its Box alive until after `Drop`.
+        unsafe { &*self.task }
     }
 }
 
 impl DerefMut for StorageWriteGuard<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
+        // SAFETY: The task's intrusive lock gives this guard exclusive payload access.
+        unsafe { &mut *self.task }
+    }
+}
+
+impl Drop for StorageWriteGuard<'_> {
+    fn drop(&mut self) {
+        // SAFETY: This guard acquired the lock in `new`, still owns it, and performs no task
+        // access after unlocking. Rust drops `inner` only after this method returns, so the Box
+        // remains alive through the unlock.
+        unsafe { (&*self.task).unlock() };
     }
 }
 
@@ -1072,7 +1108,11 @@ where
         match &mut self.shard.work {
             ShardWork::Keep(modified) => {
                 let task_id = modified.pop()?;
-                let mut inner = self.shard.storage.map.get_mut(&task_id).unwrap();
+                let mut inner = self
+                    .shard
+                    .storage
+                    .access_existing_mut(task_id)
+                    .expect("snapshot task must remain resident while snapshot mode is active");
                 let item = serialize_task(task_id, &inner);
                 // Clear the modified flags that were captured into the snapshot copy,
                 // then promote modified_during_snapshot → modified so the task stays
@@ -1110,6 +1150,12 @@ impl<P> Drop for SnapshotShardIter<'_, P> {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        sync::{Arc, Barrier, mpsc},
+        thread,
+        time::Duration,
+    };
+
     use turbo_bincode::TurboBincodeBuffer;
     use turbo_tasks::TaskId;
 
@@ -1119,6 +1165,121 @@ mod tests {
     fn non_transient_task(id: u32) -> TaskId {
         // TRANSIENT_TASK_BIT is 0x2000_0000; any id without that bit is non-transient.
         TaskId::new(id).expect("id must be non-zero")
+    }
+
+    fn task_pair(storage: &Storage, same_shard: bool) -> (TaskId, TaskId) {
+        let first = non_transient_task(1);
+        let first_shard = storage.shard_index(&first);
+        let second = (2..10_000)
+            .map(non_transient_task)
+            .find(|task| (storage.shard_index(task) == first_shard) == same_shard)
+            .expect("the test map should expose both same- and cross-shard task pairs");
+        (first, second)
+    }
+
+    #[test]
+    fn unrelated_tasks_in_one_shard_lock_independently() {
+        let storage = Arc::new(Storage::new(2, true));
+        let (task1, task2) = task_pair(&storage, true);
+        drop(storage.access_mut(task2));
+        let task1_guard = storage.access_mut(task1);
+        let (tx, rx) = mpsc::sync_channel(1);
+        let other = storage.clone();
+        let join = thread::spawn(move || {
+            drop(other.access_mut(task2));
+            tx.send(()).unwrap();
+        });
+        rx.recv_timeout(Duration::from_secs(2))
+            .expect("a different task in the same shard should not share its task lock");
+        drop(task1_guard);
+        join.join().unwrap();
+    }
+
+    #[test]
+    fn same_task_lock_excludes_another_accessor() {
+        let storage = Arc::new(Storage::new(2, true));
+        let task = non_transient_task(1);
+        let guard = storage.access_mut(task);
+        let (tx, rx) = mpsc::sync_channel(1);
+        let other = storage.clone();
+        let join = thread::spawn(move || {
+            drop(other.access_mut(task));
+            tx.send(()).unwrap();
+        });
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(guard);
+        rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        join.join().unwrap();
+    }
+
+    #[test]
+    fn concurrent_first_access_inserts_one_task() {
+        let storage = Arc::new(Storage::new(2, true));
+        let task = non_transient_task(1);
+        let barrier = Arc::new(Barrier::new(8));
+        let joins: Vec<_> = (0..8)
+            .map(|_| {
+                let storage = storage.clone();
+                let barrier = barrier.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    drop(storage.access_mut(task));
+                })
+            })
+            .collect();
+        for join in joins {
+            join.join().unwrap();
+        }
+        assert_eq!(storage.map.len(), 1);
+    }
+
+    #[test]
+    fn structural_remove_waits_for_task_guard() {
+        let storage = Arc::new(Storage::new(2, true));
+        let task = non_transient_task(1);
+        let guard = storage.access_mut(task);
+        let (tx, rx) = mpsc::sync_channel(1);
+        let other = storage.clone();
+        let join = thread::spawn(move || {
+            let removed = other.map.remove(&task).is_some();
+            tx.send(removed).unwrap();
+        });
+        assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(guard);
+        assert!(rx.recv_timeout(Duration::from_secs(2)).unwrap());
+        join.join().unwrap();
+    }
+
+    #[test]
+    fn pair_access_supports_same_and_cross_shard_opposing_order() {
+        for same_shard in [true, false] {
+            let storage = Arc::new(Storage::new(2, true));
+            let (task1, task2) = task_pair(&storage, same_shard);
+            let barrier = Arc::new(Barrier::new(2));
+            let (tx, rx) = mpsc::sync_channel(2);
+            let joins: Vec<_> = [(task1, task2), (task2, task1)]
+                .into_iter()
+                .map(|(first, second)| {
+                    let storage = storage.clone();
+                    let barrier = barrier.clone();
+                    let tx = tx.clone();
+                    thread::spawn(move || {
+                        barrier.wait();
+                        let (first_guard, second_guard) = storage.access_pair_mut(first, second);
+                        assert_eq!(*first_guard.inner.key(), first);
+                        assert_eq!(*second_guard.inner.key(), second);
+                        drop((first_guard, second_guard));
+                        tx.send(()).unwrap();
+                    })
+                })
+                .collect();
+            drop(tx);
+            rx.recv_timeout(Duration::from_secs(2)).unwrap();
+            rx.recv_timeout(Duration::from_secs(2)).unwrap();
+            for join in joins {
+                join.join().unwrap();
+            }
+        }
     }
 
     /// A process fn that returns a non-empty SnapshotItem so the iterator doesn't

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -18,14 +18,15 @@
 //! - `meta` - Rarely changed metadata (output, aggregation, flags)
 //! - `transient` - Not serialized, only exists in memory
 use std::{
+    fmt,
     hash::{BuildHasherDefault, Hash},
     sync::Arc,
 };
 
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RawMutex, lock_api::RawMutex as RawMutexTrait};
 use rustc_hash::FxHasher;
 use turbo_tasks::{
-    CellId, SharedReference, TaskExecutionReason, TaskId, TraitTypeId, ValueTypeId,
+    CellId, SharedReference, ShrinkToFit, TaskExecutionReason, TaskId, TraitTypeId, ValueTypeId,
     backend::{CachedTaskTypeArc, CellHash, TransientTaskType},
     event::Event,
     task_storage,
@@ -46,6 +47,61 @@ type AutoSet<K, const I: usize> = auto_hash_map::AutoSet<K, BuildHasherDefault<F
 ///
 /// See [`AutoSet`] for the meaning of `I`.
 type AutoMap<K, V, const I: usize> = auto_hash_map::AutoMap<K, V, BuildHasherDefault<FxHasher>, I>;
+
+/// One-byte parking_lot lock embedded in each task's storage.
+///
+/// The lock is synchronization metadata: snapshots create a fresh lock rather than copying its
+/// state. This wrapper supplies the generated storage type's trait requirements.
+pub(crate) struct IntrusiveTaskLock(RawMutex);
+
+impl IntrusiveTaskLock {
+    const fn new() -> Self {
+        Self(<RawMutex as RawMutexTrait>::INIT)
+    }
+
+    fn lock(&self) {
+        self.0.lock();
+    }
+
+    /// # Safety
+    ///
+    /// The current thread must own this lock and perform no protected access after this call.
+    unsafe fn unlock(&self) {
+        // SAFETY: Forwarded from the caller.
+        unsafe { self.0.unlock() };
+    }
+
+    #[cfg(test)]
+    fn is_locked(&self) -> bool {
+        self.0.is_locked()
+    }
+}
+
+struct IntrusiveTaskLockGuard<'a>(&'a IntrusiveTaskLock);
+
+impl Drop for IntrusiveTaskLockGuard<'_> {
+    fn drop(&mut self) {
+        // SAFETY: This lexical guard is created only after acquiring this lock and drops before
+        // the protected reference can escape.
+        unsafe { self.0.unlock() };
+    }
+}
+
+impl Default for IntrusiveTaskLock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for IntrusiveTaskLock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IntrusiveTaskLock").finish_non_exhaustive()
+    }
+}
+
+impl ShrinkToFit for IntrusiveTaskLock {
+    fn shrink_to_fit(&mut self) {}
+}
 
 /// The complete task storage schema.
 ///
@@ -559,6 +615,33 @@ pub enum KeyEvictability {
 }
 
 impl TaskStorage {
+    /// Lock this task's storage while a resident-map guard keeps its allocation alive.
+    pub(crate) fn lock(&self) {
+        self.lock.lock();
+    }
+
+    /// Unlock this task's storage.
+    ///
+    /// # Safety
+    ///
+    /// The current thread must own the task lock, hold the resident-map guard that keeps this
+    /// storage alive, and perform no protected access after this call.
+    pub(crate) unsafe fn unlock(&self) {
+        // SAFETY: Forwarded from the caller.
+        unsafe { self.lock.unlock() };
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_locked(&self) -> bool {
+        self.lock.is_locked()
+    }
+
+    pub(crate) fn with_lock<R>(&self, f: impl FnOnce(&Self) -> R) -> R {
+        self.lock();
+        let _guard = IntrusiveTaskLockGuard(&self.lock);
+        f(self)
+    }
+
     /// Determine the evictability level of this task based on its flags.
     ///
     /// This checks only the flags on the TaskStorage itself. The caller
@@ -1788,6 +1871,18 @@ mod tests {
     // ==========================================================================
     // Schema Size Tests
     // ==========================================================================
+
+    #[test]
+    fn snapshot_clone_has_an_independent_unlocked_task_lock() {
+        let storage = TaskStorage::new();
+        storage.lock();
+        assert!(storage.is_locked());
+        let snapshot = storage.clone_snapshot();
+        assert!(storage.is_locked());
+        assert!(!snapshot.is_locked());
+        // SAFETY: This test acquired the source lock above and accesses it no further.
+        unsafe { storage.unlock() };
+    }
 
     #[test]
     #[cfg(target_pointer_width = "64")]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -18,6 +18,7 @@
 //! - `meta` - Rarely changed metadata (output, aggregation, flags)
 //! - `transient` - Not serialized, only exists in memory
 use std::{
+    cell::UnsafeCell,
     fmt,
     hash::{BuildHasherDefault, Hash},
     sync::Arc,
@@ -26,7 +27,7 @@ use std::{
 use parking_lot::{Mutex, RawMutex, lock_api::RawMutex as RawMutexTrait};
 use rustc_hash::FxHasher;
 use turbo_tasks::{
-    CellId, SharedReference, ShrinkToFit, TaskExecutionReason, TaskId, TraitTypeId, ValueTypeId,
+    CellId, SharedReference, TaskExecutionReason, TaskId, TraitTypeId, ValueTypeId,
     backend::{CachedTaskTypeArc, CellHash, TransientTaskType},
     event::Event,
     task_storage,
@@ -77,16 +78,6 @@ impl IntrusiveTaskLock {
     }
 }
 
-struct IntrusiveTaskLockGuard<'a>(&'a IntrusiveTaskLock);
-
-impl Drop for IntrusiveTaskLockGuard<'_> {
-    fn drop(&mut self) {
-        // SAFETY: This lexical guard is created only after acquiring this lock and drops before
-        // the protected reference can escape.
-        unsafe { self.0.unlock() };
-    }
-}
-
 impl Default for IntrusiveTaskLock {
     fn default() -> Self {
         Self::new()
@@ -99,9 +90,81 @@ impl fmt::Debug for IntrusiveTaskLock {
     }
 }
 
-impl ShrinkToFit for IntrusiveTaskLock {
-    fn shrink_to_fit(&mut self) {}
+/// Opaque interior-mutable task slot used when a resident map guard provides lifetime but not
+/// payload exclusion.
+///
+/// # Unsafe access protocol
+///
+/// - An unlocked slot never exposes a `TaskStorage` reference.
+/// - `lock` acquires the embedded task lock through the raw slot pointer before references exist.
+/// - Only a lock-owning storage guard may call `get` or materialize a mutable reference from
+///   `as_ptr`.
+/// - A structural map write guard may call `get_mut_exclusive` because it excludes all map readers.
+/// - The task lock is released before the map guard that keeps this allocation alive.
+#[repr(transparent)]
+pub(crate) struct TaskSlot(UnsafeCell<TaskStorage>);
+
+impl TaskSlot {
+    pub(crate) fn new() -> Self {
+        Self(UnsafeCell::new(TaskStorage::new()))
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut TaskStorage {
+        self.0.get()
+    }
+
+    pub(crate) fn lock(&self) {
+        // SAFETY: Project only the embedded lock from the opaque cell. No TaskStorage reference is
+        // materialized before exclusion is acquired.
+        unsafe { (&*std::ptr::addr_of!((*self.as_ptr()).lock)).lock() };
+    }
+
+    /// # Safety
+    /// The caller must own this slot's task lock and perform no protected access after unlocking.
+    pub(crate) unsafe fn unlock(&self) {
+        // SAFETY: Forwarded from the caller; projection does not materialize TaskStorage.
+        unsafe { (&*std::ptr::addr_of!((*self.as_ptr()).lock)).unlock() };
+    }
+
+    /// # Safety
+    /// The caller must own this slot's task lock.
+    pub(crate) unsafe fn get(&self) -> &TaskStorage {
+        // SAFETY: Forwarded from the caller.
+        unsafe { &*self.as_ptr() }
+    }
+
+    pub(crate) fn get_mut_exclusive(&mut self) -> &mut TaskStorage {
+        self.0.get_mut()
+    }
+
+    pub(crate) fn into_inner(self) -> TaskStorage {
+        self.0.into_inner()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_locked(&self) -> bool {
+        // SAFETY: Reading the raw lock state does not expose the task payload.
+        unsafe { (&*std::ptr::addr_of!((*self.as_ptr()).lock)).is_locked() }
+    }
+
+    pub(crate) fn with_lock<R>(&self, f: impl FnOnce(&TaskStorage) -> R) -> R {
+        self.lock();
+        struct Unlock<'a>(&'a TaskSlot);
+        impl Drop for Unlock<'_> {
+            fn drop(&mut self) {
+                // SAFETY: `with_lock` acquired this lock and the closure has returned/unwound.
+                unsafe { self.0.unlock() };
+            }
+        }
+        let _unlock = Unlock(self);
+        // SAFETY: The lock-owning lexical guard remains alive through the closure.
+        f(unsafe { self.get() })
+    }
 }
+
+// SAFETY: all shared payload access is governed by the protocol above. Structural mutation uses
+// `&mut TaskSlot`, while ordinary mutation owns the embedded task lock.
+unsafe impl Sync for TaskSlot {}
 
 /// The complete task storage schema.
 ///
@@ -615,33 +678,6 @@ pub enum KeyEvictability {
 }
 
 impl TaskStorage {
-    /// Lock this task's storage while a resident-map guard keeps its allocation alive.
-    pub(crate) fn lock(&self) {
-        self.lock.lock();
-    }
-
-    /// Unlock this task's storage.
-    ///
-    /// # Safety
-    ///
-    /// The current thread must own the task lock, hold the resident-map guard that keeps this
-    /// storage alive, and perform no protected access after this call.
-    pub(crate) unsafe fn unlock(&self) {
-        // SAFETY: Forwarded from the caller.
-        unsafe { self.lock.unlock() };
-    }
-
-    #[cfg(test)]
-    pub(crate) fn is_locked(&self) -> bool {
-        self.lock.is_locked()
-    }
-
-    pub(crate) fn with_lock<R>(&self, f: impl FnOnce(&Self) -> R) -> R {
-        self.lock();
-        let _guard = IntrusiveTaskLockGuard(&self.lock);
-        f(self)
-    }
-
     /// Determine the evictability level of this task based on its flags.
     ///
     /// This checks only the flags on the TaskStorage itself. The caller
@@ -1874,14 +1910,15 @@ mod tests {
 
     #[test]
     fn snapshot_clone_has_an_independent_unlocked_task_lock() {
-        let storage = TaskStorage::new();
-        storage.lock();
-        assert!(storage.is_locked());
-        let snapshot = storage.clone_snapshot();
-        assert!(storage.is_locked());
-        assert!(!snapshot.is_locked());
+        let slot = TaskSlot::new();
+        slot.lock();
+        assert!(slot.is_locked());
+        // SAFETY: This test holds the slot lock until after cloning.
+        let snapshot = unsafe { slot.get() }.clone_snapshot();
+        assert!(slot.is_locked());
+        assert!(!snapshot.lock.is_locked());
         // SAFETY: This test acquired the source lock above and accesses it no further.
-        unsafe { storage.unlock() };
+        unsafe { slot.unlock() };
     }
 
     #[test]
@@ -1891,6 +1928,11 @@ mod tests {
             size_of::<TaskStorage>(),
             128,
             "TaskStorage size changed! Update this test."
+        );
+        assert_eq!(
+            size_of::<TaskSlot>(),
+            size_of::<TaskStorage>(),
+            "the transparent resident slot must add no per-task size"
         );
         // `LazyField` is 40 B = 32 B largest payload + 8 B discriminant.
         assert_eq!(

--- a/turbopack/crates/turbo-tasks-backend/src/utils/dash_map_multi.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/utils/dash_map_multi.rs
@@ -1,52 +1,39 @@
 use std::{
     hash::{BuildHasher, Hash},
-    marker::PhantomData,
-    ops::{Deref, DerefMut},
+    ops::Deref,
     ptr::NonNull,
     sync::Arc,
 };
 
 use dashmap::{DashMap, RawRwLock};
 use hashbrown::HashTable;
-use parking_lot::lock_api::RwLockWriteGuard;
+use parking_lot::lock_api::{RwLockReadGuard, RwLockWriteGuard};
 
-type RwLockWriteTableGuard<'a, K, V> = RwLockWriteGuard<'a, RawRwLock, HashTable<(K, V)>>;
+type ReadTableGuard<'a, K, V> = RwLockReadGuard<'a, RawRwLock, HashTable<(K, V)>>;
 
-pub enum RefMut<'a, K, V> {
-    Base(dashmap::mapref::one::RefMut<'a, K, V>),
+/// A read reference to one DashMap entry.
+///
+/// The shared variant lets two disjoint entries in the same shard share one read guard. This
+/// avoids recursively acquiring a writer-preferring shard lock while retaining stable entry
+/// addresses for each task's intrusive lock.
+pub enum Ref<'a, K, V> {
+    Base(dashmap::mapref::one::Ref<'a, K, V>),
     Simple {
-        _guard: RwLockWriteTableGuard<'a, K, V>,
+        _guard: ReadTableGuard<'a, K, V>,
         entry: NonNull<(K, V)>,
     },
     Shared {
-        _guard: Arc<RwLockWriteTableGuard<'a, K, V>>,
+        _guard: Arc<ReadTableGuard<'a, K, V>>,
         entry: NonNull<(K, V)>,
-        // Ensures that RefMut is !Send, preventing holding RefMut across .await points in async
-        // code, which can cause deadlocks. See safety comment on `unsafe impl Sync for RefMut`
-        // below.
-        phantom: std::marker::PhantomData<*const ()>,
     },
 }
 
-// `RefMut` is intentionally **not** `Send`. While sending the guard across threads would be sound
-// under the same reasoning that justifies `Sync` below, allowing `Send` makes it possible to hold
-// a `RefMut` (and therefore a `StorageWriteGuard`) across an `.await` in async code, since the
-// compiler will then accept the resulting future as `Send`. That pattern causes hard async
-// deadlocks: the guard parks together with the suspended future and pins the shard's write lock,
-// while every other tokio worker piles up trying to take the same lock — leaving no thread free
-// to poll the parked future. Marking the type `!Send` makes the borrow checker reject those call
-// sites at compile time.
-// SAFETY (Sync): `RefMut` contains a non-null pointer into a `DashMap` shard's `HashTable`.
-// Sharing `&RefMut` is safe because:
-// - `Simple` variant: The entry is accessed under an exclusive `RwLockWriteGuard` on a single
-//   shard. The guard provides exclusive access to all data in that shard.
-// - `Shared` variant: The entry is accessed under an `Arc<RwLockWriteGuard>`. The
-//   `get_disjoint_mut` function validates that the keys differ before obtaining both references
-//   through `HashTable::get_many_unchecked_mut`.
-// - `K: Sync + V: Sync` bounds ensure the key and value types are safe to share across threads.
-unsafe impl<K: Eq + Hash + Sync, V: Sync> Sync for RefMut<'_, K, V> {}
+// SAFETY: Each entry pointer remains valid under its shard read guard. Shared references never
+// mutate the HashTable entry; payload mutation is independently synchronized by its intrusive
+// lock. `K: Sync + V: Sync` makes shared references safe across threads.
+unsafe impl<K: Eq + Hash + Sync, V: Sync> Sync for Ref<'_, K, V> {}
 
-impl<K: Eq + Hash, V> RefMut<'_, K, V> {
+impl<K: Eq + Hash, V> Ref<'_, K, V> {
     pub fn key(&self) -> &K {
         self.pair().0
     }
@@ -55,211 +42,165 @@ impl<K: Eq + Hash, V> RefMut<'_, K, V> {
         self.pair().1
     }
 
-    pub fn value_mut(&mut self) -> &mut V {
-        self.pair_mut().1
-    }
-
-    pub fn pair(&self) -> (&K, &V) {
+    fn pair(&self) -> (&K, &V) {
         match self {
-            RefMut::Base(r) => r.pair(),
-            RefMut::Simple { entry, .. } | RefMut::Shared { entry, .. } => {
-                // SAFETY: The entry remains valid while the shard write guard is held.
+            Self::Base(reference) => reference.pair(),
+            Self::Simple { entry, .. } | Self::Shared { entry, .. } => {
+                // SAFETY: The entry remains valid while the corresponding shard read guard lives.
                 let entry = unsafe { entry.as_ref() };
                 (&entry.0, &entry.1)
             }
         }
     }
-
-    pub fn pair_mut(&mut self) -> (&K, &mut V) {
-        match self {
-            RefMut::Base(r) => r.pair_mut(),
-            RefMut::Simple { entry, .. } | RefMut::Shared { entry, .. } => {
-                // SAFETY: Same as above in `pair`, plus aliasing is prevented via:
-                // 1. The lifetime of `&mut self`.
-                // 2. `Simple` values come from separate shards (no aliasing possible).
-                // 3. `Shared` values were validated as disjoint before the pointers were created.
-                let entry = unsafe { entry.as_mut() };
-                (&entry.0, &mut entry.1)
-            }
-        }
-    }
 }
 
-impl<K: Eq + Hash, V> Deref for RefMut<'_, K, V> {
+impl<K: Eq + Hash, V> Deref for Ref<'_, K, V> {
     type Target = V;
 
-    fn deref(&self) -> &V {
+    fn deref(&self) -> &Self::Target {
         self.value()
     }
 }
 
-impl<K: Eq + Hash, V> DerefMut for RefMut<'_, K, V> {
-    fn deref_mut(&mut self) -> &mut V {
-        self.value_mut()
-    }
-}
-
-impl<'a, K, V> From<dashmap::mapref::one::RefMut<'a, K, V>> for RefMut<'a, K, V>
+impl<'a, K, V> From<dashmap::mapref::one::Ref<'a, K, V>> for Ref<'a, K, V>
 where
     K: Hash + Eq,
 {
-    fn from(r: dashmap::mapref::one::RefMut<'a, K, V>) -> Self {
-        RefMut::Base(r)
+    fn from(reference: dashmap::mapref::one::Ref<'a, K, V>) -> Self {
+        Self::Base(reference)
     }
 }
 
-pub fn get_disjoint_mut<K, V>(
+/// Get two disjoint read references, inserting missing values under shard write locks.
+///
+/// The caller must order calls to this function consistently when composing it with other locks.
+pub fn get_disjoint<K, V>(
     map: &DashMap<K, V, impl BuildHasher + Clone>,
     key1: K,
     key2: K,
     insert_with: impl Fn() -> V,
-) -> (RefMut<'_, K, V>, RefMut<'_, K, V>)
+) -> (Ref<'_, K, V>, Ref<'_, K, V>)
 where
     K: Hash + Eq + Clone,
 {
+    assert!(
+        key1 != key2,
+        "`get_disjoint` was called with equal keys, which cannot produce disjoint task guards"
+    );
+
     let hasher = map.hasher();
     let hash_entry = |entry: &(K, _)| hasher.hash_one(&entry.0);
-    let h1 = hasher.hash_one(&key1);
-    let h2 = hasher.hash_one(&key2);
-
-    // Use `determine_shard` instead of `determine_map` to avoid extra rehashing.
-    // This u64 -> usize conversion also happens internally within DashMap using `as usize`.
-    // See: `DashMap::hash_usize`
-    let s1 = map.determine_shard(h1 as usize);
-    let s2 = map.determine_shard(h2 as usize);
-
-    let eq1 = |other: &(K, _)| key1.eq(&other.0);
-    let eq2 = |other: &(K, _)| key2.eq(&other.0);
-
+    let hash1 = hasher.hash_one(&key1);
+    let hash2 = hasher.hash_one(&key2);
+    let shard1 = map.determine_shard(hash1 as usize);
+    let shard2 = map.determine_shard(hash2 as usize);
     let shards = map.shards();
-    if s1 == s2 {
-        // Equal keys would resolve to a single entry below. This must be a release-mode assertion
-        // because the unchecked lookup relies on it for memory safety.
-        assert!(
-            key1 != key2,
-            "`get_disjoint_mut` was called with equal keys, which breaks mutable referencing rules"
-        );
 
-        let mut guard = shards[s1].write();
+    let find1 = |entry: &(K, _)| key1.eq(&entry.0);
+    let find2 = |entry: &(K, _)| key2.eq(&entry.0);
 
-        if guard.find(h1, eq1).is_none() {
-            guard.insert_unique(h1, (key1.clone(), insert_with()), hash_entry);
+    if shard1 == shard2 {
+        let guard = shards[shard1].read();
+        let entry1 = guard.find(hash1, find1).map(NonNull::from);
+        let entry2 = guard.find(hash2, find2).map(NonNull::from);
+        if let (Some(entry1), Some(entry2)) = (entry1, entry2) {
+            return shared_pair(guard, entry1, entry2);
         }
-        if guard.find(h2, eq2).is_none() {
-            guard.insert_unique(h2, (key2.clone(), insert_with()), hash_entry);
+        drop(guard);
+
+        let mut guard = shards[shard1].write();
+        if guard.find(hash1, find1).is_none() {
+            guard.insert_unique(hash1, (key1.clone(), insert_with()), hash_entry);
         }
+        if guard.find(hash2, find2).is_none() {
+            guard.insert_unique(hash2, (key2.clone(), insert_with()), hash_entry);
+        }
+        let entry1 = NonNull::from(guard.find(hash1, find1).expect("first entry was inserted"));
+        let entry2 = NonNull::from(guard.find(hash2, find2).expect("second entry was inserted"));
+        return shared_pair(RwLockWriteGuard::downgrade(guard), entry1, entry2);
+    }
 
-        // SAFETY: `key1 != key2` was asserted above. Since `K: Eq`, the two equality closures
-        // cannot select the same entry, even when the hashes collide.
-        let [entry1, entry2] =
-            unsafe {
-                guard.get_many_unchecked_mut([h1, h2], |index, entry| {
-                    if index == 0 { eq1(entry) } else { eq2(entry) }
-                })
-            };
-        let entry1 = NonNull::from(entry1.expect("the first entry was inserted above"));
-        let entry2 = NonNull::from(entry2.expect("the second entry was inserted above"));
-
-        let guard = Arc::new(guard);
-        (
-            RefMut::Shared {
-                _guard: guard.clone(),
-                entry: entry1,
-                phantom: PhantomData,
-            },
-            RefMut::Shared {
-                _guard: guard,
-                entry: entry2,
-                phantom: PhantomData,
-            },
-        )
+    let (first_shard, second_shard, first_is_key1) = if shard1 < shard2 {
+        (shard1, shard2, true)
     } else {
-        let (mut guard1, mut guard2) = loop {
-            {
-                let g1 = shards[s1].write();
-                if let Some(g2) = shards[s2].try_write() {
-                    break (g1, g2);
-                }
-            }
-            {
-                let g2 = shards[s2].write();
-                if let Some(g1) = shards[s1].try_write() {
-                    break (g1, g2);
-                }
-            }
-        };
-
-        if guard1.find(h1, eq1).is_none() {
-            guard1.insert_unique(h1, (key1.clone(), insert_with()), hash_entry);
-        }
-        if guard2.find(h2, eq2).is_none() {
-            guard2.insert_unique(h2, (key2.clone(), insert_with()), hash_entry);
-        }
-        let entry1 = NonNull::from(
-            guard1
-                .find_mut(h1, eq1)
-                .expect("the first entry was inserted"),
-        );
-        let entry2 = NonNull::from(
-            guard2
-                .find_mut(h2, eq2)
-                .expect("the second entry was inserted"),
-        );
-
-        (
-            RefMut::Simple {
+        (shard2, shard1, false)
+    };
+    let first_guard = shards[first_shard].read();
+    let second_guard = shards[second_shard].read();
+    let (guard1, guard2) = if first_is_key1 {
+        (first_guard, second_guard)
+    } else {
+        (second_guard, first_guard)
+    };
+    let entry1 = guard1.find(hash1, find1).map(NonNull::from);
+    let entry2 = guard2.find(hash2, find2).map(NonNull::from);
+    if let (Some(entry1), Some(entry2)) = (entry1, entry2) {
+        return (
+            Ref::Simple {
                 _guard: guard1,
                 entry: entry1,
             },
-            RefMut::Simple {
+            Ref::Simple {
                 _guard: guard2,
                 entry: entry2,
             },
-        )
+        );
     }
+    drop(guard2);
+    drop(guard1);
+
+    let (mut guard1, mut guard2) = loop {
+        {
+            let guard1 = shards[shard1].write();
+            if let Some(guard2) = shards[shard2].try_write() {
+                break (guard1, guard2);
+            }
+        }
+        {
+            let guard2 = shards[shard2].write();
+            if let Some(guard1) = shards[shard1].try_write() {
+                break (guard1, guard2);
+            }
+        }
+    };
+    if guard1.find(hash1, find1).is_none() {
+        guard1.insert_unique(hash1, (key1.clone(), insert_with()), hash_entry);
+    }
+    if guard2.find(hash2, find2).is_none() {
+        guard2.insert_unique(hash2, (key2.clone(), insert_with()), hash_entry);
+    }
+    let entry1 = NonNull::from(guard1.find(hash1, find1).expect("first entry was inserted"));
+    let entry2 = NonNull::from(
+        guard2
+            .find(hash2, find2)
+            .expect("second entry was inserted"),
+    );
+    (
+        Ref::Simple {
+            _guard: RwLockWriteGuard::downgrade(guard1),
+            entry: entry1,
+        },
+        Ref::Simple {
+            _guard: RwLockWriteGuard::downgrade(guard2),
+            entry: entry2,
+        },
+    )
 }
 
-#[cfg(test)]
-mod tests {
-    use std::thread::scope;
-
-    use rand::prelude::SliceRandom;
-    use turbo_tasks::FxDashMap;
-
-    use super::*;
-
-    #[test]
-    fn stress_deadlock() {
-        const N: usize = 100000;
-        const THREADS: usize = 20;
-
-        let map = FxDashMap::with_hasher_and_shard_amount(Default::default(), 4);
-        let indices = (0..THREADS)
-            .map(|_| {
-                let mut vec = (0..N).collect::<Vec<_>>();
-                vec.shuffle(&mut rand::rng());
-                vec
-            })
-            .collect::<Vec<_>>();
-        let map = &map;
-        scope(|s| {
-            for indices in indices {
-                s.spawn(|| {
-                    for i in indices {
-                        let (mut a, mut b) = get_disjoint_mut(map, i, i + 1, || 0);
-                        *a += 1;
-                        *b += 1;
-                    }
-                });
-            }
-        });
-        let value = *map.get(&0).unwrap();
-        assert_eq!(value, THREADS);
-        for i in 1..N {
-            let value = *map.get(&i).unwrap();
-            assert_eq!(value, THREADS * 2);
-        }
-        let value = *map.get(&N).unwrap();
-        assert_eq!(value, THREADS);
-    }
+fn shared_pair<'a, K, V>(
+    guard: ReadTableGuard<'a, K, V>,
+    entry1: NonNull<(K, V)>,
+    entry2: NonNull<(K, V)>,
+) -> (Ref<'a, K, V>, Ref<'a, K, V>) {
+    let guard = Arc::new(guard);
+    (
+        Ref::Shared {
+            _guard: guard.clone(),
+            entry: entry1,
+        },
+        Ref::Shared {
+            _guard: guard,
+            entry: entry2,
+        },
+    )
 }

--- a/turbopack/crates/turbo-tasks-backend/src/utils/shard_amount.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/utils/shard_amount.rs
@@ -25,12 +25,12 @@ pub fn compute_shard_amount(num_workers: Option<usize>, small_preallocation: boo
     // for some constant `k` the probability of at least one collision for large `N` can be
     // approximated as: P = 1 - exp(-N^2 / (2*S)) = 1 - exp(-1/(2*k))
     //
-    // For `k = 16` this results in a collision probability of about 3%.
-    // For `k = 1` this results in a collision probability of about 39%.
+    // For `k = 2` this results in a collision probability of about 22%. Fine-grained task locks
+    // keep a shard collision from serializing independent task mutations, so the lower shard count
+    // saves memory without recreating the old shard-write-lock bottleneck.
     //
     // We clamp the number of shards to 1 << 16 to avoid excessive memory usage in case of a very
-    // high number of worker threads. This case is hit with more than 64 worker threads for `k =
-    // 16` and more than 256 worker threads for `k = 1`.
+    // high number of worker threads. With `k = 2`, this case is hit above roughly 181 workers.
 
     if small_preallocation {
         // We also clamp the maximum number of workers to 256 so all following multiplications can't
@@ -38,9 +38,8 @@ pub fn compute_shard_amount(num_workers: Option<usize>, small_preallocation: boo
         let num_workers = num_workers.min(256);
         (num_workers * num_workers).next_power_of_two()
     } else {
-        // We also clamp the maximum number of workers to 64 so all following multiplications can't
-        // overflow.
-        let num_workers = num_workers.min(64);
-        (num_workers * num_workers * 16).next_power_of_two()
+        // Clamp the worker count so the shard total stays at or below 1 << 16.
+        let num_workers = num_workers.min(181);
+        (num_workers * num_workers * 2).next_power_of_two()
     }
 }

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -1407,7 +1407,7 @@ fn generate_typed_storage_struct(grouped_fields: &GroupedFields) -> TokenStream 
             #flags_field
             #lazy_field
             #[doc = "Per-task lock used with a shared resident-map guard."]
-            pub(crate) lock: IntrusiveTaskLock,
+            lock: IntrusiveTaskLock,
         }
 
         #[automatically_derived]

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -1406,6 +1406,8 @@ fn generate_typed_storage_struct(grouped_fields: &GroupedFields) -> TokenStream 
             #(#field_defs,)*
             #flags_field
             #lazy_field
+            #[doc = "Per-task lock used with a shared resident-map guard."]
+            pub(crate) lock: IntrusiveTaskLock,
         }
 
         #[automatically_derived]


### PR DESCRIPTION
## Summary

Keep the resident DashMap, but move ordinary task mutation off DashMap shard write guards. Values are stored as `Box<TaskSlot>`, where opaque `TaskSlot(UnsafeCell<TaskStorage>)` owns the protocol-based unsafe access boundary:

- embed a one-byte `parking_lot::RawMutex` in `TaskStorage` without changing its 128-byte layout
- hold a DashMap shard **read** guard for task lifetime, with the intrusive lock providing per-task mutable exclusion
- use DashMap's atomic `RefMut::downgrade` after insertion so caller work never retains the shard write guard
- share one shard read guard for same-shard pair access; order distinct shard guards by shard index and task locks by `TaskId`
- retain shard write guards for structural insertion, removal, drain, eviction, and clear operations
- lock tasks during snapshot keep-mode and GC candidate scans now that shard read guards permit concurrent task mutation
- reduce resident/snapshot map sharding from 16× to **2× workers²**, selected after an A/B of factors 1/2/4/16

This is intentionally the first incremental step of a proposed stack:

1. **this PR:** intrusive locks while retaining DashMap lifetime/structural management
2. evaluate Papaya to eliminate common-path map reader locking
3. evaluate dense Boxcar + Kovan storage after the map comparison

The previous dense prototype is retained by signed tip `fbea6793a61835f8cc9c83d6af67de79385a63ff`, but is no longer in this PR's history.

## Results

Compared with canary `8ea76d64`:

- representative access mix: **98.04% existing hits, 1.96% actual insertions**
- `overhead.rs`: no statistically detected candidate regression
- statistically detected wins for cached different-key workloads and short parallel uncached workloads
- five alternating real-build samples per revision:
  - cold median: **20.59s → 20.41s** (−0.87%)
  - warm median: **19.91s → 20.28s** (+1.86%)
  - peak RSS effectively flat

The real build is neutral within run-to-run variance.

The shard-factor sweep selected **2× workers²**:

- GC: −5.6% at 10k garbage tasks and −2.8% at 200k versus the previous 16× factor
- real build: neutral/slightly faster (20.43s cold / 20.24s warm versus 20.53s / 20.35s)
- factor 2 reduced the shortest parallel-uncached regression seen at factor 1 while preserving different-key improvements

Focused lock-only microbenchmarks expose an important trade-off:

- existing hit: 14.44ns shard-write baseline vs 30.95ns read+intrusive
- insert/remove roundtrip: 46.54ns vs 62.21ns
- independent same-shard tasks with near-zero work: 182µs vs 380µs
- same-shard pair: 14.86ns vs 46.34ns
- 4,096-task serial scan: 4.91µs vs 50.88µs

The extra task lock is not a universal fast-path win: DashMap's shared shard-read count still changes one contended cache line, then the task lock adds a second transition. Integrated useful work can overlap and wins in `overhead.rs`, but **PR #2 is likely required** to remove the shard-reader bottleneck and realize the intended scaling.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p turbo-tasks-backend --all-targets -- -D warnings`
- `cargo check -p turbo-tasks-backend --all-targets`
- `cargo check -p turbo-tasks-backend --features trace_task_modification`
- `cargo test -p turbo-tasks-macros`
- `cargo test -p turbo-tasks-backend`
- `pnpm build-all`
- exact Criterion A/B for `overhead.rs` and the new GC benchmark, including the 1×/2×/4×/16× shard-factor sweep
- focused same-task, same-shard, pair-ordering, insertion, structural-writer, and snapshot-lock tests
- five alternating cold/warm `bench/heavy-npm-deps` builds per revision with GNU time/RSS

## Notes

- `with_task` now serializes on the task lock; its two current callers are test-only count hooks. Same-task re-entry is documented as invalid.
- `StorageWriteGuard` uses localized protocol-based unsafe access because it must own the DashMap read guard that keeps the boxed slot alive. An unlocked `TaskSlot` exposes no task reference; lock projection happens through the raw cell pointer; only a lock-owning guard materializes task references; structural shard-write paths use exclusive slot access; unlock precedes map-guard drop. The guard remains `!Send`.
- The required trace-feature check exposed an existing cfg-only undefined `modified` variable in the touched function; this PR computes it once for both tracing and branch selection.

<!-- NEXT_JS_LLM -->


<!-- fleet d61f8158-390a-4912-a125-f66278d76f77 -->