### PR TITLE
Turbopack: call process_resolve_result without a task boundary

### DIFF
--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -1020,7 +1020,9 @@ impl AssetContext for ModuleAssetContext {
             resolve_options,
         );
 
-        let mut result = self.process_resolve_result(*result.to_resolved().await?, reference_type);
+        let mut result =
+            process_resolve_result_inner(self, *result.to_resolved().await?, reference_type)
+                .await?;
         let this = self.await?;
         if this.is_types_resolving_enabled().await? {
             let types_result = type_resolve(
@@ -1040,114 +1042,7 @@ impl AssetContext for ModuleAssetContext {
         result: Vc<ResolveResult>,
         reference_type: ReferenceType,
     ) -> Result<Vc<ModuleResolveResult>> {
-        let this = self.await?;
-
-        let replace_externals = this.replace_externals;
-        let import_externals = this
-            .module_options_context
-            .await?
-            .ecmascript
-            .import_externals;
-
-        let result = result.await?;
-
-        let result = result
-            .map_primary_items(|item| {
-                let reference_type = reference_type.clone();
-                async move {
-                    Ok(match item {
-                        ResolveResultItem::Source(source) => {
-                            match &*self.process(*source, reference_type).await? {
-                                ProcessResult::Module(module) => {
-                                    ModuleResolveResultItem::Module(*module)
-                                }
-                                ProcessResult::Unknown(source) => {
-                                    ModuleResolveResultItem::Unknown(*source)
-                                }
-                                ProcessResult::Ignore => ModuleResolveResultItem::Ignore,
-                            }
-                        }
-                        ResolveResultItem::External {
-                            name,
-                            ty,
-                            traced,
-                            target,
-                        } => {
-                            let replacement = if replace_externals {
-                                // Determine the package folder, `target` is the full path to the
-                                // resolved file.
-                                let target = if let Some(mut target) = target {
-                                    loop {
-                                        let parent = target.parent();
-                                        if parent.is_root() {
-                                            break;
-                                        }
-                                        if parent.file_name() == "node_modules" {
-                                            break;
-                                        }
-                                        if parent.file_name().starts_with("@")
-                                            && parent.parent().file_name() == "node_modules"
-                                        {
-                                            break;
-                                        }
-                                        target = parent;
-                                    }
-                                    Some(target)
-                                } else {
-                                    None
-                                };
-
-                                let analyze_mode = if traced == ExternalTraced::Traced
-                                    && let Some(options) = &self
-                                        .module_options_context()
-                                        .await?
-                                        .enable_externals_tracing
-                                {
-                                    // result.affecting_sources can be ignored for tracing, as this
-                                    // request will later be resolved relative to tracing_root (or
-                                    // the .next/node_modules/lodash-1238123 symlink) anyway.
-
-                                    let options = options.await?;
-                                    let origin = PlainResolveOrigin::new(
-                                        Vc::upcast(externals_tracing_module_context(
-                                            *options.compile_time_info,
-                                            false,
-                                        )),
-                                        // If target is specified, a symlink will be created to
-                                        // make the folder
-                                        // itself available, but we still need to trace
-                                        // resolving the individual file(s) inside the package.
-                                        target
-                                            .as_ref()
-                                            .unwrap_or(&options.tracing_root)
-                                            .join("_")?,
-                                    );
-                                    CachedExternalTracingMode::Traced {
-                                        origin: ResolvedVc::upcast(origin.to_resolved().await?),
-                                    }
-                                } else {
-                                    CachedExternalTracingMode::Untraced
-                                };
-
-                                replace_external(&name, ty, target, import_externals, analyze_mode)
-                                    .await?
-                            } else {
-                                None
-                            };
-
-                            replacement
-                                .unwrap_or_else(|| ModuleResolveResultItem::External { name, ty })
-                        }
-                        ResolveResultItem::Ignore => ModuleResolveResultItem::Ignore,
-                        ResolveResultItem::Empty => ModuleResolveResultItem::Empty,
-                        ResolveResultItem::Error(e) => ModuleResolveResultItem::Error(e),
-                        ResolveResultItem::Custom(u8) => ModuleResolveResultItem::Custom(u8),
-                    })
-                }
-            })
-            .await?;
-
-        Ok(result.cell())
+        process_resolve_result_inner(self, result, reference_type).await
     }
 
     #[turbo_tasks::function]
@@ -1261,4 +1156,121 @@ pub async fn replace_external(
     Ok(Some(ModuleResolveResultItem::Module(ResolvedVc::upcast(
         module,
     ))))
+}
+
+/// The body of [`ModuleAssetContext::process_resolve_result`], as a plain async fn.
+///
+/// Callers that hold a concrete [`ModuleAssetContext`] call this directly. The task boundary on
+/// the trait method is not worth its bookkeeping here: on a large app the function runs ~223k
+/// times per production build with a near-zero cache-hit rate, so almost every call allocated a
+/// task, a cell and dependency edges for a value nothing read twice. The `process()` boundary
+/// inside still deduplicates module creation, which is the part that does get reused.
+async fn process_resolve_result_inner(
+    ctx: Vc<ModuleAssetContext>,
+    result: Vc<ResolveResult>,
+    reference_type: ReferenceType,
+) -> Result<Vc<ModuleResolveResult>> {
+    let this = ctx.await?;
+
+    let replace_externals = this.replace_externals;
+    let import_externals = this
+        .module_options_context
+        .await?
+        .ecmascript
+        .import_externals;
+
+    let result = result.await?;
+
+    let result = result
+        .map_primary_items(|item| {
+            let reference_type = reference_type.clone();
+            async move {
+                Ok(match item {
+                    ResolveResultItem::Source(source) => {
+                        match &*ctx.process(*source, reference_type).await? {
+                            ProcessResult::Module(module) => {
+                                ModuleResolveResultItem::Module(*module)
+                            }
+                            ProcessResult::Unknown(source) => {
+                                ModuleResolveResultItem::Unknown(*source)
+                            }
+                            ProcessResult::Ignore => ModuleResolveResultItem::Ignore,
+                        }
+                    }
+                    ResolveResultItem::External {
+                        name,
+                        ty,
+                        traced,
+                        target,
+                    } => {
+                        let replacement = if replace_externals {
+                            // Determine the package folder, `target` is the full path to the
+                            // resolved file.
+                            let target = if let Some(mut target) = target {
+                                loop {
+                                    let parent = target.parent();
+                                    if parent.is_root() {
+                                        break;
+                                    }
+                                    if parent.file_name() == "node_modules" {
+                                        break;
+                                    }
+                                    if parent.file_name().starts_with("@")
+                                        && parent.parent().file_name() == "node_modules"
+                                    {
+                                        break;
+                                    }
+                                    target = parent;
+                                }
+                                Some(target)
+                            } else {
+                                None
+                            };
+
+                            let analyze_mode = if traced == ExternalTraced::Traced
+                                && let Some(options) =
+                                    &ctx.module_options_context().await?.enable_externals_tracing
+                            {
+                                // result.affecting_sources can be ignored for tracing, as this
+                                // request will later be resolved relative to tracing_root (or
+                                // the .next/node_modules/lodash-1238123 symlink) anyway.
+
+                                let options = options.await?;
+                                let origin = PlainResolveOrigin::new(
+                                    Vc::upcast(externals_tracing_module_context(
+                                        *options.compile_time_info,
+                                        false,
+                                    )),
+                                    // If target is specified, a symlink will be created to
+                                    // make the folder
+                                    // itself available, but we still need to trace
+                                    // resolving the individual file(s) inside the package.
+                                    target.as_ref().unwrap_or(&options.tracing_root).join("_")?,
+                                );
+                                CachedExternalTracingMode::Traced {
+                                    origin: ResolvedVc::upcast(origin.to_resolved().await?),
+                                }
+                            } else {
+                                CachedExternalTracingMode::Untraced
+                            };
+
+                            replace_external(&name, ty, target, import_externals, analyze_mode)
+                                .await?
+                        } else {
+                            None
+                        };
+
+                        replacement
+                            .unwrap_or_else(|| ModuleResolveResultItem::External { name, ty })
+                    }
+                    ResolveResultItem::Ignore => ModuleResolveResultItem::Ignore,
+                    ResolveResultItem::Empty => ModuleResolveResultItem::Empty,
+                    ResolveResultItem::Error(e) => ModuleResolveResultItem::Error(e),
+                    ResolveResultItem::Custom(u8) => ModuleResolveResultItem::Custom(u8),
+                })
+            }
+        })
+        .await?;
+
+    Ok(result.cell())
 }


### PR DESCRIPTION
## What

This makes `ModuleAssetContext::process_resolve_result` a plain `async fn` instead of a cached task. We measured on a large app that it was called 223k times with near zero cache-hit. There may be benefit beyond my particular use case, but for this app, it was pure overhead. 

The trait method stays as a thin wrapper, so the `AssetContext` interface and any caller going through `Vc<Box<dyn AssetContext>>` are unchanged. The inner `process()` boundary, which is the one that actually deduplicates module creation across callers, is left exactly as it was.

Scope, since the diff is narrower than it may look: the `#[turbo_tasks::function]` attribute is on the `AssetContext` trait declaration and stays there. Of the four callers in the tree, only the one in `resolve_asset` holds a concrete context and changes; the three dispatching through the trait object (`resolve/mod.rs`, `references/worker.rs`, `typescript.rs`) keep the task boundary.

## Measurement, and how much to trust it

One large App Router app (~2,080 routes, ~30.7k modules), 88-core / 176-thread single-NUMA Linux host, production build, patched engine against an unpatched from-source control built from the same tree, binaries swapped with `__INTERNAL_CUSTOM_TURBOPACK_BINDINGS`.

| arm | compile |
|---|---|
| from-source control | 298 s |
| this patch | 279 s |

Two runs per arm. **Run-to-run noise on this host is +/-15-20 s**, so a 19 s delta from two runs sits at the edge of separation and we would not defend "6%" as a precise figure. What we would defend is the mechanism: the counters show ~223k task executions with essentially no cache hits, and the same patch stacked with another engine change measured 277 s against a 307 s control in the same session.

**Two caveats.**

1. **These numbers are from 16.3.3, not canary.** `#96808` (execute scheduled tasks inline when they are read) landed after the 16.3.x branch cut, and it takes pressure off exactly the path a hot uncached task travels. The mechanisms are different: this change removes the task, while `#96808` avoids one queue detour for a task that is read immediately. We have not measured the combined effect on canary, and can do that on the same host and post the numbers before anyone merges this.
2. **The measurement is one app on one machine.** A 2,000-route app on 176 threads is not a typical shape.

## Why this function and not the obvious neighbours

The gate matters more than the patch, because our first attempt at the same idea was a regression. We inlined a second `#[turbo_tasks::function]` that also had a single call site and it measured **304 s against the same 298 s control**: that function's cache *was* hitting, and removing the boundary re-did work that was previously shared. A cached function can be deduplicating across many inputs even when the source shows one caller, so call-site counting alone is not a safe signal.

We kept this change because it had both: **a single internal call site and a measured near-zero hit rate**. A third candidate selected that way removed its 123k executions cleanly and changed the wall clock by nothing at all, because those calls were never on the critical path. Two of the three candidates that looked fusable were therefore not worth doing, and one was harmful.

## Correctness

All on 16.3.3, with this patch and one other engine change applied:

- Engine crates: 766 runnable tests, no deltas against stock.
- Your `test/production` lane, run paired stock vs patched across two shards: 330 suites with **byte-identical per-file pass/fail sets between the two arms** (312 pass on both, the same 18 fail on both, and all 18 trace to our environment rather than the patch: live-network fixtures, `next/font` fetching Google Fonts at build time, two CI env vars our harness omitted, and a Node version skew in an expected error string). We did not run the `test/e2e`-in-start-mode half of that job.
- Build-output comparison across seven applications, ~127k emitted files: the patched output differs from stock by nothing beyond stock-vs-stock nondeterminism, which we measured separately and which is non-zero, so the comparison is against that floor rather than against zero.

## Risk

The trait method keeps its signature, so external callers are unaffected. The change removes a caching boundary, so a future caller that re-requests the same `(result, reference_type)` pair repeatedly would recompute instead of hitting the cache. The measurement says that does not happen today, and the inner `process()` boundary still covers the expensive part.

---

### Status: draft, numbers still being replaced

Keeping this in draft because the measurements above are not the ones I want to ship it on. They are from 16.3.3 on one large app on a 176-thread host, which is both a release behind canary and the least representative machine I could have picked, given you have said most of your users are around 30 cores. Running now, and these will replace the table before this leaves draft:

- the same stock-vs-patched comparison on canary rather than 16.3.3,
- across several apps of different sizes rather than one,
- and core-constrained at roughly 16 and 30 cores alongside the wide-machine run, so the trend is visible instead of a single unrepresentative point.

If the win disappears at 16 to 30 cores I will say so here rather than quietly leaving the big-box number up. Background, full methodology and the rest of the campaign are in #98048.

**Disclosure:** this change, the measurement harness and this description were produced with heavy AI assistance. I have reviewed the change and the numbers and I stand behind them, but the repo asks contributors to be explicit about that, so: flagged.

<!-- NEXT_JS_LLM -->



