### PR TITLE
docs: add unstable_navigation and unstable_prefetch API references

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/navigation.mdx
+++ b/docs/01-app/03-api-reference/04-functions/navigation.mdx
@@ -1,10 +1,11 @@
 ---
-title: navigation
+title: unstable_navigation
 description: API Reference for the unstable_navigation function, which keeps a subtree out of a route's prefetches so it renders when the user navigates.
 version: experimental
 related:
   links:
     - app/api-reference/functions/prefetch
+    - app/guides/adopting-partial-prefetching
     - app/api-reference/functions/io
     - app/api-reference/config/next-config-js/partialPrefetching
     - app/api-reference/config/next-config-js/cacheComponents
@@ -12,13 +13,13 @@ related:
 
 Awaiting `unstable_navigation()` defers the code below it to the navigation, instead of rendering it when a link to the route is prefetched. The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary takes its place in the prefetch, and the deferred content renders when the user navigates.
 
-It is meant to defer content that a prefetch would otherwise render, typically content that is gated by a runtime API and expensive to generate. Uncached data is left out of a prefetch already, so it gains nothing. During a build-time prerender nothing is deferred, so content below `unstable_navigation()` is prerendered as usual.
+It is meant to defer content that a prefetch would otherwise render, typically content that depends on session data or URL data and is expensive to generate. During a build-time prerender nothing is deferred, so content below `unstable_navigation()` is prerendered as usual.
 
 ## Usage
 
-The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), and throws without it.
+The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), and throws without it. It is meant for routes using [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), which you can enable globally or one route at a time by [adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching).
 
-With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), a route is rendered in stages, and content can arrive at any of three:
+A route is then rendered in stages, and content can arrive at any of three:
 
 1. The [App Shell](/docs/app/glossary#app-shell), which every `<Link>` into the route prefetches, and which holds the part of the route that does not depend on the URL.
 2. A per-link prefetch, requested with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), which resolves the URL and adds the content that depends on it.
@@ -26,9 +27,23 @@ With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partial
 
 Calling `unstable_navigation()` keeps content out of the App Shell and out of per-link prefetches, including the ones [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) requests, so it appears on the navigation.
 
-Enable Partial Prefetching globally with [`partialPrefetching`](/docs/app/api-reference/config/next-config-js/partialPrefetching) or per segment with [`prefetch = 'partial'`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch#partial). Without that opt-in a default `<Link>` still defers the content, but [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) prefetches the route in a single step that includes it.
+Without Partial Prefetching, `unstable_navigation()` still defers the content for a default `<Link>`, but [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) fetches the whole route, deferred content included, the same as a navigation.
 
 To keep content out of the App Shell while still including it in a per-link prefetch, use [`unstable_prefetch()`](/docs/app/api-reference/functions/prefetch).
+
+The example assumes the post is linked with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), so the route receives a per-link prefetch:
+
+```tsx filename="app/page.tsx"
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <Link href="/post/hello-world" prefetch={true}>
+      Hello world
+    </Link>
+  )
+}
+```
 
 Everything above `unstable_navigation()` renders in the prefetch, and everything below renders on the navigation. Place it above the code to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
 
@@ -100,21 +115,19 @@ async function getComments(slug, sort) {
 }
 ```
 
-The comments depend on the URL, so on their own they belong to a per-link prefetch. `unstable_navigation()` keeps them out of it, so they arrive on the navigation instead.
+The comments depend on the URL, so on their own they belong to a per-link prefetch. Awaiting `unstable_navigation()` keeps them out of it, so they render when the user navigates.
 
-The slug and the cookie are both read below `unstable_navigation()` and passed as arguments, so `getComments` caches per post and sort order rather than per visitor. Reading `params` there is safe, because the URL is resolved by the time the deferred content renders.
+The slug and the cookie are both read below `unstable_navigation()` and passed as arguments, so `getComments` caches per post and sort order rather than per visitor. The URL is resolved by the time the deferred content renders, so `params` is available below the call.
 
-Placement relative to a runtime API decides how the route is prefetched, and that decision is made once, when the route is built. A `cookies()` or `headers()` read above the call resolves when the route is prefetched, and only what depends on it is deferred. A read below the call is not counted, because a prefetch would never have resolved the call and so would never have reached it.
-
-It cannot sit inside a cached scope, so not under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private). Put the directive on a function called below it, as `getComments` does here.
+Put the directive on a function called below it, as `getComments` does here. `unstable_navigation()` cannot sit inside a cached scope, so not under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private).
 
 ## When to use it
 
-Most routes do not need this. Reach for it when a route reads session data and you want its prefetches to stay static, so that one build-time render serves every visitor rather than each prefetch being rendered for the visitor who asked.
+Reach for it when the content below `unstable_navigation()` is expensive to produce, in compute, in upstream requests, or in latency, and you do not want every prefetch of the route to generate it.
 
-Keeping that content out of a prefetch would otherwise mean leaving it uncached. With `unstable_navigation()` it can carry [`use cache`](/docs/app/api-reference/directives/use-cache) and a lifetime and still be deferred.
+Without `unstable_navigation`, keeping that content out of a prefetch would otherwise mean leaving it uncached.
 
-Leave it out when the content should already be on screen the moment the route commits.
+With `unstable_navigation()` the content can be cached with [`use cache`](/docs/app/api-reference/directives/use-cache), given a lifetime, deferred to the navigation, and reused by the client-side router after the first time a user navigates into the route.
 
 ## Good to know
 

--- a/docs/01-app/03-api-reference/04-functions/navigation.mdx
+++ b/docs/01-app/03-api-reference/04-functions/navigation.mdx
@@ -10,9 +10,9 @@ related:
     - app/api-reference/config/next-config-js/cacheComponents
 ---
 
-Awaiting `unstable_navigation()` interrupts a prerender. The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary is sent in place of the rest of the component, and the interrupted content renders when the user navigates.
+Awaiting `unstable_navigation()` interrupts a prefetch prerender. The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary is sent in place of the rest of the component, and the interrupted content renders when the user navigates.
 
-The call is for content that a prefetch would otherwise include, which in practice means a tree gated by a runtime API. Uncached data does not need it, because a prefetch leaves uncached reads out already. The call does not interrupt a build-time prerender, so the content below it is prerendered as usual.
+It is for content that a prefetch would otherwise include, which in practice means a tree gated by a runtime API. Uncached data is left out of a prefetch already, so it gains nothing. During a build-time prerender nothing is deferred, so content below `unstable_navigation()` is prerendered as usual.
 
 ## Usage
 
@@ -24,13 +24,13 @@ With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partial
 2. A per-link prefetch, requested with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), which resolves the URL and adds the content that depends on it.
 3. The navigation itself, which covers everything left.
 
-Calling `unstable_navigation()` keeps content out of the App Shell and out of per-link prefetches, so it renders only on the navigation. A [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) covers everything a per-link prefetch can, and it still does not reach content below the call.
+Calling `unstable_navigation()` keeps content out of the App Shell and out of per-link prefetches, so it renders only on the navigation. A [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) covers everything a per-link prefetch can, and it still does not reach the deferred content.
 
-Enable Partial Prefetching globally with [`partialPrefetching`](/docs/app/api-reference/config/next-config-js/partialPrefetching) or per segment with [`prefetch = 'partial'`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch#partial). Without that opt-in a route is prefetched in a single step that already includes the content the call would defer.
+Enable Partial Prefetching globally with [`partialPrefetching`](/docs/app/api-reference/config/next-config-js/partialPrefetching) or per segment with [`prefetch = 'partial'`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch#partial). Without that opt-in a route is prefetched in a single step that already includes what would otherwise be deferred.
 
 To keep content out of the App Shell while still including it in a per-link prefetch, use [`unstable_prefetch()`](/docs/app/api-reference/functions/prefetch).
 
-Everything above the call renders in the prefetch, and everything below it renders on the navigation. Place it above the code to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
+Everything above `unstable_navigation()` renders in the prefetch, and everything below renders on the navigation. Place it above the code to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
 
 ```tsx filename="app/post/[slug]/page.tsx" highlight={18} switcher
 import { Suspense } from 'react'
