### PR TITLE
fix: don't collapse dynamic metadata routes with generateStaticParams to '-' pathname

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -890,7 +890,16 @@ export async function isPageStatic({
 
           if (
             routeModule.definition.kind === RouteKind.APP_ROUTE &&
-            isStaticMetadataFile(pathname)
+            isStaticMetadataFile(pathname) &&
+            // Dynamic metadata routes (e.g. `sitemap.ts` under a dynamic
+            // segment) can export `generateStaticParams`; their output
+            // depends on the route params, so they must be prerendered once
+            // per param rather than collapsed to the `-`-placeholder
+            // pathname. Static metadata files never export
+            // `generateStaticParams`.
+            !segments.some(
+              (segment) => typeof segment.generateStaticParams === 'function'
+            )
           ) {
             ;({ prerenderedRoutes, fallbackMode: prerenderFallbackMode } =
               buildStaticMetadataStaticPaths(page))

--- a/test/e2e/app-dir/metadata-dynamic-routes/app/dynamic-gsp/[locale]/sitemap.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/app/dynamic-gsp/[locale]/sitemap.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next'
+
+export function generateStaticParams() {
+  return [{ locale: 'en' }, { locale: 'zh' }]
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://example.com',
+      lastModified: '2021-01-01',
+    },
+  ]
+}

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -96,6 +96,14 @@ describe('app dir - metadata dynamic routes', () => {
       expect(status).toBe(200)
     })
 
+    it('should render sitemap with generateStaticParams under a dynamic segment', async () => {
+      for (const locale of ['en', 'zh']) {
+        const res = await next.fetch(`/dynamic-gsp/${locale}/sitemap.xml`)
+        expect(res.status).toBe(200)
+        expect(await res.text()).toContain('<loc>https://example.com</loc>')
+      }
+    })
+
     it('should support alternate.languages in sitemap', async () => {
       const xml = await (await next.fetch('/lang/sitemap.xml')).text()
 
@@ -527,6 +535,8 @@ describe('app dir - metadata dynamic routes', () => {
          "/apple-icon",
          "/blog",
          "/client-ref-dependency/sitemap.xml",
+         "/dynamic-gsp/en/sitemap.xml",
+         "/dynamic-gsp/zh/sitemap.xml",
          "/gsp",
          "/gsp/icon/medium",
          "/gsp/icon/small",


### PR DESCRIPTION
### What?

A code-based metadata route under a dynamic segment (e.g. `app/[lang]/sitemap.ts`) that exports `generateStaticParams` is no longer prerendered once per param since 16.3: it is collapsed to the `-`-placeholder pathname (`/-/sitemap.xml`), so per-param URLs like `/en/sitemap.xml` disappear from the build output (and from `prerenderManifest.routes`). This breaks localized sitemaps referenced from `robots.txt` and registered in search consoles.

### Why?

#93873 introduced a shortcut in `isPageStatic` for static metadata files under dynamic segments: `isStaticMetadataFile(pathname)` matches by pathname shape and takes `buildStaticMetadataStaticPaths`, skipping `buildAppStaticPaths` entirely. That's correct for *static* metadata files (their bytes don't depend on params), but the shape check also matches code-based routes like `sitemap.ts`, whose userland `generateStaticParams` (re-exported by the metadata route loader via `createReExportsCode`) is then never invoked.

### How?

Guard the shortcut on the absence of a userland `generateStaticParams` in the collected segments. Static metadata files never export one (`getStaticAssetRouteCode` emits none), so the #93873 optimization is preserved for them — verified against the linked repro: per-param sitemaps are restored while a true static file (`app/[lang]/icon.png`) still collapses to a single `/[lang]/-/icon.png`.

Added an e2e fixture (`app/dynamic-gsp/[locale]/sitemap.ts`) and assertions in `metadata-dynamic-routes`: per-locale sitemap responses, and the per-param routes present in the prerender manifest.

Fixes #98126

🤖 Generated with [Claude Code](https://claude.com/claude-code)