### PR TITLE
Add CSP nonce to script tags of loading and template files

### DIFF
--- a/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
+++ b/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
@@ -37,6 +37,7 @@ export async function createComponentStylesAndScripts({
         src: `${ctx.assetPrefix}/_next/${encodeURIPath(href)}${getAssetQueryString(ctx, true)}`,
         async: true,
         key: `script-${scriptIndex}`,
+        nonce: ctx.nonce,
       })
     )
     scriptIndex++

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/app/layout.js
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/layout.js
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/layout.js
@@ -1,0 +1,3 @@
+export default function Layout({ children }) {
+  return <section>{children}</section>
+}

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/loading.js
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/loading.js
@@ -1,0 +1,5 @@
+import { Marker } from './marker'
+
+export default function Loading() {
+  return <Marker id="loading" />
+}

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/marker.js
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/marker.js
@@ -1,0 +1,8 @@
+'use client'
+
+import { useState } from 'react'
+
+export function Marker({ id }) {
+  const [label] = useState(id)
+  return <p id={id}>{label}</p>
+}

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/page-only.js
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/page-only.js
@@ -1,11 +1,17 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 export function PageOnly() {
+  const [hydrated, setHydrated] = useState(false)
   const [count, setCount] = useState(0)
+  useEffect(() => setHydrated(true), [])
   return (
-    <button id="page-only" onClick={() => setCount(count + 1)}>
+    <button
+      id="page-only"
+      data-hydrated={hydrated}
+      onClick={() => setCount(count + 1)}
+    >
       {count}
     </button>
   )

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/page-only.js
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/page-only.js
@@ -1,0 +1,12 @@
+'use client'
+
+import { useState } from 'react'
+
+export function PageOnly() {
+  const [count, setCount] = useState(0)
+  return (
+    <button id="page-only" onClick={() => setCount(count + 1)}>
+      {count}
+    </button>
+  )
+}

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/page.js
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/page.js
@@ -1,0 +1,13 @@
+import { connection } from 'next/server'
+import { Marker } from './marker'
+import { PageOnly } from './page-only'
+
+export default async function Page() {
+  await connection()
+  return (
+    <>
+      <Marker id="page" />
+      <PageOnly />
+    </>
+  )
+}

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/template.js
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/app/with-boundaries/template.js
@@ -1,0 +1,10 @@
+import { Marker } from './marker'
+
+export default function Template({ children }) {
+  return (
+    <>
+      <Marker id="template" />
+      {children}
+    </>
+  )
+}

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/csp-nonce-segment-scripts.test.ts
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/csp-nonce-segment-scripts.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 describe('csp-nonce-segment-scripts', () => {
   const { next } = nextTestSetup({
@@ -22,5 +23,23 @@ describe('csp-nonce-segment-scripts', () => {
     expect(scripts.filter((script) => script.nonce !== 'test-nonce')).toEqual(
       []
     )
+  })
+
+  it('should run the client code without CSP violations', async () => {
+    const browser = await next.browser('/with-boundaries')
+
+    await browser.waitForElementByCss('#page-only[data-hydrated="true"]')
+    await browser.elementByCss('#page-only').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('#page-only').text()).toBe('1')
+    })
+
+    if (global.browserName === 'chrome') {
+      const logs = await browser.log()
+      const cspViolations = logs.filter((log) =>
+        log.message.includes('Content Security Policy')
+      )
+      expect(cspViolations).toEqual([])
+    }
   })
 })

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/csp-nonce-segment-scripts.test.ts
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/csp-nonce-segment-scripts.test.ts
@@ -1,0 +1,26 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('csp-nonce-segment-scripts', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // The loading and template files import a client component that the page
+  // also imports, so their chunk is not already loaded by a layout or by a
+  // client reference, and it gets a script tag of its own.
+  it('should add the nonce to the script tags of loading and template files', async () => {
+    const $ = await next.render$('/with-boundaries')
+
+    const scripts = $('script[src]')
+      .toArray()
+      .map((element) => ({
+        src: $(element).attr('src'),
+        nonce: $(element).attr('nonce'),
+      }))
+
+    expect(scripts.length).toBeGreaterThan(0)
+    expect(scripts.filter((script) => script.nonce !== 'test-nonce')).toEqual(
+      []
+    )
+  })
+})

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/next.config.js
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/next.config.js
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/next.config.js
@@ -6,6 +6,9 @@ const nextConfig = {
   // layouts and loading files would be prerendered into a static shell, which
   // has no nonce, so this test opts out.
   cacheComponents: false,
+  experimental: {
+    cachedNavigations: false,
+  },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/next.config.js
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/next.config.js
@@ -1,6 +1,11 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {}
+const nextConfig = {
+  // Nonces are added when a request is rendered. With Cache Components the
+  // layouts and loading files would be prerendered into a static shell, which
+  // has no nonce, so this test opts out.
+  cacheComponents: false,
+}
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/csp-nonce-segment-scripts/proxy.js
+++ b/test/e2e/app-dir/csp-nonce-segment-scripts/proxy.js
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+
+export function proxy(request) {
+  const nonce = 'test-nonce'
+  const csp = `default-src 'self'; script-src 'nonce-${nonce}' 'strict-dynamic' 'unsafe-eval'; style-src 'self' 'unsafe-inline'`
+
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('Content-Security-Policy', csp)
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } })
+  response.headers.set('Content-Security-Policy', csp)
+  return response
+}


### PR DESCRIPTION
> `createComponentStylesAndScripts` renders the script tags for a segment's loading, error, and templatefound files, but unlike getLayerAssets it did not pass `ctx.nonce`. When such a file has a chunk that no layout or client reference has already loaded, the tag is served without a nonce and a nonce-based Content-Security-Policy blocks it.

### What?

Patches a bug we encountered while using [nonces](https://nextjs.org/docs/app/guides/content-security-policy#nonces) for a CSP with `strict-dynamic`, as in the docs example. In Turbopack, when a `loading.tsx` (or `error` or `template`) file has a chunk that isn’t already loaded by a layout or client component on the page, Next renders a `<script>` tag for that chunk with no `nonce`. (the same chunk script would’ve gotten a `nonce` if it were emitted for a layout or page).

Supersedes #92803; this is the same fix but with a new test included. 

### Why?

While building out our `loading.tsx` pages, we encountered browsers blocking a script and reporting CSP violations, because chunk scripts did not properly carry a `nonce`.

### How?

One-line change to bring `createComponentStylesAndScripts` to parity with `getLayerAssets`.