@@ -96,17 +96,17 @@ async function getComments(slug, sort) {
 }
 ```
 
-The comments depend on the URL, so on their own they belong to a per-link prefetch: a [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) pointing at a post would render its comments before anyone clicks, once per link and per visitor. `unstable_navigation()` moves them to the navigation instead.
+The comments depend on the URL, so on their own they belong to a per-link prefetch: a [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) pointing at a post would carry its comments in that prefetch. `unstable_navigation()` keeps them out of it, so they arrive on the navigation instead.
 
-The slug and the cookie are both read below `unstable_navigation()` and passed as arguments, so `getComments` caches per post and sort order rather than per visitor. Reading `params` there is safe, because the function resolves after the stage that supplies it.
+The slug and the cookie are both read below `unstable_navigation()` and passed as arguments, so `getComments` caches per post and sort order rather than per visitor. Reading `params` there is safe, because it resolves after the stage that supplies it.
 
-The function cannot be used inside a cached scope, so it cannot sit under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private). Put the directive on a function called below it, as `getComments` does here.
+It cannot sit inside a cached scope, so not under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private). Put the directive on a function called below it, as `getComments` does here.
 
 ## When to use it
 
-Most routes do not need this. It exists for the case where prefetching itself is expensive: a prefetch renders once per link and once per visitor, so a query or an authorization check placed in a route can reach an upstream service many times before anyone clicks.
+Most routes do not need this. It changes what a prefetch response carries: content below the call is left out of the prefetch payload and arrives on the navigation instead.
 
-Without `unstable_navigation()`, the only way to keep that work out of a prefetch is to leave it uncached. With it, the work can carry [`use cache`](/docs/app/api-reference/directives/use-cache) and a lifetime, and only its first render moves to the navigation.
+Without `unstable_navigation()`, keeping that content out of a prefetch would mean leaving it uncached. With it, the content can carry [`use cache`](/docs/app/api-reference/directives/use-cache) and a lifetime and still be excluded.
 
 Leave it out when the content should already be on screen the moment the route commits.
 
@@ -114,7 +114,7 @@ Leave it out when the content should already be on screen the moment the route c
 
 - The function has no effect on the initial load of a page.
 - Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_navigation()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache). The navigation that renders it seeds the client's route cache rather than discarding it.
-- Reading `cookies()` or `headers()` below the call does not affect how the route is prefetched. Those accesses are ignored, because they would not have resolved in a prefetch either.
+- Reading `cookies()` or `headers()` below `unstable_navigation()` does not affect how the route is prefetched. Those accesses are ignored, because they would not have resolved in a prefetch either.
 - A call outside a `<Suspense>` boundary surfaces a validation insight in development, reported even on a page that is currently prerendered in full, because the same page starts excluding content as soon as it switches to a runtime shell.
 - Calling it inside `use cache`, `use cache: private`, [`unstable_cache()`](/docs/app/api-reference/functions/unstable_cache), [`after()`](/docs/app/api-reference/functions/after), [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), or a Client Component throws.
 

--- a/docs/01-app/03-api-reference/04-functions/navigation.mdx
+++ b/docs/01-app/03-api-reference/04-functions/navigation.mdx
@@ -10,9 +10,9 @@ related:
     - app/api-reference/config/next-config-js/cacheComponents
 ---
 
-Awaiting `unstable_navigation()` interrupts a prefetch prerender. The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary is sent in place of the rest of the component, and the interrupted content renders when the user navigates.
+Awaiting `unstable_navigation()` defers the code below it to the navigation, instead of rendering it when a link to the route is prefetched. The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary takes its place in the prefetch, and the deferred content renders when the user navigates.
 
-It is for content that a prefetch would otherwise include, which in practice means a tree gated by a runtime API. Uncached data is left out of a prefetch already, so it gains nothing. During a build-time prerender nothing is deferred, so content below `unstable_navigation()` is prerendered as usual.
+It is for content that a prefetch would otherwise render, which in practice means a tree gated by a runtime API. Uncached data is left out of a prefetch already, so it gains nothing. During a build-time prerender nothing is deferred, so content below `unstable_navigation()` is prerendered as usual.
 
 ## Usage
 
@@ -24,7 +24,7 @@ With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partial
 2. A per-link prefetch, requested with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), which resolves the URL and adds the content that depends on it.
 3. The navigation itself, which covers everything left.
 
-Calling `unstable_navigation()` keeps content out of the App Shell and out of per-link prefetches, so it renders only on the navigation. A [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) covers everything a per-link prefetch can, and it still does not reach the deferred content.
+Calling `unstable_navigation()` keeps content out of the App Shell and out of per-link prefetches, so it renders on the navigation. A [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) is a navigation issued early rather than a prefetch, so it renders the deferred content the way a navigation does.
 
 Enable Partial Prefetching globally with [`partialPrefetching`](/docs/app/api-reference/config/next-config-js/partialPrefetching) or per segment with [`prefetch = 'partial'`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch#partial). Without that opt-in a route is prefetched in a single step that already includes what would otherwise be deferred.
 
@@ -32,7 +32,7 @@ To keep content out of the App Shell while still including it in a per-link pref
 
 Everything above `unstable_navigation()` renders in the prefetch, and everything below renders on the navigation. Place it above the code to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
 
-```tsx filename="app/post/[slug]/page.tsx" highlight={18} switcher
+```tsx filename="app/post/[slug]/page.tsx" highlight={20} switcher
 import { Suspense } from 'react'
 import { cookies } from 'next/headers'
 import { cacheLife, unstable_navigation } from 'next/cache'
@@ -40,7 +40,9 @@ import { cacheLife, unstable_navigation } from 'next/cache'
 export default function Page({ params }: PageProps<'/post/[slug]'>) {
   return (
     <>
-      <PostBody params={params} /> {/* in a per-link prefetch */}
+      <Suspense fallback={<p>Loading post...</p>}>
+        <PostBody params={params} /> {/* in a per-link prefetch */}
+      </Suspense>
       <Suspense fallback={<p>Loading comments...</p>}>
         {/* the fallback is in the prefetch, the comments are not */}
         <Comments params={params} />
@@ -64,7 +66,7 @@ async function getComments(slug: string, sort: string) {
 }
 ```
 
-```jsx filename="app/post/[slug]/page.js" highlight={18} switcher
+```jsx filename="app/post/[slug]/page.js" highlight={20} switcher
 import { Suspense } from 'react'
 import { cookies } from 'next/headers'
 import { cacheLife, unstable_navigation } from 'next/cache'
