### PR TITLE
[ci] Simplify `upload-preview-tarballs` workflow

### DIFF
--- a/.github/workflows/upload_preview_tarballs.yml
+++ b/.github/workflows/upload_preview_tarballs.yml
@@ -1,7 +1,8 @@
 # This workflow uploads preview tarballs to Vercel Blob after build-and-deploy
 # completes. It uses workflow_run so it always executes the DEFAULT BRANCH
-# version of this file -- an attacker who modifies this file on a feature branch
-# cannot change the code that touches the blob write token.
+# version of this file, and the upload script is checked out from canary to
+# match -- an attacker who modifies either on a feature branch cannot change
+# the code that exchanges the OIDC token for a scoped upload URL.
 name: upload-preview-tarballs
 
 on:
@@ -23,36 +24,16 @@ jobs:
     steps:
       # Checkout from the default branch (canary) -- workflow_run always uses
       # the default branch's version of the workflow file and this checkout
-      # matches that, ensuring the upload script is trusted.
+      # matches that, ensuring the upload script is trusted. The script only
+      # uses built-in modules, so no node_modules or setup-node is required.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: canary
           fetch-depth: 1
           persist-credentials: false
-
-      - name: Setup node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .node-version
-          check-latest: true
-          package-manager-cache: false
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Setup pnpm
-        run: corepack prepare
-
-      - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-v2-${{
-            hashFiles('**/pnpm-lock.yaml') }}
-          # Do not use restore-keys since it leads to indefinite growth of the cache.
-
-      - name: Install node_modules
-        run: pnpm install --frozen-lockfile
+          sparse-checkout: |
+            scripts/upload-preview-tarballs.js
+          sparse-checkout-cone-mode: false
 
       - name: Download preview-tarballs artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
The upload script dropped its `@vercel/blob` usage in #97922 and [imports only built-in modules today](https://github.com/vercel/next.js/blob/canary/scripts/upload-preview-tarballs.js), so the job no longer needs node_modules at all which allows simplifying the workflow. 

## Test plan

- [x] the next canary `upload-preview-tarballs` run after merging succeeds and is visibly faster than the previous ~1–2 min runs: https://github.com/vercel/next.js/actions/runs/33424979891/job/99596250377
