### PR TITLE
fix(cache): use atomic write for FileSystemCache to prevent corruptio…

### DIFF
--- a/packages/next/src/lib/multi-file-writer.ts
+++ b/packages/next/src/lib/multi-file-writer.ts
@@ -80,7 +80,33 @@ export class MultiFileWriter {
     // Find or create a task for the directory that contains the file.
     const task = this.findOrCreateTask(path.dirname(filePath))
 
-    const promise = task[1].then(() => this.fs.writeFile(filePath, data))
+    const promise = task[1].then(async () => {
+      // Atomic write to prevent readers from seeing partial/mixed JSON
+      // when multiple server instances write the same cache file concurrently
+      // on a shared filesystem. Fixes #98009
+      const tempPath = `${filePath}.tmp.${Math.random().toString(36).slice(2)}`
+      try {
+        await this.fs.writeFile(tempPath, data)
+        if (this.fs.rename) {
+          await this.fs.rename(tempPath, filePath)
+        } else {
+          // Fallback for custom filesystems without rename support
+          await this.fs.writeFile(filePath, data)
+          // Clean up temp file (best effort)
+          try {
+            const { unlinkSync } = await import('fs')
+            unlinkSync(tempPath)
+          } catch {}
+        }
+      } catch (e) {
+        // Clean up temp file on error (best effort)
+        try {
+          const { unlinkSync } = await import('fs')
+          unlinkSync(tempPath)
+        } catch {}
+        throw e
+      }
+    })
 
     // Attach a catch handler so that it doesn't throw an unhandled promise
     // rejection warning.

--- a/packages/next/src/server/lib/node-fs-methods.ts
+++ b/packages/next/src/server/lib/node-fs-methods.ts
@@ -9,4 +9,5 @@ export const nodeFs: CacheFs = {
   writeFile: (f, d) => fs.promises.writeFile(f, d),
   mkdir: (dir) => fs.promises.mkdir(dir, { recursive: true }),
   stat: (f) => fs.promises.stat(f),
+  rename: (oldPath, newPath) => fs.promises.rename(oldPath, newPath),
 }

--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -465,6 +465,7 @@ export interface CacheFs {
   writeFile(f: string, d: any): Promise<void>
   mkdir(dir: string): Promise<void | string>
   stat(f: string): Promise<{ mtime: Date }>
+  rename?(oldPath: string, newPath: string): Promise<void>
 }
 
 export function stringifyError(error: Error) {


### PR DESCRIPTION
…n on shared filesystem

Fixes #98009

Concurrent FileSystemCache writes from multiple server instances on a shared filesystem could interleave and corrupt JSON (e.g. SyntaxError at position 866698). Direct writeFile to final path exposes partial/mixed content to readers.

- Add rename to CacheFs and nodeFs
- MultiFileWriter now writes to temp file then renames atomically
- Falls back to direct write for custom filesystems without rename
- Readers only see previous complete value or next complete value

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
