### PR TITLE
test: migrate tooling deploy exclusions to force gates

### DIFF
--- a/test/e2e/500-page/500-page-build.test.ts
+++ b/test/e2e/500-page/500-page-build.test.ts
@@ -1,15 +1,17 @@
-import { isNextDev, nextTestSetup } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
 // This test exercises `next build` outputs and `next start` behaviour, so it
 // is meaningless in dev mode where the dev server bypasses production build
 // artifacts (e.g. statically prerendered 500.html from getStaticProps).
-;(isNextDev ? describe.skip : describe)('500 Page build validation', () => {
-  const { next, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
+// @force-gate !dev
+describe('500 Page build validation', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const gip500Err =
     /`pages\/500` can not have getInitialProps\/getServerSideProps/

--- a/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
@@ -1,6 +1,8 @@
 import { isNextDev } from 'e2e-utils'
 import { runTests } from './utils'
 
+// These cases patch fixture files and manually run local builds.
+// @force-gate !deploy
 describe('app dir - with output export - dynamic missing gsp', () => {
   describe('should error when dynamic route is missing generateStaticParams', () => {
     runTests({

--- a/test/e2e/app-dir-export/test/dynamicapiroute.test.ts
+++ b/test/e2e/app-dir-export/test/dynamicapiroute.test.ts
@@ -1,5 +1,7 @@
 import { runTests } from './utils'
 
+// These cases patch fixture files and manually run local builds.
+// @force-gate !deploy
 describe('app dir - with output export - dynamic api route', () => {
   describe.each([
     {

--- a/test/e2e/app-dir-export/test/dynamicpage.test.ts
+++ b/test/e2e/app-dir-export/test/dynamicpage.test.ts
@@ -1,5 +1,7 @@
 import { runTests } from './utils'
 
+// These cases patch fixture files and manually run local builds.
+// @force-gate !deploy
 describe('app dir - with output export - dynamic api route', () => {
   describe.each([
     { dynamicPage: 'undefined' },

--- a/test/e2e/app-dir-export/test/trailing-slash.test.ts
+++ b/test/e2e/app-dir-export/test/trailing-slash.test.ts
@@ -1,5 +1,7 @@
 import { runTests } from './utils'
 
+// These cases patch fixture files and manually run local builds.
+// @force-gate !deploy
 describe('app dir - with output export - trailing slash', () => {
   describe.each([{ trailingSlash: false }, { trailingSlash: true }])(
     "should work in prod with trailingSlash '$trailingSlash'",

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -227,15 +227,11 @@ export function runTests({
     | 'set wrong param'
   expectedErrMsg?: string | RegExp
 }) {
-  let { next, skipped, isNextDev } = nextTestSetup({
+  let { next, isNextDev } = nextTestSetup({
     files: join(__dirname, '..'),
-    skipDeployment: true,
     skipStart: true,
     disableAutoSkewProtection: true,
   })
-  if (skipped) {
-    return
-  }
 
   beforeAll(async () => {
     if (trailingSlash !== undefined) {

--- a/test/e2e/app-dir/actions/app-action-export.test.ts
+++ b/test/e2e/app-dir/actions/app-action-export.test.ts
@@ -1,16 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir action handling - next export', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     dependencies: {
       nanoid: '4.0.1',
       'server-only': 'latest',
     },
   })
-  if (skipped) return
 
   if (!isNextStart) {
     it('skip test for development mode', () => {})

--- a/test/e2e/app-dir/app-compilation/index.test.ts
+++ b/test/e2e/app-dir/app-compilation/index.test.ts
@@ -1,14 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox, retry } from 'next-test-utils'
 
+// Deploy mode exclusion: This suite only defines assertions for local dev or start modes.
+// This is skipped when deployed because there are no assertions outside of next start/next dev
+// @force-gate !deploy
 describe('app dir', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    // This is skipped when deployed because there are no assertions outside of next start/next dev
-    skipDeployment: true,
   })
 
-  if (skipped) return
+  if (isNextDeploy) {
+    it('is excluded from deploy testing by @force-gate', () => {})
+  }
 
   if (isNextStart) {
     describe('Loading', () => {

--- a/test/e2e/app-dir/app-config-crossorigin/index.test.ts
+++ b/test/e2e/app-dir/app-config-crossorigin/index.test.ts
@@ -4,15 +4,13 @@ import { isNextStart, nextTestSetup } from 'e2e-utils'
 const assetPrefix = 'https://example.vercel.sh'
 
 if (!isNextStart) {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('app dir - crossOrigin config', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('should render correctly with assetPrefix: "/"', async () => {
       const $ = await next.render$('/')
@@ -39,10 +37,11 @@ if (!isNextStart) {
   })
 } else {
   describe('app dir - unset crossOrigin config', () => {
+    // Deploy mode exclusion: This branch only runs in next start mode.
+    // @force-gate !deploy
     describe('default output', () => {
       const { next } = nextTestSetup({
         files: path.join(__dirname, 'default'),
-        skipDeployment: true,
       })
 
       function expectCrossOriginAttributesToBeOmitted(
@@ -66,6 +65,9 @@ if (!isNextStart) {
     })
 
     if (process.env.__NEXT_CACHE_COMPONENTS !== 'true') {
+      // Deploy mode exclusion: This test builds and starts the exported app
+      // through a local custom server.
+      // @force-gate !deploy
       describe('output: export', () => {
         const { next } = nextTestSetup({
           files: path.join(__dirname, 'default'),
@@ -73,7 +75,6 @@ if (!isNextStart) {
             NEXT_TEST_OUTPUT_EXPORT: '1',
           },
           skipStart: true,
-          skipDeployment: true,
           startCommand: 'node server.mjs',
           serverReadyPattern: /- Local:/,
         })

--- a/test/e2e/app-dir/bun-externals/bun-externals.test.ts
+++ b/test/e2e/app-dir/bun-externals/bun-externals.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - bun externals', () => {
-  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should handle bun builtins as external modules', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/import-meta-glob-text-type/import-meta-glob-text-type.test.ts
+++ b/test/e2e/app-dir/import-meta-glob-text-type/import-meta-glob-text-type.test.ts
@@ -1,18 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // `turbopack.rules` is a Turbopack-only feature; skip under webpack
-const testFn =
-  process.env.IS_WEBPACK_TEST || process.env.NEXT_RSPACK
-    ? describe.skip
-    : describe
-
-testFn('turbopack `text` / `raw` module types', () => {
-  const { next, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): No deploy-specific incompatibility is
+// documented.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('turbopack `text` / `raw` module types', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should load matched files as strings through a `?raw` rule', async () => {
     const $ = await next.render$('/raw')

--- a/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
+++ b/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
@@ -6,16 +6,14 @@ import {
   parseValidationMessages,
 } from 'e2e-utils/instant-validation'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant-validation-build', () => {
-  const { next, skipped, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
   if (!isNextStart) {
     it.skip('Build-time only test', () => {})
     return

--- a/test/e2e/app-dir/interception-routes-output-export/interception-routes-output-export.test.ts
+++ b/test/e2e/app-dir/interception-routes-output-export/interception-routes-output-export.test.ts
@@ -2,12 +2,13 @@ import type { ChildProcess } from 'child_process'
 import { isNextDev, isNextStart, nextTestSetup } from 'e2e-utils'
 import { findPort, killApp, retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('interception-routes-output-export', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
 
   it('should error when using interception routes with static export', async () => {

--- a/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
+++ b/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
@@ -10,9 +10,11 @@ async function testDev(browser, errorRegex) {
 }
 
 describe('Error test if the loader file export a named function', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
   describe('in Development', () => {
     const { next, isNextDev } = nextTestSetup({
-      skipDeployment: true,
       files: __dirname,
     })
 
@@ -29,9 +31,11 @@ describe('Error test if the loader file export a named function', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
   describe('in Build and Start', () => {
     const { next, isNextStart } = nextTestSetup({
-      skipDeployment: true,
       skipStart: true,
       files: __dirname,
     })

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
@@ -1,8 +1,11 @@
 import { join } from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('multiple-lockfiles - has-output-file-tracing-root', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
       // This will silence the multiple lockfiles warning.
@@ -22,15 +25,10 @@ describe('multiple-lockfiles - has-output-file-tracing-root', () => {
     },
     // So that ../package-lock.json doesn't leave the isolated testDir
     subDir: 'test',
-    skipDeployment: true,
     // The workspace file would suppress the warning itself, so the test
     // wouldn't be exercising `outputFileTracingRoot`.
     deleteWorkspaceFile: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have multiple lockfiles warnings', async () => {
     expect(next.cliOutput).not.toMatch(

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
@@ -1,8 +1,11 @@
 import { join } from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('multiple-lockfiles - has-turbo-root', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
       // This will silence the multiple lockfiles warning.
@@ -22,15 +25,10 @@ describe('multiple-lockfiles - has-turbo-root', () => {
     },
     // So that ../package-lock.json doesn't leave the isolated testDir
     subDir: 'test',
-    skipDeployment: true,
     // The workspace file would suppress the warning itself, so the test
     // wouldn't be exercising `turbopack.root`.
     deleteWorkspaceFile: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have multiple lockfiles warnings', async () => {
     expect(next.cliOutput).not.toMatch(

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
@@ -2,8 +2,11 @@ import { join } from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('multiple-lockfiles', () => {
-  const { next, skipped, isTurbopack } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
       // Write a package-lock.json file to the parent directory to simulate
@@ -21,15 +24,10 @@ describe('multiple-lockfiles', () => {
     },
     // So that ../package-lock.json doesn't leave the isolated testDir
     subDir: 'test',
-    skipDeployment: true,
     // The workspace file would be treated as the root and suppress the
     // warning.
     deleteWorkspaceFile: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have multiple lockfiles warnings', async () => {
     await retry(async () => {

--- a/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-cjs.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-cjs.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-config-ts-type-error-cjs', () => {
   // TODO: Remove this once we bump minimum Node.js version to v22
   if (!(process.features as any).typescript) {
@@ -7,15 +10,10 @@ describe('next-config-ts-type-error-cjs', () => {
     return
   }
 
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw with type error on build (CJS)', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-esm.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-config-ts-type-error-esm', () => {
   // TODO: Remove this once we bump minimum Node.js version to v22
   if (!(process.features as any).typescript) {
@@ -7,18 +10,13 @@ describe('next-config-ts-type-error-esm', () => {
     return
   }
 
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     packageJson: {
       type: 'module',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw with type error on build (ESM)', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-cjs.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-cjs.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-config-ts-type-error-cjs', () => {
   // TODO: Remove this once we bump minimum Node.js version to v22
   if (!(process.features as any).typescript) {
@@ -7,15 +10,10 @@ describe('next-config-ts-type-error-cjs', () => {
     return
   }
 
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw with type error on build (CJS)', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-esm.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-config-ts-type-error-esm', () => {
   // TODO: Remove this once we bump minimum Node.js version to v22
   if (!(process.features as any).typescript) {
@@ -7,18 +10,13 @@ describe('next-config-ts-type-error-esm', () => {
     return
   }
 
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     packageJson: {
       type: 'module',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw with type error on build (ESM)', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-cjs.test.ts
+++ b/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-cjs.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-config-ts-type-error-cjs', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw with type error on build (CJS)', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-esm.test.ts
@@ -1,18 +1,16 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-config-ts-type-error-esm', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     packageJson: {
       type: 'module',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw with type error on build (ESM)', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
+++ b/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
@@ -7,8 +7,11 @@ import {
 } from 'next-test-utils'
 import * as path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('non-root-project-monorepo', () => {
-  const { next, skipped, isTurbopack, isNextDev, isRspack } = nextTestSetup({
+  const { next, isTurbopack, isNextDev, isRspack } = nextTestSetup({
     files: {
       apps: new FileRef(path.resolve(__dirname, 'apps')),
       packages: new FileRef(path.resolve(__dirname, 'packages')),
@@ -24,12 +27,7 @@ describe('non-root-project-monorepo', () => {
     buildCommand: 'pnpm build',
     startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
     installCommand: 'pnpm i',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   describe('server relative import', () => {
     it('should resolve a `/`-rooted import from the project directory, not the workspace root', async () => {

--- a/test/e2e/app-dir/nx-handling/nx-handling.test.ts
+++ b/test/e2e/app-dir/nx-handling/nx-handling.test.ts
@@ -1,8 +1,10 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('nx-handling', () => {
   const { next } = nextTestSetup({
-    skipDeployment: true,
     files: __dirname,
     installCommand: 'npm i',
     buildCommand: 'npm run build',

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
@@ -2,17 +2,14 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('parallel-routes-leaf-segments-build-error', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'build-error'),
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    it.skip('skip test', () => {})
-    return
-  }
 
   if (isNextDev) {
     beforeAll(() => next.start())

--- a/test/e2e/app-dir/pnpm-workspace-root/pnpm-workspace-root.test.ts
+++ b/test/e2e/app-dir/pnpm-workspace-root/pnpm-workspace-root.test.ts
@@ -1,7 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('pnpm-workspace-root', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       'app/layout.tsx': `
         import { ReactNode } from 'react'
@@ -44,12 +47,7 @@ describe('pnpm-workspace-root', () => {
     },
     // So that parent files don't leave the isolated testDir
     subDir: 'test',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should detect root directory from pnpm-workspace.yaml and allow imports from outside app dir', async () => {
     // The app should start successfully when pnpm-workspace.yaml is present

--- a/test/e2e/app-dir/proxy-missing-export/proxy-missing-export.test.ts
+++ b/test/e2e/app-dir/proxy-missing-export/proxy-missing-export.test.ts
@@ -15,16 +15,14 @@ To fix it:
 
 Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('proxy-missing-export', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should error when proxy file has invalid export named middleware', async () => {
     await writeFile(

--- a/test/e2e/app-dir/root-detection/git-repository-boundary.test.ts
+++ b/test/e2e/app-dir/root-detection/git-repository-boundary.test.ts
@@ -8,8 +8,11 @@ import { packageJson, packageLock } from './test-utils'
 //     ├── .git/
 //     ├── package-lock.json
 //     └── app/                 the Next.js app
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('root-detection - git repository boundary', () => {
-  const { next, skipped, isTurbopack } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
       // a `.git` directory makes the parent directory a repository root.
@@ -21,15 +24,10 @@ describe('root-detection - git repository boundary', () => {
     },
     // So that the files written above don't leave the isolated testDir
     subDir: 'repo/app',
-    skipDeployment: true,
     // The workspace file would stop the search before the Git boundary does,
     // so the test wouldn't be exercising the boundary.
     deleteWorkspaceFile: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not select a root above the repository', async () => {
     const repoDir = dirname(next.testDir)

--- a/test/e2e/app-dir/root-detection/git-worktree-boundary.test.ts
+++ b/test/e2e/app-dir/root-detection/git-worktree-boundary.test.ts
@@ -13,8 +13,11 @@ import {
 //     ├── .git                         a file pointing at the Git directory
 //     ├── package-lock.json
 //     └── app/                         the Next.js app
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('root-detection - git worktree boundary', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
       '../.git': 'gitdir: ../repo/.git/worktrees/worktree\n',
@@ -28,15 +31,10 @@ describe('root-detection - git worktree boundary', () => {
     },
     // So that the files written above don't leave the isolated testDir
     subDir: 'worktree/app',
-    skipDeployment: true,
     // The workspace file would stop the search before the worktree boundary
     // does, so the test wouldn't be exercising the boundary.
     deleteWorkspaceFile: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not select a root above the worktree', async () => {
     const worktreeDir = dirname(next.testDir)

--- a/test/e2e/app-dir/root-detection/home-directory-boundary.test.ts
+++ b/test/e2e/app-dir/root-detection/home-directory-boundary.test.ts
@@ -41,10 +41,13 @@ const cases: Array<{
   },
 ]
 
+// This suite changes HOME for a locally managed Next.js process and inspects
+// its CLI output.
+// @force-gate !deploy
 describe.each(cases)(
   'root-detection - home directory boundary ($name)',
   ({ getHome, getRoot, getRootLockFile }) => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: {
         app: new FileRef(join(__dirname, 'app')),
         '../package.json': packageJson('project'),
@@ -54,7 +57,6 @@ describe.each(cases)(
       },
       // So that the files written above don't leave the isolated testDir
       subDir: 'project/app',
-      skipDeployment: true,
       // The workspace file would stop the search before the home directory
       // boundary does, so the test wouldn't be exercising the boundary.
       deleteWorkspaceFile: true,
@@ -63,10 +65,6 @@ describe.each(cases)(
       buildCommand: `${nextBin} build`,
       startCommand: `${nextBin} ${isNextDev ? 'dev' : 'start'}`,
     })
-
-    if (skipped) {
-      return
-    }
 
     beforeAll(async () => {
       const home = getHome(next.testDir)

--- a/test/e2e/app-dir/root-detection/package-json-workspaces.test.ts
+++ b/test/e2e/app-dir/root-detection/package-json-workspaces.test.ts
@@ -15,8 +15,11 @@ import {
 // ├── package-lock.json
 // ├── shared/utils.ts        imported by the app
 // └── test/                  the Next.js app, with a lockfile of its own
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('root-detection - package.json workspaces', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'workspace-app')),
       '../package.json': packageJson('workspace-root', {
@@ -28,15 +31,10 @@ describe('root-detection - package.json workspaces', () => {
     },
     // So that the files written above don't leave the isolated testDir
     subDir: 'test',
-    skipDeployment: true,
     // The workspace file would make the app directory a workspace root of its
     // own, so the test wouldn't be exercising the `workspaces` field.
     deleteWorkspaceFile: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should select the workspace root as the root', async () => {
     // the app imports a file from the workspace root, which is only reachable

--- a/test/e2e/app-dir/rsc-webpack-loader/rsc-webpack-loader.test.ts
+++ b/test/e2e/app-dir/rsc-webpack-loader/rsc-webpack-loader.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // Skip as Turbopack doesn't support the `!=!` Webpack syntax
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'app dir - rsc webpack loader',
   () => {

--- a/test/e2e/app-dir/segment-config-ts/segment-config-ts.test.ts
+++ b/test/e2e/app-dir/segment-config-ts/segment-config-ts.test.ts
@@ -1,9 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('TypeScript type expressions in route segment config', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   describe('app directory', () => {

--- a/test/e2e/app-dir/self-importing-package/self-importing-package.test.ts
+++ b/test/e2e/app-dir/self-importing-package/self-importing-package.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test is skipped when deployed because the local tarball appears corrupted
+// It also doesn't seem particularly useful to test when deployed
+// @force-gate !deploy
 describe('self-importing-package', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // This test is skipped when deployed because the local tarball appears corrupted
-    // It also doesn't seem particularly useful to test when deployed
-    skipDeployment: true,
     dependencies: {
       'internal-pkg': `file:${path.join(__dirname, 'internal-pkg.tar')}`,
     },

--- a/test/e2e/app-dir/server-components-externals/index.test.ts
+++ b/test/e2e/app-dir/server-components-externals/index.test.ts
@@ -1,14 +1,13 @@
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
+// Deploy mode exclusion: This suite manually changes the local `node_modules` tree.
+// This test is skipped when deployed because it relies on manually patched `node_modules`
+// @force-gate !deploy
 describe('app-dir - server components externals', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
-    // This test is skipped when deployed because it relies on manually patched `node_modules`
-    skipDeployment: true,
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) return
 
   it('should have externals for those in config.serverExternalPackages', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
+++ b/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
@@ -3,11 +3,13 @@ import { join } from 'path'
 import { existsSync } from 'fs'
 import { parseTraceFile } from '../../../lib/parse-trace-file'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('trace-build-file', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: !isNextDev,
-    skipDeployment: true,
     env: {
       // Enable persistent caching even when the git working directory is
       // dirty (e.g. when developing Next.js itself). Without this, the

--- a/test/e2e/app-dir/turbopack-loader-content-type/turbopack-loader-content-type.test.ts
+++ b/test/e2e/app-dir/turbopack-loader-content-type/turbopack-loader-content-type.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('turbopack-loader-content-type', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should apply loader based on contentType glob pattern', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
+++ b/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
@@ -5,16 +5,14 @@ import { getDistDir, retry } from 'next-test-utils'
 const strictRouteTypes =
   process.env.__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES === 'true'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('typed-routes-validator', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should generate route validation correctly', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/typed-routes/typed-links.test.ts
+++ b/test/e2e/app-dir/typed-routes/typed-links.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('typed-links', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should generate types for next/link', async () => {
     await retry(async () => {

--- a/test/e2e/app-dir/typed-routes/typed-routes.test.ts
+++ b/test/e2e/app-dir/typed-routes/typed-routes.test.ts
@@ -12,15 +12,13 @@ type RewriteRoutes = "/api-legacy/[version]/[[...endpoint]]" | "/docs-old/[...pa
 type Routes = AppRoutes | PageRoutes | LayoutRoutes | RedirectRoutes | RewriteRoutes | AppRouteHandlerRoutes
 `
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('typed-routes', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should generate route types correctly', async () => {
     // Route type generation happens after the "Ready" log fires; give it time.

--- a/test/e2e/app-dir/typegen-bundler-env/typegen-bundler-env.test.ts
+++ b/test/e2e/app-dir/typegen-bundler-env/typegen-bundler-env.test.ts
@@ -11,16 +11,14 @@ const baseEnv = {
 
 // cssChunking: "graph", is Turbopack-only, so we use this as to verify whether
 // typegen is selecting the right bundler
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('typegen bundler env', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('defaults to Turbopack, accepting Turbopack-only config', async () => {
     const { code } = await runNextCommand(['typegen', next.testDir], {

--- a/test/e2e/app-dir/typegen-error-diagnostic/typegen-error-diagnostic.test.ts
+++ b/test/e2e/app-dir/typegen-error-diagnostic/typegen-error-diagnostic.test.ts
@@ -1,17 +1,15 @@
 import { nextTestSetup } from 'e2e-utils'
 import { runNextCommand } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('typegen error diagnostic', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     // We drive `next typegen` manually; no server needed.
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('fails loudly with an actionable message when route types cannot be generated', async () => {
     // `next typegen` runs with NODE_ENV=production, which makes the fixture's

--- a/test/e2e/app-dir/undefined-default-export/undefined-default-export.test.ts
+++ b/test/e2e/app-dir/undefined-default-export/undefined-default-export.test.ts
@@ -1,11 +1,13 @@
 import path from 'path'
 import { isNextStart, nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Undefined default export', () => {
   const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname),
     skipStart: isNextStart,
-    skipDeployment: true,
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/upward-distdir/upward-distdir.test.ts
+++ b/test/e2e/app-dir/upward-distdir/upward-distdir.test.ts
@@ -1,8 +1,10 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('upward-distdir', () => {
   const { next } = nextTestSetup({
-    skipDeployment: true,
     files: __dirname,
     installCommand: 'pnpm install',
     buildCommand: 'pnpm next build apps/next-nx-test',

--- a/test/e2e/app-dir/webpack-loader-conditions/webpack-loader-conditions.test.ts
+++ b/test/e2e/app-dir/webpack-loader-conditions/webpack-loader-conditions.test.ts
@@ -1,32 +1,30 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // Specifically tests turbopack.rules.*.foreign config
-;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
-  'webpack-loader-conditions',
-  () => {
-    const { next, skipped } = nextTestSetup({
-      files: __dirname,
-      skipDeployment: true,
-    })
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('webpack-loader-conditions', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
 
-    if (skipped) return
+  it('should render correctly on server site', async () => {
+    const res = await next.fetch('/')
+    const html = (await res.text()).replaceAll(/<!-- -->/g, '')
+    expect(html).toContain(`server: {&quot;default&quot;:true}`)
+    expect(html).toContain(`client: {&quot;default&quot;:true}`)
+    expect(html).toContain(`foreignClient: {}`)
+  })
 
-    it('should render correctly on server site', async () => {
-      const res = await next.fetch('/')
-      const html = (await res.text()).replaceAll(/<!-- -->/g, '')
-      expect(html).toContain(`server: {&quot;default&quot;:true}`)
-      expect(html).toContain(`client: {&quot;default&quot;:true}`)
-      expect(html).toContain(`foreignClient: {}`)
-    })
-
-    it('should render correctly on client side', async () => {
-      const browser = await next.browser('/')
-      const text = await browser.elementByCss('body').text()
-      expect(text).toContain(`server: ${JSON.stringify({ default: true })}`)
-      expect(text).toContain(`client: ${JSON.stringify({ browser: true })}`)
-      expect(text).toContain(
-        `foreignClient: ${JSON.stringify({ browser: true, foreign: true })}`
-      )
-    })
-  }
-)
+  it('should render correctly on client side', async () => {
+    const browser = await next.browser('/')
+    const text = await browser.elementByCss('body').text()
+    expect(text).toContain(`server: ${JSON.stringify({ default: true })}`)
+    expect(text).toContain(`client: ${JSON.stringify({ browser: true })}`)
+    expect(text).toContain(
+      `foreignClient: ${JSON.stringify({ browser: true, foreign: true })}`
+    )
+  })
+})

--- a/test/e2e/app-dir/webpack-loader-errors/webpack-loader-errors.test.ts
+++ b/test/e2e/app-dir/webpack-loader-errors/webpack-loader-errors.test.ts
@@ -2,13 +2,14 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry, waitForRedbox, getRedboxSource } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('webpack-loader-errors', () => {
-  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-  if (skipped) return
 
   if (!isNextDev) {
     it('should skip in non-dev mode', () => {})

--- a/test/e2e/app-dir/webpack-loader-fs/webpack-loader-fs.test.ts
+++ b/test/e2e/app-dir/webpack-loader-fs/webpack-loader-fs.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('webpack-loader-fs', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should allow reading the input FS', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/webpack-loader-import-module/webpack-loader-import-module.test.ts
+++ b/test/e2e/app-dir/webpack-loader-import-module/webpack-loader-import-module.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('webpack-loader-import-module', () => {
-  const { next, skipped, isTurbopack } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should support this.importModule() in a webpack loader', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
+++ b/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('webpack-loader-module-type', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   // bytes type is Turbopack-only, webpack doesn't have a direct equivalent
   const itTurbopackOnly = isTurbopack ? it : it.skip

--- a/test/e2e/app-dir/webpack-loader-resolve/webpack-loader-resolve.test.ts
+++ b/test/e2e/app-dir/webpack-loader-resolve/webpack-loader-resolve.test.ts
@@ -1,15 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test is skipped because it's only expected to run in turbopack, which isn't enabled for builds
+// @force-gate !deploy
 describe('webpack-loader-resolve', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // This test is skipped because it's only expected to run in turbopack, which isn't enabled for builds
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should support resolving absolute path via loader getResolve', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
+++ b/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('webpack-loader-resource-query', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should pass query to loader', async () => {
     await next.render$('/')

--- a/test/e2e/app-dir/webpack-loader-ts-transform/webpack-loader-ts-transform.test.ts
+++ b/test/e2e/app-dir/webpack-loader-ts-transform/webpack-loader-ts-transform.test.ts
@@ -1,13 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test is skipped because it's only expected to run in turbopack, which isn't enabled for builds
+// @force-gate !deploy
 describe('webpack-loader-ts-transform', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // This test is skipped because it's only expected to run in turbopack, which isn't enabled for builds
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should accept Typescript returned from Webpack loaders', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/with-babel/with-babel.test.ts
+++ b/test/e2e/app-dir/with-babel/with-babel.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('with babel', () => {
-  const { next, isNextStart, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should support babel in app dir', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/build-indicator/test/index.test.ts
+++ b/test/e2e/build-indicator/test/index.test.ts
@@ -22,6 +22,7 @@ const installCheckVisible = (browser) => {
 
 describe('Build Activity Indicator', () => {
   // Use describe.skip so that this suite does not fail with "no tests" during deploy tests.
+  // Deploy mode exclusion: This nested suite intentionally fails a local build and asserts its CLI diagnostics.
   ;(isNextDeploy ? describe.skip : describe)('Invalid position config', () => {
     const { next } = nextTestSetup({
       files: join(__dirname, '..'),

--- a/test/e2e/cli/cli.test.ts
+++ b/test/e2e/cli/cli.test.ts
@@ -15,12 +15,14 @@ const reactDependencies = {
   'react-dom': '19.3.0-canary-fef12a01-20260413',
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('CLI Usage', () => {
   const { next, isNextStart } = nextTestSetup({
     files: join(__dirname, 'basic'),
     skipStart: true,
     dependencies: reactDependencies,
-    skipDeployment: true,
   })
 
   /**
@@ -1221,14 +1223,15 @@ Next.js Config:
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('CLI Usage: duplicate sass dependencies', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: join(__dirname, 'duplicate-sass'),
     skipStart: true,
     dependencies: reactDependencies,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   // The original integration test relied on pre-existing fake `sass` and
   // `node-sass` modules in `duplicate-sass/node_modules/`. In e2e mode the

--- a/test/e2e/config-schema-check/index.test.ts
+++ b/test/e2e/config-schema-check/index.test.ts
@@ -2,8 +2,11 @@ import stripAnsi from 'strip-ansi'
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next.config.js schema validating - defaultConfig', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       'pages/index.js': `
     export default function Page() {
@@ -16,12 +19,7 @@ describe('next.config.js schema validating - defaultConfig', () => {
     }
     `,
     },
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should validate against defaultConfig', async () => {
     const output = stripAnsi(next.cliOutput)
@@ -30,8 +28,11 @@ describe('next.config.js schema validating - defaultConfig', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next.config.js schema validating - invalid config', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: {
       'pages/index.js': `
     export default function Page() {
@@ -44,12 +45,7 @@ describe('next.config.js schema validating - invalid config', () => {
     }
     `,
     },
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should warn the invalid next config', async () => {
     await check(() => {

--- a/test/e2e/dist-dir/dist-dir.test.ts
+++ b/test/e2e/dist-dir/dist-dir.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { BUILD_ID_FILE, BUILD_MANIFEST } from 'next/constants'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('distDir', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should render the page', async () => {
     const html = await next.render('/')
@@ -27,13 +28,14 @@ describe('distDir', () => {
 })
 
 if (isNextStart) {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('distDir config validation', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should throw error with invalid distDir', async () => {
       const origConfig = await next.readFile('next.config.js')

--- a/test/e2e/env-config/env-config.test.ts
+++ b/test/e2e/env-config/env-config.test.ts
@@ -2,16 +2,17 @@ import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('env-config', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     env: {
       PROCESS_ENV_KEY: 'processenvironment',
       ENV_FILE_PROCESS_ENV: 'env-cli',
     },
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const getEnvFromHtml = async (path: string) => {
     const html = await next.render(path)

--- a/test/e2e/externals-pages-bundle/externals-pages-bundle.test.ts
+++ b/test/e2e/externals-pages-bundle/externals-pages-bundle.test.ts
@@ -2,13 +2,14 @@ import fs from 'fs/promises'
 import { join } from 'path'
 import { nextTestSetup, isNextStart, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('externals-pages-bundle', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   describe('bundle pages externals with config.bundlePagesRouterDependencies', () => {
     if (!isNextStart) {

--- a/test/e2e/import-meta-env/import-meta-env.test.ts
+++ b/test/e2e/import-meta-env/import-meta-env.test.ts
@@ -1,17 +1,13 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 
-const testFn =
-  process.env.IS_WEBPACK_TEST || process.env.NEXT_RSPACK
-    ? describe.skip
-    : describe
-
-testFn('import.meta.env', () => {
-  const { next, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): No deploy-specific incompatibility is
+// documented.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('import.meta.env', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('exposes built-in environment values on the server and client', async () => {
     const browser = await next.browser('/docs')

--- a/test/e2e/import-meta-glob/import-meta-glob.test.ts
+++ b/test/e2e/import-meta-glob/import-meta-glob.test.ts
@@ -1,18 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // import.meta.glob is a Turbopack-only feature; skip under webpack
-const testFn =
-  process.env.IS_WEBPACK_TEST || process.env.NEXT_RSPACK
-    ? describe.skip
-    : describe
-
-testFn('import-meta-glob', () => {
-  const { next, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): No deploy-specific incompatibility is
+// documented.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('import-meta-glob', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should resolve lazy glob modules', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/jsconfig-baseurl/jsconfig-baseurl.test.ts
+++ b/test/e2e/jsconfig-baseurl/jsconfig-baseurl.test.ts
@@ -2,12 +2,13 @@ import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('jsconfig.json baseurl', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   describe('default behavior', () => {
     it('should render the page', async () => {

--- a/test/e2e/jsconfig-paths/jsconfig-paths.test.ts
+++ b/test/e2e/jsconfig-paths/jsconfig-paths.test.ts
@@ -2,13 +2,13 @@ import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('jsconfig paths', () => {
-  const { next, isNextDeploy, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
-  if (isNextDeploy) return
 
   it('should alias components', async () => {
     const $ = await next.render$('/basic-alias')
@@ -96,13 +96,14 @@ describe('jsconfig paths', () => {
   }
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('jsconfig paths without baseurl', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let originalJsconfigContent: string
 

--- a/test/e2e/next-analyze/next-analyze.test.ts
+++ b/test/e2e/next-analyze/next-analyze.test.ts
@@ -4,6 +4,9 @@ import path from 'node:path'
 import type { ChildProcess } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('next experimental-analyze', () => {
   if (!shouldUseTurbopack()) {
     // Test suites require at least one test
@@ -11,17 +14,10 @@ describe('next experimental-analyze', () => {
     return
   }
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    // Test suites require at least one test
-    it('is skipped', () => {})
-    return
-  }
 
   it('runs successfully without errors', async () => {
     let serveProcess: ChildProcess | undefined

--- a/test/e2e/nullish-config/nullish-config.test.ts
+++ b/test/e2e/nullish-config/nullish-config.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Nullish configs in next.config.js', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   afterEach(async () => {
     await next.stop().catch(() => {})

--- a/test/e2e/react-compiler/react-compiler.test.ts
+++ b/test/e2e/react-compiler/react-compiler.test.ts
@@ -16,6 +16,8 @@ function normalizeCodeLocInfo(str) {
   )
 }
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe.each(['default', 'babelrc', 'rust'] as const)(
   'react-compiler %s',
   (variant) => {

--- a/test/e2e/relay-graphql-swc-multi-project/relay-graphql-swc-multi-project.test.ts
+++ b/test/e2e/relay-graphql-swc-multi-project/relay-graphql-swc-multi-project.test.ts
@@ -18,6 +18,9 @@ function relayCompilerValidate(next: NextInstance) {
 }
 
 describe('Relay Compiler Transform - Multi Project Config', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+  // @force-gate !deploy
   describe('project-a', () => {
     const { next } = nextTestSetup({
       files: __dirname,
@@ -44,8 +47,6 @@ describe('Relay Compiler Transform - Multi Project Config', () => {
       startCommand: isNextDev
         ? 'pnpm run dev-project-a'
         : 'pnpm run start-project-a',
-      // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-      skipDeployment: true,
     })
 
     relayCompilerValidate(next)
@@ -57,6 +58,9 @@ describe('Relay Compiler Transform - Multi Project Config', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+  // @force-gate !deploy
   describe('project-b', () => {
     const { next } = nextTestSetup({
       files: __dirname,
@@ -78,8 +82,6 @@ describe('Relay Compiler Transform - Multi Project Config', () => {
       startCommand: isNextDev
         ? 'pnpm run dev-project-b'
         : 'pnpm run start-project-b',
-      // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-      skipDeployment: true,
     })
 
     relayCompilerValidate(next)

--- a/test/e2e/swc-plugins-env/index.test.ts
+++ b/test/e2e/swc-plugins-env/index.test.ts
@@ -1,11 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('swc-plugins-env', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should pass correct environment to swc plugins', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/swc-plugins/index.test.ts
+++ b/test/e2e/swc-plugins/index.test.ts
@@ -1,15 +1,16 @@
-import { nextTestSetup, isNextDev } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
 describe('swcPlugins', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
   describe('supports swcPlugins', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       dependencies: {
         '@swc/plugin-react-remove-properties': '13.0.0',
       },
     })
-    if (skipped) return
 
     it('basic case', async () => {
       const html = await next.render('/')
@@ -17,15 +18,17 @@ describe('swcPlugins', () => {
       expect(html).not.toContain('data-custom-attribute')
     })
   })
-  ;(isNextDev ? describe : describe.skip)('incompatible plugin version', () => {
-    const { next, skipped, isTurbopack } = nextTestSetup({
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
+  // @force-gate dev
+  describe('incompatible plugin version', () => {
+    const { next, isTurbopack } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       dependencies: {
         '@swc/plugin-react-remove-properties': '7.0.2',
       },
     })
-    if (skipped) return
 
     it('shows a redbox in dev', async () => {
       const browser = await next.browser('/')
@@ -55,10 +58,13 @@ describe('swcPlugins', () => {
       }
     })
   })
-  ;(isNextDev ? describe : describe.skip)('invalid plugin name', () => {
-    const { next, skipped, isTurbopack } = nextTestSetup({
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
+  // @force-gate dev
+  describe('invalid plugin name', () => {
+    const { next, isTurbopack } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       overrideFiles: {
         'next.config.js': `
 module.exports = {
@@ -68,9 +74,7 @@ module.exports = {
 }`,
       },
     })
-    if (skipped) return
 
-    // eslint-disable-next-line jest/no-identical-title
     it('shows a redbox in dev', async () => {
       const browser = await next.browser('/')
 

--- a/test/e2e/swc-warnings/index.test.ts
+++ b/test/e2e/swc-warnings/index.test.ts
@@ -2,6 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 // Tests Babel, not needed for Turbopack
+// Deploy mode exclusion: This suite asserts warning output from the local
+// Next.js CLI, which is not available from a deployed runtime.
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'swc warnings by default',
   () => {

--- a/test/e2e/transpile-packages-typescript-foreign/index.test.ts
+++ b/test/e2e/transpile-packages-typescript-foreign/index.test.ts
@@ -1,19 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('transpile-packages-typescript-foreign', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('without transpilePackages', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       skipStart: true,
       dependencies: {
         pkg: `file:./pkg`,
       },
     })
-
-    if (skipped) {
-      return
-    }
 
     it('should fail', async () => {
       try {
@@ -38,10 +36,12 @@ Module parse failed: Unexpected token`)
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('with transpilePackages', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       dependencies: {
         pkg: `file:./pkg`,
       },
@@ -49,10 +49,6 @@ Module parse failed: Unexpected token`)
         transpilePackages: ['pkg'],
       },
     })
-
-    if (skipped) {
-      return
-    }
 
     it('should work', async () => {
       const $ = await next.render$('/')

--- a/test/e2e/transpile-packages/index.test.ts
+++ b/test/e2e/transpile-packages/index.test.ts
@@ -2,6 +2,8 @@ import path from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('transpile packages', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
   if ((global as any).isNextDeploy) {
     it('should skip for deploy mode for now', () => {})
     return

--- a/test/e2e/tsconfig-module-preserve/index.test.ts
+++ b/test/e2e/tsconfig-module-preserve/index.test.ts
@@ -5,8 +5,11 @@ import stripAnsi from 'strip-ansi'
 const strictRouteTypes =
   process.env.__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES === 'true'
 
+// Deploy mode exclusion: This suite reads local build artifacts that deployments do not expose.
+// This test is skipped because it relies on `next.readFile`
+// @force-gate !deploy
 describe('tsconfig module: preserve', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       'tsconfig.json': JSON.stringify({
         compilerOptions: { module: 'preserve' },
@@ -17,14 +20,10 @@ describe('tsconfig module: preserve', () => {
         } 
       `,
     },
-    // This test is skipped because it relies on `next.readFile`
-    skipDeployment: true,
     dependencies: {
       typescript: '5.4.4',
     },
   })
-
-  if (skipped) return
 
   it('allows you to skip moduleResolution, esModuleInterop and resolveJsonModule when using "module: preserve"', async () => {
     let output = ''

--- a/test/e2e/tsconfig-path/index.test.ts
+++ b/test/e2e/tsconfig-path/index.test.ts
@@ -1,16 +1,12 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('specified tsconfig', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: new FileRef(__dirname),
     dependencies: {
       typescript: '5.4.4',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('app router: allows a user-specific tsconfig via the next config', async () => {
     const html = await next.render('/')

--- a/test/e2e/turbopack-emit-collect/index.test.ts
+++ b/test/e2e/turbopack-emit-collect/index.test.ts
@@ -2,15 +2,15 @@ import { nextTestSetup } from 'e2e-utils'
 
 // Only implemented in Webpack
 // Fixture uses force-dynamic which doesn't work with cache components enabled
-;(process.env.IS_TURBOPACK_TEST && !process.env.__NEXT_CACHE_COMPONENTS
-  ? describe
-  : describe.skip)('turbopack-emit-collect', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+// Deploy mode exclusion: This suite restarts the local server to inspect
+// process-global module state.
+// @force-gate !deploy
+// @force-gate turbopack
+// @force-gate !cacheComponents
+describe('turbopack-emit-collect', () => {
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   function formatId(id: string) {
     return id.slice(id.lastIndexOf('/src/') + 5).replace(' (ecmascript)', '')

--- a/test/e2e/turbopack-import-with-type/index.test.ts
+++ b/test/e2e/turbopack-import-with-type/index.test.ts
@@ -5,54 +5,50 @@ const jsContent = `export const nope = 'nope'
 throw new Error('please dont execute me')
 `
 
-;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
-  'turbopack-import-with-type',
-  () => {
-    const { next, skipped } = nextTestSetup({
-      files: __dirname,
-      skipDeployment: true,
-    })
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('turbopack-import-with-type', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
 
-    if (skipped) {
-      return
-    }
-
-    // Testing this together on one route ensures we also avoid weird duplicate module ident things
-    it('supports import with type: text, type: bytes, and type: json', async () => {
-      const response = JSON.parse(await next.render('/api'))
-      expect(response).toEqual({
-        text: {
-          typeofString: true,
-          length: 12,
-          content: 'hello world\n',
-        },
-        jsAsText: {
-          typeofString: true,
-          content: jsContent,
-        },
-        bytes: {
-          instanceofUint8Array: true,
-          length: 18,
-          content: 'this is some data\n',
-        },
-        jsAsBytes: {
-          instanceofUint8Array: true,
-          content: jsContent,
-        },
-        configuredAsJsAsBytes: {
-          instanceofUint8Array: true,
-          content:
-            "throw new Error('this file is configured as ecmascript but imported as bytes')\n",
-        },
-        json: {
-          typeofObject: true,
-          content: { hello: 'world' },
-        },
-        jsonAsText: {
-          typeofString: true,
-          content: '{ "hello": "world" }\n',
-        },
-      })
+  // Testing this together on one route ensures we also avoid weird duplicate module ident things
+  it('supports import with type: text, type: bytes, and type: json', async () => {
+    const response = JSON.parse(await next.render('/api'))
+    expect(response).toEqual({
+      text: {
+        typeofString: true,
+        length: 12,
+        content: 'hello world\n',
+      },
+      jsAsText: {
+        typeofString: true,
+        content: jsContent,
+      },
+      bytes: {
+        instanceofUint8Array: true,
+        length: 18,
+        content: 'this is some data\n',
+      },
+      jsAsBytes: {
+        instanceofUint8Array: true,
+        content: jsContent,
+      },
+      configuredAsJsAsBytes: {
+        instanceofUint8Array: true,
+        content:
+          "throw new Error('this file is configured as ecmascript but imported as bytes')\n",
+      },
+      json: {
+        typeofObject: true,
+        content: { hello: 'world' },
+      },
+      jsonAsText: {
+        typeofString: true,
+        content: '{ "hello": "world" }\n',
+      },
     })
-  }
-)
+  })
+})

--- a/test/e2e/turbopack-loader-config/index.test.ts
+++ b/test/e2e/turbopack-loader-config/index.test.ts
@@ -1,16 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('turbopack-loader-config', () => {
-  const { next, isTurbopack, isNextDev, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     // we can't set `nextConfig` inline because it contains regexes that fail to serialize, it needs
     // to be set in a separate module (`next.config.ts`)
   })
-
-  if (skipped) {
-    return
-  }
 
   if (!isTurbopack) {
     it('should only run the test in turbopack', () => {})

--- a/test/e2e/turbopack-trace-server-query/turbopack-trace-server.test.ts
+++ b/test/e2e/turbopack-trace-server-query/turbopack-trace-server.test.ts
@@ -111,19 +111,21 @@ function runQueryTraceCli(
 
 // ─── test suite ──────────────────────────────────────────────────────────────
 
+// Deploy mode exclusion: The trace server requires local trace files and
+// child processes.
+// @force-gate !deploy
 describe('turbopack-trace-server', () => {
+  // Deploy mode exclusion: This suite reads a local trace file and spawns
+  // local MCP and CLI processes.
   if (isNextDeploy) {
     it('skipped for deploy mode', () => {})
     return
   }
 
-  const { next, isTurbopack, isNextDev, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: __dirname,
     env: { NEXT_TURBOPACK_TRACING: '1' },
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   // Error-path test: does not need turbopack or a running trace server.
   it('CLI: should show an error when the trace server is not running', async () => {

--- a/test/e2e/twoslash/standalone.test.ts
+++ b/test/e2e/twoslash/standalone.test.ts
@@ -13,7 +13,7 @@ if (!(globalThis as any).isNextStart) {
   it('should skip for non-next start', () => {})
 } else {
   describe('output: standalone with twoslash', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       dependencies: {
         twoslash: '0.3.4',
@@ -22,10 +22,6 @@ if (!(globalThis as any).isNextStart) {
       },
       skipStart: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     let server: any
     let appPort: number

--- a/test/e2e/typescript-custom-tsconfig/test/index.test.ts
+++ b/test/e2e/typescript-custom-tsconfig/test/index.test.ts
@@ -4,16 +4,12 @@ import { join } from 'path'
 import { nextTestSetup, FileRef } from 'e2e-utils'
 
 describe('Custom TypeScript Config', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: new FileRef(join(__dirname, '..')),
     dependencies: {
       typescript: '5.4.4',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('app router: allows a user-specific tsconfig via the next config', async () => {
     const html = await next.render('/')

--- a/test/e2e/typescript-version-no-warning/typescript-version-no-warning.test.ts
+++ b/test/e2e/typescript-version-no-warning/typescript-version-no-warning.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('typescript-version-no-warning', () => {
-  const { next, isNextDeploy, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDeploy, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDeploy || isNextDev) {
     it('should skip', () => {})

--- a/test/e2e/typescript-version-warning/typescript-version-warning.test.ts
+++ b/test/e2e/typescript-version-warning/typescript-version-warning.test.ts
@@ -1,18 +1,16 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('typescript-version-warning', () => {
-  const { next, isNextDeploy, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDeploy, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     dependencies: {
       typescript: '4.0.6',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDeploy || isNextDev) {
     it('should skip', () => {})

--- a/test/e2e/typescript-workspaces-paths/packages/www/test/index.test.ts
+++ b/test/e2e/typescript-workspaces-paths/packages/www/test/index.test.ts
@@ -4,6 +4,9 @@ import { join } from 'path'
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { readFileSync, writeFileSync } from 'fs'
 
+// This suite mutates the workspace config and runs custom local build/start
+// commands.
+// @force-gate !deploy
 describe('TypeScript Features', () => {
   describe.each([
     { label: '', testBaseUrl: true },
@@ -46,8 +49,7 @@ describe('TypeScript Features', () => {
       }
     })
 
-    const { next, skipped } = nextTestSetup({
-      skipDeployment: true,
+    const { next } = nextTestSetup({
       dependencies: testBaseUrl
         ? {
             typescript: '5.9.3',
@@ -58,8 +60,6 @@ describe('TypeScript Features', () => {
       startCommand:
         'pnpm next ' + (isNextDev ? 'dev' : 'start') + ' packages/www',
     })
-    if (skipped) return
-
     it('should alias components', async () => {
       const $ = await next.render$('/basic-alias')
       expect($('body').text()).toMatch(/World/)

--- a/test/e2e/typescript/typescript.test.ts
+++ b/test/e2e/typescript/typescript.test.ts
@@ -1,14 +1,15 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('TypeScript Features', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     dependencies: {
       sass: 'latest',
     },
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should render the page', async () => {
     const $ = await next.render$('/hello')
@@ -98,30 +99,30 @@ export default function EvilPage(): JSX.Element {
     })
   }
 })
-;(isNextStart ? describe : describe.skip)(
-  'TypeScript production compilation',
-  () => {
-    const { next, skipped } = nextTestSetup({
-      files: __dirname,
-      skipStart: true,
-      dependencies: {
-        sass: 'latest',
-      },
-      skipDeployment: true,
-    })
-    if (skipped) return
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate start
+describe('TypeScript production compilation', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    dependencies: {
+      sass: 'latest',
+    },
+  })
 
-    it('should build the app', async () => {
-      const { cliOutput, exitCode } = await next.build()
-      expect(cliOutput).toMatch(/Compiled successfully/)
-      expect(exitCode).toBe(0)
-    })
+  it('should build the app', async () => {
+    const { cliOutput, exitCode } = await next.build()
+    expect(cliOutput).toMatch(/Compiled successfully/)
+    expect(exitCode).toBe(0)
+  })
 
-    it('should build the app with functions in next.config.js', async () => {
-      const originalConfig = await next.readFile('next.config.js')
-      await next.patchFile(
-        'next.config.js',
-        `
+  it('should build the app with functions in next.config.js', async () => {
+    const originalConfig = await next.readFile('next.config.js')
+    await next.patchFile(
+      'next.config.js',
+      `
     module.exports = {
       webpack(config) { return config },
       onDemandEntries: {
@@ -130,45 +131,44 @@ export default function EvilPage(): JSX.Element {
       },
     }
     `
-      )
+    )
 
+    try {
+      const { cliOutput, exitCode } = await next.build()
+      expect(cliOutput).toMatch(/Compiled successfully/)
+      expect(exitCode).toBe(0)
+    } finally {
+      await next.patchFile('next.config.js', originalConfig)
+    }
+  })
+
+  describe('should compile with different types', () => {
+    it('should compile async getInitialProps for _error', async () => {
+      const errorPage = await next.readFile('pages/_error.tsx')
+      await next.patchFile(
+        'pages/_error.tsx',
+        errorPage.replace('static ', 'static async ')
+      )
       try {
-        const { cliOutput, exitCode } = await next.build()
+        const { cliOutput } = await next.build()
         expect(cliOutput).toMatch(/Compiled successfully/)
-        expect(exitCode).toBe(0)
       } finally {
-        await next.patchFile('next.config.js', originalConfig)
+        await next.patchFile('pages/_error.tsx', errorPage)
       }
     })
 
-    describe('should compile with different types', () => {
-      it('should compile async getInitialProps for _error', async () => {
-        const errorPage = await next.readFile('pages/_error.tsx')
-        await next.patchFile(
-          'pages/_error.tsx',
-          errorPage.replace('static ', 'static async ')
-        )
-        try {
-          const { cliOutput } = await next.build()
-          expect(cliOutput).toMatch(/Compiled successfully/)
-        } finally {
-          await next.patchFile('pages/_error.tsx', errorPage)
-        }
-      })
-
-      it('should compile sync getStaticPaths & getStaticProps', async () => {
-        const page = await next.readFile('pages/ssg/[slug].tsx')
-        await next.patchFile(
-          'pages/ssg/[slug].tsx',
-          page.replace(/async \(/g, '(')
-        )
-        try {
-          const { cliOutput } = await next.build()
-          expect(cliOutput).toMatch(/Compiled successfully/)
-        } finally {
-          await next.patchFile('pages/ssg/[slug].tsx', page)
-        }
-      })
+    it('should compile sync getStaticPaths & getStaticProps', async () => {
+      const page = await next.readFile('pages/ssg/[slug].tsx')
+      await next.patchFile(
+        'pages/ssg/[slug].tsx',
+        page.replace(/async \(/g, '(')
+      )
+      try {
+        const { cliOutput } = await next.build()
+        expect(cliOutput).toMatch(/Compiled successfully/)
+      } finally {
+        await next.patchFile('pages/ssg/[slug].tsx', page)
+      }
     })
-  }
-)
+  })
+})

--- a/test/e2e/undefined-webpack-config/undefined-webpack-config.test.ts
+++ b/test/e2e/undefined-webpack-config/undefined-webpack-config.test.ts
@@ -5,29 +5,28 @@ const expectedErr =
   /Webpack config is undefined. You may have forgot to return properly from within the "webpack" method of your next.config.js/
 
 // Webpack-specific test, not needed for Turbopack
-;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-  'undefined webpack config error',
-  () => {
-    const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
-      files: __dirname,
-      skipStart: true,
-      skipDeployment: true,
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate !turbopack
+describe('undefined webpack config error', () => {
+  const { next, isNextDev, isNextStart } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+  ;(isNextStart ? describe : describe.skip)('production mode', () => {
+    it.skip('should show in production mode', async () => {
+      const { cliOutput } = await next.build()
+      expect(cliOutput).toMatch(expectedErr)
     })
-    if (skipped) return
-    ;(isNextStart ? describe : describe.skip)('production mode', () => {
-      it.skip('should show in production mode', async () => {
-        const { cliOutput } = await next.build()
-        expect(cliOutput).toMatch(expectedErr)
+  })
+  ;(isNextDev ? it : it.skip)(
+    'should show error in development mode',
+    async () => {
+      await next.start()
+      await retry(async () => {
+        expect(next.cliOutput).toMatch(expectedErr)
       })
-    })
-    ;(isNextDev ? it : it.skip)(
-      'should show error in development mode',
-      async () => {
-        await next.start()
-        await retry(async () => {
-          expect(next.cliOutput).toMatch(expectedErr)
-        })
-      }
-    )
-  }
-)
+    }
+  )
+})

--- a/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
+++ b/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
@@ -75,13 +75,14 @@ function extractErrorBlock(output: string, errorTitle: string): string {
   return block.trimEnd()
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('webpack-loader-parse-error (development)', () => {
-  const { next, isTurbopack, isNextDev, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-  if (skipped) return
 
   if (!isNextDev) {
     it('skipped in production mode', () => {})
@@ -198,10 +199,12 @@ describe('webpack-loader-parse-error (development)', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('webpack-loader-parse-error (production)', () => {
   const { next, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
 


### PR DESCRIPTION
## Summary

- migrate configuration, TypeScript, bundler, compiler, loader, export, and monorepo deployment exclusions to `@force-gate`
- remove the corresponding `skipDeployment` options and `skipped` control flow while preserving each suite's rationale

This groups test-tooling exclusions so reviewers can evaluate local build and filesystem assumptions together.

## Verification

- verified on the combined top-of-stack tree with `pnpm typescript`
- compared ordinary-mode collection before and after: all 4,670 existing test names matched
- collected all 510 affected files in deploy mode: 4,578 skipped tests, zero failures

<!-- NEXT_JS_LLM -->
