### PR TITLE
fix(head): warn and filter invalid tags in next/head to prevent misleading next-head-count error

### DIFF
--- a/packages/next/src/shared/lib/head.tsx
+++ b/packages/next/src/shared/lib/head.tsx
@@ -119,8 +119,43 @@ function unique() {
 function reduceComponents(
   headChildrenElements: Array<React.ReactElement<any>>
 ) {
+  const validHeadTags = new Set([
+    'title',
+    'base',
+    'meta',
+    'link',
+    'style',
+    'script',
+    'noscript',
+    'template',
+  ])
+
   return headChildrenElements
     .reduce(onlyReactElement, [])
+    .filter((c: React.ReactElement<any>) => {
+      if (process.env.NODE_ENV === 'development') {
+        if (
+          typeof c.type === 'string' &&
+          !validHeadTags.has(c.type as string)
+        ) {
+          const { warnOnce } =
+            require('./utils/warn-once') as typeof import('./utils/warn-once')
+          warnOnce(
+            `Do not add <${c.type}> tags using next/head. Use Document instead. ` +
+              `See more info here: https://nextjs.org/docs/messages/no-head-element`
+          )
+          return false
+        }
+      } else {
+        if (
+          typeof c.type === 'string' &&
+          !validHeadTags.has(c.type as string)
+        ) {
+          return false
+        }
+      }
+      return true
+    })
     .reverse()
     .concat(defaultHead().reverse())
     .filter(unique())


### PR DESCRIPTION
Fixes #20924

When <html> or other invalid tags are used inside next/head, they were rendered to body and caused misleading 'next-head-count is missing' error with head content ending up in body.

This PR filters out invalid head tags and warns:
- Valid tags: title, base, meta, link, style, script, noscript, template
- Invalid tags like html, body, div are now filtered and warned in development
- Prevents misleading error and keeps head content in head

Tested with manual reproduction: <Head><html lang="en" /><title>Demo</title></Head> now warns about html tag and correctly renders title in head.