### PR TITLE
Fix inlineCss re-inlining stylesheets for the global error boundary

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -376,6 +376,7 @@ type AppRenderCapabilities = {
 }
 
 export type AppRenderContext = {
+  inlinedCSSPaths: Set<string>
   sharedContext: AppSharedContext
   workStore: WorkStore
   missingPrefetchHintPolicy: MissingPrefetchHintPolicy
@@ -2247,7 +2248,8 @@ async function getRSCPayload(
 
   const { GlobalError, styles: globalErrorStyles } = await getGlobalErrorStyles(
     tree,
-    ctx
+    ctx,
+    ctx.inlinedCSSPaths
   )
 
   // Assume the head we're rendering contains only partial data if PPR is
@@ -2406,7 +2408,8 @@ async function getErrorRSCPayload(
 
   const { GlobalError, styles: globalErrorStyles } = await getGlobalErrorStyles(
     tree,
-    ctx
+    ctx,
+    new Set()
   )
 
   const isPossiblyPartialHead = ctx.renderCapabilities.isPossiblyPartialResponse
@@ -2829,6 +2832,7 @@ async function prepareAppPageRender(
   )
 
   const ctx: AppRenderContext = {
+    inlinedCSSPaths: new Set(),
     componentMod: ComponentMod,
     url,
     renderOpts,
@@ -8267,6 +8271,7 @@ async function validateInstantConfigInBuildWithSample(
   return workAsyncStorage.run(workStore, async () => {
     // NOTE: match field order in renderToHTMLOrFlightImpl to avoid deopts
     const validationCtx: AppRenderContext = {
+      inlinedCSSPaths: new Set(),
       componentMod: outerCtx.componentMod,
       url: sampleUrlWithoutQuery,
       renderOpts: outerCtx.renderOpts,
@@ -10439,7 +10444,8 @@ async function iterateStreamingPrerenderChunks(
 
 const getGlobalErrorStyles = async (
   tree: LoaderTree,
-  ctx: AppRenderContext
+  ctx: AppRenderContext,
+  alreadyInlinedCSS: Set<string>
 ): Promise<{
   GlobalError: GlobalErrorComponent
   styles: ReactNode | undefined
@@ -10461,7 +10467,7 @@ const getGlobalErrorStyles = async (
     ctx,
     filePath: globalErrorModule[1],
     getComponent: globalErrorModule[0],
-    injectedCSS: new Set(),
+    injectedCSS: alreadyInlinedCSS,
     injectedJS: new Set(),
   })
 

--- a/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
+++ b/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
@@ -27,6 +27,10 @@ export async function createComponentStylesAndScripts({
     injectedJS
   )
 
+  for (const entryCssFile of entryCssFiles) {
+    ctx.inlinedCSSPaths.add(entryCssFile.path)
+  }
+
   const styles = renderCssResource(entryCssFiles, ctx)
 
   const scripts: React.ReactNode[] = []

--- a/packages/next/src/server/app-render/get-layer-assets.tsx
+++ b/packages/next/src/server/app-render/get-layer-assets.tsx
@@ -34,6 +34,10 @@ export function getLayerAssets({
       )
     : { styles: EMPTY_SET, scripts: EMPTY_SET }
 
+  for (const styleTag of styleTags) {
+    ctx.inlinedCSSPaths.add(styleTag.path)
+  }
+
   const preloadedFontFiles = layoutOrPagePath
     ? getPreloadableFonts(
         ctx.renderOpts.nextFontManifest,

--- a/test/e2e/app-dir/app-inline-css/app/global-error.css
+++ b/test/e2e/app-dir/app-inline-css/app/global-error.css
@@ -1,0 +1,7 @@
+:root {
+  --inline-css-global-error-marker: 1;
+}
+
+#global-error {
+  color: red;
+}

--- a/test/e2e/app-dir/app-inline-css/app/global-error.tsx
+++ b/test/e2e/app-dir/app-inline-css/app/global-error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import './global-error.css'
+
+export default function GlobalError() {
+  return (
+    <html>
+      <body>
+        <p id="global-error">Global error</p>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/app-inline-css/app/global.css
+++ b/test/e2e/app-dir/app-inline-css/app/global.css
@@ -1,3 +1,7 @@
+:root {
+  --inline-css-dedupe-marker: 1;
+}
+
 p {
   color: yellow;
 }

--- a/test/e2e/app-dir/app-inline-css/index.test.ts
+++ b/test/e2e/app-dir/app-inline-css/index.test.ts
@@ -93,5 +93,25 @@ describe('app dir - css - experimental inline css', () => {
       expect(res.status).toBe(200)
       expect(res.headers.get('content-type')).toContain('font')
     })
+
+    const LAYOUT_MARKER = '--inline-css-dedupe-marker'
+    const GLOBAL_ERROR_MARKER = '--inline-css-global-error-marker'
+
+    const countOccurrences = (haystack: string, needle: string) =>
+      haystack.split(needle).length - 1
+
+    it('should not re-inline stylesheets for the global-error boundary', async () => {
+      for (const pathname of ['/', '/a']) {
+        const html = await next.render(pathname)
+        const occurrences = countOccurrences(html, LAYOUT_MARKER)
+        expect({ pathname, occurrences }).toEqual({ pathname, occurrences: 2 })
+      }
+    })
+
+    it('should still inline stylesheets that only the global-error boundary uses', async () => {
+      const html = await next.render('/')
+
+      expect(countOccurrences(html, GLOBAL_ERROR_MARKER)).toBe(1)
+    })
   })
 })


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes

-->
### What?

Previously we got stylesheet embeded thrice via inlineCss, 2 of them were documented and needed, the third came from a global error boundary. The app-renderer now limits the stylesheet data to the two documented copies.

### Why?

One copy of inlineCss previous embeddings weighed 3x for turbopack, when only 2x of useful data was needed, the pr fixes this, it removes the redundant copy of data.

### How?
Following changes were made to resolve the issue:
- `getRSCPayload` passes `ctx.inlinedCSSPaths`, while `getErrorRSCPayload` passes a fresh `Set()`, since that document renders an error shell rather than the loader tree and shares `ctx` with the render that usually just failed.
- `AppRenderContext` gained `inlinedCSSPaths: Set<string>`, one per request.
- The two places that emit a stylesheet: `getLayerAssets` and `createComponentStylesAndScripts`, now record each emitted path into it.
- `getGlobalErrorStyles` takes the inlined set as an explicit argument and consults it.

Result: global-error skips sheets the document already has, and the G entry becomes "G":["$f",[]].

Fixes #98110