### PR TITLE
docs: use an H2 for agent guidance notice

### DIFF
--- a/docs/01-app/02-guides/ai-agents.mdx
+++ b/docs/01-app/02-guides/ai-agents.mdx
@@ -65,7 +65,7 @@ On Next.js 16.3 or later, run `next dev`. When an AI coding agent is detected in
 ```md filename="AGENTS.md"
 <!-- BEGIN:nextjs-agent-rules -->
 
-# This is NOT the Next.js you know
+## This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
 

--- a/docs/01-app/02-guides/upgrading/version-16.mdx
+++ b/docs/01-app/02-guides/upgrading/version-16.mdx
@@ -50,7 +50,7 @@ The managed block should look like this:
 ```md filename="AGENTS.md"
 <!-- BEGIN:nextjs-agent-rules -->
 
-# This is NOT the Next.js you know
+## This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
 

--- a/packages/create-next-app/helpers/generate-agent-files.ts
+++ b/packages/create-next-app/helpers/generate-agent-files.ts
@@ -8,7 +8,7 @@ import path from 'path'
 export function generateAgentFiles(root: string): void {
   const agentsMdContent = `<!-- BEGIN:nextjs-agent-rules -->
 
-# This is NOT the Next.js you know
+## This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in \`node_modules/next/dist/docs/\` (resolved from this file's directory; in monorepos the \`next\` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
 

--- a/packages/next/AGENTS.md
+++ b/packages/next/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- BEGIN:nextjs-agent-rules -->
 
-# This is NOT the Next.js you know
+## This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `dist/docs/` before writing any code. Heed deprecation notices.
 

--- a/packages/next/src/server/lib/generate-agent-files.ts
+++ b/packages/next/src/server/lib/generate-agent-files.ts
@@ -24,7 +24,7 @@ const LEGACY_AGENT_RULES_END_MARKER = '<!-- NEXT-AGENTS-MD-END -->'
 function buildAgentRulesBlock(): string {
   return `${AGENT_RULES_START_MARKER}
 
-# This is NOT the Next.js you know
+## This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in \`node_modules/next/dist/docs/\` (resolved from this file's directory; in monorepos the \`next\` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
 


### PR DESCRIPTION
### What?

Change the heading in the managed Next.js agent-rules block from an H1 to an H2. Update both code paths that generate `AGENTS.md`, along with the corresponding documentation examples and checked-in generated file.

### Why?

The managed block is inserted into existing `AGENTS.md` files, which may already contain a document title as an H1. Adding another H1 creates incorrect Markdown heading hierarchy. Using an H2 keeps the generated content semantically nested under the repository's main heading.

### How?

Updated the agent-file generator used by `next dev` and the generator used by `create-next-app` to emit:

```md
## This is NOT the Next.js you know
```

The documentation examples and generated package guide were updated to match.

### Verification

- Confirmed all copies of the notice now use an H2.
- `git diff --check` passed.
- The commit is SSH-signed.