### PR TITLE
test: migrate App Router deploy exclusions to force gates

### DIFF
--- a/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
@@ -2,20 +2,18 @@ import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir action allowed origins', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: join(__dirname, 'safe-origins'),
-    skipDeployment: true,
     dependencies: {
       'server-only': 'latest',
     },
     // An arbitrary & random port.
     forcedPort: 'random',
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should pass if localhost is set as a safe origin', async function () {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-disallowed-origins.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-disallowed-origins.test.ts
@@ -2,18 +2,16 @@ import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir action disallowed origins', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: join(__dirname, 'unsafe-origins'),
-    skipDeployment: true,
     dependencies: {
       'server-only': 'latest',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   // Origin should be localhost
   it('should error if x-forwarded-host does not match the origin', async function () {

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-opaque-origin.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-opaque-origin.test.ts
@@ -2,18 +2,16 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir action allowed from opaque origins', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: join(__dirname, 'opaque-origin'),
-    skipDeployment: true,
     env: {
       NEXT_TEST_ALLOW_OPAQUE_ORIGIN: '1',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should succeed on submission', async function () {
     const browser = await next.browser('/sandboxed')
@@ -28,18 +26,16 @@ describe('app-dir action allowed from opaque origins', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir action disallowed from opaque origins', () => {
-  const { isNextDev, next, skipped } = nextTestSetup({
+  const { isNextDev, next } = nextTestSetup({
     files: join(__dirname, 'opaque-origin'),
-    skipDeployment: true,
     env: {
       NEXT_TEST_ALLOW_OPAQUE_ORIGIN: '',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should fail on submission', async function () {
     const browser = await next.browser('/sandboxed')

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -18,8 +18,8 @@ describe('unrecognized server actions', () => {
     return next.cliOutput.slice(cliOutputPosition)
   }
 
-  // This is disabled when deployed because the 404 page will be served as a static route
-  // which will not support POST requests, and will return a 405 instead.
+  // Deploy mode exclusion: Deployed 404 pages are static routes, so POST
+  // requests return 405 instead of this suite's local 404 behavior.
   if (!isNextDeploy) {
     it('should 404 when POSTing a non-server-action request to a nonexistent page', async () => {
       const res = await next.fetch('/non-existent-route', {

--- a/test/e2e/app-dir/actions-unused-args/actions-unused-args.test.ts
+++ b/test/e2e/app-dir/actions-unused-args/actions-unused-args.test.ts
@@ -1,16 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from '../../../lib/next-test-utils'
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// No access to runtime logs when deployed.
+// @force-gate !deploy
 describe('actions-unused-args', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // No access to runtime logs when deployed.
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not call server actions with unused arguments', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
+++ b/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
@@ -9,7 +9,7 @@ const CONFIG_ERROR =
   'Server Actions Size Limit must be a valid number or filesize format larger than 1MB'
 
 describe('app-dir action size limit invalid config', () => {
-  const { next, isNextStart, isNextDeploy, skipped } = nextTestSetup({
+  const { next, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
     overrideFiles: process.env.TEST_NODE_MIDDLEWARE
       ? {
@@ -22,7 +22,6 @@ describe('app-dir action size limit invalid config', () => {
       'server-only': 'latest',
     },
   })
-  if (skipped) return
 
   const logs: string[] = []
 

--- a/test/e2e/app-dir/app-a11y/index.test.ts
+++ b/test/e2e/app-dir/app-a11y/index.test.ts
@@ -1,16 +1,14 @@
 import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app a11y features', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     packageJson: {},
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   describe('route announcer', () => {
     async function getAnnouncerContent(browser: Playwright) {

--- a/test/e2e/app-dir/app-esm-js/standalone.test.ts
+++ b/test/e2e/app-dir/app-esm-js/standalone.test.ts
@@ -13,7 +13,7 @@ if (!(globalThis as any).isNextStart) {
   it('should skip for non-next start', () => {})
 } else {
   describe('output: standalone with ESM app dir', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: {
         app: new FileRef(path.join(__dirname, 'app')),
         pages: new FileRef(path.join(__dirname, 'pages')),
@@ -25,10 +25,6 @@ if (!(globalThis as any).isNextStart) {
       },
       skipStart: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     beforeAll(async () => {
       await next.start()

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -15,8 +15,11 @@ async function resolveStreamResponse(response: any, onData?: any) {
   return result
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app dir - external dependency', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
       swr: '2.2.5',
@@ -32,12 +35,7 @@ describe('app dir - external dependency', () => {
     installCommand: 'pnpm i',
     startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
     buildCommand: 'pnpm build',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should be able to opt-out 3rd party packages being bundled in server components', async () => {
     await next.fetch('/react-server/optout').then(async (response) => {

--- a/test/e2e/app-dir/app-rendering/rendering.test.ts
+++ b/test/e2e/app-dir/app-rendering/rendering.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir rendering', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should serve app/page.server.js at /', async () => {
     const html = await next.render('/')

--- a/test/e2e/app-dir/app-root-params-getters/generate-static-params-error.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/generate-static-params-error.test.ts
@@ -1,13 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-root-param-getters - generateStaticParams error', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'generate-static-params-error'),
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     try {

--- a/test/e2e/app-dir/app-root-params-getters/typecheck.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/typecheck.test.ts
@@ -8,17 +8,14 @@ import { retry } from 'next-test-utils'
 // Running `tsc --noEmit` verifies the generated root-params.d.ts is wired in
 // and produces the expected types.
 
+// This suite stops the local server and invokes `pnpm tsc` in its fixture.
+// @force-gate !deploy
 describe.each([{ fixture: 'simple' }, { fixture: 'multiple-roots' }])(
   'app-root-param-getters - typecheck ($fixture)',
   ({ fixture }) => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: join(__dirname, 'fixtures', fixture),
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('should pass typecheck with generated root-params types', async () => {
       await retry(async () => {

--- a/test/e2e/app-dir/app-routes/app-custom-route-base-path.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-route-base-path.test.ts
@@ -1,2 +1,4 @@
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 process.env.BASE_PATH = '/docs'
 require('./app-custom-routes.test')

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -689,7 +689,8 @@ describe('app-custom-routes', () => {
     })
   }
 
-  // This test is skipped in deploy mode because `next.cliOutput` will only contain build-time logs.
+  // Deploy mode exclusion: This nested suite asserts local CLI output that
+  // deployments do not expose.
   if (!isNextDeploy) {
     describe('no response returned', () => {
       it('should print an error when no response is returned', async () => {

--- a/test/e2e/app-dir/app-static/app-static-custom-handler.test.ts
+++ b/test/e2e/app-dir/app-static/app-static-custom-handler.test.ts
@@ -1,2 +1,4 @@
+// Deploy mode exclusion: This suite installs a process-local custom cache
+// handler, while a hosting platform supplies its own cache infrastructure.
 process.env.CUSTOM_CACHE_HANDLER = '1'
 require('./app-static.test')

--- a/test/e2e/app-dir/app-validation/validation.test.ts
+++ b/test/e2e/app-dir/app-validation/validation.test.ts
@@ -4,15 +4,13 @@ import {
   computeLegacyCacheBustingSearchParam,
 } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - validation', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should error when passing invalid router state tree', async () => {
     const stateTree1 = JSON.stringify(['', ''])

--- a/test/e2e/app-dir/app/standalone-gsp.test.ts
+++ b/test/e2e/app-dir/app/standalone-gsp.test.ts
@@ -13,7 +13,7 @@ if (!(globalThis as any).isNextStart) {
   it('should skip for non-next start', () => {})
 } else {
   describe('output: standalone with getStaticProps', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
       dependencies: {
@@ -21,10 +21,6 @@ if (!(globalThis as any).isNextStart) {
         nanoid: '4.0.1',
       },
     })
-
-    if (skipped) {
-      return
-    }
 
     beforeAll(async () => {
       await next.patchFile(

--- a/test/e2e/app-dir/app/standalone.test.ts
+++ b/test/e2e/app-dir/app/standalone.test.ts
@@ -13,17 +13,13 @@ if (!(globalThis as any).isNextStart) {
   it('should skip for non-next start', () => {})
 } else {
   describe('output: standalone with app dir', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
       dependencies: {
         nanoid: '4.0.1',
       },
     })
-
-    if (skipped) {
-      return
-    }
 
     beforeAll(async () => {
       await next.patchFile(

--- a/test/e2e/app-dir/async-component-preload/async-component-preload.test.ts
+++ b/test/e2e/app-dir/async-component-preload/async-component-preload.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('async-component-preload', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should handle redirect in an async page', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/back-button-download-bug/back-button-download-bug.test.ts
+++ b/test/e2e/app-dir/back-button-download-bug/back-button-download-bug.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 
 // TODO-APP: fix test as it's failing randomly
 describe.skip('app-dir back button download bug', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('app-dir back button download bug', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('should redirect route when clicking link', async () => {
       const browser = await next.browser('/')

--- a/test/e2e/app-dir/client-reference-chunking/client-reference-chunking.test.ts
+++ b/test/e2e/app-dir/client-reference-chunking/client-reference-chunking.test.ts
@@ -1,10 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 import { getClientReferenceManifest } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('client-reference-chunking', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('should use the same chunks for client references across routes', async () => {

--- a/test/e2e/app-dir/client-reference-side-effects/client-reference-side-effects.test.ts
+++ b/test/e2e/app-dir/client-reference-side-effects/client-reference-side-effects.test.ts
@@ -1,9 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('client-reference-side-effects', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('side effect behavior when only importing', async () => {

--- a/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
+++ b/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
@@ -1,18 +1,16 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('conflicting-page-segments', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     // we skip start & deploy because the build will fail and we won't be able to catch it
     // start is re-triggered but caught in the assertions below.
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw an error when a route groups causes a conflict with a parallel segment', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
@@ -9,6 +9,7 @@ import stripAnsi from 'strip-ansi'
   () => {
     const isDev = (global as any).isNextDev
 
+    // Deploy mode exclusion: This suite creates and patches project files, which cannot be changed after deployment.
     if ((global as any).isNextDeploy) {
       it('should skip next deploy for now', () => {})
       return
@@ -224,40 +225,38 @@ import stripAnsi from 'strip-ansi'
     }
   }
 )
-;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
-  'app-dir missing root layout',
-  () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
-      files: {
-        app: new FileRef(path.join(__dirname, 'app')),
-        'next.config.js': new FileRef(path.join(__dirname, 'next.config.js')),
-      },
-      skipDeployment: true,
-      skipStart: true,
-    })
+// Deploy mode exclusion: This suite intentionally fails a local build
+// and inspects its output and fixture files.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('app-dir missing root layout', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: {
+      app: new FileRef(path.join(__dirname, 'app')),
+      'next.config.js': new FileRef(path.join(__dirname, 'next.config.js')),
+    },
+    skipStart: true,
+  })
 
-    if (skipped) return
+  it('reports a compiler error without modifying the app', async () => {
+    if (isNextDev) {
+      await next.start()
 
-    it('reports a compiler error without modifying the app', async () => {
-      if (isNextDev) {
-        await next.start()
+      const response = await next.fetch('/route')
+      expect(response.status).toBe(500)
 
-        const response = await next.fetch('/route')
-        expect(response.status).toBe(500)
-
-        await retry(async () => {
-          expect(stripAnsi(next.cliOutput)).toContain(
-            "route/page.js doesn't have a root layout. To fix this error, make sure every page has a root layout."
-          )
-        })
-      } else {
-        await expect(next.start()).rejects.toThrow('next build failed')
+      await retry(async () => {
         expect(stripAnsi(next.cliOutput)).toContain(
           "route/page.js doesn't have a root layout. To fix this error, make sure every page has a root layout."
         )
-      }
+      })
+    } else {
+      await expect(next.start()).rejects.toThrow('next build failed')
+      expect(stripAnsi(next.cliOutput)).toContain(
+        "route/page.js doesn't have a root layout. To fix this error, make sure every page has a root layout."
+      )
+    }
 
-      expect(await next.hasFile('app/layout.js')).toBe(false)
-    })
-  }
-)
+    expect(await next.hasFile('app/layout.js')).toBe(false)
+  })
+})

--- a/test/e2e/app-dir/dedupe-rsc-error-log/dedupe-rsc-error-log.test.ts
+++ b/test/e2e/app-dir/dedupe-rsc-error-log/dedupe-rsc-error-log.test.ts
@@ -9,11 +9,12 @@ async function expectContainOnce(next: any, search: string) {
   })
 }
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// Runtime logs aren't available when deployed
+// @force-gate !deploy
 describe('dedupe-rsc-error-log', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // Runtime logs aren't available when deployed
-    skipDeployment: true,
   })
 
   it('should only log RSC error once for nodejs runtime', async () => {

--- a/test/e2e/app-dir/duplicate-layout-components/duplicate-layout-components.test.ts
+++ b/test/e2e/app-dir/duplicate-layout-components/duplicate-layout-components.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - duplicate layout components', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not duplicate layout elements when navigating to 404', async () => {
     const browser = await next.browser('/solutions/404')

--- a/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
+++ b/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 
 process.env.__TEST_SENTINEL = 'at buildtime'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('dynamic-data', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/main',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render the dynamic apis dynamically when used in a top-level scope', async () => {
     const $ = await next.render$(
@@ -154,15 +152,13 @@ describe('dynamic-data', () => {
 })
 
 describe('dynamic-data with dynamic = "error"', () => {
-  const { next, isNextDev, isNextDeploy, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname + '/fixtures/require-static',
     skipStart: true,
   })
 
-  if (skipped) {
-    return
-  }
-
+  // Deploy mode exclusion: This suite intentionally tests dev-server errors
+  // or a failed local build, so it cannot produce a deployment.
   if (isNextDeploy) {
     it.skip('should not run in next deploy.', () => {})
     return
@@ -281,17 +277,13 @@ describe('dynamic-data with dynamic = "error"', () => {
 })
 
 describe('dynamic-data inside cache scope', () => {
-  const { isTurbopack, next, isNextDev, isNextDeploy, skipped } = nextTestSetup(
-    {
-      files: __dirname + '/fixtures/cache-scoped',
-      skipStart: true,
-    }
-  )
+  const { isTurbopack, next, isNextDev, isNextDeploy } = nextTestSetup({
+    files: __dirname + '/fixtures/cache-scoped',
+    skipStart: true,
+  })
 
-  if (skipped) {
-    return
-  }
-
+  // Deploy mode exclusion: This suite intentionally tests dev-server errors
+  // or a failed local build, so it cannot produce a deployment.
   if (isNextDeploy) {
     it.skip('should not run in next deploy..', () => {})
     return

--- a/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
+++ b/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
@@ -1,18 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('dynamic-href', () => {
-  const {
-    isNextDev: isDev,
-    next,
-    skipped,
-  } = nextTestSetup({
+  const { isNextDev: isDev, next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isDev) {
     it('should error when using dynamic href.pathname in app dir', async () => {

--- a/test/e2e/app-dir/dynamic-import-tree-shaking/dynamic-import-tree-shaking.test.ts
+++ b/test/e2e/app-dir/dynamic-import-tree-shaking/dynamic-import-tree-shaking.test.ts
@@ -2,12 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import fs from 'fs'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('dynamic-import-tree-shaking', () => {
-  const { next, skipped, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   // Recursively read all .js files in a directory
   function getAllServerFiles(dir: string): string[] {

--- a/test/e2e/app-dir/dynamic-in-generate-params/index.test.ts
+++ b/test/e2e/app-dir/dynamic-in-generate-params/index.test.ts
@@ -11,10 +11,12 @@ function assertSitemapResponse(res: Response) {
   expect(res.headers.get('content-type')).toContain('application/xml')
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir - dynamic in generate params', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('should render sitemap with generateSitemaps in force-dynamic config dynamically', async () => {

--- a/test/e2e/app-dir/dynamic/dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic/dynamic.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('app dir - next/dynamic', () => {
-  const { next, isNextStart, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextStart, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should handle ssr: false in pages when appDir is enabled', async () => {
     const $ = await next.render$('/legacy/no-ssr')

--- a/test/e2e/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
+++ b/test/e2e/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('empty-generate-static-params', () => {
-  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   function errorBlock(cliOutput: string) {
     return cliOutput.slice(

--- a/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
+++ b/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
@@ -6,13 +6,14 @@ import {
   retry,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('app-dir - error-on-next-codemod-comment', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   if (isNextDev) {
     beforeAll(async () => {

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - errors', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   describe('error component', () => {
     it('should trigger error component when an error happens during rendering', async () => {

--- a/test/e2e/app-dir/explicit-parallel-route-children-viewport-known-limitation/explicit-parallel-route-children-viewport-known-limitation.test.ts
+++ b/test/e2e/app-dir/explicit-parallel-route-children-viewport-known-limitation/explicit-parallel-route-children-viewport-known-limitation.test.ts
@@ -3,21 +3,19 @@ import { createRouterAct } from 'router-act'
 
 const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
+// Deploy mode exclusion: A deployed fixture cannot be patched before
+// startup. The ordinary deploy run remains covered; Cache Components
+// behavior is exercised in the local dev and production test runs.
+// @force-gate !deploy || !cacheComponents
 describe('explicit parallel route children viewport limitation', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     // Cache Components requires this route to declare `instant = false`, but
     // that declaration is invalid when Cache Components is disabled. Delay
     // startup only in that mode so we can add the declaration to the isolated
     // fixture first.
     skipStart: isCacheComponentsEnabled,
-    // A deployed fixture cannot be patched before startup. The ordinary deploy
-    // run remains covered; Cache Components behavior is exercised in the local
-    // dev and production test runs.
-    skipDeployment: isCacheComponentsEnabled,
   })
-
-  if (skipped) return
 
   beforeAll(async () => {
     if (!isCacheComponentsEnabled) return

--- a/test/e2e/app-dir/forbidden/default/forbidden-default.test.ts
+++ b/test/e2e/app-dir/forbidden/default/forbidden-default.test.ts
@@ -5,15 +5,13 @@ import {
   getRedboxDescription,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - forbidden with default forbidden boundary', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // TODO: error forbidden usage in root layout
   it.skip('should error on client forbidden from root layout in browser', async () => {

--- a/test/e2e/app-dir/global-error/catch-all/index.test.ts
+++ b/test/e2e/app-dir/global-error/catch-all/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - global error - with catch-all route', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render catch-all route correctly', async () => {
     expect(await next.render('/en/foo')).toContain('catch-all page')

--- a/test/e2e/app-dir/global-error/layout-error/index.test.ts
+++ b/test/e2e/app-dir/global-error/layout-error/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - global error - layout error', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render global error for error in server components', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/i18n-hybrid/i18n-hybrid.test.ts
+++ b/test/e2e/app-dir/i18n-hybrid/i18n-hybrid.test.ts
@@ -48,6 +48,8 @@ const urls = [
   })),
 ]
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('i18n-hybrid', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -1323,6 +1323,9 @@ describe('instant-navigation-testing-api - partial prefetching (App Shells)', ()
 // lock) is a dev-time concern, so this suite uses a dedicated fixture and runs
 // in dev only; `next start`/deploy register a single placeholder so the build
 // is never attempted.
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('instant-navigation-testing-api - blocking routes (dev only)', () => {
   if (!isNextDev) {
     it('skips blocking route tests outside dev (route cannot be production-built)', () => {})
@@ -1331,7 +1334,6 @@ describe('instant-navigation-testing-api - blocking routes (dev only)', () => {
 
   const { next } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'blocking'),
-    skipDeployment: true,
   })
 
   // The cookie value must not commit while the instant lock is held; it only

--- a/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
+++ b/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
@@ -2,15 +2,16 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import type { ValidationEvent } from 'next/dist/server/app-render/dev-validation-events'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('instant validation causes', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
   if (!isNextDev) {
     it.skip('Only implemented in dev', () => {})
     return

--- a/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
+++ b/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
@@ -1,16 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app dir - instant-validation-client', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should error when a client component exports instant', async () => {
     const expectedErrMsg = `"instant" is a route segment config and can only be used when the segment is a Server Component module. Remove the "use client" directive`

--- a/test/e2e/app-dir/instant-validation-level-default/instant-validation-level-default.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-default/instant-validation-level-default.test.ts
@@ -11,16 +11,17 @@ import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 // For exhaustive coverage of explicit levels and per-segment overrides,
 // see the sibling `instant-validation-level-{warning,manual-warning,error,
 // manual-error}` fixtures.
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('instant validation - default level', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     it.skip('TODO: snapshot tests for webpack', () => {})

--- a/test/e2e/app-dir/instant-validation-level-error/instant-validation-level-error.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-error/instant-validation-level-error.test.ts
@@ -5,16 +5,17 @@ import {
 } from 'e2e-utils/instant-validation'
 import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant validation - level error', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     it.skip('TODO: snapshot tests for webpack', () => {})

--- a/test/e2e/app-dir/instant-validation-level-manual-error/instant-validation-level-manual-error.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/instant-validation-level-manual-error.test.ts
@@ -5,16 +5,17 @@ import {
 } from 'e2e-utils/instant-validation'
 import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant validation - level manual-error', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     it.skip('TODO: snapshot tests for webpack', () => {})

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/instant-validation-level-manual-warning.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/instant-validation-level-manual-warning.test.ts
@@ -7,16 +7,17 @@ import {
 import { getPrerenderOutput } from '../cache-components-errors/utils'
 import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant validation - level manual-warning', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     it.skip('TODO: snapshot tests for webpack', () => {})

--- a/test/e2e/app-dir/instant-validation-level-warning/instant-validation-level-warning.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-warning/instant-validation-level-warning.test.ts
@@ -5,16 +5,17 @@ import {
 } from 'e2e-utils/instant-validation'
 import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant validation - level warning', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     it.skip('TODO: snapshot tests for webpack', () => {})

--- a/test/e2e/app-dir/instant-validation/harness.util.ts
+++ b/test/e2e/app-dir/instant-validation/harness.util.ts
@@ -43,17 +43,16 @@ export const NO_VALIDATION_ERRORS_WAIT: Parameters<
 export function runInstantValidationTests(
   registerTests: (ctx: InstantValidationCaseContext) => void
 ) {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('instant validation', () => {
-    const { next, skipped, isNextDev, isNextStart, isTurbopack } =
-      nextTestSetup({
-        files: __dirname,
-        skipStart: true, // for `prerender`
-        skipDeployment: true,
-        env: {
-          NEXT_TEST_LOG_VALIDATION: '1',
-        },
-      })
-    if (skipped) return
+    const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+      files: __dirname,
+      skipStart: true,
+      env: {
+        NEXT_TEST_LOG_VALIDATION: '1',
+      },
+    })
 
     if (isNextStart && !isTurbopack) {
       // TODO(instant-validation-build): snapshot tests for webpack

--- a/test/e2e/app-dir/instant-validation/parallel-slots.test.ts
+++ b/test/e2e/app-dir/instant-validation/parallel-slots.test.ts
@@ -7,16 +7,17 @@ import {
 } from 'e2e-utils/instant-validation'
 import { retry, waitForNoErrorToast } from '../../../lib/next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant validation - parallel slot configs', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     // TODO(instant-validation-build): snapshot tests for webpack

--- a/test/e2e/app-dir/instant-validation/server-errors.test.ts
+++ b/test/e2e/app-dir/instant-validation/server-errors.test.ts
@@ -6,16 +6,17 @@ import {
 import { retry, waitForRedbox } from '../../../lib/next-test-utils'
 import { createRedboxSnapshot } from '../../../lib/add-redbox-matchers'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant validation - server errors', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     it.skip('TODO: snapshot tests for webpack', () => {})

--- a/test/e2e/app-dir/io/io.test.ts
+++ b/test/e2e/app-dir/io/io.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('io with cache components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/cache-components',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should make content after io() dynamic during prerender', async () => {
     const $ = await next.render$('/io-boundary')
@@ -57,15 +55,13 @@ describe('io with cache components', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('io without cache components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/default',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should be a no-op during prerender without cache components', async () => {
     const $ = await next.render$('/io-boundary')

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
 for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
+  // TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+  // It was excluded as a known deploy failure without a documented root cause.
   describe(`mdx ${type}`, () => {
     const { next } = nextTestSetup({
       files: __dirname,

--- a/test/e2e/app-dir/metadata-json-manifest/index.test.ts
+++ b/test/e2e/app-dir/metadata-json-manifest/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir metadata-json-manifest', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should support metadata.json manifest', async () => {
     const response = await next.fetch('/manifest.json')

--- a/test/e2e/app-dir/metadata-static-file-gsp/metadata-static-file-gsp.test.ts
+++ b/test/e2e/app-dir/metadata-static-file-gsp/metadata-static-file-gsp.test.ts
@@ -1,13 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('metadata-static-file-gsp', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should build and serve a static metadata file colocated with generateStaticParams', async () => {
     await next.render('/results/two')

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-dynamic-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-dynamic-route.test.ts
@@ -6,13 +6,9 @@ import {
 } from './utils'
 
 describe('metadata-files-static-output-dynamic-route', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have correct link tags for dynamic page with static placeholder', async () => {
     const browser = await next.browser('/dynamic/123')

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-group-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-group-route.test.ts
@@ -6,13 +6,9 @@ import {
 } from './utils'
 
 describe('metadata-files-static-output-group-route', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have correct link tags for group page', async () => {
     const browser = await next.browser('/group')

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-intercepting-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-intercepting-route.test.ts
@@ -28,13 +28,9 @@ describe('metadata-files-static-output-intercepting-route', () => {
     return
   }
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have correct link tags for intercepting page', async () => {
     const browser = await next.browser('/intercepting')

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-parallel-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-parallel-route.test.ts
@@ -28,13 +28,9 @@ describe('metadata-files-static-output-parallel-route', () => {
     return
   }
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have correct link tags for parallel slot page', async () => {
     const browser = await next.browser('/parallel')

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-root-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-root-route.test.ts
@@ -28,13 +28,9 @@ describe('metadata-files-static-output-root-route', () => {
     return
   }
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have correct link tags for root page', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-static-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-static-route.test.ts
@@ -28,13 +28,9 @@ describe('metadata-files-static-output-static-route', () => {
     return
   }
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have correct link tags for static page', async () => {
     const browser = await next.browser('/static')

--- a/test/e2e/app-dir/metadata-suspense/index.test.ts
+++ b/test/e2e/app-dir/metadata-suspense/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - metadata dynamic routes suspense', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render metadata in head when root layout is wrapped with Suspense for bot requests', async () => {
     const $ = await next.render$('/', undefined, {

--- a/test/e2e/app-dir/metadata-warnings/metadata-warnings-missing-metadatabase.test.ts
+++ b/test/e2e/app-dir/metadata-warnings/metadata-warnings-missing-metadatabase.test.ts
@@ -3,15 +3,13 @@ import { nextTestSetup } from 'e2e-utils'
 const METADATA_BASE_WARN_STRING =
   'metadataBase property in metadata export is not set for resolving social open graph or twitter images,'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app dir - metadata missing metadataBase', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // If it's start mode, we get the whole logs since they're from build process.
   // If it's development mode, we get the logs after request

--- a/test/e2e/app-dir/metadata-warnings/metadata-warnings-with-metadatabase.test.ts
+++ b/test/e2e/app-dir/metadata-warnings/metadata-warnings-with-metadatabase.test.ts
@@ -3,10 +3,12 @@ import { nextTestSetup } from 'e2e-utils'
 const METADATA_BASE_WARN_STRING =
   'metadataBase property in metadata export is not set for resolving social open graph or twitter images,'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app dir - metadata missing metadataBase', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     overrideFiles: {
       'app/layout.js': `
         export default function Layout({ children }) {
@@ -23,10 +25,6 @@ describe('app dir - metadata missing metadataBase', () => {
       `,
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   // If it's start mode, we get the whole logs since they're from build process.
   // If it's development mode, we get the logs after request

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -16,6 +16,8 @@ import path from 'path'
 // Turbopack: /favicon.ico?favicon.<hash>.ico
 const FAVICON_REGEX = /\/favicon.ico\?\w+/
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('app dir - metadata', () => {
   const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/missing-suspense-with-csr-bailout/missing-suspense-with-csr-bailout.test.ts
+++ b/test/e2e/app-dir/missing-suspense-with-csr-bailout/missing-suspense-with-csr-bailout.test.ts
@@ -1,16 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// Deploy mode exclusion: This suite mutates fixture files, which cannot be changed after deployment.
+// This test is skipped when deployed because it's not possible to rename files after deployment.
+// @force-gate !deploy
 describe('missing-suspense-with-csr-bailout', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    // This test is skipped when deployed because it's not possible to rename files after deployment.
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     it.skip('skip test for development mode', () => {})

--- a/test/e2e/app-dir/modularizeimports/modularizeimports.test.ts
+++ b/test/e2e/app-dir/modularizeimports/modularizeimports.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('modularizeImports', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/next-condition/next-condition.test.ts
+++ b/test/e2e/app-dir/next-condition/next-condition.test.ts
@@ -1,7 +1,10 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Deploy tests are broken with `config.serverExternalPackages`
+// @force-gate !deploy
 describe('`next-js` Condition - Rendering', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname + '/fixtures/render',
     // copy shared packages over to the test folder. This will override the symlink that currently
     // exists in the fixture with relative paths
@@ -9,13 +12,7 @@ describe('`next-js` Condition - Rendering', () => {
       'sym-linked-packages': new FileRef(__dirname + '/packages'),
     },
     dependencies: require('./fixtures/render/package.json').dependencies,
-    // Deploy tests are broken with `config.serverExternalPackages`
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // TODO I should be able to access the complete config from a Next.js Server or Build
   // So I don't have to coordinate using process env variables
@@ -623,8 +620,11 @@ describe('`next-js` Condition - Rendering', () => {
   }
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Deploy tests are broken with `config.serverExternalPackages`
+// @force-gate !deploy
 describe('`next-js` Condition - middleware (legacy)', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname + '/fixtures/middleware',
     // copy shared packages over to the test folder. This will override the symlink that currently
     // exists in the fixture with relative paths
@@ -632,13 +632,7 @@ describe('`next-js` Condition - middleware (legacy)', () => {
       'sym-linked-packages': new FileRef(__dirname + '/packages'),
     },
     dependencies: require('./fixtures/middleware/package.json').dependencies,
-    // Deploy tests are broken with `config.serverExternalPackages`
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
   describe('With or Without Cache Components', () => {
@@ -668,8 +662,11 @@ describe('`next-js` Condition - middleware (legacy)', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Deploy tests are broken with `config.serverExternalPackages`
+// @force-gate !deploy
 describe('`next-js` Condition - proxy', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname + '/fixtures/proxy',
     // copy shared packages over to the test folder. This will override the symlink that currently
     // exists in the fixture with relative paths
@@ -677,13 +674,7 @@ describe('`next-js` Condition - proxy', () => {
       'sym-linked-packages': new FileRef(__dirname + '/packages'),
     },
     dependencies: require('./fixtures/proxy/package.json').dependencies,
-    // Deploy tests are broken with `config.serverExternalPackages`
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
   describe('With or Without Cache Components', () => {
@@ -713,8 +704,11 @@ describe('`next-js` Condition - proxy', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Deploy tests are broken with `config.serverExternalPackages`
+// @force-gate !deploy
 describe('`next-js` Condition - instrumentation', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname + '/fixtures/instrumentation',
     // copy shared packages over to the test folder. This will override the symlink that currently
     // exists in the fixture with relative paths
@@ -723,13 +717,7 @@ describe('`next-js` Condition - instrumentation', () => {
     },
     dependencies: require('./fixtures/instrumentation/package.json')
       .dependencies,
-    // Deploy tests are broken with `config.serverExternalPackages`
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
   describe('With or Without Cache Components', () => {

--- a/test/e2e/app-dir/not-found-default/index.test.ts
+++ b/test/e2e/app-dir/not-found-default/index.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - not found with default 404 page', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should error on client notFound from root layout in browser', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/not-found-with-layout-and-group-not-found/index.test.ts
+++ b/test/e2e/app-dir/not-found-with-layout-and-group-not-found/index.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - not found with nested layouts and custom not-found', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render the custom not-found page when notFound() is thrown from a page within the group', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/not-found-with-nested-layouts/index.test.ts
+++ b/test/e2e/app-dir/not-found-with-nested-layouts/index.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - not found with nested layouts', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render the custom not-found page when notFound() is thrown from a page', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/not-found/basic/index.test.ts
+++ b/test/e2e/app-dir/not-found/basic/index.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app dir - not-found - basic', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it("should propagate notFound errors past a segment's error boundary", async () => {
     let browser = await next.browser('/error-boundary')

--- a/test/e2e/app-dir/not-found/conflict-route/index.test.ts
+++ b/test/e2e/app-dir/not-found/conflict-route/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('app dir - not-found - conflict route', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   const runTests = () => {
     it('should use the not-found page for non-matching routes', async () => {

--- a/test/e2e/app-dir/not-found/default/default.test.ts
+++ b/test/e2e/app-dir/not-found/default/default.test.ts
@@ -2,10 +2,12 @@ import { nextTestSetup } from 'e2e-utils'
 
 const isPPREnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('app dir - not-found - default', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('should has noindex in the head html', async () => {

--- a/test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts
+++ b/test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - group routes with root not-found', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render default 404 with root layout for non-existent page', async () => {
     const browser = await next.browser('/non-existent')

--- a/test/e2e/app-dir/not-found/group-route/index.test.ts
+++ b/test/e2e/app-dir/not-found/group-route/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('app dir - not-found - group route', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   const runTests = () => {
     it('should use the not-found page under group routes', async () => {

--- a/test/e2e/app-dir/pages-router-app-not-found/pages-router-app-not-found.test.ts
+++ b/test/e2e/app-dir/pages-router-app-not-found/pages-router-app-not-found.test.ts
@@ -1,13 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
-const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
-
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The legacy builder incorrectly replaces this response with the Pages
+// Router error page. The adapter preserves the App Router not-found page.
+// @force-gate !deploy || adapter
 describe('pages-router-app-not-found', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // The legacy builder incorrectly replaces this response with the Pages
-    // Router error page. The adapter preserves the App Router not-found page.
-    skipDeployment: !isAdapterTest,
   })
 
   it('fully renders an app not-found selected by a pages route', async () => {

--- a/test/e2e/app-dir/parallel-routes-and-interception-nested-dynamic-routes/parallel-routes-and-interception-nested-dynamic-routes.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception-nested-dynamic-routes/parallel-routes-and-interception-nested-dynamic-routes.test.ts
@@ -1,11 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// TODO: re-enable when resolved related thread
+// https://vercel.slack.com/archives/C07UCHRBWGK/p1759165345308879
+// @force-gate !deploy
 describe('parallel-routes-and-interception-nested-dynamic-routes', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // TODO: re-enable when resolved related thread
-    // https://vercel.slack.com/archives/C07UCHRBWGK/p1759165345308879
-    skipDeployment: true,
   })
 
   it('should intercept the route for nested dynamic routes', async () => {

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -1056,11 +1056,12 @@ describe.each([true, false])(
   }
 )
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This is skipped when deployed as it appears to cause an issue when tracing Next.js files
+// TODO: Investigate why this causes an issue when deployed
+// @force-gate !deploy
 describe('parallel-routes-and-interception-conflicting-pages', () => {
-  const { next, skipped } = nextTestSetup({
-    // This is skipped when deployed as it appears to cause an issue when tracing Next.js files
-    // TODO: Investigate why this causes an issue when deployed
-    skipDeployment: true,
+  const { next } = nextTestSetup({
     files: {
       app: new FileRef(path.join(__dirname, 'app')),
       'app/parallel/nested-2/page.js': `
@@ -1071,8 +1072,6 @@ describe('parallel-routes-and-interception-conflicting-pages', () => {
     },
     nextConfig,
   })
-
-  if (skipped) return
 
   it('should gracefully handle when two page segments match the `children` parallel slot', async () => {
     const html = await next.render('/parallel/nested-2')

--- a/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
@@ -1,16 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// TODO: remove after deployment handling is updated
+// @force-gate !deploy
 describe('parallel-routes-and-interception', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // TODO: remove after deployment handling is updated
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // TODO: revisit the error for missing parallel routes slot
   it('should not render the @children slot when the @slot is not found', async () => {

--- a/test/e2e/app-dir/proxy-runtime/proxy-runtime.test.ts
+++ b/test/e2e/app-dir/proxy-runtime/proxy-runtime.test.ts
@@ -1,16 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('proxy-runtime', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should error when proxy file has runtime config export', async () => {
     let cliOutput: string

--- a/test/e2e/app-dir/refresh/refresh.test.ts
+++ b/test/e2e/app-dir/refresh/refresh.test.ts
@@ -1,14 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry, waitForRedbox, getRedboxDescription } from 'next-test-utils'
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// We do not have access to runtime logs when deployed
+// @force-gate !deploy
 describe('app-dir refresh', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    // We do not have access to runtime logs when deployed
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should refresh client cache when refresh() is called in a server action', async () => {
     const browser = await next.browser('/refresh')

--- a/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
+++ b/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
@@ -460,13 +460,13 @@ const cases: {
   },
 ]
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// TODO: re-enable once changes in infrastructure are merged
+// @force-gate !deploy
 describe('rewrite-headers', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // TODO: re-enable once changes in infrastructure are merged
-    skipDeployment: true,
   })
-  if (skipped) return
 
   describe.each(cases)(
     '$name ($pathname)',

--- a/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
+++ b/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
@@ -9,6 +9,8 @@ describe('redirects and rewrites', () => {
   })
 
   // TODO: investigate test failures on deploy
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // The source only records that these assertions fail after deployment; the root cause is unknown.
   if ((global as any).isNextDeploy) {
     it('should skip for deploy', () => {})
     return

--- a/test/e2e/app-dir/root-layout-render-once/index.test.ts
+++ b/test/e2e/app-dir/root-layout-render-once/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir root layout render once', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should only render root layout once', async () => {
     let $ = await next.render$('/render-once')

--- a/test/e2e/app-dir/root-layout/root-layout.test.ts
+++ b/test/e2e/app-dir/root-layout/root-layout.test.ts
@@ -1,19 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, check, getRedboxSource } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir root layout', () => {
-  const {
-    next,
-    isNextDev: isDev,
-    skipped,
-  } = nextTestSetup({
+  const { next, isNextDev: isDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isDev) {
     // TODO-APP: re-enable after reworking the error overlay.

--- a/test/e2e/app-dir/root-suspense-dynamic/root-suspense-dynamic.test.ts
+++ b/test/e2e/app-dir/root-suspense-dynamic/root-suspense-dynamic.test.ts
@@ -1,9 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Root Suspense Dynamic Rendering', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname + '/fixtures/default',
-    skipDeployment: true,
   })
 
   // TODO: remove when there is a test for isNextDev === false

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -28,6 +28,8 @@ async function resolveStreamResponse(response: any, onData?: any) {
   return result
 }
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('app dir - rsc basics', () => {
   const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/similar-pages-paths/similar-pages-paths.test.ts
+++ b/test/e2e/app-dir/similar-pages-paths/similar-pages-paths.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir similar pages paths', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have conflicts for similar pattern page paths between app and pages', async () => {
     // pages/page and app/page

--- a/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
+++ b/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
@@ -1,14 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import * as cheerio from 'cheerio'
 
-const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
-
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The latest changes to support this behavior on deployed infra are available in the adapter,
+// and are not being backported to the CLI
+// @force-gate !deploy || adapter
 describe('sub-shell-generation', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    // The latest changes to support this behavior on deployed infra are available in the adapter,
-    // and are not being backported to the CLI
-    skipDeployment: !isAdapterTest,
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/syntax-highlighter-crash/syntax-highlighter-crash.test.ts
+++ b/test/e2e/app-dir/syntax-highlighter-crash/syntax-highlighter-crash.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('syntax-highlighter-crash', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/third-parties/basic.test.ts
+++ b/test/e2e/app-dir/third-parties/basic.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('@next/third-parties basic usage', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/typeof-window/typeof-window.test.ts
+++ b/test/e2e/app-dir/typeof-window/typeof-window.test.ts
@@ -1,18 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test is skipped when deployed because the local tarball appears corrupted
+// It also doesn't seem particularly useful to test when deployed
+// @force-gate !deploy
 describe('typeof-window', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // This test is skipped when deployed because the local tarball appears corrupted
-    // It also doesn't seem particularly useful to test when deployed
-    skipDeployment: true,
     dependencies: {
       'my-differentiated-files': `file:${path.join(__dirname, 'my-differentiated-files.tar')}`,
     },
   })
-
-  if (skipped) return
 
   it('should work using cheerio', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/types/types.test.ts
+++ b/test/e2e/app-dir/types/types.test.ts
@@ -1,16 +1,14 @@
 import { execSync } from 'child_process'
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('app-dir types', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should check types', async () => {
     execSync('pnpm next typegen', { cwd: next.testDir, stdio: 'inherit' })

--- a/test/e2e/app-dir/unauthorized/default/unauthorized-default.test.ts
+++ b/test/e2e/app-dir/unauthorized/default/unauthorized-default.test.ts
@@ -5,15 +5,13 @@ import {
   getRedboxDescription,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - unauthorized with default unauthorized boundary', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // TODO: error unauthorized usage in root layout
   it.skip('should error on client unauthorized from root layout in browser', async () => {


### PR DESCRIPTION
## Summary

- migrate App Router actions, routing, rendering, metadata, and error-handling deployment exclusions to `@force-gate`
- remove the corresponding `skipDeployment` options and `skipped` control flow while preserving each suite's rationale

## Verification

- verified on the combined top-of-stack tree with `pnpm typescript`
- compared ordinary-mode collection before and after: all 4,670 existing test names matched
- collected all 510 affected files in deploy mode: 4,578 skipped tests, zero failures

<!-- NEXT_JS_LLM -->
