### PR TITLE
test: migrate caching deploy exclusions to force gates

### DIFF
--- a/test/e2e/404-page-ssg/404-page-ssg.test.ts
+++ b/test/e2e/404-page-ssg/404-page-ssg.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup, isNextStart } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('404 Page Support SSG', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should respond to 404 correctly', async () => {
     const res = await next.fetch('/404')

--- a/test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
@@ -234,6 +234,8 @@ describe('app dir client cache semantics (experimental staleTimes)', () => {
       })
     })
 
+    // Deploy mode exclusion: This nested suite reads telemetry events from the
+    // local Next.js CLI output.
     if (!isNextDeploy) {
       describe('telemetry', () => {
         it('should send staleTimes feature usage event', async () => {
@@ -368,6 +370,8 @@ describe('app dir client cache semantics (experimental staleTimes)', () => {
       })
     })
 
+    // Deploy mode exclusion: This nested suite reads telemetry events from the
+    // local Next.js CLI output.
     if (!isNextDeploy) {
       describe('telemetry', () => {
         it('should send staleTimes feature usage event', async () => {

--- a/test/e2e/app-dir/app-client-cache/client-cache.original.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.original.test.ts
@@ -9,16 +9,16 @@ import {
 import path from 'path'
 
 // This preserves existing tests for the 30s/5min heuristic (previous router defaults)
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('app dir client cache semantics (30s/5min)', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'regular'),
     nextConfig: {
       experimental: { staleTimes: { dynamic: 30, static: 180 } },
     },
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   if (isNextDev) {
     // dev doesn't support prefetch={true}, so this just performs a basic test to make sure data is reused for 30s

--- a/test/e2e/app-dir/app-custom-cache-handler-errors/app-custom-cache-handler-errors.test.ts
+++ b/test/e2e/app-dir/app-custom-cache-handler-errors/app-custom-cache-handler-errors.test.ts
@@ -2,16 +2,14 @@ import { nextTestSetup } from 'e2e-utils'
 import { hasErrorToast, retry, waitFor, waitForNoRedbox } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-custom-cache-handler-errors - get throws', () => {
-  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     env: { CACHE_HANDLER_THROW_ON: 'get' },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('surfaces the cache handler error', async () => {
     const outputIndex = next.cliOutput.length
@@ -96,16 +94,14 @@ describe('app-custom-cache-handler-errors - get throws', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-custom-cache-handler-errors - set throws', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     env: { CACHE_HANDLER_THROW_ON: 'set' },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('renders the page successfully', async () => {
     const outputIndex = next.cliOutput.length

--- a/test/e2e/app-dir/app-custom-cache-handler/index.test.ts
+++ b/test/e2e/app-dir/app-custom-cache-handler/index.test.ts
@@ -30,40 +30,39 @@ function runTests(
   })
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - custom-cache-handler - cjs', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     env: {
       CUSTOM_CACHE_HANDLER: 'cache-handler.js',
     },
   })
 
-  if (skipped) {
-    return
-  }
-
   runTests('cjs module exports', { next, isNextDev })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - custom-cache-handler - cjs-default-export', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     env: {
       CUSTOM_CACHE_HANDLER: 'cache-handler-cjs-default-export.js',
     },
   })
 
-  if (skipped) {
-    return
-  }
-
   runTests('cjs default export', { next, isNextDev })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - custom-cache-handler - esm', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: {
       app: new FileRef(__dirname + '/app'),
       'cache-handler-esm.js': new FileRef(__dirname + '/cache-handler-esm.js'),
@@ -72,7 +71,6 @@ describe('app-dir - custom-cache-handler - esm', () => {
         'export default '
       ),
     },
-    skipDeployment: true,
     packageJson: {
       type: 'module',
     },
@@ -81,29 +79,23 @@ describe('app-dir - custom-cache-handler - esm', () => {
     },
   })
 
-  if (skipped) {
-    return
-  }
-
   runTests('esm default export', { next, isNextDev })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - custom-cache-handler - esm import.meta.resolve', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: {
       app: new FileRef(__dirname + '/app'),
       'cache-handler-esm.js': new FileRef(__dirname + '/cache-handler-esm.js'),
       'next.config.js': importMetaResolveNextConfig,
     },
-    skipDeployment: true,
     packageJson: {
       type: 'module',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   runTests('esm default export', { next, isNextDev })
 })

--- a/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
+++ b/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
@@ -1,16 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-invalid-revalidate', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should error properly for invalid revalidate at layout', async () => {
     await next.stop().catch(() => {})

--- a/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
@@ -3,12 +3,14 @@ import { createRouterAct } from 'router-act'
 import { createTimeController } from './test-utils'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - prefetching (custom staleTime)', () => {
   const { next, isNextDev } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
     },
-    skipDeployment: true,
     nextConfig: {
       experimental: {
         staleTimes: {

--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -393,7 +393,8 @@ describe('app dir - prefetching', () => {
     })
   })
 
-  // These tests are skipped when deployed as they rely on runtime logs
+  // Deploy mode exclusion: This nested suite asserts runtime logs from the
+  // local Next.js process.
   if (!isNextDeploy) {
     describe('dynamic rendering', () => {
       describe.each(['/force-dynamic', '/revalidate-0'])('%s', (basePath) => {

--- a/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
@@ -291,14 +291,13 @@ describe('app-root-param-getters - cache - at build', () => {
   }
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// In deploy mode, concurrent requests could hit different lambdas.
+// @force-gate !deploy
 describe('app-root-param-getters - cache dedup with root params', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'use-cache-dedup'),
-    // In deploy mode, concurrent requests could hit different lambdas.
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should dedupe same root params and isolate different root params', async () => {
     // Three concurrent requests: ca/en, ca/fr, ca/fr.

--- a/test/e2e/app-dir/cache-components-console/cache-components.console.test.ts
+++ b/test/e2e/app-dir/cache-components-console/cache-components.console.test.ts
@@ -3,19 +3,18 @@ import { retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 // TODO(restart-on-cache-miss): cacheSignal timing changes break console log dimming/hiding tests
-describe.skip('cache-components - Console Dimming - Validation', () => {
-  const { next, skipped, isTurbopack } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate TODO
+describe('cache-components - Console Dimming - Validation', () => {
+  const { next, isTurbopack } = nextTestSetup({
     env: {
       FORCE_COLOR: '1',
     },
     files: __dirname + '/fixtures/default',
-    skipDeployment: true,
     skipStart: !isNextDev,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('dims console calls during prospective rendering', async () => {
     const path: string = '/console'
@@ -202,19 +201,17 @@ describe.skip('cache-components - Console Dimming - Validation', () => {
 
 // TODO(restart-on-cache-miss): cacheSignal timing changes break console log dimming/hiding tests
 describe.skip('cache-components - Logging after Abort', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('(default) With Dimming - Server', () => {
-    const { next, skipped, isTurbopack } = nextTestSetup({
+    const { next, isTurbopack } = nextTestSetup({
       env: {
         FORCE_COLOR: '1',
       },
       files: __dirname + '/fixtures/default',
-      skipDeployment: true,
       skipStart: !isNextDev,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('dims console calls after a prerender has aborted', async () => {
       const path: string = '/console-after-abort/server'
@@ -380,19 +377,17 @@ describe.skip('cache-components - Logging after Abort', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('(default) With Dimming - Client', () => {
-    const { next, skipped, isTurbopack } = nextTestSetup({
+    const { next, isTurbopack } = nextTestSetup({
       env: {
         FORCE_COLOR: '1',
       },
       files: __dirname + '/fixtures/default',
-      skipDeployment: true,
       skipStart: !isNextDev,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('dims console calls after a prerender has aborted', async () => {
       const path: string = '/console-after-abort/client'
@@ -549,19 +544,17 @@ describe.skip('cache-components - Logging after Abort', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('With Hiding - Server', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       env: {
         FORCE_COLOR: '1',
       },
       files: __dirname + '/fixtures/hide-logs-after-abort',
-      skipDeployment: true,
       skipStart: !isNextDev,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('hides console calls after a prerender has aborted', async () => {
       const path: string = '/console-after-abort/server'
@@ -650,19 +643,17 @@ describe.skip('cache-components - Logging after Abort', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('With Hiding - Client', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       env: {
         FORCE_COLOR: '1',
       },
       files: __dirname + '/fixtures/hide-logs-after-abort',
-      skipDeployment: true,
       skipStart: !isNextDev,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('hides console calls after a prerender has aborted', async () => {
       const path: string = '/console-after-abort/client'

--- a/test/e2e/app-dir/cache-components-create-component-tree/cache-components-create-component-tree.test.ts
+++ b/test/e2e/app-dir/cache-components-create-component-tree/cache-components-create-component-tree.test.ts
@@ -1,11 +1,13 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('hello-world', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: !isNextDev,
-    skipDeployment: true,
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
+++ b/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
@@ -158,13 +158,13 @@ describe('async imports in cacheComponents', () => {
   })
 })
 
+// This block intentionally exercises a failed build, so there is no deployment to test.
+// @force-gate !deploy
 describe('async imports in cacheComponents - external packages', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: path.join(__dirname, 'external'),
-    skipDeployment: true,
     skipStart: true,
   })
-  if (skipped) return
 
   // This is currently expected to fail because we can only track `import()` in bundled code,
   // and packages marked as external aren't bundled.

--- a/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
@@ -1,16 +1,14 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { getPrerenderOutput } from './utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Cache Components Errors - Client Hook Abort Reasons', () => {
-  const { next, isTurbopack, isNextStart, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextStart } = nextTestSetup({
     files: __dirname + '/fixtures/client-hook-abort-reasons',
     skipStart: !isNextDev,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliOutputLength: number
 

--- a/test/e2e/app-dir/cache-components-errors/client.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/client.test.ts
@@ -1,16 +1,14 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { getPrerenderOutput } from './utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Cache Components Errors - Client Components', () => {
-  const { next, isTurbopack, isNextStart, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextStart } = nextTestSetup({
     files: __dirname + '/fixtures/client',
     skipStart: !isNextDev,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliOutputLength: number
 

--- a/test/e2e/app-dir/cache-components-errors/console-patch.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/console-patch.test.ts
@@ -2,19 +2,17 @@ import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { getPrerenderOutput } from './utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Cache Components Errors', () => {
-  const { next, isTurbopack, isNextStart, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextStart } = nextTestSetup({
     files: __dirname + '/fixtures/console-patch',
-    skipDeployment: true,
     skipStart: !isNextDev,
     env: {
       NODE_OPTIONS: '--require ./patch-console.js',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliOutputLength: number
 

--- a/test/e2e/app-dir/cache-components-errors/dev-cache-bypass.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/dev-cache-bypass.test.ts
@@ -1,13 +1,9 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 
 describe('Cache Components Errors', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname + '/fixtures/dev-cache-bypass',
   })
-
-  if (skipped) {
-    return
-  }
 
   describe('Warning for Bypassing Caches in Dev', () => {
     async function enableDraftMode() {

--- a/test/e2e/app-dir/cache-components-errors/error-attribution.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/error-attribution.util.ts
@@ -10,7 +10,7 @@ import type { CacheComponentsErrorsContext } from './shared.util'
 export function registerErrorAttributionTests(
   ctx: CacheComponentsErrorsContext
 ) {
-  const { next, isTurbopack, isDebugPrerender, prerender, skipped } = ctx
+  const { next, isTurbopack, isDebugPrerender, prerender } = ctx
 
   let cliOutputLength: number
   beforeEach(() => {
@@ -20,10 +20,6 @@ export function registerErrorAttributionTests(
   describe('Error Attribution with Sync IO', () => {
     describe('Guarded RSC with guarded Client sync IO', () => {
       const pathname = '/sync-attribution/guarded-async-guarded-clientsync'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('does not show a validation error in the dev overlay', async () => {
@@ -45,10 +41,6 @@ export function registerErrorAttributionTests(
 
     describe('Guarded RSC with unguarded Client sync IO', () => {
       const pathname = '/sync-attribution/guarded-async-unguarded-clientsync'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should show a collapsed redbox error', async () => {
@@ -193,10 +185,6 @@ export function registerErrorAttributionTests(
     describe('Unguarded RSC with guarded Client sync IO', () => {
       const pathname = '/sync-attribution/unguarded-async-guarded-clientsync'
 
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should show a collapsed redbox error', async () => {
           const browser = await next.browser(pathname)
@@ -327,10 +315,6 @@ export function registerErrorAttributionTests(
       const pathname =
         '/sync-attribution/unguarded-async-client-microtask-syncio'
 
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should show request data rather than attribute a microtask sync IO access', async () => {
           const browser = await next.browser(pathname)
@@ -368,10 +352,6 @@ export function registerErrorAttributionTests(
 
     describe('unguarded RSC with unguarded Client sync IO', () => {
       const pathname = '/sync-attribution/unguarded-async-unguarded-clientsync'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should show a collapsed redbox error', async () => {

--- a/test/e2e/app-dir/cache-components-errors/http-access-fallback-prerender.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/http-access-fallback-prerender.test.ts
@@ -2,16 +2,14 @@ import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { getPrerenderOutput } from './utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Cache Components HTTP Access Fallback Prerender', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname + '/fixtures/http-access-fallback-prerender',
     skipStart: !isNextDev,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliOutputLength: number
 

--- a/test/e2e/app-dir/cache-components-errors/module-scope.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/module-scope.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Lazy Module Init', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/lazy-module-init',
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     it('does not run in dev', () => {})

--- a/test/e2e/app-dir/cache-components-errors/prospective-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/prospective-errors.test.ts
@@ -2,17 +2,14 @@ import { nextTestSetup } from 'e2e-utils'
 
 const isTurbopack = !!process.env.IS_TURBOPACK_TEST
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// Accessing cliOutput is only available on the deployment
+// @force-gate !deploy
 describe(`Cache Components Prospective Render Errors - Debug Build`, () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/prospective-render-errors',
     env: { NEXT_DEBUG_BUILD: 'true' },
-    // Accessing cliOutput is only available on the deployment
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     // In next dev there really isn't a prospective render but we still assert we error on the first visit to each page
@@ -146,13 +143,9 @@ describe(`Cache Components Prospective Render Errors - Debug Build`, () => {
 })
 
 describe(`Cache Components Prospective Render Errors - Standard Build`, () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/prospective-render-errors',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     // In next dev there really isn't a prospective render but we still assert we error on the first visit to each page

--- a/test/e2e/app-dir/cache-components-errors/shared.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/shared.util.ts
@@ -8,9 +8,6 @@ export interface CacheComponentsErrorsContext {
   isNextStart: boolean
   isDebugPrerender: boolean
   prerender: (pathname: string) => Promise<void>
-  // Always false when sections run (the wrapper returns early when skipped);
-  // exposed because some sections carry redundant guards.
-  skipped: boolean
 }
 
 // This suite is far too slow to run as a single CI test file, so it's split
@@ -21,18 +18,14 @@ export interface CacheComponentsErrorsContext {
 export function runCacheComponentsErrorsTests(
   registerTests: (ctx: CacheComponentsErrorsContext) => void
 ) {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('Cache Components Errors', () => {
-    const { next, isTurbopack, isNextStart, skipped, isRspack } = nextTestSetup(
-      {
-        files: __dirname + '/fixtures/default',
-        skipStart: !isNextDev,
-        skipDeployment: true,
-      }
-    )
-
-    if (skipped) {
-      return
-    }
+    const { next, isTurbopack, isNextStart, isRspack } = nextTestSetup({
+      files: __dirname + '/fixtures/default',
+      skipStart: !isNextDev,
+    })
 
     afterEach(async () => {
       if (isNextStart) {
@@ -99,7 +92,6 @@ export function runCacheComponentsErrorsTests(
         isNextStart,
         isDebugPrerender,
         prerender,
-        skipped,
       })
     })
   })

--- a/test/e2e/app-dir/cache-components-errors/sync-dynamic.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/sync-dynamic.util.ts
@@ -3,8 +3,7 @@ import { getPrerenderOutput } from './utils'
 import type { CacheComponentsErrorsContext } from './shared.util'
 
 export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
-  const { next, isTurbopack, isRspack, isDebugPrerender, prerender, skipped } =
-    ctx
+  const { next, isTurbopack, isRspack, isDebugPrerender, prerender } = ctx
 
   let cliOutputLength: number
   beforeEach(() => {
@@ -14,10 +13,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
   describe('Sync Dynamic Platform', () => {
     describe('With Fallback - Math.random()', () => {
       const pathname = '/sync-random-with-fallback'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should show a collapsed redbox error', async () => {
@@ -161,10 +156,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
 
     describe('Without Fallback - Math.random()', () => {
       const pathname = '/sync-random-without-fallback'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should show a collapsed redbox error', async () => {
@@ -314,10 +305,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
     describe('client searchParams', () => {
       const pathname = '/sync-client-search'
 
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should return `undefined` for `searchParams.foo`', async () => {
           const browser = await next.browser(`${pathname}?foo=test`)
@@ -351,10 +338,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
     describe('server searchParams', () => {
       const pathname = '/sync-server-search'
 
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should return `undefined` for `searchParams.foo`', async () => {
           const browser = await next.browser(`${pathname}?foo=test`)
@@ -387,10 +370,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
 
     describe('cookies', () => {
       const pathname = '/sync-cookies'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should show a redbox with a sync access error and a runtime error', async () => {
@@ -566,10 +545,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
     })
 
     describe('cookies at runtime', () => {
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should show a redbox with a sync access error and a runtime error', async () => {
           const browser = await next.browser('/sync-cookies-runtime')
@@ -666,10 +641,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
     describe('draftMode', () => {
       const pathname = '/sync-draft-mode'
 
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should return `undefined` for `draftMode().isEnabled`', async () => {
           const browser = await next.browser(`${pathname}`)
@@ -719,10 +690,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
 
     describe('headers', () => {
       const pathname = '/sync-headers'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should show a redbox with a sync access error and a runtime error', async () => {
@@ -898,10 +865,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
     })
 
     describe('headers at runtime', () => {
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should show a redbox with a sync access error and a runtime error', async () => {
           const browser = await next.browser('/sync-headers-runtime')
@@ -998,10 +961,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
     describe('client params', () => {
       const pathname = '/sync-client-params'
 
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should return `undefined` for `params.slug`', async () => {
           const browser = await next.browser(`${pathname}/test`)
@@ -1032,10 +991,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
 
     describe('server params', () => {
       const pathname = '/sync-server-params'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should return `undefined` for `params.slug`', async () => {

--- a/test/e2e/app-dir/cache-components-errors/unstable-deprecations.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/unstable-deprecations.test.ts
@@ -1,13 +1,9 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 
 describe('Cache Components Errors', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname + '/fixtures/unstable-deprecations',
   })
-
-  if (skipped) {
-    return
-  }
 
   describe('Deprecating `unstable` prefix for `cacheLife` and `cacheTag`', () => {
     it('warns if you use `cacheLife` through `unstable_cacheLife`', async () => {

--- a/test/e2e/app-dir/cache-components-prerender-matrix/cache-components-prerender-matrix.test.ts
+++ b/test/e2e/app-dir/cache-components-prerender-matrix/cache-components-prerender-matrix.test.ts
@@ -9,8 +9,6 @@ import { retry } from 'next-test-utils'
 // not implement it yet — its blocking entries still key and bake
 // never-prerenderable params — so deploy runs are limited to adapter
 // deployments until that ships (see vercel/vercel#17179).
-const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
-
 type NextInstance = ReturnType<typeof nextTestSetup>['next']
 
 // A first-principles test matrix for cache components prerendering.
@@ -67,7 +65,7 @@ type NextInstance = ReturnType<typeof nextTestSetup>['next']
 // allowQuery, keying and baking them on deployed infra. The fully-static
 // and dynamic matrices pass before and after those fixes and guard them
 // against over-correction. Deploy runs are adapter-only for now (see the
-// `skipDeployment` note above the `isAdapterTest` declaration).
+// `@force-gate !deploy || adapter` on the suite below).
 
 const PARAMS = ['lang', 'category', 'id'] as const
 type ParamName = (typeof PARAMS)[number]
@@ -449,10 +447,12 @@ function createDocumentFetcher(next: NextInstance) {
   }
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy || adapter
 describe('cache-components-prerender-matrix', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    skipDeployment: !isAdapterTest,
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/cache-components-request-apis/cache-components-request-apis.test.ts
+++ b/test/e2e/app-dir/cache-components-request-apis/cache-components-request-apis.test.ts
@@ -38,14 +38,10 @@ function createExpectError(cliOutput: string) {
 
 describe(`Request Promises`, () => {
   describe('On Prerender Completion', () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
+    const { next, isNextDev } = nextTestSetup({
       files: __dirname + '/fixtures/reject-hanging-promises-static',
       skipStart: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     if (isNextDev) {
       it('does not run in dev', () => {})
@@ -78,16 +74,14 @@ describe(`Request Promises`, () => {
       )
     })
   })
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('On Prerender Interruption', () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
+    const { next, isNextDev } = nextTestSetup({
       files: __dirname + '/fixtures/reject-hanging-promises-dynamic',
       skipStart: true,
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     if (isNextDev) {
       it('does not run in dev', () => {})

--- a/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
@@ -5,16 +5,14 @@ import {
   getRedboxSource,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components-route-handler-errors', () => {
-  const { next, skipped, isNextDev, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it("should error when route handlers use segment configs that aren't supported by cacheComponents", async () => {
     try {

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
@@ -23,30 +23,27 @@ function filterToErrorHeaders(output: string): string {
 
 // Only Turbopack runs the transform on the layout once in edge and non-edge contexts
 // so we only test this on Turbopack
-;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
-  'cache-components-edge-deduplication',
-  () => {
-    const { next, skipped, isNextDev } = nextTestSetup({
-      files: __dirname + '/fixtures/edge-deduplication',
-      skipStart: true,
-      skipDeployment: true,
-    })
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('cache-components-edge-deduplication', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname + '/fixtures/edge-deduplication',
+    skipStart: true,
+  })
 
-    if (skipped) {
-      return
+  it('should not duplicate errors when layout is compiled for both edge and non-edge contexts', async () => {
+    try {
+      await next.start()
+    } catch {
+      // we expect the build to fail
     }
 
-    it('should not duplicate errors when layout is compiled for both edge and non-edge contexts', async () => {
-      try {
-        await next.start()
-      } catch {
-        // we expect the build to fail
-      }
-
-      if (isNextDev) {
-        const browser = await next.browser('/edge-with-layout/edge')
-        waitForRedbox(browser)
-        await expect(browser).toDisplayRedbox(`
+    if (isNextDev) {
+      const browser = await next.browser('/edge-with-layout/edge')
+      waitForRedbox(browser)
+      await expect(browser).toDisplayRedbox(`
          {
            "description": "Route segment config "dynamic" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
            "environmentLabel": null,
@@ -59,34 +56,33 @@ function filterToErrorHeaders(output: string): string {
          }
         `)
 
-        // Count occurrences of the layout error at the specific location
-        // Filter out browser logs to avoid counting forwarded browser errors
-        const filteredOutput = filterToErrorHeaders(next.cliOutput)
-        const layoutErrorMatches = filteredOutput.match(
-          /\.\/app\/edge-with-layout\/layout\.tsx:1:14/g
-        )
-        // We don't show an error stack, just the individual error messages at each location
-        expect(layoutErrorMatches.length).toBe(1)
-      } else {
-        // Check that both the layout and edge page errors appear
-        expect(next.cliOutput).toContain('./app/edge-with-layout/layout.tsx')
-        expect(next.cliOutput).toContain('./app/edge-with-layout/edge/page.tsx')
-        expect(next.cliOutput).toContain(
-          '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
-        )
-        expect(next.cliOutput).toContain(
-          '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
-        )
-        // Count occurrences of the layout error at the specific location
-        const layoutErrorMatches = next.cliOutput.match(
-          /\.\/app\/layout\.tsx:1:14/g
-        )
+      // Count occurrences of the layout error at the specific location
+      // Filter out browser logs to avoid counting forwarded browser errors
+      const filteredOutput = filterToErrorHeaders(next.cliOutput)
+      const layoutErrorMatches = filteredOutput.match(
+        /\.\/app\/edge-with-layout\/layout\.tsx:1:14/g
+      )
+      // We don't show an error stack, just the individual error messages at each location
+      expect(layoutErrorMatches.length).toBe(1)
+    } else {
+      // Check that both the layout and edge page errors appear
+      expect(next.cliOutput).toContain('./app/edge-with-layout/layout.tsx')
+      expect(next.cliOutput).toContain('./app/edge-with-layout/edge/page.tsx')
+      expect(next.cliOutput).toContain(
+        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+      )
+      expect(next.cliOutput).toContain(
+        '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+      )
+      // Count occurrences of the layout error at the specific location
+      const layoutErrorMatches = next.cliOutput.match(
+        /\.\/app\/layout\.tsx:1:14/g
+      )
 
-        // The location appears once, in the formatted error message. The
-        // stack of the build error holds framework frames only, and none of
-        // them names the route.
-        expect(layoutErrorMatches.length).toBe(1)
-      }
-    })
-  }
-)
+      // The location appears once, in the formatted error message. The
+      // stack of the build error holds framework frames only, and none of
+      // them names the route.
+      expect(layoutErrorMatches.length).toBe(1)
+    }
+  })
+})

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
@@ -6,16 +6,14 @@ import {
   getRedboxSource,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('cache-components-segment-configs', () => {
-  const { next, skipped, isNextDev, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname + '/fixtures/default',
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it("it should error when using segment configs that aren't supported by cacheComponents", async () => {
     try {

--- a/test/e2e/app-dir/cache-components/cache-components.connection.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.connection.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should partially prerender pages that use connection', async () => {
     let $ = await next.render$('/connection/static-behavior/boundary', {})

--- a/test/e2e/app-dir/cache-components/cache-components.cookies.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.cookies.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should partially prerender pages that use cookies', async () => {
     let $ = await next.render$('/cookies/static-behavior', {})

--- a/test/e2e/app-dir/cache-components/cache-components.date.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.date.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import expect from 'expect'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have route specific errors', async () => {
     expect(next.cliOutput).not.toMatch('Error: Route "/')

--- a/test/e2e/app-dir/cache-components/cache-components.draft-mode.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.draft-mode.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliIndex = 0
   beforeEach(() => {

--- a/test/e2e/app-dir/cache-components/cache-components.headers.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.headers.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should partially prerender pages that use headers', async () => {
     let $ = await next.render$('/headers/static-behavior', {})

--- a/test/e2e/app-dir/cache-components/cache-components.node-crypto.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.node-crypto.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have route specific errors', async () => {
     expect(next.cliOutput).not.toMatch('Error: Route "/')

--- a/test/e2e/app-dir/cache-components/cache-components.params.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.params.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // cSpell:words lowcard highcard
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliIndex = 0
   beforeEach(() => {

--- a/test/e2e/app-dir/cache-components/cache-components.random.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.random.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have route specific errors', async () => {
     expect(next.cliOutput).not.toMatch('Error: Route "/')

--- a/test/e2e/app-dir/cache-components/cache-components.routes.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.routes.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliIndex = 0
   beforeEach(() => {

--- a/test/e2e/app-dir/cache-components/cache-components.search.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.search.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should partially prerender pages that await searchParams in a server component', async () => {
     let $ = await next.render$('/search/server/await?sentinel=hello')

--- a/test/e2e/app-dir/cache-components/cache-components.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.test.ts
@@ -5,15 +5,13 @@ import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/util
 import cheerio from 'cheerio'
 import { fetchViaHTTP, findPort } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have route specific errors', async () => {
     expect(next.cliOutput).not.toMatch('Error: Route "/')

--- a/test/e2e/app-dir/cache-components/cache-components.web-crypto.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.web-crypto.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have route specific errors', async () => {
     expect(next.cliOutput).not.toMatch('Error: Route "/')

--- a/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
+++ b/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
@@ -5,6 +5,8 @@ describe('custom-cache-control', () => {
     files: __dirname,
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // The hosting platform applies cache headers outside the Next.js server, so deploy mode needs separate expectations.
   if (isNextDeploy) {
     // customizing these headers won't apply on environments
     // where headers are applied outside of the Next.js server

--- a/test/e2e/app-dir/draft-mode-middleware/draft-mode-middleware.test.ts
+++ b/test/e2e/app-dir/draft-mode-middleware/draft-mode-middleware.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - draft-mode-middleware', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should be able to enable draft mode with middleware present', async () => {
     const browser = await next.browser(

--- a/test/e2e/app-dir/instant-validation-static-shells/instant-validation-static-shells.test.ts
+++ b/test/e2e/app-dir/instant-validation-static-shells/instant-validation-static-shells.test.ts
@@ -2,12 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitForNoErrorToast } from 'next-test-utils'
 import { join } from 'node:path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('instant validation - opting out of static shells', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'valid'),
-    skipDeployment: true,
   })
-  if (skipped) return
 
   // NOTE: if something's wrong in build, we'll fail before any tests run.
   // Visiting the pages is mostly just a sanity check.
@@ -30,13 +31,14 @@ describe('instant validation - opting out of static shells', () => {
 })
 
 describe('instant validation', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('requires a static shell if a below a static layout page is configured as blocking', () => {
-    const { next, skipped, isNextDev } = nextTestSetup({
+    const { next, isNextDev } = nextTestSetup({
       files: join(__dirname, 'fixtures', 'invalid-blocking-page-below-static'),
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     if (isNextDev) {
       beforeAll(() => next.start())

--- a/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
+++ b/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
@@ -4,15 +4,13 @@ import {
   RSC_HEADER,
 } from 'next/dist/client/components/app-router-headers'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('non-rsc-router-prefetch', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   beforeAll(async () => {
     const res = await next.fetch('/')

--- a/test/e2e/app-dir/partial-fallback-root-blocking/partial-fallback-root-blocking.test.ts
+++ b/test/e2e/app-dir/partial-fallback-root-blocking/partial-fallback-root-blocking.test.ts
@@ -2,14 +2,13 @@ import cheerio from 'cheerio'
 import { nextTestSetup } from 'e2e-utils'
 import { splitResponseWithPPRSentinel } from 'e2e-utils/ppr'
 
-const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
-
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The latest changes to support this behavior on deployed infra are available in the adapter,
+// and are not being backported to the CLI
+// @force-gate !deploy || adapter
 describe('partial-fallback-root-blocking', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    // The latest changes to support this behavior on deployed infra are available in the adapter,
-    // and are not being backported to the CLI
-    skipDeployment: !isAdapterTest,
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
@@ -4,8 +4,6 @@ import { splitResponseWithPPRSentinel } from 'e2e-utils/ppr'
 import { retry, waitFor } from 'next-test-utils'
 import path from 'path'
 
-const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
-
 type NextInstance = ReturnType<typeof nextTestSetup>['next']
 
 function createSplitHTMLFetcher(next: NextInstance) {
@@ -32,14 +30,15 @@ function createSplitHTMLFetcher(next: NextInstance) {
   }
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The latest changes to support this behavior on deployed infra are available in the adapter,
+// and are not being backported to the CLI
+// @force-gate !deploy || adapter
 describe('partial-fallback-shell-upgrade', () => {
   const { next, isNextDev } = nextTestSetup({
     // Deployed shell upgrades require `partialFallback` metadata, which the
     // adapter only emits when Partial Prefetching is enabled in the fixture.
     files: path.join(__dirname, 'fixtures', 'default'),
-    // The latest changes to support this behavior on deployed infra are available in the adapter,
-    // and are not being backported to the CLI
-    skipDeployment: !isAdapterTest,
   })
 
   if (isNextDev) {
@@ -171,12 +170,13 @@ describe('partial-fallback-shell-upgrade', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The latest changes to support this behavior on deployed infra are available in the adapter,
+// and are not being backported to the CLI
+// @force-gate !deploy || adapter
 describe('partial-fallback-shell-upgrade - partialPrefetching disabled', () => {
   const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'partial-prefetching-disabled'),
-    // The latest changes to support this behavior on deployed infra are available in the adapter,
-    // and are not being backported to the CLI
-    skipDeployment: !isAdapterTest,
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/ppr-metadata-blocking/ppr-metadata-blocking-ppr-fallback.test.ts
+++ b/test/e2e/app-dir/ppr-metadata-blocking/ppr-metadata-blocking-ppr-fallback.test.ts
@@ -5,17 +5,17 @@ function countSubstring(str: string, substr: string): number {
 }
 
 // TODO(NAR-423): Migrate to Cache Components.
-describe.skip('ppr-metadata-blocking-ppr-fallback', () => {
-  const { next, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Need to skip deployment because the test uses the private env cannot be used in deployment
+// @force-gate !deploy
+// @force-gate TODO
+describe('ppr-metadata-blocking-ppr-fallback', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-    // Need to skip deployment because the test uses the private env cannot be used in deployment
-    skipDeployment: true,
     env: {
       __NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING: '1',
     },
   })
-
-  if (skipped) return
 
   it('should not include metadata in partial shell when page is fully dynamic', async () => {
     const $ = await next.render$('/fully-dynamic?__nextppronly=fallback')

--- a/test/e2e/app-dir/ppr-missing-root-params/ppr-missing-root-params.test.ts
+++ b/test/e2e/app-dir/ppr-missing-root-params/ppr-missing-root-params.test.ts
@@ -1,13 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('ppr-missing-root-params (single)', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures/single'),
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     try {
@@ -26,13 +27,14 @@ describe('ppr-missing-root-params (single)', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('ppr-missing-root-params (multiple)', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures/multiple'),
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     try {
@@ -51,13 +53,14 @@ describe('ppr-missing-root-params (multiple)', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('ppr-missing-root-params (nested)', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures/nested'),
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     try {

--- a/test/e2e/app-dir/ppr-navigations/avoid-popstate-flash/avoid-popstate-flash.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/avoid-popstate-flash/avoid-popstate-flash.test.ts
@@ -4,6 +4,7 @@ import { createTestDataServer } from 'test-data-service/writer'
 import { createTestLog } from 'test-log'
 
 describe('avoid-popstate-flash', () => {
+  // Deploy mode exclusion: This suite depends on a test-data service running on a local port.
   if ((global as any).isNextDev || (global as any).isNextDeploy) {
     // this is skipped in dev because PPR is not enabled in dev
     // and in deploy we can't rely on this test data service existing

--- a/test/e2e/app-dir/ppr-navigations/stale-prefetch-entry/stale-prefetch-entry.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/stale-prefetch-entry/stale-prefetch-entry.test.ts
@@ -4,6 +4,7 @@ import { createTestDataServer } from 'test-data-service/writer'
 import { createTestLog } from 'test-log'
 
 describe('stale-prefetch-entry', () => {
+  // Deploy mode exclusion: This suite depends on a test-data service running on a local port.
   if ((global as any).isNextDev || (global as any).isNextDeploy) {
     // this is skipped in dev because PPR is not enabled in dev
     // and in deploy we can't rely on this test data service existing

--- a/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
+++ b/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
@@ -7,15 +7,16 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// the file-patching strategy we use for synchronizing the test doesn't work
+// on deployments
+// @force-gate !deploy
 describe('PPR - partial hydration', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    // the file-patching strategy we use for synchronizing the test doesn't work
-    // on deployments
-    skipDeployment: true,
   })
 
-  if (isNextDev || skipped) {
+  if (isNextDev) {
     it.skip('only testable in production (non-deployment)', () => {})
     return
   }

--- a/test/e2e/app-dir/ppr-unstable-cache/ppr-unstable-cache.test.ts
+++ b/test/e2e/app-dir/ppr-unstable-cache/ppr-unstable-cache.test.ts
@@ -3,6 +3,7 @@ import { findPort } from 'next-test-utils'
 import http from 'node:http'
 
 describe('ppr-unstable-cache', () => {
+  // Deploy mode exclusion: This suite starts a local HTTP data server on a dynamically allocated port.
   if (isNextDeploy) {
     it.skip('should not run in deploy mode', () => {})
     return

--- a/test/e2e/app-dir/revalidate-dynamic/revalidate-dynamic.test.ts
+++ b/test/e2e/app-dir/revalidate-dynamic/revalidate-dynamic.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('app-dir revalidate-dynamic', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
@@ -7,6 +7,8 @@ import { isNextDeploy, isNextDev, nextTestSetup } from 'e2e-utils'
 import { createFakeCDN } from './server.mjs'
 
 describe('segment cache (CDN cache busting)', () => {
+  // Deploy mode exclusion: This suite runs Next.js behind an in-process fake
+  // CDN on local ports.
   if (isNextDev || isNextDeploy) {
     test('should not run during dev or deploy test runs', () => {})
     return

--- a/test/e2e/app-dir/segment-cache/prefetch-fallback-retry/prefetch-fallback-retry.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-fallback-retry/prefetch-fallback-retry.test.ts
@@ -7,6 +7,8 @@ describe('segment cache prefetch fallback retry', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
+  // Deploy mode exclusion: This suite requires direct observation and control
+  // of local ISR cache state and background regeneration.
   if (isNextDev || isNextDeploy) {
     // Prefetching is disabled in dev, and the recovery test relies on
     // observing ISR cache state and background regeneration, which aren't

--- a/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
+++ b/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
@@ -6,6 +6,8 @@ import { createTestLog } from 'test-log'
 import { findPort } from 'next-test-utils'
 
 describe('segment cache (revalidation)', () => {
+  // Deploy mode exclusion: This suite starts and mutates a process-local test
+  // data server.
   if (isNextDev || isNextDeploy) {
     test('disabled in development / deployment', () => {})
     return

--- a/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/runtime-prerender-cache-warming.test.ts
+++ b/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/runtime-prerender-cache-warming.test.ts
@@ -4,12 +4,12 @@ import { createRouterAct } from 'router-act'
 
 import { UNEXPECTED_CACHE_MISS_MESSAGE } from 'next/src/server/use-cache/use-cache-errors'
 
+// Deploy mode exclusion: This suite asserts local server CLI output.
+// @force-gate !deploy
 describe('runtime prerender cache warming', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true, // reads CLI output
   })
-  if (skipped) return
 
   if (isNextDev) {
     it.skip('no prefetching in dev', () => {})

--- a/test/e2e/app-dir/static-shell-debugging/static-shell-debugging.test.ts
+++ b/test/e2e/app-dir/static-shell-debugging/static-shell-debugging.test.ts
@@ -1,18 +1,20 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // TODO(NAR-423): Migrate to Cache Components.
-describe.skip('static-shell-debugging', () => {
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test skips deployment because env vars that are doubled underscore prefixed
+// are not supported. This is also intended to be used in development.
+// @force-gate !deploy
+// @force-gate TODO
+describe('static-shell-debugging', () => {
   const cacheComponents = Boolean(process.env.__NEXT_CACHE_COMPONENTS)
   const context = {
     cacheComponents,
     debugging: cacheComponents,
   }
 
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    // This test skips deployment because env vars that are doubled underscore prefixed
-    // are not supported. This is also intended to be used in development.
-    skipDeployment: true,
     env: {
       __NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING: context.debugging
         ? '1'
@@ -22,8 +24,6 @@ describe.skip('static-shell-debugging', () => {
       cacheComponents: context.cacheComponents,
     },
   })
-
-  if (skipped) return
 
   if (context.debugging && context.cacheComponents) {
     it('should only render the static shell', async () => {

--- a/test/e2e/app-dir/use-cache-after-uncached-io/use-cache-after-uncached-io.test.ts
+++ b/test/e2e/app-dir/use-cache-after-uncached-io/use-cache-after-uncached-io.test.ts
@@ -4,10 +4,12 @@ import { createRouterAct } from '../../../lib/router-act'
 import { setTimeout } from 'timers/promises'
 import { retry } from '../../../lib/next-test-utils'
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// reads cli logs
+// @force-gate !deploy
 describe('use cache called after tasky uncached IO', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true, // reads cli logs
   })
 
   if (isNextStart) {

--- a/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
+++ b/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
@@ -7,16 +7,14 @@ import {
 } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-close-over-function', () => {
-  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     it('should show an error toast for client-side usage', async () => {

--- a/test/e2e/app-dir/use-cache-configured-timeout/use-cache-configured-timeout.test.ts
+++ b/test/e2e/app-dir/use-cache-configured-timeout/use-cache-configured-timeout.test.ts
@@ -8,16 +8,14 @@ function expectedTimeoutErrorMessage(route: string) {
   return `Route "${route}": ${timeoutErrorMessage}`
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-configured-timeout', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     describe('when a "use cache" fill is below the configured dev `useCacheTimeout`', () => {

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -3,14 +3,13 @@ import { retry } from 'next-test-utils'
 
 const isoDateRegExp = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Skip deployment so we can test the custom cache handlers log output
+// @force-gate !deploy
 describe('use-cache-custom-handler', () => {
-  const { next, skipped, isNextStart } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    // Skip deployment so we can test the custom cache handlers log output
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   let outputIndex: number
 

--- a/test/e2e/app-dir/use-cache-deadlock-probe/use-cache-deadlock-probe.test.ts
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/use-cache-deadlock-probe.test.ts
@@ -24,18 +24,17 @@ function expectedDeadlockMessage(route: string) {
 // than detected as a deadlock. Revisit by surfacing these deadlocks at build
 // time via `next build --debug-prerender`, then re-enable (and retarget) this
 // suite.
-describe.skip('use-cache-deadlock-probe', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate TODO
+describe('use-cache-deadlock-probe', () => {
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     // Probe behavior is dev-only; skip the production server start, but
     // let dev mode auto-start.
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (!isNextDev) {
     it('is a dev-only suite', () => {})

--- a/test/e2e/app-dir/use-cache-default-handler-expire-zero/use-cache-default-handler-expire-zero.test.ts
+++ b/test/e2e/app-dir/use-cache-default-handler-expire-zero/use-cache-default-handler-expire-zero.test.ts
@@ -1,19 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-default-handler-expire-zero', () => {
-  const { next, skipped, isNextStart } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
     // Enable the built-in default cache handler's debug logging so we can
     // assert on its `set()` decisions in the CLI output. That output is not
     // available on deploy, so skip the deploy variant.
     env: { NEXT_PRIVATE_DEBUG_CACHE: '1' },
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextStart) {
     it('does not save an expire:0 cache to the built-in default handler, but saves a short-lived one', async () => {

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -17,16 +17,14 @@ function expectedTimeoutErrorMessage(route: string) {
   return `Route "${route}": ${timeoutErrorMessage}`
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-hanging-inputs', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     // TODO(restart-on-cache-miss): reenable when fixed

--- a/test/e2e/app-dir/use-cache-hanging/use-cache-hanging.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging/use-cache-hanging.test.ts
@@ -9,16 +9,14 @@ function expectedTimeoutErrorMessage(route: string) {
   return `Route "${route}": ${timeoutErrorMessage}`
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-hanging', () => {
-  const { next, isNextDev, skipped, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     describe('when a "use cache" fill hangs in the static stage', () => {

--- a/test/e2e/app-dir/use-cache-infinity-profile/use-cache-infinity-profile.test.ts
+++ b/test/e2e/app-dir/use-cache-infinity-profile/use-cache-infinity-profile.test.ts
@@ -3,11 +3,12 @@ import { nextTestSetup } from 'e2e-utils'
 const uuidRegExp =
   /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Deployment platforms provide their own cache handlers.
+// @force-gate !deploy
 describe('use-cache-infinity-profile', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    // Deployment platforms provide their own cache handlers.
-    skipDeployment: true,
   })
 
   it('caches forever with a configured profile using Infinity revalidate and expire', async () => {

--- a/test/e2e/app-dir/use-cache-og-image-top-level-await/use-cache-og-image-top-level-await.test.ts
+++ b/test/e2e/app-dir/use-cache-og-image-top-level-await/use-cache-og-image-top-level-await.test.ts
@@ -1,17 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The prerendered output can't be observed in a deployment, and without
+// it nothing distinguishes broken from fixed behavior.
+// @force-gate !deploy
 describe('use-cache-og-image-top-level-await', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    // The prerendered output can't be observed in a deployment, and without
-    // it nothing distinguishes broken from fixed behavior.
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextStart) {
     beforeAll(async () => {

--- a/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
+++ b/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
@@ -3,10 +3,12 @@ import { renderViaHTTP, startCleanStaticServer } from 'next-test-utils'
 import { join } from 'path'
 import { AddressInfo, Server } from 'net'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-output-export', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
 

--- a/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
+++ b/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
@@ -5,16 +5,14 @@ import stripAnsi from 'strip-ansi'
 const getExpectedErrorMessage = (route: string) =>
   `Route "${route}": \`searchParams\` can't be read inside \`"use cache"\`. Await it outside the cached function and pass what you need as an argument.\nLearn more: https://nextjs.org/docs/messages/next-request-in-use-cache`
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-search-params', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     let route: string

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -2,16 +2,14 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitForRedbox } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('use-cache-segment-configs', () => {
-  const { next, skipped, isNextDev, isTurbopack, isRspack } = nextTestSetup({
+  const { next, isNextDev, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it("it should error when using segment configs that aren't supported by useCache", async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
+++ b/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-swr', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   let outputIndex: number
 

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -9,16 +9,14 @@ import {
 import stripAnsi from 'strip-ansi'
 import { createSandbox } from 'development-sandbox'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('use-cache-unknown-cache-kind', () => {
-  const { next, isNextStart, isTurbopack, isRspack, skipped } = nextTestSetup({
+  const { next, isNextStart, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextStart) {
     beforeAll(async () => {

--- a/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
+++ b/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
@@ -13,16 +13,14 @@ const nextConfigWithUseCache: NextConfig = {
   experimental: { useCache: true },
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('use-cache-without-experimental-flag', () => {
-  const { next, isNextStart, isTurbopack, skipped, isRspack } = nextTestSetup({
+  const { next, isNextStart, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextStart) {
     it('should fail the build with an error', async () => {

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -19,17 +19,13 @@ const GENERIC_RSC_ERROR =
 
 const withCacheComponents = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache', () => {
-  const { next, isNextDev, isNextDeploy, isNextStart, skipped } = nextTestSetup(
-    {
-      files: __dirname,
-      skipDeployment: true,
-    }
-  )
-
-  if (skipped) {
-    return
-  }
+  const { next, isNextDev, isNextDeploy, isNextStart } = nextTestSetup({
+    files: __dirname,
+  })
 
   let cliOutputLength: number
 

--- a/test/e2e/cache-handlers-upstream-wiring/index.test.ts
+++ b/test/e2e/cache-handlers-upstream-wiring/index.test.ts
@@ -3,15 +3,13 @@ import { retry } from 'next-test-utils'
 import { join } from 'path'
 
 describe('cache-handlers-upstream-wiring', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('pages router non-edge', () => {
-    const { next, skipped, isNextDev } = nextTestSetup({
+    const { next, isNextDev } = nextTestSetup({
       files: join(__dirname, 'fixtures/pages-router-non-edge'),
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     let outputIndex = 0
 
@@ -51,15 +49,13 @@ describe('cache-handlers-upstream-wiring', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('cacheComponents enabled, non-edge app router', () => {
-    const { next, skipped, isNextDev } = nextTestSetup({
+    const { next, isNextDev } = nextTestSetup({
       files: join(__dirname, 'fixtures/non-edge-cache-components'),
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     let outputIndex = 0
 
@@ -98,16 +94,14 @@ describe('cache-handlers-upstream-wiring', () => {
       })
     })
   })
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   // @force-gate !cacheComponents
   describe('cacheComponents disabled, edge app router', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: join(__dirname, 'fixtures/edge-without-cache-components'),
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     let outputIndex = 0
 

--- a/test/e2e/custom-cache-handler-image/custom-cache-handler-image.test.ts
+++ b/test/e2e/custom-cache-handler-image/custom-cache-handler-image.test.ts
@@ -1,19 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('custom-cache-handler-image', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     env: {
       // Set max cache entries to 2 to easily test eviction
       MAX_IMAGE_CACHE_ENTRIES: '2',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should use custom cache handler for image optimization', async () => {
     // First, render the page to get the image URLs

--- a/test/e2e/draft-mode/draft-mode.test.ts
+++ b/test/e2e/draft-mode/draft-mode.test.ts
@@ -12,12 +12,17 @@ function getData(html: string) {
   }
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Test Draft Mode', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
+
+  if (isNextDeploy) {
+    it('is excluded from deploy testing by @force-gate', () => {})
+  }
 
   if (isNextDev) {
     it('should start development application', async () => {

--- a/test/e2e/fallback-false-rewrite/fallback-false-rewrite.test.ts
+++ b/test/e2e/fallback-false-rewrite/fallback-false-rewrite.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('fallback: false rewrite', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should rewrite correctly for path at same level as fallback: false SSR', async () => {
     const res = await next.fetch('/hello', { redirect: 'manual' })

--- a/test/e2e/filesystem-cache/build-cache-default.test.ts
+++ b/test/e2e/filesystem-cache/build-cache-default.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup, isNextStart } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import fs from 'fs/promises'
 import path from 'path'
 
@@ -9,109 +9,106 @@ import path from 'path'
 // This is a Turbopack + build (start) mode test. It runs `next build` with
 // controlled local and CI environments and checks whether anything is written
 // to `.next/cache/turbopack`.
-;(process.env.IS_TURBOPACK_TEST && isNextStart ? describe : describe.skip)(
-  'filesystem-cache build default',
-  () => {
-    const { next, skipped } = nextTestSetup({
-      files: __dirname,
-      skipStart: true,
-      skipDeployment: true,
-    })
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
+// @force-gate turbopack
+// @force-gate start
+describe('filesystem-cache build default', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
 
-    if (skipped) {
-      return
-    }
+  // Simulate a non-CI (local) environment by clearing the common CI signals.
+  const NON_CI_ENV = {
+    CI: '',
+    CONTINUOUS_INTEGRATION: '',
+    BUILD_NUMBER: '',
+    RUN_ID: '',
+    GITHUB_ACTIONS: '',
+    NOW_BUILDER: '',
+    // Persist even a tiny snapshot so the assertion doesn't depend on the
+    // minimum-compilation-time threshold.
+    TURBO_ENGINE_IGNORE_DIRTY: '1',
+    TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS: '0',
+  }
 
-    // Simulate a non-CI (local) environment by clearing the common CI signals.
-    const NON_CI_ENV = {
-      CI: '',
-      CONTINUOUS_INTEGRATION: '',
-      BUILD_NUMBER: '',
-      RUN_ID: '',
-      GITHUB_ACTIONS: '',
-      NOW_BUILDER: '',
-      // Persist even a tiny snapshot so the assertion doesn't depend on the
-      // minimum-compilation-time threshold.
-      TURBO_ENGINE_IGNORE_DIRTY: '1',
-      TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS: '0',
-    }
+  function cachePath() {
+    return path.join(next.testDir, '.next', 'cache', 'turbopack')
+  }
 
-    function cachePath() {
-      return path.join(next.testDir, '.next', 'cache', 'turbopack')
-    }
-
-    async function getCacheSize(): Promise<number> {
-      let entries
-      try {
-        entries = await fs.readdir(cachePath(), {
-          recursive: true,
-          withFileTypes: true,
-        })
-      } catch {
-        // Directory doesn't exist -> nothing was cached.
-        return 0
-      }
-      let totalSize = 0
-      for (const entry of entries) {
-        if (entry.isFile()) {
-          const filePath = path.join(entry.parentPath ?? entry.path, entry.name)
-          totalSize += (await fs.stat(filePath)).size
-        }
-      }
-      return totalSize
-    }
-
-    async function cleanBuildOutput() {
-      await fs.rm(path.join(next.testDir, '.next'), {
+  async function getCacheSize(): Promise<number> {
+    let entries
+    try {
+      entries = await fs.readdir(cachePath(), {
         recursive: true,
-        force: true,
+        withFileTypes: true,
       })
+    } catch {
+      // Directory doesn't exist -> nothing was cached.
+      return 0
     }
-
-    // The shared fixture's next.config.js sets the flag explicitly from
-    // `ENABLE_CACHING`; overwrite it so we exercise the *default* instead.
-    async function setConfig(experimental: Record<string, unknown> = {}) {
-      await next.patchFile(
-        'next.config.js',
-        `module.exports = ${JSON.stringify({ experimental }, null, 2)}`
-      )
+    let totalSize = 0
+    for (const entry of entries) {
+      if (entry.isFile()) {
+        const filePath = path.join(entry.parentPath ?? entry.path, entry.name)
+        totalSize += (await fs.stat(filePath)).size
+      }
     }
+    return totalSize
+  }
 
-    afterEach(async () => {
-      await setConfig()
-    })
-
-    it('writes the cache by default (no config, local environment)', async () => {
-      await cleanBuildOutput()
-      await setConfig()
-
-      const { exitCode } = await next.build({ env: NON_CI_ENV })
-      expect(exitCode).toBe(0)
-
-      expect(await getCacheSize()).toBeGreaterThan(0)
-    })
-
-    it('writes nothing when turbopackFileSystemCacheForBuild is false', async () => {
-      await cleanBuildOutput()
-      await setConfig({ turbopackFileSystemCacheForBuild: false })
-
-      const { exitCode } = await next.build({ env: NON_CI_ENV })
-      expect(exitCode).toBe(0)
-
-      expect(await getCacheSize()).toBe(0)
-    })
-
-    it('writes the cache by default in CI', async () => {
-      await cleanBuildOutput()
-      await setConfig()
-
-      const { exitCode } = await next.build({
-        // Force a generic CI environment.
-        env: { ...NON_CI_ENV, CI: '1' },
-      })
-      expect(exitCode).toBe(0)
-
-      expect(await getCacheSize()).toBeGreaterThan(0)
+  async function cleanBuildOutput() {
+    await fs.rm(path.join(next.testDir, '.next'), {
+      recursive: true,
+      force: true,
     })
   }
-)
+
+  // The shared fixture's next.config.js sets the flag explicitly from
+  // `ENABLE_CACHING`; overwrite it so we exercise the *default* instead.
+  async function setConfig(experimental: Record<string, unknown> = {}) {
+    await next.patchFile(
+      'next.config.js',
+      `module.exports = ${JSON.stringify({ experimental }, null, 2)}`
+    )
+  }
+
+  afterEach(async () => {
+    await setConfig()
+  })
+
+  it('writes the cache by default (no config, local environment)', async () => {
+    await cleanBuildOutput()
+    await setConfig()
+
+    const { exitCode } = await next.build({ env: NON_CI_ENV })
+    expect(exitCode).toBe(0)
+
+    expect(await getCacheSize()).toBeGreaterThan(0)
+  })
+
+  it('writes nothing when turbopackFileSystemCacheForBuild is false', async () => {
+    await cleanBuildOutput()
+    await setConfig({ turbopackFileSystemCacheForBuild: false })
+
+    const { exitCode } = await next.build({ env: NON_CI_ENV })
+    expect(exitCode).toBe(0)
+
+    expect(await getCacheSize()).toBe(0)
+  })
+
+  it('writes the cache by default in CI', async () => {
+    await cleanBuildOutput()
+    await setConfig()
+
+    const { exitCode } = await next.build({
+      // Force a generic CI environment.
+      env: { ...NON_CI_ENV, CI: '1' },
+    })
+    expect(exitCode).toBe(0)
+
+    expect(await getCacheSize()).toBeGreaterThan(0)
+  })
+})

--- a/test/e2e/filesystem-cache/evict-after-snapshot.test.ts
+++ b/test/e2e/filesystem-cache/evict-after-snapshot.test.ts
@@ -1,9 +1,13 @@
-import { nextTestSetup, isNextDev } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { retry, waitFor } from 'next-test-utils'
 
 // Eviction requires the dev server (HMR) and persistent caching (Turbopack).
 // Skip entirely in prod/start mode.
-;(isNextDev ? describe : describe.skip)('evict-after-snapshot', () => {
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
+// @force-gate dev
+describe('evict-after-snapshot', () => {
   const envVars = [
     'ENABLE_CACHING=1',
     'TURBO_ENGINE_IGNORE_DIRTY=1',
@@ -14,9 +18,8 @@ import { retry, waitFor } from 'next-test-utils'
     'ENABLE_EVICTION=1',
   ].join(' ')
 
-  const { skipped, next } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     packageJson: {
       scripts: {
         dev: `${envVars} next dev`,
@@ -25,10 +28,6 @@ import { retry, waitFor } from 'next-test-utils'
     installCommand: 'npm i',
     startCommand: 'npm run dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   async function waitForSnapshotAndEviction() {
     // The idle timeout is 1s, give extra time for snapshot + eviction to complete

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -28,6 +28,9 @@ async function getDirectorySize(dirPath: string): Promise<number> {
 }
 
 for (const cacheEnabled of [false, true]) {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely mutates files in the isolated local fixture after setup.
+  // @force-gate !deploy
   describe(`filesystem-caching with cache ${cacheEnabled ? 'enabled' : 'disabled'}`, () => {
     beforeAll(() => {
       process.env.NEXT_PUBLIC_ENV_VAR = 'hello world'
@@ -47,9 +50,8 @@ for (const cacheEnabled of [false, true]) {
       `TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS=0`,
     ].join(' ')
 
-    const { skipped, next, isTurbopack } = nextTestSetup({
+    const { next, isTurbopack } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       packageJson: {
         packageManager: 'npm@10.9.2',
         scripts: {
@@ -64,10 +66,6 @@ for (const cacheEnabled of [false, true]) {
       buildCommand: `npm run build`,
       startCommand: isNextDev ? 'npm run dev' : 'npm run start',
     })
-
-    if (skipped) {
-      return
-    }
 
     beforeAll(() => {
       // We can skip the dev watch delay since this is not an HMR test

--- a/test/e2e/filesystem-cache/warm-restart-task-stats.test.ts
+++ b/test/e2e/filesystem-cache/warm-restart-task-stats.test.ts
@@ -25,103 +25,100 @@ type TaskStats = Record<string, TaskFunctionStatistics>
 
 const STATS_RELATIVE_PATH = '.next/warm-restart-task-stats.json'
 
-;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
-  'warm-restart task statistics',
-  () => {
-    const env = [
-      'ENABLE_CACHING=1',
-      'TURBO_ENGINE_IGNORE_DIRTY=1',
-      'TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS=1000',
-      // Persist even tiny snapshots so the test doesn't depend on the
-      // minimum-compilation-time threshold.
-      'TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS=0',
-      `NEXT_TURBOPACK_TASK_STATISTICS=${STATS_RELATIVE_PATH}`,
-      // The task-statistics file is written by an `on_exit` handler in the
-      // napi binding. In dev that handler only runs if the child process
-      // gets a chance to clean up (i.e. SIGTERM, not SIGKILL). The parent
-      // `next dev` process gives the child 100ms by default before
-      // escalating to SIGKILL — bump that so the on-exit handler can flush.
-      'NEXT_EXIT_TIMEOUT_MS=30000',
-    ].join(' ')
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('warm-restart task statistics', () => {
+  const env = [
+    'ENABLE_CACHING=1',
+    'TURBO_ENGINE_IGNORE_DIRTY=1',
+    'TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS=1000',
+    // Persist even tiny snapshots so the test doesn't depend on the
+    // minimum-compilation-time threshold.
+    'TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS=0',
+    `NEXT_TURBOPACK_TASK_STATISTICS=${STATS_RELATIVE_PATH}`,
+    // The task-statistics file is written by an `on_exit` handler in the
+    // napi binding. In dev that handler only runs if the child process
+    // gets a chance to clean up (i.e. SIGTERM, not SIGKILL). The parent
+    // `next dev` process gives the child 100ms by default before
+    // escalating to SIGKILL — bump that so the on-exit handler can flush.
+    'NEXT_EXIT_TIMEOUT_MS=30000',
+  ].join(' ')
 
-    const { skipped, next } = nextTestSetup({
-      files: __dirname,
-      skipDeployment: true,
-      packageJson: {
-        packageManager: 'npm@10.9.2',
-        scripts: {
-          build: `${env} next build`,
-          dev: `${env} next dev`,
-          start: 'next start',
-        },
+  const { next } = nextTestSetup({
+    files: __dirname,
+    packageJson: {
+      packageManager: 'npm@10.9.2',
+      scripts: {
+        build: `${env} next build`,
+        dev: `${env} next dev`,
+        start: 'next start',
       },
-      installCommand: 'npm i',
-      buildCommand: 'npm run build',
-      startCommand: isNextDev ? 'npm run dev' : 'npm run start',
-    })
+    },
+    installCommand: 'npm i',
+    buildCommand: 'npm run build',
+    startCommand: isNextDev ? 'npm run dev' : 'npm run start',
+  })
 
-    if (skipped) {
-      return
-    }
+  beforeAll(() => {
+    // No file edits in this test — skip HMR debounce.
+    ;(next as any).handleDevWatchDelayBeforeChange = () => {}
+    ;(next as any).handleDevWatchDelayAfterChange = () => {}
+  })
 
-    beforeAll(() => {
-      // No file edits in this test — skip HMR debounce.
-      ;(next as any).handleDevWatchDelayBeforeChange = () => {}
-      ;(next as any).handleDevWatchDelayAfterChange = () => {}
-    })
-
-    async function stop() {
-      if (isNextDev) {
-        // Persistent cache snapshot is on a 1s idle timer; give it room.
-        await waitFor(3000)
-        // SIGTERM (not the harness default SIGKILL) so the dev server gets
-        // to run its cleanup, which is what flushes the task-stats file.
-        await next.stop('SIGTERM')
-      } else {
-        await next.stop()
-      }
-    }
-
-    async function readMissedTaskNames(): Promise<string[]> {
-      const absPath = path.join(next.testDir, STATS_RELATIVE_PATH)
-      const raw = await fs.readFile(absPath, 'utf8')
-      const stats = JSON.parse(raw) as TaskStats
-      const misses: string[] = []
-      for (const [name, s] of Object.entries(stats)) {
-        if (s.cache_miss > 0) misses.push(name)
-      }
-      // Turbopack sorts on the Rust side, but sort again here to be robust
-      // against the JSON parser's object iteration order.
-      misses.sort()
-      return misses
-    }
-
+  async function stop() {
     if (isNextDev) {
-      it('snapshot of tasks with cache misses on warm dev restart', async () => {
-        // Cycle 1: the harness already auto-started; perform a request so the
-        // SSR/Node chunk work runs and gets persisted on shutdown.
-        async function runDevCycle() {
-          const browser = await next.browser('/')
-          // Wait for actual rendered content before declaring "ready".
-          await browser.elementByCss('p')
-          // Settle: the dev server keeps doing background work after first
-          // paint (HMR socket handshake, tail compilation). A fixed sleep
-          // is the least-bad option here since next.js doesn't expose
-          // turbopack's internal idle signal. If this proves flaky in CI,
-          // raise the value.
-          await waitFor(2000)
-          await browser.close()
-        }
-        await runDevCycle()
-        await stop()
+      // Persistent cache snapshot is on a 1s idle timer; give it room.
+      await waitFor(3000)
+      // SIGTERM (not the harness default SIGKILL) so the dev server gets
+      // to run its cleanup, which is what flushes the task-stats file.
+      await next.stop('SIGTERM')
+    } else {
+      await next.stop()
+    }
+  }
 
-        // Cycle 2: warm.
-        await next.start()
-        await runDevCycle()
-        await stop()
+  async function readMissedTaskNames(): Promise<string[]> {
+    const absPath = path.join(next.testDir, STATS_RELATIVE_PATH)
+    const raw = await fs.readFile(absPath, 'utf8')
+    const stats = JSON.parse(raw) as TaskStats
+    const misses: string[] = []
+    for (const [name, s] of Object.entries(stats)) {
+      if (s.cache_miss > 0) misses.push(name)
+    }
+    // Turbopack sorts on the Rust side, but sort again here to be robust
+    // against the JSON parser's object iteration order.
+    misses.sort()
+    return misses
+  }
 
-        const missed = await readMissedTaskNames()
-        expect(missed).toMatchInlineSnapshot(`
+  if (isNextDev) {
+    it('snapshot of tasks with cache misses on warm dev restart', async () => {
+      // Cycle 1: the harness already auto-started; perform a request so the
+      // SSR/Node chunk work runs and gets persisted on shutdown.
+      async function runDevCycle() {
+        const browser = await next.browser('/')
+        // Wait for actual rendered content before declaring "ready".
+        await browser.elementByCss('p')
+        // Settle: the dev server keeps doing background work after first
+        // paint (HMR socket handshake, tail compilation). A fixed sleep
+        // is the least-bad option here since next.js doesn't expose
+        // turbopack's internal idle signal. If this proves flaky in CI,
+        // raise the value.
+        await waitFor(2000)
+        await browser.close()
+      }
+      await runDevCycle()
+      await stop()
+
+      // Cycle 2: warm.
+      await next.start()
+      await runDevCycle()
+      await stop()
+
+      const missed = await readMissedTaskNames()
+      expect(missed).toMatchInlineSnapshot(`
          [
            "<turbopack_browser::ecmascript::list::content::EcmascriptDevChunkListContent as dyn turbopack_core::version::VersionedContent>::update",
            "next_api::project::Project::hmr_update",
@@ -131,22 +128,21 @@ const STATS_RELATIVE_PATH = '.next/warm-restart-task-stats.json'
            "turbopack_core::version::VersionState::get",
          ]
         `)
-      }, 180_000)
-    } else {
-      it('snapshot of tasks with cache misses on warm build', async () => {
-        // In start mode the harness auto-runs `next build` then `next start`.
-        // The build is cycle 1. We stop the server (we don't care about it)
-        // and run a second build manually for the warm measurement.
-        await stop()
+    }, 180_000)
+  } else {
+    it('snapshot of tasks with cache misses on warm build', async () => {
+      // In start mode the harness auto-runs `next build` then `next start`.
+      // The build is cycle 1. We stop the server (we don't care about it)
+      // and run a second build manually for the warm measurement.
+      await stop()
 
-        const result = await (next as any).build()
-        if (result.exitCode !== 0) {
-          throw new Error(`next build exited with ${result.exitCode}`)
-        }
+      const result = await (next as any).build()
+      if (result.exitCode !== 0) {
+        throw new Error(`next build exited with ${result.exitCode}`)
+      }
 
-        const missed = await readMissedTaskNames()
-        expect(missed).toMatchInlineSnapshot(`[]`)
-      }, 240_000)
-    }
+      const missed = await readMissedTaskNames()
+      expect(missed).toMatchInlineSnapshot(`[]`)
+    }, 240_000)
   }
-)
+})

--- a/test/e2e/persistent-caching-migration/persistent-caching-migration.test.ts
+++ b/test/e2e/persistent-caching-migration/persistent-caching-migration.test.ts
@@ -18,8 +18,11 @@ const CASES = [
 
 describe('persistent-caching-migration', () => {
   for (const [option, error] of CASES) {
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
+    // @force-gate !deploy
     describe(option, () => {
-      const { skipped, next, isTurbopack, isNextStart } = nextTestSetup({
+      const { next, isTurbopack, isNextStart } = nextTestSetup({
         files: {
           'next.config.js': `module.exports = {
   experimental: {
@@ -27,13 +30,8 @@ describe('persistent-caching-migration', () => {
   },
 }`,
         },
-        skipDeployment: true,
         skipStart: true,
       })
-
-      if (skipped) {
-        return
-      }
 
       if (!isTurbopack) {
         it.skip('only for turbopack', () => {})

--- a/test/e2e/prerender-fallback-encoding/prerender-fallback-encoding.test.ts
+++ b/test/e2e/prerender-fallback-encoding/prerender-fallback-encoding.test.ts
@@ -3,11 +3,12 @@ import { retry } from 'next-test-utils'
 import fs from 'fs'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('Fallback path encoding', () => {
   const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
 
   const urlPaths = [

--- a/test/e2e/ssg-dynamic-routes-404-page/ssg-dynamic-routes-404-page.test.ts
+++ b/test/e2e/ssg-dynamic-routes-404-page/ssg-dynamic-routes-404-page.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('ssg-dynamic-routes-404-page', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -7,8 +10,6 @@ describe('ssg-dynamic-routes-404-page', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
 
   it('should respond to a not existing page with 404', async () => {


### PR DESCRIPTION
## Summary

- migrate Cache Components, PPR, prefetching, prerendering, revalidation, and SSG deployment exclusions to `@force-gate`
- remove the corresponding `skipDeployment` options and `skipped` control flow while preserving each suite's rationale

This keeps caching-related exclusions together so their deployed semantics can be reviewed by the same owners.

## Verification

- verified on the combined top-of-stack tree with `pnpm typescript`
- compared ordinary-mode collection before and after: all 4,670 existing test names matched
- collected all 510 affected files in deploy mode: 4,578 skipped tests, zero failures

<!-- NEXT_JS_LLM -->
