### PR TITLE
turbo-tasks-backend: GC allows task ids to be reused

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -90,7 +90,7 @@ use crate::{
         endpoint::ExternalEndpoint,
         turbopack_ctx::{
             MemoryEvictionMode, NapiNextTurbopackCallbacks, NapiNextTurbopackCallbacksJsObject,
-            NextTurboTasks, NextTurbopackContext, create_turbo_tasks,
+            NapiTurbopackGcOptions, NextTurboTasks, NextTurbopackContext, create_turbo_tasks,
         },
         utils::{
             DetachedVc, NapiIssue, NapiUsedFeature, SubscriptionTask, TurbopackResult, get_issues,
@@ -290,6 +290,8 @@ pub struct NapiTurboEngineOptions {
     pub skip_compaction: Option<bool>,
     /// Turbopack memory eviction mode for the persistent cache.
     pub turbopack_memory_eviction: MemoryEvictionMode,
+    /// Tuning for Turbopack's reference-counting GC. `None` disables the GC.
+    pub gc: Option<NapiTurbopackGcOptions>,
 }
 
 impl From<NapiWatchOptions> for WatchOptions {
@@ -581,7 +583,7 @@ pub fn project_new<'env>(
     env.spawn_future(
         async move {
             let dependency_tracking = turbo_engine_options.dependency_tracking.unwrap_or(true);
-            let turbopack_memory_eviction = turbo_engine_options.turbopack_memory_eviction;
+
             let turbo_tasks = create_turbo_tasks(
                 PathBuf::from(&options.dist_dir),
                 &options.next_version,
@@ -592,7 +594,8 @@ pub fn project_new<'env>(
                     is_short_session: turbo_engine_options.is_short_session.unwrap_or(false),
                     skip_compaction: turbo_engine_options.skip_compaction.unwrap_or(false),
                 },
-                turbopack_memory_eviction,
+                turbo_engine_options.turbopack_memory_eviction,
+                turbo_engine_options.gc,
             )?;
             let turbopack_ctx = NextTurbopackContext::new(turbo_tasks.clone(), napi_callbacks);
 

--- a/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
+++ b/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
@@ -6,7 +6,7 @@ use std::{
     io::{self, BufRead, Write},
     path::PathBuf,
     sync::{Arc, LazyLock, Mutex},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use anyhow::Result;
@@ -285,6 +285,27 @@ impl From<MemoryEvictionMode> for EvictionMode {
     }
 }
 
+#[napi(object)]
+#[derive(Debug, Clone, Copy)]
+pub struct NapiTurbopackGcOptions {
+    /// How long a GC pass runs before it will honour an interrupt, in milliseconds.
+    pub min_progress_ms: Option<f64>,
+    /// How long a GC root may go un-anchored before it ages out, in milliseconds.
+    pub root_ttl_ms: Option<f64>,
+}
+
+/// Converts a millisecond count that crossed the napi boundary into a `Duration`.
+fn duration_from_millis_f64(ms: Option<f64>) -> Option<Duration> {
+    if let Some(ms) = ms
+        && ms.is_finite()
+        && ms >= 0.0
+    {
+        Some(Duration::from_secs_f64(ms / 1000.0))
+    } else {
+        None
+    }
+}
+
 pub fn create_turbo_tasks(
     output_path: PathBuf,
     next_version: &str,
@@ -292,6 +313,7 @@ pub fn create_turbo_tasks(
     dependency_tracking: bool,
     storage_options: BackingStorageOptions,
     turbopack_memory_eviction: MemoryEvictionMode,
+    gc: Option<NapiTurbopackGcOptions>,
 ) -> Result<NextTurboTasks> {
     let BackingStorageOptions {
         is_ci,
@@ -306,6 +328,17 @@ pub fn create_turbo_tasks(
             &version_info,
             storage_options,
         )?;
+        let (gc, gc_min_progress, gc_root_ttl) = match gc {
+            Some(NapiTurbopackGcOptions {
+                min_progress_ms,
+                root_ttl_ms,
+            }) => (
+                Some(true),
+                duration_from_millis_f64(min_progress_ms),
+                duration_from_millis_f64(root_ttl_ms),
+            ),
+            None => (None, None, None),
+        };
         let tt = TurboTasks::new(TurboTasksBackend::new(
             BackendOptions {
                 storage_mode: Some(if env::var("TURBO_ENGINE_READ_ONLY").is_ok() {
@@ -318,6 +351,9 @@ pub fn create_turbo_tasks(
                 dependency_tracking,
                 num_workers: Some(tokio::runtime::Handle::current().metrics().num_workers()),
                 eviction_mode: EvictionMode::from(turbopack_memory_eviction),
+                gc,
+                gc_min_progress,
+                gc_root_ttl,
                 ..Default::default()
             },
             backing_storage,
@@ -331,6 +367,8 @@ pub fn create_turbo_tasks(
             BackendOptions {
                 storage_mode: None,
                 dependency_tracking,
+                // GC is deliberately left at its default (off) here: without backing storage
+                // there is nothing to reclaim from disk, so `gc` would have no effect.
                 ..Default::default()
             },
             noop_backing_storage(),

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -528,6 +528,22 @@ export interface NapiTurboEngineOptions {
   skipCompaction?: boolean
   /** Turbopack memory eviction mode for the persistent cache. */
   turbopackMemoryEviction: MemoryEvictionMode
+  /** Tuning for Turbopack's reference-counting GC. `None` disables the GC. */
+  gc?: NapiTurbopackGcOptions
+}
+
+/**
+ * Tuning for Turbopack's reference-counting GC, mirroring the
+ * `experimental.turbopackGc` config option.
+ *
+ * The presence of this object means GC is enabled; each field is optional and
+ * falls back to the backend default when omitted.
+ */
+export interface NapiTurbopackGcOptions {
+  /** How long a GC pass runs before it will honour an interrupt, in milliseconds. */
+  minProgressMs?: number
+  /** How long a GC root may go un-anchored before it ages out, in milliseconds. */
+  rootTtlMs?: number
 }
 
 export interface NapiUpdateInfo {

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -13,6 +13,7 @@ import type {
   TraceQueryOptions,
   TraceQueryResult,
   MemoryEvictionMode,
+  NapiTurbopackGcOptions,
   ServerHmrVersion as NativeServerHmrVersion,
 } from './generated-native'
 
@@ -21,6 +22,8 @@ export type { TraceServerHandle, TraceQueryOptions, TraceQueryResult }
 export type { NapiTurboEngineOptions as TurboEngineOptions }
 
 export type { MemoryEvictionMode }
+
+export type { NapiTurbopackGcOptions as TurbopackGcOptions }
 
 export type Lockfile = { __napiType: 'Lockfile' }
 

--- a/packages/next/src/build/turbopack-analyze/index.ts
+++ b/packages/next/src/build/turbopack-analyze/index.ts
@@ -94,6 +94,7 @@ export async function turbopackAnalyze(
     },
     {
       turbopackMemoryEviction: config.experimental.turbopackMemoryEvictionMode,
+      gc: config.experimental.turbopackGcOptions,
       dependencyTracking: persistentCaching,
       isCi: isCI,
       isShortSession: true,

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -117,6 +117,7 @@ export async function turbopackBuild(telemetry: Telemetry): Promise<{
 
   const sharedTurboOptions = {
     turbopackMemoryEviction: config.experimental.turbopackMemoryEvictionMode,
+    gc: config.experimental.turbopackGcOptions,
     dependencyTracking: persistentCaching || hasDeferredEntries,
     isCi: isCI,
     isShortSession: true,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -374,6 +374,15 @@ export const experimentalSchema = {
   turbopackMemoryEviction: z
     .union([z.literal(false), z.literal('full'), z.literal('auto')])
     .optional(),
+  turbopackGc: z
+    .union([
+      z.boolean(),
+      z.strictObject({
+        minProgressMs: z.number().min(0).finite().optional(),
+        rootTtlMs: z.number().min(0).finite().optional(),
+      }),
+    ])
+    .optional(),
   turbopackPluginRuntimeStrategy: z
     .enum(['workerThreads', 'childProcesses'])
     .optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -14,7 +14,7 @@ import type { SupportedTestRunners } from '../cli/next-test'
 import { INFINITE_CACHE } from '../lib/constants'
 import { isStableBuild } from '../shared/lib/errors/canary-only-config-error'
 import type { FallbackRouteParam } from '../build/static-paths/types'
-import type { MemoryEvictionMode } from '../build/swc/types'
+import type { MemoryEvictionMode, TurbopackGcOptions } from '../build/swc/types'
 import type { CacheLife } from './use-cache/cache-life'
 
 /**
@@ -79,6 +79,9 @@ export type NextConfigComplete = Required<
       instantInsights: { validationLevel: ValidationLevel }
       // Normalized by finalized config with a default and the expected type
       turbopackMemoryEvictionMode: MemoryEvictionMode
+      // Normalized by config.ts: `false`/unset becomes `undefined` (GC off),
+      // `true` becomes `{}` (GC on with default timings)
+      turbopackGcOptions: TurbopackGcOptions | undefined
     }
     // The root directory of the distDir. In development mode, this is the parent directory of `distDir`
     // since development builds use `{distDir}/dev`. This is used to ensure that the bundler doesn't
@@ -776,6 +779,26 @@ export interface ExperimentalConfig {
    * Defaults to `'auto'`
    */
   turbopackMemoryEviction?: false | 'full' | 'auto'
+
+  /**
+   * Enables Turbopack's reference-counting garbage collector, which deletes
+   * unreachable tasks from the persistent cache and from memory.
+   *
+   * Only effective in dev sessions where
+   * `experimental.turbopackFileSystemCacheForDev` is enabled (which it is by
+   * default), and where `experimental.turbopackMemoryEviction` is not disabled:
+   * the GC reclaims memory by way of eviction, so with eviction off it would
+   * leave collected tasks resident forever.
+   *
+   * - `false` (default): never collect.
+   * - `true`: collect, using the default timings.
+   * - An object: collect, overriding individual timings.
+   *   - `minProgressMs`: how long a GC pass runs before it will honour an
+   *     interrupt. Defaults to 100ms.
+   *   - `rootTtlMs`: how long a GC root may go un-anchored before it ages out.
+   *     Defaults to 3 days.
+   */
+  turbopackGc?: boolean | { minProgressMs?: number; rootTtlMs?: number }
 
   /**
    * Selects the backend used by Turbopack for Node.js evaluation, e.g. webpack

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -56,7 +56,7 @@ import type { NextAdapter } from '../build/adapter/build-complete'
 import { HardDeprecatedConfigError } from '../shared/lib/errors/hard-deprecated-config-error'
 import { NextInstanceErrorState } from './mcp/tools/next-instance-error-state'
 import { Bundler } from '../lib/bundler'
-import type { MemoryEvictionMode } from '../build/swc/types'
+import type { MemoryEvictionMode, TurbopackGcOptions } from '../build/swc/types'
 import { hrtimeBigIntDurationToString } from '../build/duration-to-string'
 
 export { normalizeConfig } from './config-shared'
@@ -504,6 +504,23 @@ function assignDefaultsAndValidate(
   }
   ;(result as NextConfigComplete).experimental.turbopackMemoryEvictionMode =
     turbopackMemoryEvictionMode as MemoryEvictionMode
+
+  // Normalize the user-facing `turbopackGc` (`boolean | { minProgressMs?,
+  // rootTtlMs? } | undefined`) into the object napi expects
+  const turbopackGc = result.experimental.turbopackGc
+  let turbopackGcOptions: TurbopackGcOptions | undefined
+  if (turbopackGc === true) {
+    turbopackGcOptions = {}
+  } else if (typeof turbopackGc === 'object' && turbopackGc !== null) {
+    turbopackGcOptions = {
+      minProgressMs: turbopackGc.minProgressMs,
+      rootTtlMs: turbopackGc.rootTtlMs,
+    }
+  } else {
+    turbopackGcOptions = undefined
+  }
+  ;(result as NextConfigComplete).experimental.turbopackGcOptions =
+    turbopackGcOptions
 
   // Normalize experimental.browserDebugInfoInTerminal to logging.browserToTerminal
   if (

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -529,6 +529,7 @@ export async function createHotReloaderTurbopack(
     {
       turbopackMemoryEviction:
         opts.nextConfig.experimental.turbopackMemoryEvictionMode,
+      gc: opts.nextConfig.experimental.turbopackGcOptions,
       isShortSession: false,
     }
   )

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -391,6 +391,8 @@ impl TurboTasksBackend {
             && let Err(err) = self.backing_storage.save_snapshot(
                 Vec::new(),
                 Some(roots),
+                // This hook runs no eviction, so it frees no ids to persist.
+                None,
                 Vec::<Vec<SnapshotItem>>::new(),
             )
         {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -377,8 +377,7 @@ impl TurboTasksBackend {
         // A pass sets `deleted` flags, and the persist path only knows how to tombstone those when
         // GC is enabled. Running a pass on a GC-disabled backend would leave soft-deleted tasks
         // that persistence refuses to handle, so require the backend to be configured for GC
-        // (`BackendOptions::gc` or `TURBO_ENGINE_GC`) rather than silently diverging from
-        // production.
+        // (`BackendOptions::gc`) rather than silently diverging from production.
         assert!(
             self.gc_enabled,
             "gc_for_testing requires a GC-enabled backend: set `BackendOptions::gc = Some(true)`"

--- a/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/gc.rs
@@ -190,7 +190,6 @@ impl TurboTasksBackend {
         let aged_out = self.gc_roots_refresh_and_age_out(&mut roots, now);
 
         let aged_out_count = aged_out.len();
-        // TODO(perf): recycle the task ids of collected tasks.
         let budget = if interruptible {
             Some(GcBudget {
                 phase,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/id_reuse.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/id_reuse.rs
@@ -1,0 +1,170 @@
+//! Deferred reuse of the task ids freed by GC.
+//!
+//! # Why reuse ids at all
+//!
+//! Not exhaustion — the persistent id space is ~1.07B and real sessions stay well under 15M. The
+//! goal is **density**: keeping the live id set packed near `[1, max_live)` is what makes flat,
+//! array-backed storage viable in place of a sharded `DashMap<TaskId, _>`. So the metric that
+//! matters is peak `next_free_task_id` against peak live task count, not the reuse count itself.
+//!
+//! # Why the ids are held back
+//!
+//! Handing a freed id straight back to [`IdFactoryWithReuse`] would make a stale reference — one
+//! that outlived the task it names — silently resolve to an unrelated live task. Today such a
+//! reference fails loudly instead: `open_task` with `TaskAccess::MustExist` asserts that the task
+//! "exists in neither memory nor persistent storage". Reuse is what would turn that panic into a
+//! wrong answer.
+//!
+//! While an id sits in this queue it is in neither the resident map, the task cache, nor on disk,
+//! so a stale reference still hits that assert. The queue is therefore not merely probabilistic
+//! hardening: it *preserves the existing loud failure* for the whole deferral window. A bug in the
+//! reuse pipeline shows up as the same panic it does today, just later.
+//!
+//! The window is measured in snapshot cycles rather than queue depth because the hazard is
+//! phase-relative (a task is freed as part of one cycle's eviction), not volume-relative. A quiet
+//! session simply doesn't reuse, which costs nothing but a little density.
+//!
+//! # Alternative considered and rejected: generation-tagged ids
+//!
+//! Stealing 2 bits of [`TaskId`] for a generation counter, bumped on each reuse, would make a
+//! stale reference resolve to a *different* id and so fail loudly forever rather than for a
+//! window. It was rejected because it gives every task two identities — a masked in-memory id and
+//! an unmasked on-disk key — and `kv_backing_storage` converts ids to key bytes by bare deref in
+//! several places (`IntKey::new(*task_id)`, `(*task_id).to_le_bytes()`), plus
+//! `max_new_task_id.max(*task_id)`, which would compare generation bits as magnitude. Any missed
+//! mask is a silent wrong-row read. It would also change the on-disk key format, requiring a
+//! `db_versioning` bump. Revisit only if deferral proves insufficient in practice.
+
+use std::collections::VecDeque;
+
+use parking_lot::Mutex;
+use turbo_tasks::TaskId;
+
+/// How many snapshot cycles a freed id waits before it may be handed out again.
+///
+/// One cycle would already cover the eviction that freed it; the extra margin covers a stale
+/// reference held across a cycle boundary. Overridable per-backend for tests.
+pub(crate) const DEFAULT_ID_REUSE_DELAY_CYCLES: u32 = 2;
+
+/// Freed task ids waiting out their deferral window, oldest first.
+///
+/// Ids enter from
+/// [`Storage::evict_after_snapshot`](crate::backend::storage::Storage::evict_after_snapshot) once a
+/// GC-deleted task has been erased from both the resident map and the task cache, and leave
+/// once `delay_cycles` snapshot cycles have elapsed.
+pub(crate) struct DeferredIdReuse {
+    /// `(id, cycle it was freed in)`, pushed in cycle order so the front is always the oldest.
+    queue: Mutex<VecDeque<(TaskId, u32)>>,
+    /// Monotonic count of completed snapshot cycles. Only ever advanced by
+    /// [`Self::advance_cycle`].
+    cycle: Mutex<u32>,
+    /// Cycles an id must wait. `0` releases immediately, which is what the aliasing-pressure tests
+    /// want.
+    delay_cycles: u32,
+}
+
+impl DeferredIdReuse {
+    pub(crate) fn new(delay_cycles: u32) -> Self {
+        Self {
+            queue: Mutex::new(VecDeque::new()),
+            cycle: Mutex::new(0),
+            delay_cycles,
+        }
+    }
+
+    /// Records ids freed by the eviction sweep of the current cycle.
+    ///
+    /// The caller must have already removed each id from the resident map **and** the task cache;
+    /// an id whose `task_cache` entry survives could still be handed back by
+    /// `get_or_create_persistent_task`.
+    pub(crate) fn defer(&self, ids: impl IntoIterator<Item = TaskId>) {
+        let cycle = *self.cycle.lock();
+        let mut queue = self.queue.lock();
+        queue.extend(ids.into_iter().map(|id| (id, cycle)));
+    }
+
+    /// Ends the current snapshot cycle and returns the ids whose window has now elapsed.
+    ///
+    /// Returned ids are safe to hand to [`IdFactoryWithReuse::reuse`].
+    pub(crate) fn advance_cycle(&self) -> Vec<TaskId> {
+        let cycle = {
+            let mut cycle = self.cycle.lock();
+            *cycle = cycle.saturating_add(1);
+            *cycle
+        };
+        let mut queue = self.queue.lock();
+        let mut released = Vec::new();
+        // The queue is in cycle order, so the first entry that is too young ends the scan.
+        while let Some(&(id, freed_at)) = queue.front() {
+            if cycle.saturating_sub(freed_at) < self.delay_cycles {
+                break;
+            }
+            queue.pop_front();
+            released.push(id);
+        }
+        released
+    }
+
+    /// Number of ids currently waiting out their window. Observability only.
+    pub(crate) fn pending(&self) -> usize {
+        self.queue.lock().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(n: u32) -> TaskId {
+        TaskId::try_from(n).unwrap()
+    }
+
+    #[test]
+    fn releases_after_the_delay() {
+        let q = DeferredIdReuse::new(2);
+        q.defer([id(1), id(2)]);
+        assert!(q.advance_cycle().is_empty(), "one cycle is not enough");
+        assert_eq!(q.pending(), 2);
+        assert_eq!(q.advance_cycle(), vec![id(1), id(2)]);
+        assert_eq!(q.pending(), 0);
+    }
+
+    #[test]
+    fn zero_delay_releases_on_the_next_cycle() {
+        // The aliasing-pressure configuration: maximum reuse, minimum window.
+        let q = DeferredIdReuse::new(0);
+        q.defer([id(7)]);
+        assert_eq!(q.advance_cycle(), vec![id(7)]);
+    }
+
+    #[test]
+    fn ids_freed_in_later_cycles_wait_their_own_window() {
+        let q = DeferredIdReuse::new(1);
+        q.defer([id(1)]);
+        assert_eq!(q.advance_cycle(), vec![id(1)]);
+        // Deferred during cycle 1, so it must not come back until cycle 2.
+        q.defer([id(2)]);
+        assert_eq!(q.advance_cycle(), vec![id(2)]);
+    }
+
+    #[test]
+    fn a_quiet_cycle_releases_nothing() {
+        let q = DeferredIdReuse::new(1);
+        assert!(q.advance_cycle().is_empty());
+        assert_eq!(q.pending(), 0);
+    }
+
+    #[test]
+    fn mixed_ages_release_in_order_without_stranding_the_tail() {
+        // Regression guard for the early-break scan: a young entry at the front must not hide
+        // older ones behind it, and must not be released with them either.
+        let q = DeferredIdReuse::new(2);
+        q.defer([id(1)]);
+        q.advance_cycle();
+        q.defer([id(2)]);
+        // cycle 2: id(1) is 2 cycles old, id(2) is only 1.
+        assert_eq!(q.advance_cycle(), vec![id(1)]);
+        assert_eq!(q.pending(), 1);
+        assert_eq!(q.advance_cycle(), vec![id(2)]);
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/id_reuse.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/id_reuse.rs
@@ -38,6 +38,7 @@
 use std::collections::VecDeque;
 
 use parking_lot::Mutex;
+use rustc_hash::FxHashSet;
 use turbo_tasks::TaskId;
 
 /// How many snapshot cycles a freed id waits before it may be handed out again.
@@ -61,6 +62,10 @@ pub(crate) struct DeferredIdReuse {
     /// Cycles an id must wait. `0` releases immediately, which is what the aliasing-pressure tests
     /// want.
     delay_cycles: u32,
+    /// Ids already handed back to the factory this session. Retained only so that
+    /// [`Self::persistable`] can offer them to the next session too — an id reused in *this*
+    /// session is still free from the perspective of a fresh one, which rebuilds its own graph.
+    released: Mutex<FxHashSet<TaskId>>,
 }
 
 impl DeferredIdReuse {
@@ -69,6 +74,7 @@ impl DeferredIdReuse {
             queue: Mutex::new(VecDeque::new()),
             cycle: Mutex::new(0),
             delay_cycles,
+            released: Mutex::new(FxHashSet::default()),
         }
     }
 
@@ -101,6 +107,7 @@ impl DeferredIdReuse {
             }
             queue.pop_front();
             released.push(id);
+            self.released.lock().insert(id);
         }
         released
     }
@@ -108,6 +115,21 @@ impl DeferredIdReuse {
     /// Number of ids currently waiting out their window. Observability only.
     pub(crate) fn pending(&self) -> usize {
         self.queue.lock().len()
+    }
+
+    /// Every id this session has freed and not since seen resurrected, for persistence.
+    ///
+    /// No retraction path is needed for resurrection: `resurrect_deleted` can only revive a task
+    /// while it is still resident, and eviction is what puts an id in this queue, so a resurrected
+    /// task never reaches [`Self::defer`] in the first place. Includes ids still
+    /// inside their in-memory window: the window exists to protect *this* session's stale
+    /// references, and a fresh session starts with no resident state, so nothing can hold one.
+    pub(crate) fn persistable(&self) -> Vec<TaskId> {
+        let queue = self.queue.lock();
+        let released = self.released.lock();
+        let mut ids: Vec<TaskId> = queue.iter().map(|&(id, _)| id).collect();
+        ids.extend(released.iter().copied());
+        ids
     }
 }
 
@@ -145,6 +167,19 @@ mod tests {
         // Deferred during cycle 1, so it must not come back until cycle 2.
         q.defer([id(2)]);
         assert_eq!(q.advance_cycle(), vec![id(2)]);
+    }
+
+    #[test]
+    fn persistable_covers_both_waiting_and_released_ids() {
+        // The next session has no resident state, so an id that is still inside this session's
+        // window is nonetheless free from its point of view — both halves must be offered.
+        let q = DeferredIdReuse::new(1);
+        q.defer([id(1)]);
+        assert_eq!(q.advance_cycle(), vec![id(1)]);
+        q.defer([id(2)]);
+        let mut persistable = q.persistable();
+        persistable.sort();
+        assert_eq!(persistable, vec![id(1), id(2)]);
     }
 
     #[test]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -345,15 +345,47 @@ impl TurboTasksBackend {
             gc_enabled = false;
         }
 
+        // Ids the previous session freed. Validated before use: a corrupt or stale entry would
+        // otherwise hand out an id that is still live, which reuse must never do. Anything
+        // suspicious drops the whole set rather than part of it — the cost is lost density, and
+        // the alternative is trusting the rest of a record we already know is wrong.
+        let free_task_ids = match backing_storage.free_task_ids() {
+            Ok(ids) => {
+                let valid = ids
+                    .iter()
+                    .all(|id| !id.is_transient() && **id < *next_task_id);
+                if valid {
+                    ids
+                } else {
+                    eprintln!(
+                        "warning: persisted free task id set contains ids outside the allocated                          range; ignoring it"
+                    );
+                    Vec::new()
+                }
+            }
+            Err(err) => {
+                eprintln!("failed to read free task ids, treating as empty: {err:?}");
+                Vec::new()
+            }
+        };
+
         Self {
             options,
             gc_enabled,
             start_time: Instant::now(),
             deferred_id_reuse: DeferredIdReuse::new(id_reuse_delay_cycles),
-            persisted_task_id_factory: IdFactoryWithReuse::new(
-                next_task_id,
-                TaskId::try_from(TRANSIENT_TASK_BIT - 1).unwrap(),
-            ),
+            persisted_task_id_factory: {
+                let factory = IdFactoryWithReuse::new(
+                    next_task_id,
+                    TaskId::try_from(TRANSIENT_TASK_BIT - 1).unwrap(),
+                );
+                // SAFETY: each id was freed by a previous session's GC, its tombstone was
+                // committed, and it was validated above to be a persistent id below the
+                // allocation watermark. A fresh session has no resident state, so nothing in this
+                // process can be holding a reference to one.
+                unsafe { factory.seed_free_ids(free_task_ids) };
+                factory
+            },
             transient_task_id_factory: IdFactoryWithReuse::new(
                 TaskId::try_from(TRANSIENT_TASK_BIT).unwrap(),
                 TaskId::MAX,
@@ -1259,7 +1291,12 @@ impl TurboTasksBackend {
         let snapshot_time = Instant::now();
         drop(snapshot_phase);
 
-        if !has_modifications && gc_roots_to_persist.is_none() {
+        // Ids this session freed still need to reach disk even when nothing else changed —
+        // otherwise a session whose last cycle had no modifications silently drops them and the
+        // next session re-mints instead of reusing.
+        let has_free_ids_to_persist =
+            self.gc_enabled && !self.deferred_id_reuse.persistable().is_empty();
+        if !has_modifications && gc_roots_to_persist.is_none() && !has_free_ids_to_persist {
             // No tasks modified since the last snapshot — drop the guard (which
             // calls end_snapshot) and skip the expensive O(N) scan.
             drop(snapshot_guard);
@@ -1437,6 +1474,10 @@ impl TurboTasksBackend {
         // For tasks accessed during snapshot mode, a frozen copy was made and its `modified`
         // flags were copied from the live task at snapshot creation time, reflecting which
         // categories were dirtied before the snapshot was taken.
+        // Only collected at shutdown; see the `Delete` branch below. `Arc` because `process` is
+        // borrowed by the parallel scan and must not keep the value borrowed past it.
+        let tombstoned_this_commit: Option<Arc<Mutex<Vec<TaskId>>>> =
+            (self.gc_enabled && reason.drain_entries()).then(|| Arc::new(Mutex::new(Vec::new())));
         let process = |task_id: TaskId, inner: &TaskStorage, buffer: &mut TurboBincodeBuffer| {
             let encode_category = |task_id: TaskId,
                                    data: &TaskStorage,
@@ -1482,6 +1523,12 @@ impl TurboTasksBackend {
                             .get_persistent_task_type()
                             .expect("a GC-deleted task must have a task type"),
                     );
+                    // Shutdown only: this is the last commit, so these ids can be offered to the
+                    // next session directly instead of waiting for a follow-up commit that will
+                    // never come. `process` runs in parallel across shards, hence the lock.
+                    if let Some(tombstoned) = &tombstoned_this_commit {
+                        tombstoned.lock().push(task_id);
+                    }
                     return SnapshotItem::Delete {
                         task_id,
                         task_type_hash,
@@ -1553,7 +1600,7 @@ impl TurboTasksBackend {
         let snapshot_duration = start.elapsed();
         let task_count = task_snapshots.len();
 
-        if task_snapshots.is_empty() && gc_roots_to_persist.is_none() {
+        if task_snapshots.is_empty() && gc_roots_to_persist.is_none() && !has_free_ids_to_persist {
             // This should be impossible — if we got here, modified_count was nonzero or gc_roots
             // was present, and every modification that increments the count also failed
             // during encoding.
@@ -1572,9 +1619,26 @@ impl TurboTasksBackend {
         // Tasks were already consumed by take_snapshot, so a future snapshot
         // would not re-persist them — returning an error signals to the caller
         // that further persist attempts would corrupt the task graph in storage.
+        // Recomputed each commit rather than accumulated: an id that was freed and has since been
+        // resurrected simply drops out of the set. Ids freed by *this* cycle's eviction are not
+        // here yet — eviction runs after this returns — so they ride the next commit, which is
+        // also the commit after their tombstone is durable.
+        //
+        // At shutdown there is no next commit, so fold in the tasks this snapshot is tombstoning
+        // right now. Nothing can resurrect them: this is the process's last write.
+        let free_task_ids = if self.gc_enabled {
+            let mut ids = self.deferred_id_reuse.persistable();
+            if let Some(tombstoned) = &tombstoned_this_commit {
+                ids.extend(tombstoned.lock().iter().copied());
+            }
+            Some(ids)
+        } else {
+            None
+        };
         let snapshot_meta = self.backing_storage.save_snapshot(
             suspended_operations,
             gc_roots_to_persist,
+            free_task_ids,
             task_snapshots,
         )?;
         span.record("snapshot_meta", display(snapshot_meta));

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -157,16 +157,17 @@ pub struct BackendOptions {
     /// This reclaims memory by clearing persisted data that can be re-loaded from disk on demand.
     pub eviction_mode: EvictionMode,
 
-    /// Overrides whether the reference-counting GC runs for this backend. `None` (default) derives
-    /// it from the `TURBO_ENGINE_GC` env var;
+    /// Whether the reference-counting GC runs for this backend. `None` (default) leaves it off.
+    ///
+    /// In Next.js this is driven by the `experimental.turbopackGc` config option.
     pub gc: Option<bool>,
 
-    /// Overrides how long a GC root may go un-anchored before it ages out. `None` (default)
-    /// derives it from the `TURBO_ENGINE_GC_ROOT_TTL_MS` env var, falling back to
+    /// How long a GC root may go un-anchored before it ages out. `None` (default) uses
     /// [`DEFAULT_GC_ROOT_TTL`].
     pub gc_root_ttl: Option<Duration>,
 
-    /// Overrides how long a GC pass runs before it will honour an interrupt.
+    /// How long a GC pass runs before it will honour an interrupt. `None` (default) uses
+    /// [`GC_MIN_PROGRESS`].
     pub gc_min_progress: Option<Duration>,
 }
 
@@ -311,57 +312,24 @@ impl TurboTasksBackend {
             options.active_tracking = false;
         }
         let small_preallocation = options.small_preallocation;
+        let gc_root_ttl = options.gc_root_ttl.unwrap_or(DEFAULT_GC_ROOT_TTL);
+        let gc_min_progress = options.gc_min_progress.unwrap_or(GC_MIN_PROGRESS);
         let next_task_id = backing_storage
             .next_free_task_id()
             .expect("Failed to get task id");
 
-        let mut gc_enabled = options.gc.unwrap_or_else(|| {
-            std::env::var_os("TURBO_ENGINE_GC")
-                .is_some_and(|v| matches!(v.to_str(), Some("1" | "true" | "yes")))
-        });
+        let mut gc_enabled = options.gc.unwrap_or(false);
         if gc_enabled
             && options.storage_mode == Some(StorageMode::ReadWrite)
             && options.eviction_mode == EvictionMode::Off
         {
             eprintln!(
-                "warning: GC is enabled but eviction is disabled on a ReadWrite backend; GC would \
-                 leave collected tasks resident forever. Forcing GC off. Enable eviction \
-                 ('auto'/'full') to use GC in this mode."
+                "warning: GC is enabled but eviction is disabled; GC would leave collected tasks \
+                 resident forever. Forcing GC off. Enable eviction ('auto'/'full') to use GC in \
+                 this mode."
             );
             gc_enabled = false;
         }
-
-        let gc_min_progress = options.gc_min_progress.unwrap_or_else(|| {
-            match std::env::var("TURBO_ENGINE_GC_MIN_PROGRESS_MS") {
-                Ok(v) => match v.parse::<u64>() {
-                    Ok(ms) => Duration::from_millis(ms),
-                    Err(e) => {
-                        eprintln!(
-                            "warning: TURBO_ENGINE_GC_MIN_PROGRESS_MS set but is not parsable: \
-                             {e}. Using the default instead."
-                        );
-                        GC_MIN_PROGRESS
-                    }
-                },
-                Err(_) => GC_MIN_PROGRESS,
-            }
-        });
-
-        let gc_root_ttl = options.gc_root_ttl.unwrap_or_else(|| {
-            match std::env::var("TURBO_ENGINE_GC_ROOT_TTL_MS") {
-                Ok(v) => match v.parse::<u64>() {
-                    Ok(ms) => Duration::from_millis(ms),
-                    Err(e) => {
-                        eprintln!(
-                            "warning: TURBO_ENGINE_GC_ROOT_TTL_MS set but is not parsable: {e}. \
-                             Using the default instead."
-                        );
-                        DEFAULT_GC_ROOT_TTL
-                    }
-                },
-                Err(_) => DEFAULT_GC_ROOT_TTL,
-            }
-        });
 
         Self {
             options,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2,6 +2,7 @@ mod cell_data;
 mod counter_map;
 mod eviction;
 mod gc;
+mod id_reuse;
 mod operation;
 mod snapshot_coordinator;
 mod storage;
@@ -27,6 +28,7 @@ use auto_hash_map::{AutoMap, AutoSet};
 use gc::DEFAULT_GC_ROOT_TTL;
 pub use gc::{GcStats, TtlCounter};
 use hashbrown::hash_table::Entry;
+use id_reuse::{DEFAULT_ID_REUSE_DELAY_CYCLES, DeferredIdReuse};
 use indexmap::IndexSet;
 use parking_lot::{Mutex, RwLock};
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
@@ -169,6 +171,11 @@ pub struct BackendOptions {
     /// How long a GC pass runs before it will honour an interrupt. `None` (default) uses
     /// [`GC_MIN_PROGRESS`].
     pub gc_min_progress: Option<Duration>,
+
+    /// How many snapshot cycles a GC-freed task id waits before it may be reused. `None`
+    /// (default) uses [`DEFAULT_ID_REUSE_DELAY_CYCLES`]. `0` reuses as soon as the next cycle
+    /// ends, which is what tests use to maximize aliasing pressure.
+    pub id_reuse_delay_cycles: Option<u32>,
 }
 
 impl Default for BackendOptions {
@@ -181,8 +188,9 @@ impl Default for BackendOptions {
             small_preallocation: false,
             eviction_mode: EvictionMode::Off,
             gc: None,
-            gc_root_ttl: None,
             gc_min_progress: None,
+            gc_root_ttl: None,
+            id_reuse_delay_cycles: None,
         }
     }
 }
@@ -231,6 +239,9 @@ pub struct TurboTasksBackend {
     start_time: Instant,
 
     persisted_task_id_factory: IdFactoryWithReuse<TaskId>,
+    /// Task ids freed by GC that are waiting out their deferral window before being handed back to
+    /// `persisted_task_id_factory`. See [`DeferredIdReuse`].
+    deferred_id_reuse: DeferredIdReuse,
     transient_task_id_factory: IdFactoryWithReuse<TaskId>,
 
     storage: Storage,
@@ -314,6 +325,9 @@ impl TurboTasksBackend {
         let small_preallocation = options.small_preallocation;
         let gc_root_ttl = options.gc_root_ttl.unwrap_or(DEFAULT_GC_ROOT_TTL);
         let gc_min_progress = options.gc_min_progress.unwrap_or(GC_MIN_PROGRESS);
+        let id_reuse_delay_cycles = options
+            .id_reuse_delay_cycles
+            .unwrap_or(DEFAULT_ID_REUSE_DELAY_CYCLES);
         let next_task_id = backing_storage
             .next_free_task_id()
             .expect("Failed to get task id");
@@ -335,6 +349,7 @@ impl TurboTasksBackend {
             options,
             gc_enabled,
             start_time: Instant::now(),
+            deferred_id_reuse: DeferredIdReuse::new(id_reuse_delay_cycles),
             persisted_task_id_factory: IdFactoryWithReuse::new(
                 next_task_id,
                 TaskId::try_from(TRANSIENT_TASK_BIT - 1).unwrap(),
@@ -410,6 +425,38 @@ impl TurboTasksBackend {
         )
     }
 
+    /// Hands the ids an eviction sweep freed to the deferral queue, ends the cycle, and returns
+    /// whatever has now waited long enough to the id factory.
+    ///
+    /// # Safety of the `reuse` calls
+    ///
+    /// Each id released here named a GC-deleted task that `evict_after_snapshot` erased from the
+    /// resident map and the task cache, whose tombstone was committed by the snapshot that ran
+    /// immediately before, and which has since sat out its deferral window. Nothing can resolve it
+    /// any more, which is what [`IdFactoryWithReuse::reuse`] requires.
+    fn recycle_freed_task_ids(&self, freed: Vec<TaskId>) {
+        let freed_count = freed.len();
+        self.deferred_id_reuse.defer(freed);
+        let released = self.deferred_id_reuse.advance_cycle();
+        // The headline number for this feature is density: peak allocated id vs. peak live tasks.
+        // A ratio that climbs over a long session means ids are not coming back.
+        tracing::trace!(
+            target: "turbo_tasks_backend::id_reuse",
+            freed = freed_count,
+            released = released.len(),
+            pending = self.deferred_id_reuse.pending(),
+            resident = self.storage.resident_persistent_task_count_for_testing(),
+        );
+        for id in released {
+            debug_assert!(
+                !id.is_transient(),
+                "only persistent task ids are collected by GC"
+            );
+            // SAFETY: see the doc comment above.
+            unsafe { self.persisted_task_id_factory.reuse(id) };
+        }
+    }
+
     /// Perform a snapshot and then evict all evictable tasks from memory.
     ///
     /// This is exposed for integration tests that need to verify the
@@ -437,7 +484,8 @@ impl TurboTasksBackend {
                 return TestSnapshotOutcome::default();
             }
         };
-        let eviction_counts = self.storage.evict_after_snapshot(None);
+        let (eviction_counts, freed_ids) = self.storage.evict_after_snapshot(None);
+        self.recycle_freed_task_ids(freed_ids);
         TestSnapshotOutcome {
             had_new_data,
             eviction_counts,
@@ -448,6 +496,18 @@ impl TurboTasksBackend {
     /// The number of persistent (non-transient) tasks resident in the map. Test-only hook; see
     /// [`Storage::resident_persistent_task_count_for_testing`] for why the metric excludes
     /// transient tasks.
+    #[doc(hidden)]
+    /// `(pending_deferral, next_fresh_id)`: how many freed ids are waiting out their window, and
+    /// the next id the factory would mint if its free list were empty. The second is the density
+    /// watermark — if reuse is working, it stops climbing once a workload reaches steady state.
+    #[doc(hidden)]
+    pub fn id_reuse_state_for_testing(&self) -> (usize, u64) {
+        (
+            self.deferred_id_reuse.pending(),
+            self.persisted_task_id_factory.peek_next_fresh(),
+        )
+    }
+
     #[doc(hidden)]
     pub fn resident_persistent_task_count_for_testing(&self) -> usize {
         self.storage.resident_persistent_task_count_for_testing()
@@ -3255,6 +3315,9 @@ impl TurboTasksBackend {
                                     // memory so racing with execution is as likely to save time as
                                     // cost it.
                                     self.storage.evict_after_snapshot(background_span.id());
+                                    let (_counts, freed_ids) =
+                                        self.storage.evict_after_snapshot(background_span.id());
+                                    self.recycle_freed_task_ids(freed_ids);
                                     true
                                 } else {
                                     false

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -633,7 +633,11 @@ impl Storage {
     /// - `No`: skip
     ///
     /// Must be called when NOT in snapshot mode (i.e., after `end_snapshot()`).
-    pub fn evict_after_snapshot(&self, parent_span: Option<Id>) -> EvictionCounts {
+    /// Returns the eviction counts and the ids of the GC-deleted tasks this sweep erased. Those
+    /// ids are gone from both the resident map and the task cache, so they are candidates for
+    /// reuse — see [`DeferredIdReuse`](crate::backend::id_reuse::DeferredIdReuse) for why they are
+    /// not handed back immediately.
+    pub fn evict_after_snapshot(&self, parent_span: Option<Id>) -> (EvictionCounts, Vec<TaskId>) {
         let span = tracing::trace_span!(
             parent: parent_span,
             "evict_after_snapshot",
@@ -647,9 +651,15 @@ impl Storage {
             "evict_after_snapshot must not be called during snapshot mode"
         );
 
-        let counts: Vec<EvictionCounts> = parallel::map_collect(self.map.shards(), |shard| {
+        type ShardResult = (EvictionCounts, Vec<TaskId>);
+        let counts: Vec<ShardResult> = parallel::map_collect(self.map.shards(), |shard| {
             let mut shard = shard.write();
             let mut evicted = EvictionCounts::default();
+            // Ids of GC-deleted tasks erased below. Collected rather than released inline: an
+            // id is only safe to reuse once its `task_cache` entry is gone too,
+            // and a contended removal is deferred to after this shard's lock is
+            // dropped.
+            let mut freed_ids: Vec<TaskId> = Vec::new();
             // task_cache removals that we couldn't perform inline because the target shard
             // was contended. We defer them until after the map shard lock is released to
             // avoid a lock cycle with get_or_create_persistent_task, which takes task_cache
@@ -690,6 +700,7 @@ impl Storage {
                         &mut deferred_task_cache_removals,
                         task_type,
                     );
+                    freed_ids.push(*task_id);
                     evicted.full += 1;
                     return false;
                 }
@@ -701,8 +712,9 @@ impl Storage {
                         // re-populated by task_by_type() on the next cache miss.
                         let task_type = task.get_persistent_task_type().unwrap();
                         // Only try to acquire the lock, if we cannot just remove at the end
-                        // Because `get_or_create_task` acquires 'task_cache' then `storage.map` and
-                        // we do the opposite we need to be defensive here.  Attempting here is just
+                        // Because `get_or_create_task` acquires 'task_cache' then `storage.map`
+                        // and we do the opposite we need to be
+                        // defensive here.  Attempting here is just
                         // an optimization to avoid pushing into `deferred_task_cache_removals`
                         remove_from_task_cache(
                             &mut evicted,
@@ -752,12 +764,15 @@ impl Storage {
                     evicted.key_evictions += 1;
                 }
             }
-            evicted
+            // Only now is every freed id absent from the task cache as well as the map.
+            (evicted, freed_ids)
         });
 
         let mut totals = EvictionCounts::default();
-        for evicted in counts {
+        let mut freed_ids = Vec::new();
+        for (evicted, mut ids) in counts {
             totals += evicted;
+            freed_ids.append(&mut ids);
         }
         // Shrink task_cache only when we evicted more entries than remain — i.e. the map
         // is less than half full. Rehashing each surviving CachedTaskType isn't free, so
@@ -774,7 +789,7 @@ impl Storage {
         }
         span.record("counts", tracing::field::display(&totals));
 
-        totals
+        (totals, freed_ids)
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -37,6 +37,8 @@ enum InfraKey {
     Operations = 0,
     NextFreeTaskId = 1,
     GcRoots = 2,
+    /// Task ids that GC freed and eviction erased, available for reuse by the next session.
+    FreeTaskIds = 3,
 }
 
 impl InfraKey {
@@ -263,10 +265,27 @@ impl TurboBackingStorage {
         get(&self.inner.database).context("Unable to read GC roots from database")
     }
 
+    /// Reads the persisted free task id set (see [`InfraKey::FreeTaskIds`]). Empty on a fresh
+    /// database.
+    ///
+    /// The caller must validate the contents before trusting them; a corrupt or stale entry could
+    /// otherwise hand out an id that is still in use.
+    pub(crate) fn free_task_ids(&self) -> Result<Vec<TaskId>> {
+        fn get(database: &TurboKeyValueDatabase) -> Result<Vec<TaskId>> {
+            let Some(ids) = database.get(KeySpace::Infra, InfraKey::FreeTaskIds.key().as_ref())?
+            else {
+                return Ok(Vec::new());
+            };
+            Ok(turbo_bincode_decode(ids.borrow())?)
+        }
+        get(&self.inner.database).context("Unable to read free task ids from database")
+    }
+
     pub(crate) fn save_snapshot<I>(
         &self,
         operations: Vec<Arc<AnyOperation>>,
         roots: Option<Vec<(TaskId, TtlCounter)>>,
+        free_task_ids: Option<Vec<TaskId>>,
         snapshots: Vec<I>,
     ) -> Result<SnapshotMeta>
     where
@@ -367,7 +386,7 @@ impl TurboBackingStorage {
             let mut next_task_id = get_next_free_task_id(&batch)?;
             next_task_id = next_task_id.max(snapshot_meta.max_next_task_id + 1);
 
-            save_infra(&batch, next_task_id, operations, roots)?;
+            save_infra(&batch, next_task_id, operations, roots, free_task_ids)?;
             {
                 let _span = tracing::trace_span!("commit").entered();
                 // Byte totals are the physical on-disk bytes (post-compression, including .sst /
@@ -496,6 +515,7 @@ fn save_infra(
     next_task_id: u32,
     operations: Vec<Arc<AnyOperation>>,
     roots: Option<Vec<(TaskId, TtlCounter)>>,
+    free_task_ids: Option<Vec<TaskId>>,
 ) -> Result<(), anyhow::Error> {
     batch
         .put(
@@ -527,6 +547,20 @@ fn save_infra(
                 WriteBuffer::SmallVec(roots),
             )
             .context("Unable to write GC roots")?;
+    }
+    if let Some(free_task_ids) = free_task_ids {
+        let _span =
+            tracing::trace_span!("update free task ids", free_task_ids = free_task_ids.len())
+                .entered();
+        let free_task_ids =
+            turbo_bincode_encode(&free_task_ids).context("Unable to serialize free task ids")?;
+        batch
+            .put(
+                KeySpace::Infra,
+                WriteBuffer::Borrowed(InfraKey::FreeTaskIds.key().as_ref()),
+                WriteBuffer::SmallVec(free_task_ids),
+            )
+            .context("Unable to write free task ids")?;
     }
     // Safety: save_infra is called after all concurrent writes to Infra are done.
     unsafe { batch.flush(KeySpace::Infra)? };
@@ -729,6 +763,7 @@ mod tests {
         // Snapshot with no task data, just the one deletion.
         storage.save_snapshot(
             Vec::new(),
+            None,
             None,
             vec![vec![SnapshotItem::Delete {
                 task_id: deleted_id,

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_id_reuse.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_id_reuse.rs
@@ -1,0 +1,185 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+//! Task ids freed by GC are handed back to the id factory, but only after a deferral window.
+//!
+//! The point of reuse is **density** — keeping the live id set packed so that flat, array-backed
+//! storage stays viable — so these tests assert on the id watermark (`next_fresh`), not on reuse
+//! counts. A watermark that keeps climbing while the live task count is flat means ids are leaking
+//! out of the pipeline even if some are being recycled.
+
+mod gc_fixture;
+mod util;
+
+use std::time::Duration;
+
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, Vc, unmark_top_level_task_may_leak_eventually_consistent_state};
+use turbo_tasks_backend::{BackendOptions, EvictionMode};
+
+use crate::{
+    gc_fixture::{Selector, create_selector},
+    util::create_tt_with_options,
+};
+
+#[turbo_tasks::function]
+fn reuse_leaf(n: u32) -> Vc<u32> {
+    Vc::cell(n)
+}
+
+/// A root op that allocates `count` distinct new leaf tasks, so a test can force the factory to
+/// hand out exactly that many ids.
+#[turbo_tasks::function(operation, root)]
+async fn allocate_fresh(base: u32, count: u32) -> Result<Vc<u32>> {
+    let mut sum = 0u32;
+    for n in base..(base + count) {
+        sum = sum.wrapping_add(*reuse_leaf(n).await?);
+    }
+    Ok(Vc::cell(sum))
+}
+
+#[turbo_tasks::function]
+async fn reuse_branch(generation: u32) -> Result<Vc<u32>> {
+    Ok(Vc::cell(1 + *reuse_leaf(generation).await?))
+}
+
+/// Reads a branch keyed by the selector's generation. Bumping the generation disconnects the whole
+/// previous branch, orphaning it for GC.
+#[turbo_tasks::function(operation, root)]
+async fn select_generation(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
+    let use_second = *selector.await?.get();
+    let value = if use_second {
+        *reuse_branch(2).await?
+    } else {
+        *reuse_branch(1).await?
+    };
+    Ok(Vc::cell(value))
+}
+
+/// Options with GC on and the reuse delay pinned, so a test controls the window explicitly rather
+/// than depending on the default or the env var.
+fn options(delay_cycles: u32) -> BackendOptions {
+    BackendOptions {
+        num_workers: Some(2),
+        small_preallocation: true,
+        storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
+        eviction_mode: EvictionMode::Full,
+        gc: Some(true),
+        gc_root_ttl: Some(Duration::from_secs(3600)),
+        id_reuse_delay_cycles: Some(delay_cycles),
+        ..Default::default()
+    }
+}
+
+/// With the window at zero, an id freed by GC comes back on the very next cycle and the factory
+/// hands it out again instead of minting a fresh one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn freed_ids_are_reused_after_the_window() {
+    let (tt, _dir) = create_tt_with_options("gc_id_reuse_reused", options(0));
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+
+        let output = select_generation(selector_vc);
+        output.read_strongly_consistent().await?;
+        // Orphan the first branch and its leaf.
+        selector.set(true);
+        output.read_strongly_consistent().await?;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    let (pending_before, watermark_before) = tt2.backend().id_reuse_state_for_testing();
+    assert_eq!(pending_before, 0, "nothing deferred before the first sweep");
+
+    // Collect, tombstone, evict. With delay 0 the freed ids are released by this same cycle.
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert!(collected > 0, "the orphaned branch should be collected");
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+
+    let (pending_after, watermark_after) = tt2.backend().id_reuse_state_for_testing();
+    assert_eq!(
+        pending_after, 0,
+        "with a zero-cycle window every freed id is released immediately"
+    );
+    assert_eq!(
+        watermark_before, watermark_after,
+        "eviction must not mint ids"
+    );
+
+    // Allocate exactly as many new tasks as GC freed. If reuse works they all come from the free
+    // list and the watermark — the count of ids ever *minted* — does not move.
+    let freshly_needed = collected as u32;
+    let tt3 = tt.clone();
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        // Distinct arguments, so these are genuinely new tasks the factory must allocate ids for.
+        allocate_fresh(100, freshly_needed)
+            .read_strongly_consistent()
+            .await?;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    let (_, watermark_rebuilt) = tt3.backend().id_reuse_state_for_testing();
+    // `allocate_fresh` is itself a new task and its id cannot come from the free list (it is
+    // created before any leaf), so the watermark may advance by at most that one. Every leaf must
+    // come from the free list.
+    let minted = watermark_rebuilt - watermark_after;
+    assert!(
+        minted <= 1,
+        "allocating {freshly_needed} tasks after freeing {collected} should draw from the free \
+         list; the factory minted {minted} fresh ids instead (watermark {watermark_after} -> \
+         {watermark_rebuilt})"
+    );
+
+    tt.stop_and_wait().await;
+}
+
+/// With a non-zero window, a freed id is held back: it is neither reusable nor lost, and the
+/// factory mints fresh ids in the meantime rather than aliasing one that may still be referenced.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn freed_ids_wait_out_the_window() {
+    let (tt, _dir) = create_tt_with_options("gc_id_reuse_deferred", options(5));
+    let tt2 = tt.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+        let output = select_generation(selector_vc);
+        output.read_strongly_consistent().await?;
+        selector.set(true);
+        output.read_strongly_consistent().await?;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert!(collected > 0, "the orphaned branch should be collected");
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+
+    let (pending, _) = tt2.backend().id_reuse_state_for_testing();
+    assert_eq!(
+        pending, collected,
+        "every collected id must be waiting out the window, neither reused nor dropped"
+    );
+
+    // Further cycles with no new garbage must not release them early.
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    let (still_pending, _) = tt2.backend().id_reuse_state_for_testing();
+    assert_eq!(
+        still_pending, collected,
+        "a 5-cycle window must not release after 2 cycles"
+    );
+
+    tt.stop_and_wait().await;
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_id_reuse.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_id_reuse.rs
@@ -20,7 +20,7 @@ use turbo_tasks_backend::{BackendOptions, EvictionMode};
 
 use crate::{
     gc_fixture::{Selector, create_selector},
-    util::create_tt_with_options,
+    util::{create_persistence_dir, create_tt_with_options, reopen_tt_with_id_reuse},
 };
 
 #[turbo_tasks::function]
@@ -58,7 +58,7 @@ async fn select_generation(selector: ResolvedVc<Selector>) -> Result<Vc<u32>> {
 }
 
 /// Options with GC on and the reuse delay pinned, so a test controls the window explicitly rather
-/// than depending on the default or the env var.
+/// than depending on the default.
 fn options(delay_cycles: u32) -> BackendOptions {
     BackendOptions {
         num_workers: Some(2),
@@ -179,6 +179,68 @@ async fn freed_ids_wait_out_the_window() {
     assert_eq!(
         still_pending, collected,
         "a 5-cycle window must not release after 2 cycles"
+    );
+
+    tt.stop_and_wait().await;
+}
+
+/// Ids freed in one session are offered to the next one: the id space does not grow just because
+/// the process restarted. This is the cross-session half of reuse — the in-memory free list dies
+/// with the process, so without the persisted set a restart would always mint fresh ids.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn freed_ids_survive_a_restart() {
+    let dir = create_persistence_dir("gc_id_reuse_cross_session");
+
+    // Session 1: build a subtree, orphan it, collect it, and shut down.
+    let tt = reopen_tt_with_id_reuse(&dir, 0);
+    let tt2 = tt.clone();
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        let selector_op = create_selector(false);
+        let selector_vc = selector_op.resolve().strongly_consistent().await?;
+        let selector = selector_op.read_strongly_consistent().await?;
+        let output = select_generation(selector_vc);
+        output.read_strongly_consistent().await?;
+        selector.set(true);
+        output.read_strongly_consistent().await?;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    let collected = tt2.backend().gc_for_testing(&tt2);
+    assert!(collected > 0, "the orphaned branch should be collected");
+    tt2.backend().snapshot_and_evict_for_testing(&tt2);
+    let (_, watermark_session1) = tt2.backend().id_reuse_state_for_testing();
+    tt.stop_and_wait().await;
+
+    // Session 2: the freed ids should have been seeded into the factory's free list, so the
+    // allocation watermark starts where session 1 left it and new tasks draw from the free list.
+    let tt = reopen_tt_with_id_reuse(&dir, 0);
+    let tt2 = tt.clone();
+    let (_, watermark_start) = tt2.backend().id_reuse_state_for_testing();
+    assert!(
+        watermark_start <= watermark_session1,
+        "a restart must not advance the id watermark ({watermark_session1} -> {watermark_start})"
+    );
+
+    let needed = collected as u32;
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        unmark_top_level_task_may_leak_eventually_consistent_state();
+        allocate_fresh(500, needed)
+            .read_strongly_consistent()
+            .await?;
+        anyhow::Ok(())
+    })
+    .await;
+    result.unwrap();
+
+    let (_, watermark_after) = tt2.backend().id_reuse_state_for_testing();
+    let minted = watermark_after - watermark_start;
+    assert!(
+        minted <= 1,
+        "allocating {needed} tasks in a fresh session should draw on the ids the previous session \
+         freed; the factory minted {minted} instead ({watermark_start} -> {watermark_after})"
     );
 
     tt.stop_and_wait().await;

--- a/turbopack/crates/turbo-tasks-backend/tests/util.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/util.rs
@@ -96,6 +96,39 @@ pub fn reopen_tt_with_gc_ttl(
     open_tt_at_with_gc(dir.path(), 2, Some(true), Some(gc_root_ttl), None)
 }
 
+/// Reopens a backend on an existing persistence directory with GC on and the id-reuse window
+/// pinned, for tests that assert on ids surviving a restart.
+pub fn reopen_tt_with_id_reuse(
+    dir: &tempfile::TempDir,
+    id_reuse_delay_cycles: u32,
+) -> Arc<TurboTasks<TurboTasksBackend>> {
+    TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions {
+            num_workers: Some(2),
+            small_preallocation: true,
+            storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
+            eviction_mode: EvictionMode::Full,
+            gc: Some(true),
+            id_reuse_delay_cycles: Some(id_reuse_delay_cycles),
+            ..Default::default()
+        },
+        turbo_tasks_backend::turbo_backing_storage(
+            dir.path(),
+            &GitVersionInfo {
+                describe: "test-unversioned",
+                dirty: false,
+            },
+            BackingStorageOptions {
+                is_short_session: true,
+                skip_compaction: true,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .0,
+    ))
+}
+
 /// A fresh persistent backend in its own temp directory, with `num_workers` workers.
 pub fn create_tt_with_workers(
     name: &str,

--- a/turbopack/crates/turbo-tasks-backend/tests/util.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/util.rs
@@ -118,5 +118,34 @@ pub fn create_tt_with_gc_min_progress(
 ) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
     let dir = create_persistence_dir(name);
     let tt = open_tt_at_with_gc(dir.path(), 2, Some(true), None, Some(gc_min_progress));
+
+    (tt, dir)
+}
+
+/// A fresh persistent backend built from caller-supplied [`BackendOptions`], for tests that need
+/// to pin an option the helpers above don't expose. The caller owns every option, including `gc`
+/// — the other helpers' GC-on default does not apply.
+pub fn create_tt_with_options(
+    name: &str,
+    options: BackendOptions,
+) -> (Arc<TurboTasks<TurboTasksBackend>>, tempfile::TempDir) {
+    let dir = create_persistence_dir(name);
+    let tt = TurboTasks::new(TurboTasksBackend::new(
+        options,
+        turbo_tasks_backend::turbo_backing_storage(
+            dir.path(),
+            &GitVersionInfo {
+                describe: "test-unversioned",
+                dirty: false,
+            },
+            BackingStorageOptions {
+                is_short_session: true,
+                skip_compaction: true,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .0,
+    ));
     (tt, dir)
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/util.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/util.rs
@@ -26,10 +26,10 @@ fn open_tt_at(path: &Path, num_workers: usize) -> Arc<TurboTasks<TurboTasksBacke
     open_tt_at_with_gc(path, num_workers, Some(true), None, None)
 }
 
-/// Like [`open_tt_at`], but forces the GC on or off for this backend instead of deriving it from
-/// the `TURBO_ENGINE_GC` env var, which every test in the binary would share.
+/// Like [`open_tt_at`], but sets the GC on or off for this backend explicitly, and optionally
+/// pins the GC timings. A `None` timing leaves the backend default in place.
 ///
-/// A test that depends on the persisted GC roots map must force it on: the map is only written by
+/// A test that depends on the persisted GC roots map must turn it on: the map is only written by
 /// the GC branch of `snapshot_and_persist`, so with GC off a session persists an empty root set and
 /// the cross-session behaviour under test silently never engages.
 fn open_tt_at_with_gc(

--- a/turbopack/crates/turbo-tasks/src/id_factory.rs
+++ b/turbopack/crates/turbo-tasks/src/id_factory.rs
@@ -164,6 +164,15 @@ where
         self.free_ids.pop().unwrap_or_else(|_| self.factory.get())
     }
 
+    /// The next id this factory would mint from its counter, ignoring the free list.
+    ///
+    /// A watermark, not an allocation: it is the high-water mark of the id space this factory has
+    /// consumed, which is what "are ids being reused" is measured against. Only meaningful as an
+    /// observation — a racing `get` can advance it immediately.
+    pub fn peek_next_fresh(&self) -> u64 {
+        self.factory.counter.load(Ordering::Relaxed) + self.factory.id_offset
+    }
+
     /// Add an id to the free list, allowing it to be re-used on a subsequent call to
     /// [`IdFactoryWithReuse::get`].
     ///

--- a/turbopack/crates/turbo-tasks/src/id_factory.rs
+++ b/turbopack/crates/turbo-tasks/src/id_factory.rs
@@ -164,6 +164,18 @@ where
         self.free_ids.pop().unwrap_or_else(|_| self.factory.get())
     }
 
+    /// Seed the free list with ids that are known to be unused.
+    ///
+    /// # Safety
+    ///
+    /// Same contract as [`IdFactoryWithReuse::reuse`], for every id: each must be a valid id in
+    /// this factory's range that nothing refers to any more.
+    pub unsafe fn seed_free_ids(&self, ids: impl IntoIterator<Item = T>) {
+        for id in ids {
+            let _ = self.free_ids.push(id);
+        }
+    }
+
     /// The next id this factory would mint from its counter, ignoring the free list.
     ///
     /// A watermark, not an allocation: it is the high-water mark of the id space this factory has


### PR DESCRIPTION
## What

When the GC runs it drops certain tasks, we now capture the task ids and record them for reuse.

Reuse is two strategies

* Store reusable task ids in a new Infra table key, so we can recover them in a new session
* Capture dropped task ids in dev and reuse them in session

GC currently only deletes tasks when there are no remaining references, to guard against bugs in that process the `task` function asserts existence.  A too readily reused task_id might confuse that mechanism leading to 'use after free' style problems.   To guard against this we buffer reusable task ids for 2 cycles until we allow them to be reused.

## Why

In theory this closes the final 'leak' from GC, now not even task _ids_ grow without bound.  That of course is mostly a theoretical concern since we know of no cases where task ids have been exhausted.

The main benefit is that this would unblock alternative task storage mechanism, e.g. #97703 proposes a simpler TaskStorage approach

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>