@@ -72,7 +74,9 @@ import { cacheLife, unstable_navigation } from 'next/cache'
 export default function Page({ params }) {
   return (
     <>
-      <PostBody params={params} /> {/* in a per-link prefetch */}
+      <Suspense fallback={<p>Loading post...</p>}>
+        <PostBody params={params} /> {/* in a per-link prefetch */}
+      </Suspense>
       <Suspense fallback={<p>Loading comments...</p>}>
         {/* the fallback is in the prefetch, the comments are not */}
         <Comments params={params} />
@@ -96,17 +100,21 @@ async function getComments(slug, sort) {
 }
 ```
 
-The comments depend on the URL, so on their own they belong to a per-link prefetch: a [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) pointing at a post would carry its comments in that prefetch. `unstable_navigation()` keeps them out of it, so they arrive on the navigation instead.
+The comments depend on the URL, so on their own they belong to a per-link prefetch. `unstable_navigation()` keeps them out of it, so they arrive on the navigation instead.
 
 The slug and the cookie are both read below `unstable_navigation()` and passed as arguments, so `getComments` caches per post and sort order rather than per visitor. Reading `params` there is safe, because it resolves after the stage that supplies it.
+
+Placement relative to a runtime API decides how the route is prefetched. A `cookies()` or `headers()` read above the call resolves when the route is prefetched, and only what depends on it is deferred. A read below the call is not treated as a reason to render the prefetch per request, so it can be served from static output.
 
 It cannot sit inside a cached scope, so not under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private). Put the directive on a function called below it, as `getComments` does here.
 
 ## When to use it
 
-Most routes do not need this. It changes what a prefetch response carries: content below the call is left out of the prefetch payload and arrives on the navigation instead.
+Most routes do not need this. A prefetch that depends on session data is rendered for each visitor and each link, and this keeps the code below it from running in those renders, which is worth doing when that code reaches an upstream service.
 
-Without `unstable_navigation()`, keeping that content out of a prefetch would mean leaving it uncached. With it, the content can carry [`use cache`](/docs/app/api-reference/directives/use-cache) and a lifetime and still be excluded.
+Without `unstable_navigation()`, keeping that content out of a prefetch would mean leaving it uncached. With it, the content can carry [`use cache`](/docs/app/api-reference/directives/use-cache) and a lifetime and still be deferred.
+
+A [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) is the exception. It is a navigation issued early, so the deferred content renders then, and nothing is saved.
 
 Leave it out when the content should already be on screen the moment the route commits.
 
@@ -114,7 +122,7 @@ Leave it out when the content should already be on screen the moment the route c
 
 - The function has no effect on the initial load of a page.
 - Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_navigation()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache). The navigation that renders it seeds the client's route cache rather than discarding it.
-- Reading `cookies()` or `headers()` below `unstable_navigation()` does not affect how the route is prefetched. Those accesses are ignored, because they would not have resolved in a prefetch either.
+- Reading `cookies()` or `headers()` below `unstable_navigation()` does not make the route's prefetches render per request, so they can still be served from static output. Those accesses are ignored, because they would not have resolved in a prefetch either.
 - A call outside a `<Suspense>` boundary surfaces a validation insight in development, reported even on a page that is currently prerendered in full, because the same page starts excluding content as soon as it switches to a runtime shell.
 - Calling it inside `use cache`, `use cache: private`, [`unstable_cache()`](/docs/app/api-reference/functions/unstable_cache), [`after()`](/docs/app/api-reference/functions/after), [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), or a Client Component throws.
 

--- a/docs/01-app/03-api-reference/04-functions/navigation.mdx
+++ b/docs/01-app/03-api-reference/04-functions/navigation.mdx
@@ -1,0 +1,141 @@
+---
+title: navigation
+description: API Reference for the unstable_navigation function, which keeps a subtree out of a route's prefetches so it renders when the user navigates.
+version: experimental
+related:
+  links:
+    - app/api-reference/functions/prefetch
+    - app/api-reference/functions/io
+    - app/api-reference/config/next-config-js/partialPrefetching
+    - app/api-reference/config/next-config-js/cacheComponents
+---
+
+Awaiting `unstable_navigation()` interrupts a prerender. The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary is sent in place of the rest of the component, and the interrupted content renders when the user navigates.
+
+The call is for content that a prefetch would otherwise include, which in practice means a tree gated by a runtime API. Uncached data does not need it, because a prefetch leaves uncached reads out already. The call does not interrupt a build-time prerender, so the content below it is prerendered as usual.
+
+## Usage
+
+The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), and throws without it. It also requires Partial Prefetching, without which it has no effect.
+
+With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), a route is rendered in stages, and content can arrive at any of three:
+
+1. The [App Shell](/docs/app/glossary#app-shell), which every `<Link>` into the route prefetches, and which holds the part of the route that does not depend on the URL.
+2. A per-link prefetch, requested with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), which resolves the URL and adds the content that depends on it.
+3. The navigation itself, which covers everything left.
+
+Calling `unstable_navigation()` keeps content out of the App Shell and out of per-link prefetches, so it renders only on the navigation. A [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) covers everything a per-link prefetch can, and it still does not reach content below the call.
+
+Enable Partial Prefetching globally with [`partialPrefetching`](/docs/app/api-reference/config/next-config-js/partialPrefetching) or per segment with [`prefetch = 'partial'`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch#partial). Without that opt-in a route is prefetched in a single step that already includes the content the call would defer.
+
+To keep content out of the App Shell while still including it in a per-link prefetch, use [`unstable_prefetch()`](/docs/app/api-reference/functions/prefetch).
+
+Everything above the call renders in the prefetch, and everything below it renders on the navigation. Place it above the code to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
+
+```tsx filename="app/post/[slug]/page.tsx" highlight={18} switcher
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+import { cacheLife, unstable_navigation } from 'next/cache'
+
+export default function Page({ params }: PageProps<'/post/[slug]'>) {
+  return (
+    <>
+      <PostBody params={params} /> {/* in a per-link prefetch */}
+      <Suspense fallback={<p>Loading comments...</p>}>
+        {/* the fallback is in the prefetch, the comments are not */}
+        <Comments params={params} />
+      </Suspense>
+    </>
+  )
+}
+
+async function Comments({ params }: { params: Promise<{ slug: string }> }) {
+  await unstable_navigation() // everything below renders on the navigation
+  const { slug } = await params
+  const sort = (await cookies()).get('comment-sort')?.value ?? 'newest'
+  const items = await getComments(slug, sort)
+  return <CommentList items={items} />
+}
+
+async function getComments(slug: string, sort: string) {
+  'use cache'
+  cacheLife('hours')
+  return db.comments.list({ slug, sort })
+}
+```
+
+```jsx filename="app/post/[slug]/page.js" highlight={18} switcher
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+import { cacheLife, unstable_navigation } from 'next/cache'
+
+export default function Page({ params }) {
+  return (
+    <>
+      <PostBody params={params} /> {/* in a per-link prefetch */}
+      <Suspense fallback={<p>Loading comments...</p>}>
+        {/* the fallback is in the prefetch, the comments are not */}
+        <Comments params={params} />
+      </Suspense>
+    </>
+  )
+}
+
+async function Comments({ params }) {
+  await unstable_navigation() // everything below renders on the navigation
+  const { slug } = await params
+  const sort = (await cookies()).get('comment-sort')?.value ?? 'newest'
+  const items = await getComments(slug, sort)
+  return <CommentList items={items} />
+}
+
+async function getComments(slug, sort) {
+  'use cache'
+  cacheLife('hours')
+  return db.comments.list({ slug, sort })
+}
+```
+
+The comments depend on the URL, so on their own they belong to a per-link prefetch: a [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) pointing at a post would render its comments before anyone clicks, once per link and per visitor. `unstable_navigation()` moves them to the navigation instead.
+
+The slug and the cookie are both read below `unstable_navigation()` and passed as arguments, so `getComments` caches per post and sort order rather than per visitor. Reading `params` there is safe, because the function resolves after the stage that supplies it.
+
+The function cannot be used inside a cached scope, so it cannot sit under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private). Put the directive on a function called below it, as `getComments` does here.
+
+## When to use it
+
+Most routes do not need this. It exists for the case where prefetching itself is expensive: a prefetch renders once per link and once per visitor, so a query or an authorization check placed in a route can reach an upstream service many times before anyone clicks.
+
+Without `unstable_navigation()`, the only way to keep that work out of a prefetch is to leave it uncached. With it, the work can carry [`use cache`](/docs/app/api-reference/directives/use-cache) and a lifetime, and only its first render moves to the navigation.
+
+Leave it out when the content should already be on screen the moment the route commits.
+
+## Good to know
+
+- The function has no effect on the initial load of a page.
+- Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_navigation()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache). The navigation that renders it seeds the client's route cache rather than discarding it.
+- Reading `cookies()` or `headers()` below the call does not affect how the route is prefetched. Those accesses are ignored, because they would not have resolved in a prefetch either.
+- A call outside a `<Suspense>` boundary surfaces a validation insight in development, reported even on a page that is currently prerendered in full, because the same page starts excluding content as soon as it switches to a runtime shell.
+- Calling it inside `use cache`, `use cache: private`, [`unstable_cache()`](/docs/app/api-reference/functions/unstable_cache), [`after()`](/docs/app/api-reference/functions/after), [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), or a Client Component throws.
+
+## Reference
+
+### Type
+
+```ts
+function unstable_navigation(): Promise<void>
+```
+
+### Parameters
+
+- The function does not accept any parameters.
+
+### Returns
+
+A `Promise<void>`. It is not meant to be consumed.
+
+## Version History
+
+| Version   | Changes                      |
+| --------- | ---------------------------- |
+| `v16.4.0` | `unstable_navigation` added. |

--- a/docs/01-app/03-api-reference/04-functions/navigation.mdx
+++ b/docs/01-app/03-api-reference/04-functions/navigation.mdx
@@ -12,11 +12,11 @@ related:
 
 Awaiting `unstable_navigation()` defers the code below it to the navigation, instead of rendering it when a link to the route is prefetched. The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary takes its place in the prefetch, and the deferred content renders when the user navigates.
 
-It is for content that a prefetch would otherwise render, which in practice means a tree gated by a runtime API. Uncached data is left out of a prefetch already, so it gains nothing. During a build-time prerender nothing is deferred, so content below `unstable_navigation()` is prerendered as usual.
+It is meant to defer content that a prefetch would otherwise render, typically content that is gated by a runtime API and expensive to generate. Uncached data is left out of a prefetch already, so it gains nothing. During a build-time prerender nothing is deferred, so content below `unstable_navigation()` is prerendered as usual.
 
 ## Usage
 
-The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), and throws without it. It also requires Partial Prefetching, without which it has no effect.
+The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), and throws without it.
 
 With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), a route is rendered in stages, and content can arrive at any of three:
 
@@ -24,9 +24,9 @@ With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partial
 2. A per-link prefetch, requested with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), which resolves the URL and adds the content that depends on it.
 3. The navigation itself, which covers everything left.
 
-Calling `unstable_navigation()` keeps content out of the App Shell and out of per-link prefetches, so it renders on the navigation. A [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) is a navigation issued early rather than a prefetch, so it renders the deferred content the way a navigation does.
+Calling `unstable_navigation()` keeps content out of the App Shell and out of per-link prefetches, including the ones [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) requests, so it appears on the navigation.
 
-Enable Partial Prefetching globally with [`partialPrefetching`](/docs/app/api-reference/config/next-config-js/partialPrefetching) or per segment with [`prefetch = 'partial'`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch#partial). Without that opt-in a route is prefetched in a single step that already includes what would otherwise be deferred.
+Enable Partial Prefetching globally with [`partialPrefetching`](/docs/app/api-reference/config/next-config-js/partialPrefetching) or per segment with [`prefetch = 'partial'`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch#partial). Without that opt-in a default `<Link>` still defers the content, but [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) prefetches the route in a single step that includes it.
 
 To keep content out of the App Shell while still including it in a per-link prefetch, use [`unstable_prefetch()`](/docs/app/api-reference/functions/prefetch).
 
@@ -102,28 +102,26 @@ async function getComments(slug, sort) {
 
 The comments depend on the URL, so on their own they belong to a per-link prefetch. `unstable_navigation()` keeps them out of it, so they arrive on the navigation instead.
 
-The slug and the cookie are both read below `unstable_navigation()` and passed as arguments, so `getComments` caches per post and sort order rather than per visitor. Reading `params` there is safe, because it resolves after the stage that supplies it.
+The slug and the cookie are both read below `unstable_navigation()` and passed as arguments, so `getComments` caches per post and sort order rather than per visitor. Reading `params` there is safe, because the URL is resolved by the time the deferred content renders.
 
-Placement relative to a runtime API decides how the route is prefetched. A `cookies()` or `headers()` read above the call resolves when the route is prefetched, and only what depends on it is deferred. A read below the call is not treated as a reason to render the prefetch per request, so it can be served from static output.
+Placement relative to a runtime API decides how the route is prefetched, and that decision is made once, when the route is built. A `cookies()` or `headers()` read above the call resolves when the route is prefetched, and only what depends on it is deferred. A read below the call is not counted, because a prefetch would never have resolved the call and so would never have reached it.
 
 It cannot sit inside a cached scope, so not under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private). Put the directive on a function called below it, as `getComments` does here.
 
 ## When to use it
 
-Most routes do not need this. A prefetch that depends on session data is rendered for each visitor and each link, and this keeps the code below it from running in those renders, which is worth doing when that code reaches an upstream service.
+Most routes do not need this. Reach for it when a route reads session data and you want its prefetches to stay static, so that one build-time render serves every visitor rather than each prefetch being rendered for the visitor who asked.
 
-Without `unstable_navigation()`, keeping that content out of a prefetch would mean leaving it uncached. With it, the content can carry [`use cache`](/docs/app/api-reference/directives/use-cache) and a lifetime and still be deferred.
-
-A [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) is the exception. It is a navigation issued early, so the deferred content renders then, and nothing is saved.
+Keeping that content out of a prefetch would otherwise mean leaving it uncached. With `unstable_navigation()` it can carry [`use cache`](/docs/app/api-reference/directives/use-cache) and a lifetime and still be deferred.
 
 Leave it out when the content should already be on screen the moment the route commits.
 
 ## Good to know
 
 - The function has no effect on the initial load of a page.
-- Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_navigation()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache). The navigation that renders it seeds the client's route cache rather than discarding it.
+- Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_navigation()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache). It keeps its cache lifetime, so navigating to the route again reuses the content instead of rendering it a second time.
 - Reading `cookies()` or `headers()` below `unstable_navigation()` does not make the route's prefetches render per request, so they can still be served from static output. Those accesses are ignored, because they would not have resolved in a prefetch either.
-- A call outside a `<Suspense>` boundary surfaces a validation insight in development, reported even on a page that is currently prerendered in full, because the same page starts excluding content as soon as it switches to a runtime shell.
+- A call outside a `<Suspense>` boundary surfaces a validation insight in development. It is reported even on a page that is currently prerendered in full, because the same page starts deferring content as soon as it switches to a runtime shell.
 - Calling it inside `use cache`, `use cache: private`, [`unstable_cache()`](/docs/app/api-reference/functions/unstable_cache), [`after()`](/docs/app/api-reference/functions/after), [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), or a Client Component throws.
 
 ## Reference

--- a/docs/01-app/03-api-reference/04-functions/navigation.mdx
+++ b/docs/01-app/03-api-reference/04-functions/navigation.mdx
@@ -128,7 +128,7 @@ async function getComments(slug, sort) {
 
 The comments depend on the URL, so on their own they belong to a per-link prefetch. Awaiting `unstable_navigation()` keeps them out of it, so they render when the user navigates.
 
-The slug and the cookie are both read below `unstable_navigation()` and passed as arguments, so `getComments` caches per post and sort order rather than per visitor. The URL is resolved by the time the deferred content renders, so `params` is available below the call.
+The slug and the cookie are both read below `unstable_navigation()` and passed as arguments, so `getComments` caches per post and sort order rather than per visitor. The URL is resolved by the time the deferred content renders, so `params` is available below `unstable_navigation()`.
 
 Put the directive on a function called below it, as `getComments` does here. `unstable_navigation()` cannot sit inside a cached scope, so not under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private).
 
@@ -136,14 +136,46 @@ Put the directive on a function called below it, as `getComments` does here. `un
 
 Reach for it when the content below `unstable_navigation()` is expensive to produce, in compute, in upstream requests, or in latency, and you do not want every prefetch of the route to generate it.
 
+A prefetch of the route does not run that code at all, at either prefetch stage, so the requests it makes are not issued until the user navigates.
+
 Without `unstable_navigation`, keeping that content out of a prefetch would otherwise mean leaving it uncached.
 
-With `unstable_navigation()` the content can be cached with [`use cache`](/docs/app/api-reference/directives/use-cache), given a lifetime, deferred to the navigation, and reused by the client-side router after the first time a user navigates into the route.
+With `unstable_navigation()` the content can be cached with [`use cache`](/docs/app/api-reference/directives/use-cache), given a lifetime, and deferred to the navigation. Give it a [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time of five minutes or more and the client-side router reuses it after the first time a user navigates into the route. Below that, a [short lifetime keeps it out of the App Shell](/docs/app/api-reference/functions/cacheLife#prerendering-behavior), so each navigation fetches it again.
+
+### Keeping a route's prefetch static
+
+Nothing below `unstable_navigation()` renders during a prefetch. When every read of [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), `params`, and `searchParams` sits below it, the prerender a prefetch would trigger cannot produce more than the static output the build already generated, so the prefetch is served from that output instead. Shaping a route this way is an optional optimization: a static response can be cached in a CDN, so a link into the route costs no server CPU at all.
+
+```tsx filename="app/post/[slug]/page.tsx" highlight={17}
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+import { unstable_navigation } from 'next/cache'
+
+export default function Page({ params }: PageProps<'/post/[slug]'>) {
+  return (
+    <>
+      <PostBody /> {/* static, and so is the whole prefetch */}
+      <Suspense fallback={<p>Loading comments...</p>}>
+        <Comments params={params} />
+      </Suspense>
+    </>
+  )
+}
+
+async function Comments({ params }: { params: Promise<{ slug: string }> }) {
+  await unstable_navigation()
+  const { slug } = await params
+  const sort = (await cookies()).get('comment-sort')?.value ?? 'newest'
+  return <CommentList items={await getComments(slug, sort)} />
+}
+```
+
+Adding UI above `unstable_navigation()` later is fine. A greeting that reads a cookie wakes a server for that part of the prefetch, and everything below stays deferred.
 
 ## Good to know
 
 - The function has no effect on the initial load of a page.
-- Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_navigation()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache). It keeps its cache lifetime, so navigating to the route again reuses the content instead of rendering it a second time.
+- Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_navigation()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache). It keeps its cache lifetime, and with a [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time of five minutes or more, the client-side router reuses it on a later navigation instead of rendering it again.
 - Reading `cookies()` or `headers()` below `unstable_navigation()` does not make the route's prefetches render per request, so they can still be served from static output. Those accesses are ignored, because they would not have resolved in a prefetch either.
 - A call outside a `<Suspense>` boundary surfaces a validation insight in development. It is reported even on a page that is currently prerendered in full, because the same page starts deferring content as soon as it switches to a runtime shell.
 - Calling it inside `use cache`, `use cache: private`, [`unstable_cache()`](/docs/app/api-reference/functions/unstable_cache), [`after()`](/docs/app/api-reference/functions/after), [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), or a Client Component throws.

--- a/docs/01-app/03-api-reference/04-functions/navigation.mdx
+++ b/docs/01-app/03-api-reference/04-functions/navigation.mdx
@@ -11,7 +11,7 @@ related:
     - app/api-reference/config/next-config-js/cacheComponents
 ---
 
-Awaiting `unstable_navigation()` defers the code below it to the navigation, instead of rendering it when a link to the route is prefetched. The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary takes its place in the prefetch, and the deferred content renders when the user navigates.
+Calling `await unstable_navigation()` defers the code below it to the navigation, instead of rendering it when a link to the route is prefetched. The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary takes its place in the prefetch, and the deferred content renders when the user navigates.
 
 It is meant to defer content that a prefetch would otherwise render, typically content that depends on session data or URL data and is expensive to generate. During a build-time prerender nothing is deferred, so content below `unstable_navigation()` is prerendered as usual.
 
@@ -19,19 +19,30 @@ It is meant to defer content that a prefetch would otherwise render, typically c
 
 The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), and throws without it. It is meant for routes using [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), which you can enable globally or one route at a time by [adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching).
 
+```ts filename="next.config.ts" highlight={4,5}
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true,
+}
+
+export default nextConfig
+```
+
 A route is then rendered in stages, and content can arrive at any of three:
 
 1. The [App Shell](/docs/app/glossary#app-shell), which every `<Link>` into the route prefetches, and which holds the part of the route that does not depend on the URL.
 2. A per-link prefetch, requested with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), which resolves the URL and adds the content that depends on it.
 3. The navigation itself, which covers everything left.
 
-Calling `unstable_navigation()` keeps content out of the App Shell and out of per-link prefetches, including the ones [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) requests, so it appears on the navigation.
+Calling `unstable_navigation()` keeps content out of the App Shell and out of per-link prefetches, including the ones [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) requests, so it only appears on the navigation.
 
 Without Partial Prefetching, `unstable_navigation()` still defers the content for a default `<Link>`, but [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) fetches the whole route, deferred content included, the same as a navigation.
 
 To keep content out of the App Shell while still including it in a per-link prefetch, use [`unstable_prefetch()`](/docs/app/api-reference/functions/prefetch).
 
-The example assumes the post is linked with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), so the route receives a per-link prefetch:
+The example below links the post with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), so the route receives a per-link prefetch:
 
 ```tsx filename="app/page.tsx"
 import Link from 'next/link'

--- a/docs/01-app/03-api-reference/04-functions/navigation.mdx
+++ b/docs/01-app/03-api-reference/04-functions/navigation.mdx
@@ -36,7 +36,7 @@ A route is then rendered in three stages, and content can arrive at any of them:
 2. A per-link prefetch, requested with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), which resolves the URL and adds the content that depends on it.
 3. The navigation itself, which covers everything left.
 
-Calling `unstable_navigation()` keeps content out of the App Shell and out of per-link prefetches, including the ones [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) requests, so it only appears on the navigation.
+Awaiting `unstable_navigation()` keeps content out of the App Shell and out of per-link prefetches, so it renders only on the navigation.
 
 Without Partial Prefetching, `unstable_navigation()` still defers the content for a default `<Link>`, but [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch) fetches the whole route, deferred content included, the same as a navigation.
 
@@ -122,9 +122,9 @@ Put the directive on a function called below it, as `getComments` does here. Awa
 
 Reach for it when the content below `unstable_navigation()` is expensive to produce, in compute, in upstream requests, or in latency, and you do not want every prefetch of the route to generate it.
 
-A prefetch of the route does not run that code at all, at either prefetch stage, so the requests it makes are not issued until the user navigates.
+Neither prefetch stage runs that code, so its upstream requests are not issued until the user navigates.
 
-Without `unstable_navigation`, keeping that content out of a prefetch would otherwise mean leaving it uncached.
+Keeping that content out of a prefetch would otherwise mean leaving it uncached.
 
 With `unstable_navigation()` the content can be cached with [`use cache`](/docs/app/api-reference/directives/use-cache), given a lifetime, and deferred to the navigation. Give it a [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time of five minutes or more and the client-side router reuses it after the first time a user navigates into the route. Below that, a [short lifetime keeps it out of the App Shell](/docs/app/api-reference/functions/cacheLife#prerendering-behavior), so each navigation fetches it again.
 
@@ -132,34 +132,33 @@ With `unstable_navigation()` the content can be cached with [`use cache`](/docs/
 
 When every read of [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), `params`, and `searchParams` sits below `unstable_navigation()`, the prerender a prefetch would trigger cannot produce more than the static output the build already generated, so the prefetch is served from that output instead. Shaping a route this way is an optional optimization: a static response can be cached in a CDN, so a link into the route costs no server CPU at all.
 
-```tsx filename="app/post/[slug]/page.tsx" highlight={17}
+```tsx filename="app/feed/page.tsx" highlight={17}
 import { Suspense } from 'react'
 import { cookies } from 'next/headers'
 import { unstable_navigation } from 'next/cache'
 
-export default function Page({ params }: PageProps<'/post/[slug]'>) {
+export default function Page() {
   return (
     <>
-      <PostBody /> {/* static, and so is the whole prefetch */}
-      <Suspense fallback={<p>Loading comments...</p>}>
-        <Comments params={params} />
+      <FeedHeader /> {/* static, and so is the whole prefetch */}
+      <Suspense fallback={<p>Loading stories...</p>}>
+        <Stories />
       </Suspense>
     </>
   )
 }
 
-async function Comments({ params }: { params: Promise<{ slug: string }> }) {
+async function Stories() {
   await unstable_navigation()
-  const { slug } = await params
-  const sort = (await cookies()).get('comment-sort')?.value ?? 'newest'
-  return <CommentList items={await getComments(slug, sort)} />
+  const topic = (await cookies()).get('topic')?.value ?? 'all'
+  return <StoryList items={await getStories(topic)} />
 }
 ```
 
 ## Good to know
 
 - The function has no effect on the initial load of a page.
-- Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_navigation()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache). It keeps its cache lifetime, and with a [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time of five minutes or more, the client-side router reuses it on a later navigation instead of rendering it again.
+- Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_navigation()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache). It also keeps its cache lifetime.
 - Reading `cookies()` or `headers()` below `unstable_navigation()` does not make the route's prefetches render per request, so they can still be served from static output. Those accesses are ignored, because they would not have resolved in a prefetch either.
 - A call outside a `<Suspense>` boundary surfaces a validation insight in development. It is reported even on a page that is currently prerendered in full, because the same page starts deferring content as soon as it switches to a runtime shell.
 - Calling it inside `use cache`, `use cache: private`, [`unstable_cache()`](/docs/app/api-reference/functions/unstable_cache), [`after()`](/docs/app/api-reference/functions/after), [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), or a Client Component throws.

--- a/docs/01-app/03-api-reference/04-functions/navigation.mdx
+++ b/docs/01-app/03-api-reference/04-functions/navigation.mdx
@@ -13,7 +13,7 @@ related:
 
 Calling `await unstable_navigation()` defers the code below it to the navigation, instead of rendering it when a link to the route is prefetched. The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary takes its place in the prefetch, and the deferred content renders when the user navigates.
 
-It is meant to defer content that a prefetch would otherwise render, typically content that depends on session data or URL data and is expensive to generate. During a build-time prerender nothing is deferred, so content below `unstable_navigation()` is prerendered as usual.
+It is meant to defer content that a prefetch would otherwise render, even content that would sit in the App Shell, typically because it depends on session data or URL data and is expensive to generate. During a build-time prerender nothing is deferred, so content below `unstable_navigation()` is prerendered as usual.
 
 ## Usage
 
@@ -30,7 +30,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-A route is then rendered in stages, and content can arrive at any of three:
+A route is then rendered in three stages, and content can arrive at any of them:
 
 1. The [App Shell](/docs/app/glossary#app-shell), which every `<Link>` into the route prefetches, and which holds the part of the route that does not depend on the URL.
 2. A per-link prefetch, requested with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), which resolves the URL and adds the content that depends on it.
