### PR TITLE
Improve redirect error helper messages and expand test coverage

### DIFF
--- a/packages/next/src/client/components/redirect.test.ts
+++ b/packages/next/src/client/components/redirect.test.ts
@@ -1,7 +1,14 @@
-import { getURLFromRedirectError, redirect } from './redirect'
+import {
+  getRedirectStatusCodeFromError,
+  getRedirectTypeFromError,
+  getURLFromRedirectError,
+  permanentRedirect,
+  redirect,
+} from './redirect'
+import { RedirectStatusCode } from './redirect-status-code'
 import { isRedirectError } from './redirect-error'
 
-describe('test', () => {
+describe('redirect', () => {
   it('should throw a redirect error', () => {
     try {
       redirect('/dashboard')
@@ -9,6 +16,56 @@ describe('test', () => {
     } catch (err: any) {
       expect(isRedirectError(err)).toBeTruthy()
       expect(getURLFromRedirectError(err)).toEqual('/dashboard')
+      expect(getRedirectTypeFromError(err)).toEqual('replace')
+      expect(getRedirectStatusCodeFromError(err)).toEqual(
+        RedirectStatusCode.TemporaryRedirect
+      )
     }
+  })
+
+  it('should preserve a destination that contains semicolons', () => {
+    try {
+      redirect('/dashboard?ids=1;2;3')
+      throw new Error('did not throw')
+    } catch (err: any) {
+      expect(getURLFromRedirectError(err)).toEqual('/dashboard?ids=1;2;3')
+    }
+  })
+})
+
+describe('permanentRedirect', () => {
+  it('should throw a redirect error with a permanent status code', () => {
+    try {
+      permanentRedirect('/dashboard')
+      throw new Error('did not throw')
+    } catch (err: any) {
+      expect(isRedirectError(err)).toBeTruthy()
+      expect(getURLFromRedirectError(err)).toEqual('/dashboard')
+      expect(getRedirectStatusCodeFromError(err)).toEqual(
+        RedirectStatusCode.PermanentRedirect
+      )
+    }
+  })
+})
+
+describe('getURLFromRedirectError', () => {
+  it('returns null when the error is not a redirect error', () => {
+    expect(getURLFromRedirectError(new Error('boom'))).toBeNull()
+  })
+})
+
+describe('getRedirectTypeFromError / getRedirectStatusCodeFromError', () => {
+  it('throw a descriptive error when the value is not a redirect error', () => {
+    const notRedirect = new Error('boom')
+
+    expect(() => getRedirectTypeFromError(notRedirect as any)).toThrow(
+      /Expected a redirect error/
+    )
+    expect(() => getRedirectStatusCodeFromError(notRedirect as any)).toThrow(
+      /Expected a redirect error/
+    )
+    expect(() => getRedirectTypeFromError('nope' as any)).toThrow(
+      /a value of type "string"/
+    )
   })
 })

--- a/packages/next/src/client/components/redirect.ts
+++ b/packages/next/src/client/components/redirect.ts
@@ -76,9 +76,22 @@ export function getURLFromRedirectError(error: unknown): string | null {
   return error.digest.split(';').slice(2, -2).join(';')
 }
 
+function notARedirectError(error: unknown): Error {
+  const received =
+    error instanceof Error
+      ? `an error with digest ${JSON.stringify(
+          (error as { digest?: unknown }).digest
+        )}`
+      : `a value of type "${typeof error}"`
+
+  return new Error(
+    `Expected a redirect error from \`redirect()\` or \`permanentRedirect()\`, but got ${received}.`
+  )
+}
+
 export function getRedirectTypeFromError(error: RedirectError): RedirectType {
   if (!isRedirectError(error)) {
-    throw new Error('Not a redirect error')
+    throw notARedirectError(error)
   }
 
   return error.digest.split(';', 2)[1] as RedirectType
@@ -86,7 +99,7 @@ export function getRedirectTypeFromError(error: RedirectError): RedirectType {
 
 export function getRedirectStatusCodeFromError(error: RedirectError): number {
   if (!isRedirectError(error)) {
-    throw new Error('Not a redirect error')
+    throw notARedirectError(error)
   }
 
   return Number(error.digest.split(';').at(-2))


### PR DESCRIPTION
### What?

Make `getRedirectTypeFromError` / `getRedirectStatusCodeFromError` throw a descriptive error instead of a bare `"Not a redirect error"`, and add the missing test coverage for the redirect error helpers.

### Why?

When the `isRedirectError` guard in these helpers trips, the bare `"Not a redirect error"` message gives no indication of what was actually passed in. Reporting the received value (and its `digest` when it is an error) makes accidental misuse easier to debug.

`redirect.test.ts` also only covered `redirect()` and the `getURLFromRedirectError` happy path, so `permanentRedirect()`, the `getURLFromRedirectError` null path, and both throwing helpers were untested.

### How?

- Extract a shared `notARedirectError()` helper in `redirect.ts` that formats the received value into the thrown message.
- Expand `redirect.test.ts` to cover `permanentRedirect()`, semicolon-containing destinations, the `getURLFromRedirectError` null path, and the new error message. Also rename the placeholder `describe('test')` block.

No public API or behavior change — only the text of an error that is already thrown, plus tests.