### PR TITLE
Return client errors for unrecognized Server Actions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -611,7 +611,13 @@ export async function handleAction({
     isPossibleServerAction,
   } = getServerActionRequestMetadata(req)
 
-  const handleUnrecognizedFetchAction = (err: unknown): HandleActionResult => {
+  const handleUnrecognizedAction = (
+    err: unknown,
+    statusCode: 400 | 409 = actionId !== null &&
+    !mightBeServerReferenceId(actionId)
+      ? 400
+      : 409
+  ): HandleActionResult => {
     // If the deployment doesn't have skew protection, this is expected to occasionally happen,
     // so we use a warning instead of an error.
     console.warn(err)
@@ -622,10 +628,7 @@ export async function handleAction({
     // (i.e. without needing to invoke a lambda)
     res.setHeader(NEXT_ACTION_NOT_FOUND_HEADER, '1')
     res.setHeader('content-type', 'text/plain')
-    // A malformed ID is a bad request. A well-formed but unknown ID can be
-    // caused by deployment skew, so it conflicts with the current app state.
-    res.statusCode =
-      actionId !== null && !mightBeServerReferenceId(actionId) ? 400 : 409
+    res.statusCode = statusCode
     return {
       type: 'done',
       result: RenderResult.fromStatic('Server action not found.', 'text/plain'),
@@ -658,7 +661,7 @@ export async function handleAction({
       actionId !== null && !mightBeServerReferenceId(actionId)
         ? getInvalidServerReferenceIdError(actionId)
         : getActionNotFoundError(actionId)
-    return handleUnrecognizedFetchAction(error)
+    return handleUnrecognizedAction(error)
   }
 
   let temporaryReferences: TemporaryReferenceSet | undefined
@@ -872,7 +875,7 @@ export async function handleAction({
               try {
                 actionModId = getActionModIdOrError(actionId, serverModuleMap)
               } catch (err) {
-                return handleUnrecognizedFetchAction(err)
+                return handleUnrecognizedAction(err)
               }
 
               boundActionArguments = await decodeReply<unknown[]>(
@@ -883,11 +886,14 @@ export async function handleAction({
             } else {
               // Multipart POST, but not a fetch action.
               // Potentially an MPA action, we have to try decoding it to check.
-              if (areAllActionIdsValid(formData, serverModuleMap) === false) {
-                // TODO: This can be from skew or manipulated input. We should handle this case
-                // more gracefully but this preserves the prior behavior where decodeAction would throw instead.
-                throw new Error(
-                  `Failed to find Server Action. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
+              const invalidAction = getInvalidActionInfo(
+                formData,
+                serverModuleMap
+              )
+              if (invalidAction !== null) {
+                return handleUnrecognizedAction(
+                  invalidAction[1],
+                  invalidAction[0]
                 )
               }
 
@@ -936,7 +942,7 @@ export async function handleAction({
             try {
               actionModId = getActionModIdOrError(actionId, serverModuleMap)
             } catch (err) {
-              return handleUnrecognizedFetchAction(err)
+              return handleUnrecognizedAction(err)
             }
 
             // A fetch action with a non-multipart body.
@@ -1033,7 +1039,7 @@ export async function handleAction({
               try {
                 actionModId = getActionModIdOrError(actionId, serverModuleMap)
               } catch (err) {
-                return handleUnrecognizedFetchAction(err)
+                return handleUnrecognizedAction(err)
               }
 
               const busboy = (
@@ -1090,11 +1096,14 @@ export async function handleAction({
                 throw err
               }
 
-              if (areAllActionIdsValid(formData, serverModuleMap) === false) {
-                // TODO: This can be from skew or manipulated input. We should handle this case
-                // more gracefully but this preserves the prior behavior where decodeAction would throw instead.
-                throw new Error(
-                  `Failed to find Server Action. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
+              const invalidAction = getInvalidActionInfo(
+                formData,
+                serverModuleMap
+              )
+              if (invalidAction !== null) {
+                return handleUnrecognizedAction(
+                  invalidAction[1],
+                  invalidAction[0]
                 )
               }
 
@@ -1145,7 +1154,7 @@ export async function handleAction({
             try {
               actionModId = getActionModIdOrError(actionId, serverModuleMap)
             } catch (err) {
-              return handleUnrecognizedFetchAction(err)
+              return handleUnrecognizedAction(err)
             }
 
             // A fetch action with a non-multipart body.
@@ -1495,14 +1504,16 @@ const $ACTION_ID_ = '$ACTION_ID_'
  * It pre-parses the FormData to ensure that any action IDs referred to are actual action IDs for
  * this Next.js application.
  */
-function areAllActionIdsValid(
+type InvalidActionInfo = readonly [statusCode: 400 | 409, error: unknown]
+
+function getInvalidActionInfo(
   mpaFormData: FormData,
   serverModuleMap: ServerModuleMap
-): boolean {
+): InvalidActionInfo | null {
   let seenActionRefs = 0
   let hasAtLeastOneAction = false
-  // Before we attempt to decode the payload for a possible MPA action, assert that all
-  // action IDs are valid IDs. If not we should disregard the payload
+  // Before we attempt to decode the payload for a possible MPA action, assert
+  // that all action IDs are valid IDs.
   for (let key of mpaFormData.keys()) {
     if (!key.startsWith($ACTION_)) {
       // not a relevant field
@@ -1511,8 +1522,12 @@ function areAllActionIdsValid(
 
     if (key.startsWith($ACTION_ID_)) {
       // No Bound args case
-      if (isInvalidActionIdFieldName(key, serverModuleMap)) {
-        return false
+      const invalidAction = getInvalidActionIdInfo(
+        key.slice($ACTION_ID_.length),
+        serverModuleMap
+      )
+      if (invalidAction !== null) {
+        return invalidAction
       }
 
       hasAtLeastOneAction = true
@@ -1521,7 +1536,7 @@ function areAllActionIdsValid(
         // We only expect to see at most 2 $ACTION_REF_ fields in the form data:
         // one from <form action="..." method="post">
         // and one from <input action="..." type="submit">
-        return false
+        return getInvalidActionRequestInfo()
       }
 
       // Bound args case
@@ -1529,71 +1544,67 @@ function areAllActionIdsValid(
         $ACTION_ + key.slice($ACTION_REF_.length) + ':0'
       const actionFields = mpaFormData.getAll(actionDescriptorField)
       if (actionFields.length !== 1) {
-        return false
+        return getInvalidActionRequestInfo()
       }
       const actionField = actionFields[0]
       if (typeof actionField !== 'string') {
-        return false
+        return getInvalidActionRequestInfo()
       }
 
-      if (isInvalidStringActionDescriptor(actionField, serverModuleMap)) {
-        return false
+      const invalidAction = getInvalidActionDescriptorInfo(
+        actionField,
+        serverModuleMap
+      )
+      if (invalidAction !== null) {
+        return invalidAction
       }
       hasAtLeastOneAction = true
     }
   }
-  return hasAtLeastOneAction
+  return hasAtLeastOneAction ? null : getInvalidActionRequestInfo()
 }
 
 const ACTION_DESCRIPTOR_ID_PREFIX = '{"id":"'
-function isInvalidStringActionDescriptor(
+function getInvalidActionDescriptorInfo(
   actionDescriptor: string,
   serverModuleMap: ServerModuleMap
-): unknown {
+): InvalidActionInfo | null {
   if (actionDescriptor.startsWith(ACTION_DESCRIPTOR_ID_PREFIX) === false) {
-    return true
+    return getInvalidActionRequestInfo()
   }
 
   const from = ACTION_DESCRIPTOR_ID_PREFIX.length
   const to = actionDescriptor.indexOf('"', from)
   if (to === -1) {
-    return true
+    return getInvalidActionRequestInfo()
   }
 
   // We expect actionDescriptor to be '{"id":"<actionId>",...}'
   const actionId = actionDescriptor.slice(from, to)
-  if (!mightBeServerReferenceId(actionId)) {
-    return true
-  }
-
-  const entry = serverModuleMap[actionId]
-
-  if (entry == null) {
-    return true
-  }
-
-  return false
+  return getInvalidActionIdInfo(actionId, serverModuleMap)
 }
 
-function isInvalidActionIdFieldName(
-  actionIdFieldName: string,
+function getInvalidActionIdInfo(
+  actionId: string,
   serverModuleMap: ServerModuleMap
-): boolean {
-  // The field name must always start with $ACTION_ID_ but since it is
-  // the id is extracted from the key of the field we have already validated
-  // this before entering this function
-  const actionId = actionIdFieldName.slice($ACTION_ID_.length)
+): InvalidActionInfo | null {
   if (!mightBeServerReferenceId(actionId)) {
-    // this field name has too few or too many characters
-    // or it is otherwise in the wrong format
-    return true
+    return [400, getInvalidServerReferenceIdError(actionId)]
   }
 
-  const entry = serverModuleMap[actionId]
+  try {
+    const entry = serverModuleMap[actionId]
 
-  if (entry == null) {
-    return true
+    if (entry == null) {
+      return [409, getActionNotFoundError(actionId)]
+    }
+  } catch (err) {
+    return [409, err]
   }
 
-  return false
+  return null
+}
+
+function getInvalidActionRequestInfo(): InvalidActionInfo {
+  return [400, new Error('Invalid Server Actions request.')]
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -306,7 +306,7 @@ async function createForwardedActionResponse(
     if (response.headers.get(NEXT_ACTION_NOT_FOUND_HEADER) === '1') {
       res.setHeader(NEXT_ACTION_NOT_FOUND_HEADER, '1')
       res.setHeader('content-type', 'text/plain')
-      res.statusCode = 404
+      res.statusCode = response.status
       return RenderResult.fromStatic('Server action not found.', 'text/plain')
     }
   } catch (err) {
@@ -622,7 +622,10 @@ export async function handleAction({
     // (i.e. without needing to invoke a lambda)
     res.setHeader(NEXT_ACTION_NOT_FOUND_HEADER, '1')
     res.setHeader('content-type', 'text/plain')
-    res.statusCode = 404
+    // A malformed ID is a bad request. A well-formed but unknown ID can be
+    // caused by deployment skew, so it conflicts with the current app state.
+    res.statusCode =
+      actionId !== null && !mightBeServerReferenceId(actionId) ? 400 : 409
     return {
       type: 'done',
       result: RenderResult.fromStatic('Server action not found.', 'text/plain'),
@@ -649,7 +652,7 @@ export async function handleAction({
     }
   }
 
-  // If the app has no server actions at all, we can 404 early.
+  // If the app has no server actions at all, we can reject the request early.
   if (!hasServerActions()) {
     const error =
       actionId !== null && !mightBeServerReferenceId(actionId)

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -94,6 +94,10 @@ function hasServerActions() {
   )
 }
 
+function getUnrecognizedActionStatusCode(actionId: string | null): 400 | 409 {
+  return actionId !== null && !mightBeServerReferenceId(actionId) ? 400 : 409
+}
+
 function nodeHeadersToRecord(
   headers: IncomingHttpHeaders | OutgoingHttpHeaders
 ) {
@@ -212,7 +216,8 @@ async function createForwardedActionResponse(
   res: BaseNextResponse,
   host: Host,
   workerPathname: string,
-  basePath: string
+  basePath: string,
+  actionId: string
 ) {
   if (!host) {
     throw new Error(
@@ -306,7 +311,9 @@ async function createForwardedActionResponse(
     if (response.headers.get(NEXT_ACTION_NOT_FOUND_HEADER) === '1') {
       res.setHeader(NEXT_ACTION_NOT_FOUND_HEADER, '1')
       res.setHeader('content-type', 'text/plain')
-      res.statusCode = response.status
+      // The marker denotes an unavailable action. Derive the status from the
+      // requested ID so mixed-version workers cannot change its semantics.
+      res.statusCode = getUnrecognizedActionStatusCode(actionId)
       return RenderResult.fromStatic('Server action not found.', 'text/plain')
     }
   } catch (err) {
@@ -613,10 +620,7 @@ export async function handleAction({
 
   const handleUnrecognizedAction = (
     err: unknown,
-    statusCode: 400 | 409 = actionId !== null &&
-    !mightBeServerReferenceId(actionId)
-      ? 400
-      : 409
+    statusCode: 400 | 409 = getUnrecognizedActionStatusCode(actionId)
   ): HandleActionResult => {
     // If the deployment doesn't have skew protection, this is expected to occasionally happen,
     // so we use a warning instead of an error.
@@ -787,7 +791,8 @@ export async function handleAction({
           res,
           host,
           forwardedWorker,
-          ctx.renderOpts.basePath
+          ctx.renderOpts.basePath,
+          actionId
         ),
       }
     }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -886,15 +886,15 @@ export async function handleAction({
             } else {
               // Multipart POST, but not a fetch action.
               // Potentially an MPA action, we have to try decoding it to check.
-              const invalidAction = getInvalidActionInfo(
-                formData,
-                serverModuleMap
-              )
-              if (invalidAction !== null) {
-                return handleUnrecognizedAction(
-                  invalidAction[1],
-                  invalidAction[0]
-                )
+              try {
+                if (!areAllActionIdsValid(formData, serverModuleMap)) {
+                  return handleUnrecognizedAction(
+                    new Error('Invalid Server Actions request.'),
+                    400
+                  )
+                }
+              } catch (err) {
+                return handleUnrecognizedAction(err, 409)
               }
 
               const action = await decodeAction(formData, serverModuleMap)
@@ -1096,15 +1096,15 @@ export async function handleAction({
                 throw err
               }
 
-              const invalidAction = getInvalidActionInfo(
-                formData,
-                serverModuleMap
-              )
-              if (invalidAction !== null) {
-                return handleUnrecognizedAction(
-                  invalidAction[1],
-                  invalidAction[0]
-                )
+              try {
+                if (!areAllActionIdsValid(formData, serverModuleMap)) {
+                  return handleUnrecognizedAction(
+                    new Error('Invalid Server Actions request.'),
+                    400
+                  )
+                }
+              } catch (err) {
+                return handleUnrecognizedAction(err, 409)
               }
 
               // TODO: Refactor so it is harder to accidentally decode an action before you have validated that the
@@ -1504,12 +1504,10 @@ const $ACTION_ID_ = '$ACTION_ID_'
  * It pre-parses the FormData to ensure that any action IDs referred to are actual action IDs for
  * this Next.js application.
  */
-type InvalidActionInfo = readonly [statusCode: 400 | 409, error: unknown]
-
-function getInvalidActionInfo(
+function areAllActionIdsValid(
   mpaFormData: FormData,
   serverModuleMap: ServerModuleMap
-): InvalidActionInfo | null {
+): boolean {
   let seenActionRefs = 0
   let hasAtLeastOneAction = false
   // Before we attempt to decode the payload for a possible MPA action, assert
@@ -1522,12 +1520,8 @@ function getInvalidActionInfo(
 
     if (key.startsWith($ACTION_ID_)) {
       // No Bound args case
-      const invalidAction = getInvalidActionIdInfo(
-        key.slice($ACTION_ID_.length),
-        serverModuleMap
-      )
-      if (invalidAction !== null) {
-        return invalidAction
+      if (isInvalidActionIdFieldName(key, serverModuleMap)) {
+        return false
       }
 
       hasAtLeastOneAction = true
@@ -1536,7 +1530,7 @@ function getInvalidActionInfo(
         // We only expect to see at most 2 $ACTION_REF_ fields in the form data:
         // one from <form action="..." method="post">
         // and one from <input action="..." type="submit">
-        return getInvalidActionRequestInfo()
+        return false
       }
 
       // Bound args case
@@ -1544,67 +1538,71 @@ function getInvalidActionInfo(
         $ACTION_ + key.slice($ACTION_REF_.length) + ':0'
       const actionFields = mpaFormData.getAll(actionDescriptorField)
       if (actionFields.length !== 1) {
-        return getInvalidActionRequestInfo()
+        return false
       }
       const actionField = actionFields[0]
       if (typeof actionField !== 'string') {
-        return getInvalidActionRequestInfo()
+        return false
       }
 
-      const invalidAction = getInvalidActionDescriptorInfo(
-        actionField,
-        serverModuleMap
-      )
-      if (invalidAction !== null) {
-        return invalidAction
+      if (isInvalidStringActionDescriptor(actionField, serverModuleMap)) {
+        return false
       }
       hasAtLeastOneAction = true
     }
   }
-  return hasAtLeastOneAction ? null : getInvalidActionRequestInfo()
+  return hasAtLeastOneAction
 }
 
 const ACTION_DESCRIPTOR_ID_PREFIX = '{"id":"'
-function getInvalidActionDescriptorInfo(
+function isInvalidStringActionDescriptor(
   actionDescriptor: string,
   serverModuleMap: ServerModuleMap
-): InvalidActionInfo | null {
+): boolean {
   if (actionDescriptor.startsWith(ACTION_DESCRIPTOR_ID_PREFIX) === false) {
-    return getInvalidActionRequestInfo()
+    return true
   }
 
   const from = ACTION_DESCRIPTOR_ID_PREFIX.length
   const to = actionDescriptor.indexOf('"', from)
   if (to === -1) {
-    return getInvalidActionRequestInfo()
+    return true
   }
 
   // We expect actionDescriptor to be '{"id":"<actionId>",...}'
   const actionId = actionDescriptor.slice(from, to)
-  return getInvalidActionIdInfo(actionId, serverModuleMap)
-}
-
-function getInvalidActionIdInfo(
-  actionId: string,
-  serverModuleMap: ServerModuleMap
-): InvalidActionInfo | null {
   if (!mightBeServerReferenceId(actionId)) {
-    return [400, getInvalidServerReferenceIdError(actionId)]
+    return true
   }
 
-  try {
-    const entry = serverModuleMap[actionId]
+  const entry = serverModuleMap[actionId]
 
-    if (entry == null) {
-      return [409, getActionNotFoundError(actionId)]
-    }
-  } catch (err) {
-    return [409, err]
+  if (entry == null) {
+    return true
   }
 
-  return null
+  return false
 }
 
-function getInvalidActionRequestInfo(): InvalidActionInfo {
-  return [400, new Error('Invalid Server Actions request.')]
+function isInvalidActionIdFieldName(
+  actionIdFieldName: string,
+  serverModuleMap: ServerModuleMap
+): boolean {
+  // The field name must always start with $ACTION_ID_ but since it is
+  // the id is extracted from the key of the field we have already validated
+  // this before entering this function
+  const actionId = actionIdFieldName.slice($ACTION_ID_.length)
+  if (!mightBeServerReferenceId(actionId)) {
+    // this field name has too few or too many characters
+    // or it is otherwise in the wrong format
+    return true
+  }
+
+  const entry = serverModuleMap[actionId]
+
+  if (entry == null) {
+    return true
+  }
+
+  return false
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -98,6 +98,12 @@ function getUnrecognizedActionStatusCode(actionId: string | null): 400 | 409 {
   return actionId !== null && !mightBeServerReferenceId(actionId) ? 400 : 409
 }
 
+function getUnrecognizedActionResponseBody(statusCode: 400 | 409): string {
+  return statusCode === 400
+    ? 'Invalid Server Action request.'
+    : 'Server Action unavailable.'
+}
+
 function nodeHeadersToRecord(
   headers: IncomingHttpHeaders | OutgoingHttpHeaders
 ) {
@@ -313,8 +319,12 @@ async function createForwardedActionResponse(
       res.setHeader('content-type', 'text/plain')
       // The marker denotes an unavailable action. Derive the status from the
       // requested ID so mixed-version workers cannot change its semantics.
-      res.statusCode = getUnrecognizedActionStatusCode(actionId)
-      return RenderResult.fromStatic('Server action not found.', 'text/plain')
+      const statusCode = getUnrecognizedActionStatusCode(actionId)
+      res.statusCode = statusCode
+      return RenderResult.fromStatic(
+        getUnrecognizedActionResponseBody(statusCode),
+        'text/plain'
+      )
     }
   } catch (err) {
     // we couldn't stream the forwarded response, so we'll just return an empty response
@@ -635,7 +645,10 @@ export async function handleAction({
     res.statusCode = statusCode
     return {
       type: 'done',
-      result: RenderResult.fromStatic('Server action not found.', 'text/plain'),
+      result: RenderResult.fromStatic(
+        getUnrecognizedActionResponseBody(statusCode),
+        'text/plain'
+      ),
     }
   }
 

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -620,7 +620,7 @@ export async function handleAction({
 
   const handleUnrecognizedAction = (
     err: unknown,
-    statusCode: 400 | 409 = getUnrecognizedActionStatusCode(actionId)
+    statusCode: 400 | 409
   ): HandleActionResult => {
     // If the deployment doesn't have skew protection, this is expected to occasionally happen,
     // so we use a warning instead of an error.
@@ -665,7 +665,10 @@ export async function handleAction({
       actionId !== null && !mightBeServerReferenceId(actionId)
         ? getInvalidServerReferenceIdError(actionId)
         : getActionNotFoundError(actionId)
-    return handleUnrecognizedAction(error)
+    return handleUnrecognizedAction(
+      error,
+      getUnrecognizedActionStatusCode(actionId)
+    )
   }
 
   let temporaryReferences: TemporaryReferenceSet | undefined
@@ -880,7 +883,10 @@ export async function handleAction({
               try {
                 actionModId = getActionModIdOrError(actionId, serverModuleMap)
               } catch (err) {
-                return handleUnrecognizedAction(err)
+                return handleUnrecognizedAction(
+                  err,
+                  getUnrecognizedActionStatusCode(actionId)
+                )
               }
 
               boundActionArguments = await decodeReply<unknown[]>(
@@ -947,7 +953,10 @@ export async function handleAction({
             try {
               actionModId = getActionModIdOrError(actionId, serverModuleMap)
             } catch (err) {
-              return handleUnrecognizedAction(err)
+              return handleUnrecognizedAction(
+                err,
+                getUnrecognizedActionStatusCode(actionId)
+              )
             }
 
             // A fetch action with a non-multipart body.
@@ -1044,7 +1053,10 @@ export async function handleAction({
               try {
                 actionModId = getActionModIdOrError(actionId, serverModuleMap)
               } catch (err) {
-                return handleUnrecognizedAction(err)
+                return handleUnrecognizedAction(
+                  err,
+                  getUnrecognizedActionStatusCode(actionId)
+                )
               }
 
               const busboy = (
@@ -1159,7 +1171,10 @@ export async function handleAction({
             try {
               actionModId = getActionModIdOrError(actionId, serverModuleMap)
             } catch (err) {
-              return handleUnrecognizedAction(err)
+              return handleUnrecognizedAction(
+                err,
+                getUnrecognizedActionStatusCode(actionId)
+              )
             }
 
             // A fetch action with a non-multipart body.

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -6,7 +6,7 @@ import { outdent } from 'outdent'
 describe('unrecognized server actions', () => {
   const unrecognizedActionId = '0'.repeat(42)
 
-  const { next, isNextDeploy, isNextDev } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
@@ -132,6 +132,54 @@ describe('unrecognized server actions', () => {
   describe.each(['nodejs', 'edge'])(
     'should error and log a warning when submitting a server action with an unrecognized ID - %s',
     (runtime) => {
+      if (!isNextDeploy) {
+        it.each([
+          {
+            description: 'a malformed ID',
+            actionId: '123',
+            expectedStatus: 400,
+            expectedError: outdent`
+              The Server Reference ID did not match the expected format. Received "123".
+              Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
+            `,
+          },
+          {
+            description: 'a plausible but missing ID',
+            actionId: unrecognizedActionId,
+            expectedStatus: 409,
+            expectedError: outdent`
+              Failed to find Server Action "${unrecognizedActionId}". This request might be from an older or newer deployment.
+              Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
+            `,
+          },
+        ])(
+          'should reject an MPA action with $description',
+          async ({ actionId, expectedStatus, expectedError }) => {
+            const boundary = '----nextjs-test-boundary'
+            const body = `--${boundary}\r\nContent-Disposition: form-data; name="$ACTION_ID_${actionId}"\r\n\r\n\r\n--${boundary}--\r\n`
+
+            const response = await next.fetch(
+              `/${runtime}/unrecognized-action`,
+              {
+                method: 'POST',
+                headers: {
+                  'content-type': `multipart/form-data; boundary=${boundary}`,
+                },
+                body,
+              }
+            )
+
+            expect(response.status).toBe(expectedStatus)
+            expect(response.headers.get('content-type')).toStartWith(
+              'text/plain'
+            )
+            expect(await response.text()).toBe('Server action not found.')
+
+            await retry(async () => expect(getLogs()).toInclude(expectedError))
+          }
+        )
+      }
+
       const testUnrecognizedActionSubmission = async ({
         formId,
         disableJavaScript,
@@ -187,38 +235,18 @@ describe('unrecognized server actions', () => {
         } else {
           // An MPA action, sent without JS.
 
-          // FIXME: When deployed, the request is logged as a 500, but returns a 405.
-          // We also don't seem to display the error page correctly
           if (!isNextDeploy) {
-            // FIXME: Currently, an unrecognized id in an MPA action results in a 500.
-            // This is not ideal, and ignores all nested `error.js` files, only showing the topmost one.
-            expect(response.status()).toBe(500)
-            if (isNextDev) {
-              expect(response.headers()['content-type']).toStartWith(
-                'text/html'
-              )
-            } else {
-              const responseText = await response.text()
-              expect(responseText).toBe('Internal Server Error')
-              expect(response.headers()['content-type']).toStartWith(
-                'text/plain'
-              )
-            }
+            expect(response.status()).toBe(409)
+            expect(response.headers()['content-type']).toStartWith('text/plain')
+            expect(await browser.elementByCss('body').text()).toBe(
+              'Server action not found.'
+            )
 
-            // In dev, the 500 page doesn't have any SSR'd html, so it won't show anything without JS.
-            if (!isNextDev) {
-              expect(await browser.elementByCss('body').text()).toContain(
-                'Internal Server Error'
+            await retry(async () =>
+              expect(getLogs()).toInclude(
+                `Error: Failed to find Server Action "${unrecognizedActionId}". This request might be from an older or newer deployment`
               )
-            }
-
-            if (!isNextDeploy) {
-              await retry(async () =>
-                expect(getLogs()).toInclude(
-                  `Error: Failed to find Server Action "${unrecognizedActionId}". This request might be from an older or newer deployment`
-                )
-              )
-            }
+            )
           }
         }
       }

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -42,6 +42,7 @@ describe('unrecognized server actions', () => {
       {
         idType: 'malformed',
         actionId: '123',
+        expectedStatus: 400,
         expectedError: outdent`
           The Server Reference ID did not match the expected format. Received "123".
           Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
@@ -50,6 +51,7 @@ describe('unrecognized server actions', () => {
       {
         idType: 'plausible but missing',
         actionId: unrecognizedActionId,
+        expectedStatus: 409,
         expectedError: outdent`
           Failed to find Server Action "${unrecognizedActionId}". This request might be from an older or newer deployment.
           Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
@@ -62,12 +64,13 @@ describe('unrecognized server actions', () => {
         // We should still surface a diagnosable error instead of a TypeError.
         idType: 'well-known property name',
         actionId: 'toString',
+        expectedStatus: 400,
         expectedError: outdent`
           The Server Reference ID did not match the expected format. Received "toString".
           Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
         `,
       },
-    ])('with a $idType id', ({ actionId, expectedError }) => {
+    ])('with a $idType id', ({ actionId, expectedStatus, expectedError }) => {
       it.each([
         {
           // encodeReply encodes simple args as plaintext.
@@ -87,7 +90,7 @@ describe('unrecognized server actions', () => {
           },
         },
       ])(
-        'should 404 when POSTing a server action to a nonexistent page: $name',
+        'should reject a server action POST to a nonexistent page: $name',
         async ({ request: { contentType, body } }) => {
           const res = await next.fetch('/non-existent-route', {
             method: 'POST',
@@ -99,7 +102,7 @@ describe('unrecognized server actions', () => {
             body,
           })
 
-          expect(res.status).toBe(404)
+          expect(res.status).toBe(expectedStatus)
 
           const cliOutput = getLogs()
           expect(cliOutput).not.toContain('TypeError')
@@ -156,7 +159,7 @@ describe('unrecognized server actions', () => {
 
         if (!disableJavaScript) {
           // A fetch action, sent via the router.
-          expect(response.status()).toBe(404)
+          expect(response.status()).toBe(409)
           // NOTE: we cannot validate the response text, because playwright hangs on `response.text()` for some reason.
           expect(response.headers()['content-type']).toStartWith('text/plain')
 
@@ -165,7 +168,7 @@ describe('unrecognized server actions', () => {
             /Error boundary: Server Action ".+?" was not found on the server\./
           )
 
-          // We responded with a 404, but we shouldn't trigger a not-found (either a custom or a default one)
+          // We responded with a 409, but we shouldn't trigger a not-found (either a custom or a default one)
           expect(await browser.elementByCss('body').text()).not.toContain(
             'Not found'
           )

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -132,52 +132,47 @@ describe('unrecognized server actions', () => {
   describe.each(['nodejs', 'edge'])(
     'should error and log a warning when submitting a server action with an unrecognized ID - %s',
     (runtime) => {
-      if (!isNextDeploy) {
-        it.each([
-          {
-            description: 'a malformed ID',
-            actionId: '123',
-            expectedStatus: 400,
-            expectedBody: 'Invalid Server Action request.',
-            expectedError: 'Invalid Server Actions request.',
-          },
-          {
-            description: 'a plausible but missing ID',
-            actionId: unrecognizedActionId,
-            expectedStatus: 409,
-            expectedBody: 'Server Action unavailable.',
-            expectedError: outdent`
+      it.each([
+        {
+          description: 'a malformed ID',
+          actionId: '123',
+          expectedStatus: 400,
+          expectedBody: 'Invalid Server Action request.',
+          expectedError: 'Invalid Server Actions request.',
+        },
+        {
+          description: 'a plausible but missing ID',
+          actionId: unrecognizedActionId,
+          expectedStatus: 409,
+          expectedBody: 'Server Action unavailable.',
+          expectedError: outdent`
               Failed to find Server Action "${unrecognizedActionId}". This request might be from an older or newer deployment.
               Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
             `,
-          },
-        ])(
-          'should reject an MPA action with $description',
-          async ({ actionId, expectedStatus, expectedBody, expectedError }) => {
-            const boundary = '----nextjs-test-boundary'
-            const body = `--${boundary}\r\nContent-Disposition: form-data; name="$ACTION_ID_${actionId}"\r\n\r\n\r\n--${boundary}--\r\n`
+        },
+      ])(
+        'should reject an MPA action with $description',
+        async ({ actionId, expectedStatus, expectedBody, expectedError }) => {
+          const boundary = '----nextjs-test-boundary'
+          const body = `--${boundary}\r\nContent-Disposition: form-data; name="$ACTION_ID_${actionId}"\r\n\r\n\r\n--${boundary}--\r\n`
 
-            const response = await next.fetch(
-              `/${runtime}/unrecognized-action`,
-              {
-                method: 'POST',
-                headers: {
-                  'content-type': `multipart/form-data; boundary=${boundary}`,
-                },
-                body,
-              }
-            )
+          const response = await next.fetch(`/${runtime}/unrecognized-action`, {
+            method: 'POST',
+            headers: {
+              'content-type': `multipart/form-data; boundary=${boundary}`,
+            },
+            body,
+          })
 
-            expect(response.status).toBe(expectedStatus)
-            expect(response.headers.get('content-type')).toStartWith(
-              'text/plain'
-            )
-            expect(await response.text()).toBe(expectedBody)
+          expect(response.status).toBe(expectedStatus)
+          expect(response.headers.get('content-type')).toStartWith('text/plain')
+          expect(await response.text()).toBe(expectedBody)
 
+          if (!isNextDeploy) {
             await retry(async () => expect(getLogs()).toInclude(expectedError))
           }
-        )
-      }
+        }
+      )
 
       const testUnrecognizedActionSubmission = async ({
         formId,
@@ -233,14 +228,13 @@ describe('unrecognized server actions', () => {
           }
         } else {
           // An MPA action, sent without JS.
+          expect(response.status()).toBe(409)
+          expect(response.headers()['content-type']).toStartWith('text/plain')
+          expect(await browser.elementByCss('body').text()).toBe(
+            'Server Action unavailable.'
+          )
 
           if (!isNextDeploy) {
-            expect(response.status()).toBe(409)
-            expect(response.headers()['content-type']).toStartWith('text/plain')
-            expect(await browser.elementByCss('body').text()).toBe(
-              'Server Action unavailable.'
-            )
-
             await retry(async () =>
               expect(getLogs()).toInclude(
                 `Error: Failed to find Server Action "${unrecognizedActionId}". This request might be from an older or newer deployment`

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -138,12 +138,14 @@ describe('unrecognized server actions', () => {
             description: 'a malformed ID',
             actionId: '123',
             expectedStatus: 400,
+            expectedBody: 'Invalid Server Action request.',
             expectedError: 'Invalid Server Actions request.',
           },
           {
             description: 'a plausible but missing ID',
             actionId: unrecognizedActionId,
             expectedStatus: 409,
+            expectedBody: 'Server Action unavailable.',
             expectedError: outdent`
               Failed to find Server Action "${unrecognizedActionId}". This request might be from an older or newer deployment.
               Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
@@ -151,7 +153,7 @@ describe('unrecognized server actions', () => {
           },
         ])(
           'should reject an MPA action with $description',
-          async ({ actionId, expectedStatus, expectedError }) => {
+          async ({ actionId, expectedStatus, expectedBody, expectedError }) => {
             const boundary = '----nextjs-test-boundary'
             const body = `--${boundary}\r\nContent-Disposition: form-data; name="$ACTION_ID_${actionId}"\r\n\r\n\r\n--${boundary}--\r\n`
 
@@ -170,7 +172,7 @@ describe('unrecognized server actions', () => {
             expect(response.headers.get('content-type')).toStartWith(
               'text/plain'
             )
-            expect(await response.text()).toBe('Server action not found.')
+            expect(await response.text()).toBe(expectedBody)
 
             await retry(async () => expect(getLogs()).toInclude(expectedError))
           }
@@ -236,7 +238,7 @@ describe('unrecognized server actions', () => {
             expect(response.status()).toBe(409)
             expect(response.headers()['content-type']).toStartWith('text/plain')
             expect(await browser.elementByCss('body').text()).toBe(
-              'Server action not found.'
+              'Server Action unavailable.'
             )
 
             await retry(async () =>

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -138,10 +138,7 @@ describe('unrecognized server actions', () => {
             description: 'a malformed ID',
             actionId: '123',
             expectedStatus: 400,
-            expectedError: outdent`
-              The Server Reference ID did not match the expected format. Received "123".
-              Read more: https://nextjs.org/docs/messages/failed-to-find-server-action
-            `,
+            expectedError: 'Invalid Server Actions request.',
           },
           {
             description: 'a plausible but missing ID',

--- a/test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
+++ b/test/e2e/app-dir/no-server-actions/no-server-actions.test.ts
@@ -11,17 +11,19 @@ describe('app-dir - no server actions', () => {
     {
       description: 'a malformed id',
       actionId: 'abc123',
+      expectedStatus: 400,
       expectedError:
         'The Server Reference ID did not match the expected format. Received "abc123".\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action',
     },
     {
       description: 'a plausible but missing id',
       actionId: missingActionId,
+      expectedStatus: 409,
       expectedError: `Failed to find Server Action "${missingActionId}". This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`,
     },
   ])(
     'should error when triggering a fetch action with $description on an app with no server actions',
-    async ({ actionId, expectedError }) => {
+    async ({ actionId, expectedStatus, expectedError }) => {
       const res = await next.fetch('/', {
         method: 'POST',
         headers: {
@@ -29,7 +31,7 @@ describe('app-dir - no server actions', () => {
         },
       })
 
-      expect(res.status).toBe(404)
+      expect(res.status).toBe(expectedStatus)
       expect(res.headers.get('x-nextjs-action-not-found')).toBe('1')
 
       // Runtime logs and custom headers are not forwarded to the client when deployed.
@@ -52,7 +54,7 @@ describe('app-dir - no server actions', () => {
       body: formData,
     })
 
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(409)
     expect(res.headers.get('x-nextjs-action-not-found')).toBe('1')
 
     // Runtime logs are not available when deployed.


### PR DESCRIPTION
## Summary

- return `400 Bad Request` when a Server Action reference ID does not match the expected format
- return `409 Conflict` when a well-formed action ID is unavailable in the current deployment, including deployment skew
- apply the same classification to IDs from the `Next-Action` header and multipart MPA forms, including direct and bound actions in Node and Edge runtimes
- return generic text bodies matching the client error category, without exposing action-ID details
- derive marked forwarded-action responses from the original action ID so an unexpected or mixed-version worker response cannot change the client error semantics

Fetch actions previously had dedicated 404 handling, while equivalent MPA form submissions fell through to the generic error path and returned 500. This removes that transport-dependent behavior and distinguishes malformed or scanning traffic from legitimate stale clients without treating either case as a missing page or an internal server failure.

## Verification

- `pnpm test-dev-turbo test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts`
- `pnpm test-dev-turbo test/e2e/app-dir/actions/app-action.test.ts -t 'forward.*action'`
- `pnpm test-start-turbo test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts`
- `pnpm test-dev-webpack test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts`
- `pnpm test-dev-turbo test/e2e/app-dir/no-server-actions/no-server-actions.test.ts`

<!-- NEXT_JS_LLM -->