@@ -42,21 +42,7 @@ Without Partial Prefetching, `unstable_navigation()` still defers the content fo
 
 To keep content out of the App Shell while still including it in a per-link prefetch, use [`unstable_prefetch()`](/docs/app/api-reference/functions/prefetch).
 
-The example below links the post with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), so the route receives a per-link prefetch:
-
-```tsx filename="app/page.tsx"
-import Link from 'next/link'
-
-export default function Page() {
-  return (
-    <Link href="/post/hello-world" prefetch={true}>
-      Hello world
-    </Link>
-  )
-}
-```
-
-Everything above `unstable_navigation()` renders in the prefetch, and everything below renders on the navigation. Place it above the code to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
+Everything above `unstable_navigation()` renders in the prefetch, and everything below renders on the navigation. Deferral is scoped to the component that awaits it and the tree below: sibling branches render in the prefetch as usual. Place it above the code to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
 
 ```tsx filename="app/post/[slug]/page.tsx" highlight={20} switcher
 import { Suspense } from 'react'
@@ -126,11 +112,11 @@ async function getComments(slug, sort) {
 }
 ```
 
-The comments depend on the URL, so on their own they belong to a per-link prefetch. Awaiting `unstable_navigation()` keeps them out of it, so they render when the user navigates.
+Comments are fetched by slug, so prefetching them would take a per-link prefetch. Awaiting `unstable_navigation()` before that data access keeps them out of the prefetch, so they render when the user navigates.
 
 The slug and the cookie are both read below `unstable_navigation()` and passed as arguments, so `getComments` caches per post and sort order rather than per visitor. The URL is resolved by the time the deferred content renders, so `params` is available below `unstable_navigation()`.
 
-Put the directive on a function called below it, as `getComments` does here. `unstable_navigation()` cannot sit inside a cached scope, so not under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private).
+Put the directive on a function called below it, as `getComments` does here. Awaiting `unstable_navigation()` inside a cached scope, such as [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private), is not allowed.
 
 ## When to use it
 
@@ -144,7 +130,7 @@ With `unstable_navigation()` the content can be cached with [`use cache`](/docs/
 
 ### Keeping a route's prefetch static
 
-Nothing below `unstable_navigation()` renders during a prefetch. When every read of [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), `params`, and `searchParams` sits below it, the prerender a prefetch would trigger cannot produce more than the static output the build already generated, so the prefetch is served from that output instead. Shaping a route this way is an optional optimization: a static response can be cached in a CDN, so a link into the route costs no server CPU at all.
+When every read of [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers), `params`, and `searchParams` sits below `unstable_navigation()`, the prerender a prefetch would trigger cannot produce more than the static output the build already generated, so the prefetch is served from that output instead. Shaping a route this way is an optional optimization: a static response can be cached in a CDN, so a link into the route costs no server CPU at all.
 
 ```tsx filename="app/post/[slug]/page.tsx" highlight={17}
 import { Suspense } from 'react'
@@ -170,8 +156,6 @@ async function Comments({ params }: { params: Promise<{ slug: string }> }) {
 }
 ```
 
-Adding UI above `unstable_navigation()` later is fine. A greeting that reads a cookie wakes a server for that part of the prefetch, and everything below stays deferred.
-
 ## Good to know
 
 - The function has no effect on the initial load of a page.
@@ -179,6 +163,8 @@ Adding UI above `unstable_navigation()` later is fine. A greeting that reads a c
 - Reading `cookies()` or `headers()` below `unstable_navigation()` does not make the route's prefetches render per request, so they can still be served from static output. Those accesses are ignored, because they would not have resolved in a prefetch either.
 - A call outside a `<Suspense>` boundary surfaces a validation insight in development. It is reported even on a page that is currently prerendered in full, because the same page starts deferring content as soon as it switches to a runtime shell.
 - Calling it inside `use cache`, `use cache: private`, [`unstable_cache()`](/docs/app/api-reference/functions/unstable_cache), [`after()`](/docs/app/api-reference/functions/after), [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), or a Client Component throws.
+
+{/* TODO: link the validation insight error page from the bullet above once it merges. */}
 
 ## Reference
 

--- a/docs/01-app/03-api-reference/04-functions/prefetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/prefetch.mdx
@@ -1,0 +1,148 @@
+---
+title: prefetch
+description: API Reference for the unstable_prefetch function, which keeps a subtree out of a route's App Shell so it renders on a prefetch or a navigation.
+version: experimental
+related:
+  links:
+    - app/api-reference/functions/navigation
+    - app/api-reference/config/next-config-js/partialPrefetching
+    - app/api-reference/config/next-config-js/cacheComponents
+---
+
+Awaiting `unstable_prefetch()` interrupts the prerender of a route's [App Shell](/docs/app/glossary#app-shell). The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary is sent in place of the rest of the component, and the interrupted content renders once a prefetch or a navigation happens.
+
+The call is for content that the App Shell would otherwise include, which in practice means work that depends on session data. Uncached data does not need it, because a prefetch leaves uncached reads out already. The call does not interrupt a build-time prerender, so the content below it is prerendered as usual.
+
+## Usage
+
+The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), and throws without it. It also requires Partial Prefetching, without which it has no effect.
+
+With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), a route is rendered in stages, and content can arrive at any of three:
+
+1. The App Shell, which every `<Link>` into the route prefetches, and which holds the part of the route that does not depend on the URL.
+2. A per-link prefetch, requested with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), which resolves the URL and adds the content that depends on it.
+3. The navigation itself, which covers everything left.
+
+Calling `unstable_prefetch()` keeps content out of the App Shell, so it renders on a per-link prefetch or on the navigation. Enable Partial Prefetching globally with [`partialPrefetching`](/docs/app/api-reference/config/next-config-js/partialPrefetching) or per segment with [`prefetch = 'partial'`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch#partial). Without that opt-in a route has no App Shell, so there is nothing to keep content out of.
+
+To keep content out of per-link prefetches as well, so it renders only on the navigation, use [`unstable_navigation()`](/docs/app/api-reference/functions/navigation).
+
+Everything above the call renders in the App Shell, and everything below it renders on the prefetch. Place it above the work to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
+
+```tsx filename="app/dashboard/page.tsx" highlight={26} switcher
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+import { cacheLife, unstable_prefetch } from 'next/cache'
+
+export default function Page() {
+  return (
+    <>
+      <Suspense fallback={<p>Loading greeting...</p>}>
+        <Greeting /> {/* in the App Shell */}
+      </Suspense>
+      <Suspense fallback={<p>Loading recommendations...</p>}>
+        {/* the fallback is in the App Shell, the recommendations are not */}
+        <Recommendations />
+      </Suspense>
+    </>
+  )
+}
+
+async function Greeting() {
+  const session = (await cookies()).get('session')?.value
+  return <p>{session ? 'Welcome back' : 'Welcome'}</p>
+}
+
+async function Recommendations() {
+  const session = (await cookies()).get('session')?.value
+  await unstable_prefetch() // everything below renders on the prefetch
+  const items = await getRecommendations(session)
+  return <List items={items} />
+}
+
+async function getRecommendations(session?: string) {
+  'use cache: private'
+  cacheLife('hours')
+  return rank(session)
+}
+```
+
+```jsx filename="app/dashboard/page.js" highlight={26} switcher
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+import { cacheLife, unstable_prefetch } from 'next/cache'
+
+export default function Page() {
+  return (
+    <>
+      <Suspense fallback={<p>Loading greeting...</p>}>
+        <Greeting /> {/* in the App Shell */}
+      </Suspense>
+      <Suspense fallback={<p>Loading recommendations...</p>}>
+        {/* the fallback is in the App Shell, the recommendations are not */}
+        <Recommendations />
+      </Suspense>
+    </>
+  )
+}
+
+async function Greeting() {
+  const session = (await cookies()).get('session')?.value
+  return <p>{session ? 'Welcome back' : 'Welcome'}</p>
+}
+
+async function Recommendations() {
+  const session = (await cookies()).get('session')?.value
+  await unstable_prefetch() // everything below renders on the prefetch
+  const items = await getRecommendations(session)
+  return <List items={items} />
+}
+
+async function getRecommendations(session) {
+  'use cache: private'
+  cacheLife('hours')
+  return rank(session)
+}
+```
+
+Both components read the session themselves, and only the greeting stays in the shell. The session is read above the call, so it resolves in the shell like any other session data, and only the work that depends on it moves to the prefetch. Remove the `unstable_prefetch()` call and `getRecommendations` runs whenever any link into the route is prefetched, before anyone has clicked.
+
+The function cannot be used inside a cached scope, so it cannot sit under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private). Put the directive on a function called below it, as `getRecommendations` does here.
+
+## When to use it
+
+Most routes do not need this. It exists for the case where the App Shell itself is expensive: session data resolves inside the shell, so work that depends on `cookies()` or `headers()` is part of the shell by default, and an authorization check placed there reaches an upstream service on every prefetch of every link into the route.
+
+Without `unstable_prefetch()`, the only way to keep that work out of the shell is to leave it uncached. With it, the work can carry [`use cache: private`](/docs/app/api-reference/directives/use-cache-private) and a lifetime, and only its first render moves to the prefetch.
+
+Leave it out for content that does not depend on session data. Uncached reads, values with a short [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time, and anything behind `params` or `searchParams` are already left out of the shell without the call.
+
+## Good to know
+
+- The function has no effect on the initial load of a page.
+- Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_prefetch()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache).
+- Content that depends on the URL, through `params` or `searchParams`, is already left out of the App Shell without the call.
+- A call outside a `<Suspense>` boundary surfaces a validation insight in development, reported even on a page that is currently prerendered in full, because the same page starts excluding content as soon as it switches to a runtime shell.
+- Calling it inside `use cache`, `use cache: private`, [`unstable_cache()`](/docs/app/api-reference/functions/unstable_cache), [`after()`](/docs/app/api-reference/functions/after), [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), or a Client Component throws.
+
+## Reference
+
+### Type
+
+```ts
+function unstable_prefetch(): Promise<void>
+```
+
+### Parameters
+
+- The function does not accept any parameters.
+
+### Returns
+
+A `Promise<void>`. It is not meant to be consumed.
+
+## Version History
+
+| Version   | Changes                    |
+| --------- | -------------------------- |
+| `v16.4.0` | `unstable_prefetch` added. |

--- a/docs/01-app/03-api-reference/04-functions/prefetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/prefetch.mdx
@@ -1,33 +1,37 @@
 ---
