### PR TITLE
[test] Fix 16.3 deploy test assertions

### DIFF
--- a/test/e2e/incremental-cache-path-traversal/index.test.ts
+++ b/test/e2e/incremental-cache-path-traversal/index.test.ts
@@ -34,8 +34,8 @@ describeSkipCacheComponents('incremental-cache path traversal', () => {
         pageProps: {
           rest: isNextDeploy
             ? isAdapterTest
-              ? '../../server-reference-manifest'
-              : ['..', '..', 'server-reference-manifest']
+              ? ['..', '..', 'server-reference-manifest']
+              : ['../../server-reference-manifest']
             : [`..${sep}..${sep}server-reference-manifest`],
         },
         __N_SSG: true,


### PR DESCRIPTION
Got mixed up when syncing backports. Updates the [assertions to match the ones on canary](https://github.com/vercel/next.js/blob/1076c4745318e439062d3464a76881d2b967f886/test/e2e/incremental-cache-path-traversal/index.test.ts#L36-L38).

Fixes https://github.com/vercel/next.js/actions/runs/33433820538/job/99648362051#step:35:555

## test plan

- [x] [deploy test passes on this branch](https://github.com/vercel/next.js/actions/runs/33497513005/job/99824908312?pr=98133#step:35:104)