### PR TITLE
Skip discussions in the `issue_lock` workflow

### DIFF
--- a/.github/workflows/issue_lock.yml
+++ b/.github/workflows/issue_lock.yml
@@ -27,3 +27,6 @@ jobs:
           issue-comment: 'This closed issue has been automatically locked because it had no new activity for 2 weeks. If you are running into a similar issue, please create a new issue with the steps to reproduce. Thank you.'
           pr-inactive-days: 14
           log-output: true
+          # The token has no `discussions` permission and discussions are not
+          # meant to be locked, so skip them (they are processed by default).
+          process-only: 'issues, prs'


### PR DESCRIPTION
The last remaining `Lock Threads` failures are likely due to missing permissions for discussions which `dessant/lock-threads` handles by default.

This disables discussion handling to get the workflow green to start tracking regressions. We can discuss if we want to lock inactive discussions in a follow-up (which would be new behavior this workflow never performed).