-title: prefetch
-description: API Reference for the unstable_prefetch function, which keeps a subtree out of a route's App Shell so it renders on a prefetch or a navigation.
+title: unstable_prefetch
+description: API Reference for the unstable_prefetch function, which keeps a subtree out of a route's App Shell so it renders on a per-link prefetch or a navigation.
 version: experimental
 related:
   links:
     - app/api-reference/functions/navigation
+    - app/guides/adopting-partial-prefetching
+    - app/api-reference/functions/io
     - app/api-reference/config/next-config-js/partialPrefetching
     - app/api-reference/config/next-config-js/cacheComponents
 ---
 
 Awaiting `unstable_prefetch()` defers the code below it to a per-link prefetch or a navigation, instead of rendering it in the route's [App Shell](/docs/app/glossary#app-shell). The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary takes its place in the shell, and the deferred content renders once one of those happens.
 
-It is meant to defer content that the App Shell would otherwise render, typically content that depends on session data and is expensive to generate. Uncached data is left out of a prefetch already, so it gains nothing. During a build-time prerender nothing is deferred, so content below `unstable_prefetch()` is prerendered as usual.
+It is meant to defer content that the App Shell would otherwise render, typically content that depends on session data and is expensive to generate. During a build-time prerender nothing is deferred, so content below `unstable_prefetch()` is prerendered as usual.
 
 ## Usage
 
-The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), and throws without it. It also requires Partial Prefetching, without which it has no effect.
+The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), and throws without it. It also requires [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), which you can enable globally or one route at a time by [adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching).
 
-With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), a route is rendered in stages, and content can arrive at any of three:
+A route is then rendered in stages, and content can arrive at any of three:
 
 1. The App Shell, which every `<Link>` into the route prefetches, and which holds the part of the route that does not depend on the URL.
 2. A per-link prefetch, requested with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), which resolves the URL and adds the content that depends on it.
 3. The navigation itself, which covers everything left.
 
-Calling `unstable_prefetch()` keeps content out of the App Shell, so it renders on a per-link prefetch or on the navigation. Enable Partial Prefetching globally with [`partialPrefetching`](/docs/app/api-reference/config/next-config-js/partialPrefetching) or per segment with [`prefetch = 'partial'`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch#partial). Without that opt-in a route has no App Shell, so there is nothing to keep content out of.
+Calling `unstable_prefetch()` keeps content out of the App Shell, so it renders on a per-link prefetch or on the navigation.
+
+Without Partial Prefetching, a route has no App Shell, so there is nothing to keep content out of.
 
 To keep content out of per-link prefetches as well, so it renders only on the navigation, use [`unstable_navigation()`](/docs/app/api-reference/functions/navigation).
 
-Everything above `unstable_prefetch()` renders in the App Shell, and everything below renders on the prefetch. Place it above the work to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
+Everything above `unstable_prefetch()` renders in the App Shell, and everything below renders on a per-link prefetch or on the navigation. Place it above the work to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
 
 ```tsx filename="app/dashboard/page.tsx" highlight={26} switcher
 import { Suspense } from 'react'
@@ -55,7 +59,7 @@ async function Greeting() {
 
 async function Recommendations() {
   const session = (await cookies()).get('session')?.value
-  await unstable_prefetch() // everything below renders on the prefetch
+  await unstable_prefetch() // everything below renders on a per-link prefetch
   const items = await getRecommendations(session)
   return <List items={items} />
 }
@@ -93,7 +97,7 @@ async function Greeting() {
 
 async function Recommendations() {
   const session = (await cookies()).get('session')?.value
-  await unstable_prefetch() // everything below renders on the prefetch
+  await unstable_prefetch() // everything below renders on a per-link prefetch
   const items = await getRecommendations(session)
   return <List items={items} />
 }
@@ -105,23 +109,22 @@ async function getRecommendations(session) {
 }
 ```
 
-Both components read the session themselves, and only the greeting stays in the shell. The session is read above `unstable_prefetch()`, so it resolves in the shell like any other session data, and only the content that depends on it is left out. Remove the call and the recommendations become part of the App Shell that every link into the route prefetches.
+Both components read the session themselves, and only the greeting stays in the shell. The session is read above `unstable_prefetch()`, so it resolves in the shell like any other session data, and only the content that depends on it is left out. Remove `unstable_prefetch()` and the recommendations become part of the App Shell that every link into the route prefetches.
 
-It cannot sit inside a cached scope, so not under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private). Put the directive on a function called below it, as `getRecommendations` does here.
+Put the directive on a function called below it, as `getRecommendations` does here. `unstable_prefetch()` cannot sit inside a cached scope, so not under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private).
 
 ## When to use it
 
-Most routes do not need this. The App Shell resolves session data, so content that depends on `cookies()` or `headers()` is part of the shell by default, and the shell is what every `<Link>` into the route prefetches. This keeps that content out of it, so the shell stays small and the content arrives on a per-link prefetch or on the navigation instead.
+Reach for it when the content below `unstable_prefetch()` is expensive to produce, in compute, in upstream requests, or in latency, and you do not want it generated in the App Shell that every `<Link>` into the route prefetches.
 
-Keeping that content out of the shell would otherwise mean leaving it uncached. With `unstable_prefetch()` it can carry [`use cache: private`](/docs/app/api-reference/directives/use-cache-private) and a lifetime and still be deferred.
+Keeping that content out of the shell would otherwise mean leaving it uncached. With `unstable_prefetch()` it can be cached with [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private), given a lifetime, and deferred to a per-link prefetch or the navigation.
 
