### PR TITLE
[15.5.x][test] Disable deploy tests triggering bot challenge

### DIFF
--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -523,14 +523,16 @@ describe('app-custom-routes', () => {
   })
 
   describe('error conditions', () => {
-    it('responds with 400 (Bad Request) when the requested method is not a valid HTTP method', async () => {
-      const res = await next.fetch(basePath + '/status/405', {
-        method: 'HEADER',
-      })
+    if (!isNextDeploy) {
+      it('responds with 400 (Bad Request) when the requested method is not a valid HTTP method', async () => {
+        const res = await next.fetch(basePath + '/status/405', {
+          method: 'HEADER',
+        })
 
-      expect(res.status).toEqual(400)
-      expect(await res.text()).toBeEmpty()
-    })
+        expect(res.status).toEqual(400)
+        expect(await res.text()).toBeEmpty()
+      })
+    }
 
     it('responds with 405 (Method Not Allowed) when method is not implemented', async () => {
       const res = await next.fetch(basePath + '/status/405', {


### PR DESCRIPTION
Backports https://github.com/vercel/next.js/pull/89036/changes#diff-cf635dd531d3fcad56634e5dec0bc4974b226005935e1a42370d5518ed9ee687R526

The `HEADER` method will cause Vercel to treat these tests as originating from bots causing challenges in later tests.

Fixes https://github.com/vercel/next.js/actions/runs/33433813993/job/99643438429#step:35:377

## test plan

- [x] [deploy test passes on this branch](https://github.com/vercel/next.js/actions/runs/33496592051/job/99840891680?pr=98132)