### PR TITLE
fix(eslint-config-next): lint .mts and .cts with the TypeScript parser

### DIFF
--- a/packages/eslint-config-next/src/index.ts
+++ b/packages/eslint-config-next/src/index.ts
@@ -87,7 +87,7 @@ const config: Linter.Config[] = [
   {
     name: 'next/typescript',
     // Default files, users can overwrite this.
-    files: ['**/*.ts', '**/*.tsx'],
+    files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
     plugins: {
       '@typescript-eslint': tsEslint.plugin,
     },

--- a/test/unit/eslint-config-next/typescript/eslint-config-next-typescript.test.ts
+++ b/test/unit/eslint-config-next/typescript/eslint-config-next-typescript.test.ts
@@ -2,17 +2,21 @@ import { join } from 'path'
 import { execSync } from 'child_process'
 import { getEslintConfigSnapshot } from '../utils'
 
+function printConfig(file: string) {
+  return execSync(
+    // Pass explicit absolute path to not get affected by the root eslint config.
+    `pnpm eslint --config ${join(__dirname, 'eslint.config.mjs')} --print-config ${join(__dirname, file)}`,
+    {
+      cwd: __dirname,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'inherit'],
+    }
+  )
+}
+
 describe('eslint-config-next/typescript', () => {
   it('should match expected resolved configuration', () => {
-    const eslintConfigAfterSetupJSON = execSync(
-      // Pass explicit absolute path to not get affected by the root eslint config.
-      `pnpm eslint --config ${join(__dirname, 'eslint.config.mjs')} --print-config ${join(__dirname, 'test.tsx')}`,
-      {
-        cwd: __dirname,
-        encoding: 'utf8',
-        stdio: ['pipe', 'pipe', 'inherit'],
-      }
-    )
+    const eslintConfigAfterSetupJSON = printConfig('test.tsx')
 
     const { languageOptions, ...eslintConfigAfterSetup } = JSON.parse(
       eslintConfigAfterSetupJSON
@@ -120,5 +124,16 @@ describe('eslint-config-next/typescript', () => {
        },
      }
     `)
+  })
+
+  it('should use the TypeScript parser for .mts and .cts files', () => {
+    for (const file of ['test.mts', 'test.cts']) {
+      const { languageOptions } = JSON.parse(printConfig(file))
+      expect({
+        parser: languageOptions.parser,
+      }).toEqual({
+        parser: expect.stringContaining('typescript-eslint'),
+      })
+    }
   })
 })

--- a/test/unit/eslint-config-next/typescript/test.cts
+++ b/test/unit/eslint-config-next/typescript/test.cts
@@ -1,0 +1,2 @@
+// Dummy file for testing eslint-config-next typescript configuration on .cts
+export const message: string = 'ok'

--- a/test/unit/eslint-config-next/typescript/test.mts
+++ b/test/unit/eslint-config-next/typescript/test.mts
@@ -1,0 +1,2 @@
+// Dummy file for testing eslint-config-next typescript configuration on .mts
+export const message: string = 'ok'


### PR DESCRIPTION
The base config lints **/*.{js,jsx,mjs,ts,tsx,mts,cts} with the babel parser, but the next/typescript block only routes **/*.ts and **/*.tsx to @typescript-eslint/parser. 

A .mts or .cts file (vitest.config.mts, next.config.mts, eslint.config.mts) is therefore parsed by babel, and on ESLint 10 that parser crashes before linting a anything:

  TypeError: scopeManager.addGlobals is not a function

Add the two extensions to the next/typescript block so they get the same parser as .ts and .tsx.

What: One line in packages/eslint-config-next/src/index.ts: the next/typescript block's files gains '**/*.mts' and '**/*.cts'.

Why: The base block lints '**/*.{js,jsx,mjs,ts,tsx,mts,cts}' with the babel parser (eslint-config-next/parser), but next/typescript only routes .ts/.tsx to @typescript-eslint/parser. So .mts/.cts files (vitest.config.mts, next.config.mts, eslint.config.mts) get babel. On ESLint 10 that parser crashes before linting anything: TypeError: scopeManager.addGlobals is not a function. Present in eslint-config-next@16.3.4 and 16.4.0-canary.13.

How: Extend the block's files so the two extensions get the same parser and plugin as .ts/.tsx. No other change; the block is already commented "users can overwrite this," so existing overrides are unaffected. No tests cover the config blocks upstream, so none were changed.

To reproduce:
npx create-next-app@latest repro --ts --eslint --app --no-tailwind --no-src-dir --use-npm --yes
cd repro && npm i -D eslint@10 vitest @vitejs/plugin-react
printf 'import { defineConfig } from "vitest/config"\nexport default defineConfig({})\n' > vitest.config.mts
npx eslint .   # TypeError: scopeManager.addGlobals is not a function