-Leave it out for content that does not depend on session data. Uncached reads, values with a short [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time, and anything behind `params` or `searchParams` are already left out of the shell on their own.
+Uncached reads, values with a short [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time, and anything behind `params` or `searchParams` are already left out of the shell on their own.
 
 ## Good to know
 
 - The function has no effect on the initial load of a page.
 - Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_prefetch()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache).
-- Content that depends on the URL, through `params` or `searchParams`, is already left out of the App Shell on its own.
 - A call outside a `<Suspense>` boundary surfaces a validation insight in development. It is reported even on a page that is currently prerendered in full, because the same page starts deferring content as soon as it switches to a runtime shell.
 - Calling it inside `use cache`, `use cache: private`, [`unstable_cache()`](/docs/app/api-reference/functions/unstable_cache), [`after()`](/docs/app/api-reference/functions/after), [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), or a Client Component throws.
 

--- a/docs/01-app/03-api-reference/04-functions/prefetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/prefetch.mdx
@@ -11,7 +11,7 @@ related:
 
 Awaiting `unstable_prefetch()` defers the code below it to a per-link prefetch or a navigation, instead of rendering it in the route's [App Shell](/docs/app/glossary#app-shell). The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary takes its place in the shell, and the deferred content renders once one of those happens.
 
-It is for content that the App Shell would otherwise render, which in practice means content that depends on session data. Uncached data is left out of a prefetch already, so it gains nothing. During a build-time prerender nothing is deferred, so content below `unstable_prefetch()` is prerendered as usual.
+It is meant to defer content that the App Shell would otherwise render, typically content that depends on session data and is expensive to generate. Uncached data is left out of a prefetch already, so it gains nothing. During a build-time prerender nothing is deferred, so content below `unstable_prefetch()` is prerendered as usual.
 
 ## Usage
 
@@ -63,7 +63,7 @@ async function Recommendations() {
 async function getRecommendations(session?: string) {
   'use cache: private'
   cacheLife('hours')
-  return rank(session)
+  return db.recommendations.rank({ session })
 }
 ```
 
@@ -101,7 +101,7 @@ async function Recommendations() {
 async function getRecommendations(session) {
   'use cache: private'
   cacheLife('hours')
-  return rank(session)
+  return db.recommendations.rank({ session })
 }
 ```
 
@@ -111,9 +111,9 @@ It cannot sit inside a cached scope, so not under [`use cache`](/docs/app/api-re
 
 ## When to use it
 
-Most routes do not need this. The App Shell resolves session data, so content that depends on `cookies()` or `headers()` renders in it by default, once for every `<Link>` into the route that a visitor sees. This keeps the code below it from running there, which is worth doing when that code reaches an upstream service.
+Most routes do not need this. The App Shell resolves session data, so content that depends on `cookies()` or `headers()` is part of the shell by default, and the shell is what every `<Link>` into the route prefetches. This keeps that content out of it, so the shell stays small and the content arrives on a per-link prefetch or on the navigation instead.
 
-Without `unstable_prefetch()`, keeping that content out of the shell would mean leaving it uncached. With it, the content can carry [`use cache: private`](/docs/app/api-reference/directives/use-cache-private) and a lifetime and still be deferred.
+Keeping that content out of the shell would otherwise mean leaving it uncached. With `unstable_prefetch()` it can carry [`use cache: private`](/docs/app/api-reference/directives/use-cache-private) and a lifetime and still be deferred.
 
 Leave it out for content that does not depend on session data. Uncached reads, values with a short [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time, and anything behind `params` or `searchParams` are already left out of the shell on their own.
 
@@ -122,7 +122,7 @@ Leave it out for content that does not depend on session data. Uncached reads, v
 - The function has no effect on the initial load of a page.
 - Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_prefetch()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache).
 - Content that depends on the URL, through `params` or `searchParams`, is already left out of the App Shell on its own.
-- A call outside a `<Suspense>` boundary surfaces a validation insight in development, reported even on a page that is currently prerendered in full, because the same page starts excluding content as soon as it switches to a runtime shell.
+- A call outside a `<Suspense>` boundary surfaces a validation insight in development. It is reported even on a page that is currently prerendered in full, because the same page starts deferring content as soon as it switches to a runtime shell.
 - Calling it inside `use cache`, `use cache: private`, [`unstable_cache()`](/docs/app/api-reference/functions/unstable_cache), [`after()`](/docs/app/api-reference/functions/after), [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), or a Client Component throws.
 
 ## Reference

--- a/docs/01-app/03-api-reference/04-functions/prefetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/prefetch.mdx
@@ -9,9 +9,9 @@ related:
     - app/api-reference/config/next-config-js/cacheComponents
 ---
 
-Awaiting `unstable_prefetch()` interrupts the prerender of a route's [App Shell](/docs/app/glossary#app-shell). The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary is sent in place of the rest of the component, and the interrupted content renders once a prefetch or a navigation happens.
+Awaiting `unstable_prefetch()` defers the code below it to a per-link prefetch or a navigation, instead of rendering it in the route's [App Shell](/docs/app/glossary#app-shell). The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary takes its place in the shell, and the deferred content renders once one of those happens.
 
-It is for content that the App Shell would otherwise include, which in practice means content that depends on session data. Uncached data is left out of a prefetch already, so it gains nothing. During a build-time prerender nothing is deferred, so content below `unstable_prefetch()` is prerendered as usual.
+It is for content that the App Shell would otherwise render, which in practice means content that depends on session data. Uncached data is left out of a prefetch already, so it gains nothing. During a build-time prerender nothing is deferred, so content below `unstable_prefetch()` is prerendered as usual.
 
 ## Usage
 
@@ -111,9 +111,9 @@ It cannot sit inside a cached scope, so not under [`use cache`](/docs/app/api-re
 
 ## When to use it
 
-Most routes do not need this. It changes what the App Shell carries: session data resolves inside the shell, so content that depends on `cookies()` or `headers()` is part of the shell payload by default, and this leaves it out.
+Most routes do not need this. The App Shell resolves session data, so content that depends on `cookies()` or `headers()` renders in it by default, once for every `<Link>` into the route that a visitor sees. This keeps the code below it from running there, which is worth doing when that code reaches an upstream service.
 
-Without `unstable_prefetch()`, keeping that content out of the shell would mean leaving it uncached. With it, the content can carry [`use cache: private`](/docs/app/api-reference/directives/use-cache-private) and a lifetime and still be excluded.
+Without `unstable_prefetch()`, keeping that content out of the shell would mean leaving it uncached. With it, the content can carry [`use cache: private`](/docs/app/api-reference/directives/use-cache-private) and a lifetime and still be deferred.
 
 Leave it out for content that does not depend on session data. Uncached reads, values with a short [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time, and anything behind `params` or `searchParams` are already left out of the shell on their own.
 

--- a/docs/01-app/03-api-reference/04-functions/prefetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/prefetch.mdx
@@ -11,7 +11,7 @@ related:
 
 Awaiting `unstable_prefetch()` interrupts the prerender of a route's [App Shell](/docs/app/glossary#app-shell). The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary is sent in place of the rest of the component, and the interrupted content renders once a prefetch or a navigation happens.
 
-The call is for content that the App Shell would otherwise include, which in practice means work that depends on session data. Uncached data does not need it, because a prefetch leaves uncached reads out already. The call does not interrupt a build-time prerender, so the content below it is prerendered as usual.
+It is for content that the App Shell would otherwise include, which in practice means content that depends on session data. Uncached data is left out of a prefetch already, so it gains nothing. During a build-time prerender nothing is deferred, so content below `unstable_prefetch()` is prerendered as usual.
 
 ## Usage
 
@@ -27,7 +27,7 @@ Calling `unstable_prefetch()` keeps content out of the App Shell, so it renders 
 
 To keep content out of per-link prefetches as well, so it renders only on the navigation, use [`unstable_navigation()`](/docs/app/api-reference/functions/navigation).
 
-Everything above the call renders in the App Shell, and everything below it renders on the prefetch. Place it above the work to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
+Everything above `unstable_prefetch()` renders in the App Shell, and everything below renders on the prefetch. Place it above the work to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
 
 ```tsx filename="app/dashboard/page.tsx" highlight={26} switcher
 import { Suspense } from 'react'
@@ -105,23 +105,23 @@ async function getRecommendations(session) {
 }
 ```
 
-Both components read the session themselves, and only the greeting stays in the shell. The session is read above the call, so it resolves in the shell like any other session data, and only the work that depends on it moves to the prefetch. Remove the `unstable_prefetch()` call and `getRecommendations` runs whenever any link into the route is prefetched, before anyone has clicked.
+Both components read the session themselves, and only the greeting stays in the shell. The session is read above `unstable_prefetch()`, so it resolves in the shell like any other session data, and only the content that depends on it is left out. Remove the call and the recommendations become part of the App Shell that every link into the route prefetches.
 
-The function cannot be used inside a cached scope, so it cannot sit under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private). Put the directive on a function called below it, as `getRecommendations` does here.
+It cannot sit inside a cached scope, so not under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private). Put the directive on a function called below it, as `getRecommendations` does here.
 
 ## When to use it
 
-Most routes do not need this. It exists for the case where the App Shell itself is expensive: session data resolves inside the shell, so work that depends on `cookies()` or `headers()` is part of the shell by default, and an authorization check placed there reaches an upstream service on every prefetch of every link into the route.
+Most routes do not need this. It changes what the App Shell carries: session data resolves inside the shell, so content that depends on `cookies()` or `headers()` is part of the shell payload by default, and this leaves it out.
 
-Without `unstable_prefetch()`, the only way to keep that work out of the shell is to leave it uncached. With it, the work can carry [`use cache: private`](/docs/app/api-reference/directives/use-cache-private) and a lifetime, and only its first render moves to the prefetch.
+Without `unstable_prefetch()`, keeping that content out of the shell would mean leaving it uncached. With it, the content can carry [`use cache: private`](/docs/app/api-reference/directives/use-cache-private) and a lifetime and still be excluded.
 
-Leave it out for content that does not depend on session data. Uncached reads, values with a short [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time, and anything behind `params` or `searchParams` are already left out of the shell without the call.
+Leave it out for content that does not depend on session data. Uncached reads, values with a short [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time, and anything behind `params` or `searchParams` are already left out of the shell on their own.
 
 ## Good to know
 
 - The function has no effect on the initial load of a page.
 - Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_prefetch()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache).
-- Content that depends on the URL, through `params` or `searchParams`, is already left out of the App Shell without the call.
+- Content that depends on the URL, through `params` or `searchParams`, is already left out of the App Shell on its own.
 - A call outside a `<Suspense>` boundary surfaces a validation insight in development, reported even on a page that is currently prerendered in full, because the same page starts excluding content as soon as it switches to a runtime shell.
 - Calling it inside `use cache`, `use cache: private`, [`unstable_cache()`](/docs/app/api-reference/functions/unstable_cache), [`after()`](/docs/app/api-reference/functions/after), [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), or a Client Component throws.
 

--- a/docs/01-app/03-api-reference/04-functions/prefetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/prefetch.mdx
@@ -128,9 +128,15 @@ Put the directive on a function called below it, as `getRecommendations` does he
 
 Reach for it when the content below `unstable_prefetch()` is expensive to produce, in compute, in upstream requests, or in latency, and you do not want it generated in the App Shell that every `<Link>` into the route prefetches.
 
+Producing the App Shell does not run that code, so the requests it makes are not issued until a per-link prefetch or the navigation.
+
 Keeping that content out of the shell would otherwise mean leaving it uncached. With `unstable_prefetch()` it can be cached with [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private), given a lifetime, and deferred to a per-link prefetch or the navigation.
 
 Uncached reads, values with a short [`stale`](/docs/app/api-reference/functions/cacheLife#stale) time, and anything behind `params` or `searchParams` are already left out of the shell on their own.
+
+### Keeping the App Shell static
+
+Nothing below `unstable_prefetch()` renders into the App Shell. When every read of [`cookies()`](/docs/app/api-reference/functions/cookies) and [`headers()`](/docs/app/api-reference/functions/headers) sits below it, the prerender a shell prefetch would trigger cannot produce more than the static output the build already generated, so the shell is served from that output instead. Shaping a route this way is an optional optimization: a static response can be cached in a CDN, so a default `<Link>` into the route costs no server CPU at all. A route that resolves `params` or `searchParams` gets that prerender instead, and so does the example above: it reads the session above `unstable_prefetch()`, so its shell renders once per visitor and only the recommendations are deferred.
 
 ## Good to know
 

--- a/docs/01-app/03-api-reference/04-functions/prefetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/prefetch.mdx
@@ -11,7 +11,7 @@ related:
     - app/api-reference/config/next-config-js/cacheComponents
 ---
 
-Awaiting `unstable_prefetch()` defers the code below it to a per-link prefetch or a navigation, instead of rendering it in the route's [App Shell](/docs/app/glossary#app-shell). The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary takes its place in the shell, and the deferred content renders once one of those happens.
+Calling `await unstable_prefetch()` defers the code below it to a per-link prefetch or a navigation, instead of rendering it in the route's [App Shell](/docs/app/glossary#app-shell). The fallback of the nearest [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary takes its place in the shell, and the deferred content renders once one of those happens.
 
 It is meant to defer content that the App Shell would otherwise render, typically content that depends on session data and is expensive to generate. During a build-time prerender nothing is deferred, so content below `unstable_prefetch()` is prerendered as usual.
 
@@ -19,13 +19,24 @@ It is meant to defer content that the App Shell would otherwise render, typicall
 
 The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), and throws without it. It also requires [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), which you can enable globally or one route at a time by [adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching).
 
+```ts filename="next.config.ts" highlight={4,5}
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true,
+}
+
+export default nextConfig
+```
+
 A route is then rendered in stages, and content can arrive at any of three:
 
 1. The App Shell, which every `<Link>` into the route prefetches, and which holds the part of the route that does not depend on the URL.
 2. A per-link prefetch, requested with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), which resolves the URL and adds the content that depends on it.
 3. The navigation itself, which covers everything left.
 
-Calling `unstable_prefetch()` keeps content out of the App Shell, so it renders on a per-link prefetch or on the navigation.
+Calling `unstable_prefetch()` keeps content out of the App Shell, so it only renders on a per-link prefetch or on the navigation.
 
 Without Partial Prefetching, a route has no App Shell, so there is nothing to keep content out of.
 

--- a/docs/01-app/03-api-reference/04-functions/prefetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/prefetch.mdx
@@ -36,7 +36,7 @@ A route is then rendered in three stages, and content can arrive at any of them:
 2. A per-link prefetch, requested with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), which resolves the URL and adds the content that depends on it.
 3. The navigation itself, which covers everything left.
 
-Calling `unstable_prefetch()` keeps content out of the App Shell, so it only renders on a per-link prefetch or on the navigation.
+Awaiting `unstable_prefetch()` keeps content out of the App Shell, so it renders only on a per-link prefetch or on the navigation.
 
 To keep content out of per-link prefetches as well, so it renders only on the navigation, use [`unstable_navigation()`](/docs/app/api-reference/functions/navigation).
 
@@ -126,7 +126,7 @@ Put the directive on a function called below it, as `getRecommendations` does he
 
 Reach for it when the content below `unstable_prefetch()` is expensive to produce, in compute, in upstream requests, or in latency, and you do not want it generated in the App Shell that every `<Link>` into the route prefetches.
 
-Producing the App Shell does not run that code, so the requests it makes are not issued until a per-link prefetch or the navigation.
+Producing the App Shell does not run that code, so its upstream requests are not issued until a per-link prefetch or the navigation.
 
 Keeping that content out of the shell would otherwise mean leaving it uncached. With `unstable_prefetch()` it can be cached with [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private), given a lifetime, and deferred to a per-link prefetch or the navigation.
 
@@ -134,7 +134,7 @@ Uncached reads, values with a short [`stale`](/docs/app/api-reference/functions/
 
 ### Keeping the App Shell static
 
-Nothing below `unstable_prefetch()` renders into the App Shell. When every read of [`cookies()`](/docs/app/api-reference/functions/cookies) and [`headers()`](/docs/app/api-reference/functions/headers) sits below it, the prerender a shell prefetch would trigger cannot produce more than the static output the build already generated, so the shell is served from that output instead. Shaping a route this way is an optional optimization: a static response can be cached in a CDN, so a default `<Link>` into the route costs no server CPU at all. A route that resolves `params` or `searchParams` gets that prerender instead, and so does the example above: it reads the session above `unstable_prefetch()`, so its shell renders once per visitor and only the recommendations are deferred.
+When every read of [`cookies()`](/docs/app/api-reference/functions/cookies) and [`headers()`](/docs/app/api-reference/functions/headers) sits below `unstable_prefetch()`, the prerender a shell prefetch would trigger cannot produce more than the static output the build already generated, so the shell is served from that output instead. Shaping a route this way is an optional optimization: a static response can be cached in a CDN, so a default `<Link>` into the route costs no server CPU at all. A route that resolves `params` or `searchParams` gets that prerender instead, and so does the example above: it reads the session above `unstable_prefetch()`, so its shell renders once per visitor and only the recommendations are deferred.
 
 ## Good to know
 

--- a/docs/01-app/03-api-reference/04-functions/prefetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/prefetch.mdx
@@ -17,7 +17,7 @@ It is meant to defer content that the App Shell would otherwise render, typicall
 
 ## Usage
 
-The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), and throws without it. It also requires [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), which you can enable globally or one route at a time by [adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching).
+The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), and throws without it. It also has no effect without [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), because a route without it has no App Shell to keep content out of. Enable it globally or one route at a time by [adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching).
 
 ```ts filename="next.config.ts" highlight={4,5}
 import type { NextConfig } from 'next'
@@ -30,7 +30,7 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-A route is then rendered in stages, and content can arrive at any of three:
+A route is then rendered in three stages, and content can arrive at any of them:
 
 1. The App Shell, which every `<Link>` into the route prefetches, and which holds the part of the route that does not depend on the URL.
 2. A per-link prefetch, requested with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch), which resolves the URL and adds the content that depends on it.
@@ -38,11 +38,9 @@ A route is then rendered in stages, and content can arrive at any of three:
 
 Calling `unstable_prefetch()` keeps content out of the App Shell, so it only renders on a per-link prefetch or on the navigation.
 
-Without Partial Prefetching, a route has no App Shell, so there is nothing to keep content out of.
-
 To keep content out of per-link prefetches as well, so it renders only on the navigation, use [`unstable_navigation()`](/docs/app/api-reference/functions/navigation).
 
-Everything above `unstable_prefetch()` renders in the App Shell, and everything below renders on a per-link prefetch or on the navigation. Place it above the work to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
+Everything above `unstable_prefetch()` renders in the App Shell, and everything below renders on a per-link prefetch or on the navigation. Deferral is scoped to the component that awaits it and the tree below: sibling branches render in the shell as usual. Place it above the work to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
 
 ```tsx filename="app/dashboard/page.tsx" highlight={26} switcher
 import { Suspense } from 'react'
@@ -120,9 +118,9 @@ async function getRecommendations(session) {
 }
 ```
 
-Both components read the session themselves, and only the greeting stays in the shell. The session is read above `unstable_prefetch()`, so it resolves in the shell like any other session data, and only the content that depends on it is left out. Remove `unstable_prefetch()` and the recommendations become part of the App Shell that every link into the route prefetches.
+Both components read the session themselves. It resolves in the shell either way, so the greeting stays there and only the ranking that depends on it is left out. Remove `unstable_prefetch()` and the recommendations become part of the App Shell that every link into the route prefetches.
 
-Put the directive on a function called below it, as `getRecommendations` does here. `unstable_prefetch()` cannot sit inside a cached scope, so not under [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private).
+Put the directive on a function called below it, as `getRecommendations` does here. Awaiting `unstable_prefetch()` inside a cached scope, such as [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private), is not allowed.
 
 ## When to use it
 
@@ -144,6 +142,8 @@ Nothing below `unstable_prefetch()` renders into the App Shell. When every read 
 - Unlike [`connection()`](/docs/app/api-reference/functions/connection), it does not mark the subtree as request-dependent. Content below `await unstable_prefetch()` stays fully cacheable and can be wrapped in [`use cache`](/docs/app/api-reference/directives/use-cache).
 - A call outside a `<Suspense>` boundary surfaces a validation insight in development. It is reported even on a page that is currently prerendered in full, because the same page starts deferring content as soon as it switches to a runtime shell.
 - Calling it inside `use cache`, `use cache: private`, [`unstable_cache()`](/docs/app/api-reference/functions/unstable_cache), [`after()`](/docs/app/api-reference/functions/after), [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params), or a Client Component throws.
+
+{/* TODO: link the validation insight error page from the bullet above once it merges. */}
 
 ## Reference
 

--- a/docs/01-app/03-api-reference/04-functions/prefetch.mdx
+++ b/docs/01-app/03-api-reference/04-functions/prefetch.mdx
@@ -17,7 +17,7 @@ It is meant to defer content that the App Shell would otherwise render, typicall
 
 ## Usage
 
-The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), and throws without it. It also has no effect without [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), because a route without it has no App Shell to keep content out of. Enable it globally or one route at a time by [adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching).
+The function requires [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) and throws an error if not enabled. Without [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching) a route has no App Shell, so the function has no effect. Enable Partial Prefetching globally, or one route at a time, by [adopting Partial Prefetching](/docs/app/guides/adopting-partial-prefetching).
 
 ```ts filename="next.config.ts" highlight={4,5}
 import type { NextConfig } from 'next'
@@ -42,7 +42,7 @@ To keep content out of per-link prefetches as well, so it renders only on the na
 
 Everything above `unstable_prefetch()` renders in the App Shell, and everything below renders on a per-link prefetch or on the navigation. Deferral is scoped to the component that awaits it and the tree below: sibling branches render in the shell as usual. Place it above the work to defer, and wrap the component in [`<Suspense>`](https://react.dev/reference/react/Suspense):
 
-```tsx filename="app/dashboard/page.tsx" highlight={26} switcher
+```tsx filename="app/dashboard/page.tsx" highlight={25} switcher
 import { Suspense } from 'react'
 import { cookies } from 'next/headers'
 import { cacheLife, unstable_prefetch } from 'next/cache'
@@ -67,20 +67,20 @@ async function Greeting() {
 }
 
 async function Recommendations() {
-  const session = (await cookies()).get('session')?.value
   await unstable_prefetch() // everything below renders on a per-link prefetch
-  const items = await getRecommendations(session)
+  const items = await getRecommendations()
   return <List items={items} />
 }
 
-async function getRecommendations(session?: string) {
+async function getRecommendations() {
   'use cache: private'
   cacheLife('hours')
+  const session = (await cookies()).get('session')?.value
   return db.recommendations.rank({ session })
 }
 ```
 
-```jsx filename="app/dashboard/page.js" highlight={26} switcher
+```jsx filename="app/dashboard/page.js" highlight={25} switcher
 import { Suspense } from 'react'
 import { cookies } from 'next/headers'
 import { cacheLife, unstable_prefetch } from 'next/cache'
@@ -105,20 +105,20 @@ async function Greeting() {
 }
 
 async function Recommendations() {
-  const session = (await cookies()).get('session')?.value
   await unstable_prefetch() // everything below renders on a per-link prefetch
-  const items = await getRecommendations(session)
+  const items = await getRecommendations()
   return <List items={items} />
 }
 
-async function getRecommendations(session) {
+async function getRecommendations() {
   'use cache: private'
   cacheLife('hours')
+  const session = (await cookies()).get('session')?.value
   return db.recommendations.rank({ session })
 }
 ```
 
-Both components read the session themselves. It resolves in the shell either way, so the greeting stays there and only the ranking that depends on it is left out. Remove `unstable_prefetch()` and the recommendations become part of the App Shell that every link into the route prefetches.
+The greeting reads the session and stays in the App Shell. The recommendations read it too, inside `getRecommendations`, so that read is deferred along with the ranking. Remove `unstable_prefetch()` and they become part of the App Shell that every link into the route prefetches.
 
 Put the directive on a function called below it, as `getRecommendations` does here. Awaiting `unstable_prefetch()` inside a cached scope, such as [`use cache`](/docs/app/api-reference/directives/use-cache) or [`use cache: private`](/docs/app/api-reference/directives/use-cache-private), is not allowed.
 
@@ -134,7 +134,7 @@ Uncached reads, values with a short [`stale`](/docs/app/api-reference/functions/
 
 ### Keeping the App Shell static
 
-When every read of [`cookies()`](/docs/app/api-reference/functions/cookies) and [`headers()`](/docs/app/api-reference/functions/headers) sits below `unstable_prefetch()`, the prerender a shell prefetch would trigger cannot produce more than the static output the build already generated, so the shell is served from that output instead. Shaping a route this way is an optional optimization: a static response can be cached in a CDN, so a default `<Link>` into the route costs no server CPU at all. A route that resolves `params` or `searchParams` gets that prerender instead, and so does the example above: it reads the session above `unstable_prefetch()`, so its shell renders once per visitor and only the recommendations are deferred.
+When every read of [`cookies()`](/docs/app/api-reference/functions/cookies) and [`headers()`](/docs/app/api-reference/functions/headers) sits below `unstable_prefetch()`, the prerender a shell prefetch would trigger cannot produce more than the static output the build already generated, so the shell is served from that output instead. Shaping a route this way is an optional optimization: a static response can be cached in a CDN, so a default `<Link>` into the route costs no server CPU at all. A route that resolves `params` or `searchParams` gets that prerender instead, and so does the example above: its greeting reads the session in the shell, so the shell renders once per visitor and only the recommendations are deferred.
 
 ## Good to know
 


### PR DESCRIPTION
Adds API reference pages for the two render-interruption functions, both marked `version: experimental`.

- `unstable_navigation()`, which keeps a subtree out of a route's prefetches so it renders on the navigation.
- `unstable_prefetch()`, which keeps a subtree out of a route's App Shell so it renders on a per-link prefetch or on the navigation.

Each page opens with the App Shell, per-link prefetch, navigation ladder, states which boundary its function moves content past, and cross-references the sibling function and the Adopting Partial Prefetching guide.