### PR TITLE
test: migrate Pages Router deploy exclusions to force gates

### DIFF
--- a/test/e2e/404-page-custom-error/404-page-custom-error.test.ts
+++ b/test/e2e/404-page-custom-error/404-page-custom-error.test.ts
@@ -1,48 +1,43 @@
 /* eslint-disable jest/no-standalone-expect */
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 
-const shouldSkip =
-  (isNextStart && !!process.env.TURBOPACK_DEV) ||
-  (isNextDev && !!process.env.TURBOPACK_BUILD)
+// TODO(deploy-test-completion): This likely inspects local build artifacts that
+// deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate !start || !turbopackDev
+// @force-gate !dev || !turbopackBuild
+describe('Default 404 Page with custom _error', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
 
-;(shouldSkip ? describe.skip : describe)(
-  'Default 404 Page with custom _error',
-  () => {
-    const { next } = nextTestSetup({
-      files: __dirname,
-      skipDeployment: true,
-    })
+  it('should respond to 404 correctly', async () => {
+    const res = await next.fetch('/404')
+    expect(res.status).toBe(404)
+    expect(await res.text()).toContain('This page could not be found')
+  })
 
-    it('should respond to 404 correctly', async () => {
-      const res = await next.fetch('/404')
-      expect(res.status).toBe(404)
-      expect(await res.text()).toContain('This page could not be found')
-    })
+  it('should render error correctly', async () => {
+    const text = await next.render('/err')
+    expect(text).toContain(isNextDev ? 'oops' : 'Internal Server Error')
+  })
 
-    it('should render error correctly', async () => {
-      const text = await next.render('/err')
-      expect(text).toContain(isNextDev ? 'oops' : 'Internal Server Error')
-    })
-
-    it('should render index page normal', async () => {
-      const html = await next.render('/')
-      expect(html).toContain('hello from index')
-    })
-    ;(isNextStart ? it : it.skip)(
-      'should set pages404 in routes-manifest correctly',
-      async () => {
-        const data = JSON.parse(
-          await next.readFile('.next/routes-manifest.json')
-        )
-        expect(data.pages404).toBe(true)
-      }
+  it('should render index page normal', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('hello from index')
+  })
+  ;(isNextStart ? it : it.skip)(
+    'should set pages404 in routes-manifest correctly',
+    async () => {
+      const data = JSON.parse(await next.readFile('.next/routes-manifest.json'))
+      expect(data.pages404).toBe(true)
+    }
+  )
+  ;(isNextStart ? it : it.skip)('should have output 404.html', async () => {
+    const pagesManifest = await next.readJSON(
+      '.next/server/pages-manifest.json'
     )
-    ;(isNextStart ? it : it.skip)('should have output 404.html', async () => {
-      const pagesManifest = await next.readJSON(
-        '.next/server/pages-manifest.json'
-      )
-      const page = pagesManifest['/404']
-      expect(page.endsWith('.html')).toBe(true)
-    })
-  }
-)
+    const page = pagesManifest['/404']
+    expect(page.endsWith('.html')).toBe(true)
+  })
+})

--- a/test/e2e/404-page-router/index.test.ts
+++ b/test/e2e/404-page-router/index.test.ts
@@ -49,6 +49,8 @@ describe('404-page-router', () => {
     (options) => {
       const isDev = (global as any).isNextDev
 
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It currently avoids creating five deployments rather than documenting an incompatibility.
       if ((global as any).isNextDeploy) {
         // TODO: investigate condensing these tests to avoid
         // 5 separate deploys for this one test

--- a/test/e2e/404-page/404-page.test.ts
+++ b/test/e2e/404-page/404-page.test.ts
@@ -1,10 +1,12 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('404 Page Support', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   const gip404Err =
@@ -133,13 +135,15 @@ describe('404 Page Support', () => {
     })
   }
 })
-;(isNextStart ? describe : describe.skip)('404 Page build validation', () => {
-  const { next, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
+// @force-gate start
+describe('404 Page build validation', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const gip404Err =
     /`pages\/404` can not have getInitialProps\/getServerSideProps/

--- a/test/e2e/500-page/500-page.test.ts
+++ b/test/e2e/500-page/500-page.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('500 Page Support', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should use pages/500', async () => {
     const html = await next.render('/500')

--- a/test/e2e/api-body-parser/api-body-parser.test.ts
+++ b/test/e2e/api-body-parser/api-body-parser.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('API body parser', () => {
+  // Deploy mode exclusion: This suite controls a local server or proxy process.
+  // Uses a custom HTTP/proxy server in front of Next.js; not applicable in deploy mode.
+  // @force-gate !deploy
   describe('without custom server', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      // Uses a custom HTTP/proxy server in front of Next.js; not applicable in deploy mode.
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should parse JSON body', async () => {
       const res = await next.fetch('/api', {
@@ -22,8 +22,11 @@ describe('API body parser', () => {
     })
   })
 
+  // Deploy mode exclusion: This suite controls a local server or proxy process.
+  // Uses a custom HTTP/proxy server in front of Next.js; not applicable in deploy mode.
+  // @force-gate !deploy
   describe('with custom server (pre-parsed body)', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       startCommand: 'node server.js',
       serverReadyPattern: /- Local:/,
@@ -31,10 +34,7 @@ describe('API body parser', () => {
       dependencies: {
         express: '4',
       },
-      // Uses a custom HTTP/proxy server in front of Next.js; not applicable in deploy mode.
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should not throw if request body is already parsed in custom middleware', async () => {
       const res = await next.fetch('/api', {

--- a/test/e2e/api-catch-all/api-catch-all.test.ts
+++ b/test/e2e/api-catch-all/api-catch-all.test.ts
@@ -1,45 +1,43 @@
-import { nextTestSetup, isNextStart } from 'e2e-utils'
-;(process.env.TURBOPACK_DEV && isNextStart ? describe.skip : describe)(
-  'API routes',
-  () => {
-    const { next, skipped } = nextTestSetup({
-      files: __dirname,
-      // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-      skipDeployment: true,
+import { nextTestSetup } from 'e2e-utils'
+// TODO(deploy-test-completion): Assertions may differ from a local Next.js
+// server when deployed.
+// @force-gate !deploy
+// @force-gate !start || !turbopackDev
+describe('API routes', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should return data when catch-all', async () => {
+    const data = await next
+      .fetch('/api/users/1', {})
+      .then((res) => res.ok && res.json())
+
+    expect(data).toEqual({ slug: ['1'] })
+  })
+
+  it('should return redirect when catch-all with index and trailing slash', async () => {
+    const res = await next.fetch('/api/users/', {
+      redirect: 'manual',
     })
-    if (skipped) return
+    expect(res.status).toBe(308)
+    const text = await res.text()
+    expect(text).toEqual('/api/users')
+  })
 
-    it('should return data when catch-all', async () => {
-      const data = await next
-        .fetch('/api/users/1', {})
-        .then((res) => res.ok && res.json())
+  it('should return data when catch-all with index and trailing slash', async () => {
+    const data = await next
+      .fetch('/api/users/', {})
+      .then((res) => res.ok && res.json())
 
-      expect(data).toEqual({ slug: ['1'] })
-    })
+    expect(data).toEqual({})
+  })
 
-    it('should return redirect when catch-all with index and trailing slash', async () => {
-      const res = await next.fetch('/api/users/', {
-        redirect: 'manual',
-      })
-      expect(res.status).toBe(308)
-      const text = await res.text()
-      expect(text).toEqual('/api/users')
-    })
+  it('should return data when catch-all with index and no trailing slash', async () => {
+    const data = await next
+      .fetch('/api/users', {})
+      .then((res) => res.ok && res.json())
 
-    it('should return data when catch-all with index and trailing slash', async () => {
-      const data = await next
-        .fetch('/api/users/', {})
-        .then((res) => res.ok && res.json())
-
-      expect(data).toEqual({})
-    })
-
-    it('should return data when catch-all with index and no trailing slash', async () => {
-      const data = await next
-        .fetch('/api/users', {})
-        .then((res) => res.ok && res.json())
-
-      expect(data).toEqual({})
-    })
-  }
-)
+    expect(data).toEqual({})
+  })
+})

--- a/test/e2e/api-resolver-query-writeable/api-resolver-query-writeable.test.ts
+++ b/test/e2e/api-resolver-query-writeable/api-resolver-query-writeable.test.ts
@@ -1,9 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('api-resolver-query-writeable', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     startCommand: 'node server.js',
     serverReadyPattern: /Next mode: (production|development)/,
     dependencies: {
@@ -11,10 +13,6 @@ describe('api-resolver-query-writeable', () => {
       express: '5.1.0',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should allow req.query to be writable and reflect changes made in the API handler', async () => {
     const res = await next.fetch('/api?hello=yes', {

--- a/test/e2e/api-support/api-support.test.ts
+++ b/test/e2e/api-support/api-support.test.ts
@@ -7,18 +7,19 @@ import {
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import json from './big.json'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('API routes', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
       'http-proxy': 'latest',
       cors: 'latest',
       'node-fetch': '2.6.7',
     },
-    skipDeployment: true,
     disableAutoSkewProtection: true,
   })
-  if (skipped) return
 
   it('should not strip .json from API route', async () => {
     const res = await next.fetch('/api/hello.json')
@@ -594,8 +595,11 @@ describe('API routes', () => {
   }
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('API routes output export error', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
       'http-proxy': 'latest',
@@ -603,10 +607,8 @@ describe('API routes output export error', () => {
       'node-fetch': '2.6.7',
     },
     skipStart: true,
-    skipDeployment: true,
     disableAutoSkewProtection: true,
   })
-  if (skipped) return
 
   it('should show error with output export', async () => {
     if (isNextDev) return

--- a/test/e2e/app-document/client.test.ts
+++ b/test/e2e/app-document/client.test.ts
@@ -1,10 +1,12 @@
 import { retry } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('Document and App - Client side', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('should share module state with pages', async () => {

--- a/test/e2e/basepath/basepath.test.ts
+++ b/test/e2e/basepath/basepath.test.ts
@@ -10,6 +10,8 @@ import {
   renderViaHTTP,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('basePath', () => {
   const basePath = '/docs'
 

--- a/test/e2e/cancel-request/stream-cancel.test.ts
+++ b/test/e2e/cancel-request/stream-cancel.test.ts
@@ -2,6 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { sleep } from './sleep'
 import { get } from 'http'
 
+// Deploy mode exclusion: This suite aborts a raw client connection, but
+// a hosting proxy changes cancellation propagation before Next.js receives it.
 describe('streaming responses cancel inner stream after disconnect', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/catches-missing-getStaticProps/catches-missing-getStaticProps.test.ts
+++ b/test/e2e/catches-missing-getStaticProps/catches-missing-getStaticProps.test.ts
@@ -1,14 +1,15 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
-;((isNextDev && process.env.TURBOPACK_BUILD) ||
-  (isNextStart && process.env.TURBOPACK_DEV)
-  ? describe.skip
-  : describe)('Catches Missing getStaticProps', () => {
+// TODO(deploy-test-completion): This asserts local build/runtime output that
+// deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate !start || !turbopackDev
+// @force-gate !dev || !turbopackBuild
+describe('Catches Missing getStaticProps', () => {
   const errorRegex = /getStaticPaths was added without a getStaticProps in/
 
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: isNextStart,
-    skipDeployment: true,
   })
 
   if (isNextDev) {
@@ -16,9 +17,7 @@ import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
       const html = await next.render('/hello')
       expect(html).toMatch(errorRegex)
     })
-  }
-
-  if (isNextStart) {
+  } else {
     it('should catch it in server build mode', async () => {
       const { cliOutput } = await next.build()
       expect(cliOutput).toMatch(errorRegex)

--- a/test/e2e/client-404/client-404.test.ts
+++ b/test/e2e/client-404/client-404.test.ts
@@ -4,13 +4,13 @@ import {
   getClientBuildManifestLoaderChunkUrlPath,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('Client 404', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     // pre-build the home page so that navigating to it from the

--- a/test/e2e/client-max-body-size/index.test.ts
+++ b/test/e2e/client-max-body-size/index.test.ts
@@ -2,14 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('client-max-body-size', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // Deployed environment has it's own configured limits.
+  // @force-gate !deploy
   describe('default 10MB limit', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      // Deployed environment has it's own configured limits.
-      skipDeployment: true,
     })
-
-    if (skipped) return
 
     it('should accept request body over 10MB but only buffer up to limit', async () => {
       const bodySize = 11 * 1024 * 1024 // 11MB
@@ -77,18 +76,18 @@ describe('client-max-body-size', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('custom limit with string format', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       nextConfig: {
         experimental: {
           proxyClientMaxBodySize: '5mb',
         },
       },
     })
-
-    if (skipped) return
 
     it('should accept request body over custom 5MB limit but only buffer up to limit', async () => {
       const bodySize = 6 * 1024 * 1024 // 6MB
@@ -136,18 +135,18 @@ describe('client-max-body-size', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('custom limit with number format', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       nextConfig: {
         experimental: {
           proxyClientMaxBodySize: 2 * 1024 * 1024, // 2MB in bytes
         },
       },
     })
-
-    if (skipped) return
 
     it('should accept request body over custom 2MB limit but only buffer up to limit', async () => {
       const bodySize = 3 * 1024 * 1024 // 3MB
@@ -195,18 +194,18 @@ describe('client-max-body-size', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('large custom limit', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       nextConfig: {
         experimental: {
           proxyClientMaxBodySize: '50mb',
         },
       },
     })
-
-    if (skipped) return
 
     it('should accept request body up to 50MB with custom limit', async () => {
       const bodySize = 20 * 1024 * 1024 // 20MB

--- a/test/e2e/conflicting-app-page-error/index.test.ts
+++ b/test/e2e/conflicting-app-page-error/index.test.ts
@@ -8,15 +8,17 @@ import {
 } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Conflict between app file and pages file', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
 
-  if (skipped) {
-    return
+  if (isNextDeploy) {
+    it('is excluded from deploy testing by @force-gate', () => {})
   }
 
   if (isNextStart) {

--- a/test/e2e/conflicting-public-file-page/conflicting-public-file-page.test.ts
+++ b/test/e2e/conflicting-public-file-page/conflicting-public-file-page.test.ts
@@ -1,12 +1,17 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Errors on conflict between public file and page file', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
+
+  if (isNextDeploy) {
+    it('is excluded from deploy testing by @force-gate', () => {})
+  }
 
   if (isNextDev) {
     it('should show conflict error during development', async () => {

--- a/test/e2e/custom-app-render/custom-app-render.test.ts
+++ b/test/e2e/custom-app-render/custom-app-render.test.ts
@@ -1,20 +1,18 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('custom-app-render', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     startCommand: 'node server.js',
     serverReadyPattern: /Next mode: (production|development)/,
     dependencies: {
       'get-port': '5.1.1',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it.each(['/', '/render'])('should render %s', async (page) => {
     const $ = await next.render$(page)

--- a/test/e2e/custom-error/custom-error.test.ts
+++ b/test/e2e/custom-error/custom-error.test.ts
@@ -4,15 +4,21 @@ import { retry } from 'next-test-utils'
 const customErrNo404Match =
   /You have added a custom \/_error page without a custom \/404 page/
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Custom _error', () => {
-  const { next, isNextDev, isNextStart } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
     dependencies: {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    skipDeployment: true,
   })
+
+  if (isNextDeploy) {
+    it('is excluded from deploy testing by @force-gate', () => {})
+  }
 
   if (isNextDev) {
     it('should not warn with /_error and /404 when rendering error first', async () => {

--- a/test/e2e/custom-routes-i18n-index-redirect/custom-routes-i18n-index-redirect.test.ts
+++ b/test/e2e/custom-routes-i18n-index-redirect/custom-routes-i18n-index-redirect.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('Custom routes i18n with index redirect', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should respond to default locale redirects correctly for index redirect', async () => {
     for (const [path, dest] of [

--- a/test/e2e/custom-routes-i18n/custom-routes-i18n.test.ts
+++ b/test/e2e/custom-routes-i18n/custom-routes-i18n.test.ts
@@ -3,13 +3,14 @@ import cheerio from 'cheerio'
 import { findPort, retry } from 'next-test-utils'
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('Custom routes i18n', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let server: http.Server
   let externalPort: number

--- a/test/e2e/custom-routes/custom-routes.test.ts
+++ b/test/e2e/custom-routes/custom-routes.test.ts
@@ -11,16 +11,17 @@ import {
   normalizeManifest,
   retry,
 } from 'next-test-utils'
-import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
+import { nextTestSetup, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Custom routes', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
     disableAutoSkewProtection: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let externalServerPort: number
   let externalServer: http.Server
@@ -3471,16 +3472,17 @@ describe('Custom routes', () => {
     })
   }
 })
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Custom routes no-op rewrite', () => {
-  const { next, isTurbopack, isNextStart, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextStart } = nextTestSetup({
     files: __dirname,
     skipStart: true,
     env: {
       ADD_NOOP_REWRITE: 'true',
     },
-    skipDeployment: true,
   })
-  if (skipped) return
   if (isTurbopack && isNextStart) {
     it('skipped - not supported in turbopack build mode', () => {})
     return
@@ -3528,14 +3530,15 @@ describe('Custom routes no-op rewrite', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Custom routes solo types', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
     disableAutoSkewProtection: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let externalServer: http.Server
   let externalServerPort: number
@@ -3651,13 +3654,15 @@ describe('Custom routes solo types', () => {
     }
   })
 })
-;(isNextStart ? describe : describe.skip)('Custom routes export', () => {
-  const { next, isNextDeploy } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate start
+describe('Custom routes export', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (isNextDeploy) return
 
   it('should not show warning for custom routes when not next export', async () => {
     await next.patchFile('next.config.js', (content) =>

--- a/test/e2e/data-fetching-errors/data-fetching-errors.test.ts
+++ b/test/e2e/data-fetching-errors/data-fetching-errors.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import {
   GSP_NO_RETURNED_VALUE,
@@ -6,12 +6,14 @@ import {
 } from '../../../packages/next/dist/lib/constants'
 
 describe('GS(S)P Page Errors', () => {
-  ;(isNextDev ? describe : describe.skip)('development mode', () => {
-    const { next, skipped } = nextTestSetup({
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
+  // @force-gate dev
+  describe('development mode', () => {
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should show error for getStaticProps as component member', async () => {
       const outputIndex = next.cliOutput.length
@@ -103,13 +105,15 @@ describe('GS(S)P Page Errors', () => {
       )
     })
   })
-  ;(isNextStart ? describe : describe.skip)('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
+  // @force-gate start
+  describe('production mode', () => {
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should show build error for getStaticProps as component member', async () => {
       await next.patchFile(

--- a/test/e2e/deferred-entries/deferred-entries.test.ts
+++ b/test/e2e/deferred-entries/deferred-entries.test.ts
@@ -114,15 +114,15 @@ async function waitForCallbackTimestampToStabilize(
   )
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('deferred-entries', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
     dependencies: {},
   })
-
-  if (skipped) return
 
   beforeAll(async () => {
     // Clear log files before starting

--- a/test/e2e/disable-js/disable-js.test.ts
+++ b/test/e2e/disable-js/disable-js.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('disabled runtime JS', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should render the page', async () => {
     const html = await next.render('/')

--- a/test/e2e/dynamic-optional-routing/dynamic-optional-routing.test.ts
+++ b/test/e2e/dynamic-optional-routing/dynamic-optional-routing.test.ts
@@ -2,12 +2,13 @@ import cheerio from 'cheerio'
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Dynamic Optional Routing', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should render catch-all top-level route with multiple segments', async () => {
     const html = await next.render('/hello/world')
@@ -216,13 +217,14 @@ describe('Dynamic Optional Routing', () => {
   }
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Dynamic Optional Routing - build validation', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const DUMMY_PAGE = 'export default () => null'
 

--- a/test/e2e/dynamic-routing/dynamic-routing.test.ts
+++ b/test/e2e/dynamic-routing/dynamic-routing.test.ts
@@ -1,16 +1,16 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { runTests } from './shared'
 
+// Deploy mode exclusion: The assertions exercise behavior specific to the local Next.js server.
+// Some assertions (`should not decode slashes`, `should serve file with
+// plus from public/static folder`) depend on local Next.js URL handling
+// and don't apply to Vercel's deploy infrastructure.
+// @force-gate !deploy
 describe('Dynamic Routing', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
-    // Some assertions (`should not decode slashes`, `should serve file with
-    // plus from public/static folder`) depend on local Next.js URL handling
-    // and don't apply to Vercel's deploy infrastructure.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   runTests({ next, isNextDev, isTurbopack, middlewareEnabled: false })
 })

--- a/test/e2e/fetch-polyfill/fetch-polyfill.test.ts
+++ b/test/e2e/fetch-polyfill/fetch-polyfill.test.ts
@@ -3,21 +3,21 @@ import cheerio from 'cheerio'
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { findPort } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('Fetch polyfill', () => {
   let apiServerPort: number
   let apiServer: http.Server
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
     dependencies: {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     apiServerPort = await findPort()

--- a/test/e2e/getserversideprops-preview/getserversideprops-preview.test.ts
+++ b/test/e2e/getserversideprops-preview/getserversideprops-preview.test.ts
@@ -15,13 +15,13 @@ function getData(html: string) {
   }
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('ServerSide Props Preview Mode', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   if (isNextStart) {
     it('should compile successfully', async () => {

--- a/test/e2e/gip-identifier/gip-identifier.test.ts
+++ b/test/e2e/gip-identifier/gip-identifier.test.ts
@@ -2,12 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('gip identifiers', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const getNextData = async () => {
     const html = await next.render('/')

--- a/test/e2e/gssp-redirect-base-path/gssp-redirect-base-path.test.ts
+++ b/test/e2e/gssp-redirect-base-path/gssp-redirect-base-path.test.ts
@@ -3,16 +3,17 @@ import { retry } from 'next-test-utils'
 
 const basePath = '/docs'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('GS(S)P Redirect with basePath', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
       react: '19.3.0-canary-da9325b5-20260417',
       'react-dom': '19.3.0-canary-da9325b5-20260417',
     },
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should apply temporary redirect when visited directly for GSSP page', async () => {
     const res = await next.fetch(`${basePath}/gssp-blog/redirect-1`, {

--- a/test/e2e/gssp-redirect/gssp-redirect.test.ts
+++ b/test/e2e/gssp-redirect/gssp-redirect.test.ts
@@ -1,16 +1,17 @@
 import { nextTestSetup, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('GS(S)P Redirect Support', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should apply temporary redirect when visited directly for GSSP page', async () => {
     const res = await next.fetch('/gssp-blog/redirect-1', {

--- a/test/e2e/i18n-data-fetching-redirect/redirect-from-context.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/redirect-from-context.test.ts
@@ -2,13 +2,10 @@ import { join } from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The source only records that these assertions fail after deployment; the root cause is unknown.
+// @force-gate !deploy
 describe('i18n-data-fetching-redirect', () => {
-  // TODO: investigate tests failures on deploy
-  if ((global as any).isNextDeploy) {
-    it('should skip temporarily', () => {})
-    return
-  }
-
   const { next } = nextTestSetup({
     files: {
       pages: new FileRef(join(__dirname, 'app/pages')),

--- a/test/e2e/i18n-data-fetching-redirect/redirect.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/redirect.test.ts
@@ -4,6 +4,8 @@ import { check } from 'next-test-utils'
 
 describe('i18n-data-fetching-redirect', () => {
   // TODO: investigate tests failures on deploy
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // The source only records that these assertions fail after deployment; the root cause is unknown.
   if ((global as any).isNextDeploy) {
     it('should skip temporarily', () => {})
     return

--- a/test/e2e/i18n-data-route/i18n-data-route.test.ts
+++ b/test/e2e/i18n-data-route/i18n-data-route.test.ts
@@ -12,19 +12,18 @@ function checkDataRoute(data: any, page: string) {
   expect(data.pageProps).toHaveProperty('page', page)
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test skips deployment because env vars that are doubled underscore prefixed
+// are not supported.
+// @force-gate !deploy
 describe('i18n-data-route', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // This test skips deployment because env vars that are doubled underscore prefixed
-    // are not supported.
-    skipDeployment: true,
     env: {
       // Disable internal header stripping so we can test the invoke output.
       __NEXT_NO_STRIP_INTERNAL_HEADERS: '1',
     },
   })
-
-  if (skipped) return
 
   describe('with locale prefix', () => {
     describe.each(i18n.locales)('/%s', (locale) => {

--- a/test/e2e/i18n-disallow-multiple-locales/i18n-disallow-multiple-locales.test.ts
+++ b/test/e2e/i18n-disallow-multiple-locales/i18n-disallow-multiple-locales.test.ts
@@ -13,16 +13,13 @@ async function verify(res, locale) {
   expect($('#router-locale').text()).toBe(locale)
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// TODO: re-enable after this behavior is corrected
+// @force-gate !deploy
 describe('i18n-disallow-multiple-locales', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // TODO: re-enable after this behavior is corrected
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should verify the default locale works', async () => {
     const res = await next.fetch('/', { redirect: 'manual' })

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
@@ -5,15 +5,13 @@ import fs from 'fs-extra'
 
 const locales = ['', '/en', '/sv', '/nl']
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely reads files from the isolated local fixture.
+// @force-gate !deploy
 describe('i18n-ignore-rewrite-source-locale with basepath', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   test.each(locales)(
     'get public file by skipping locale in rewrite, locale: %s',

--- a/test/e2e/i18n-support-base-path/i18n-support-base-path.test.ts
+++ b/test/e2e/i18n-support-base-path/i18n-support-base-path.test.ts
@@ -7,13 +7,14 @@ import { nextTestSetup, isNextDev, type NextInstance } from 'e2e-utils'
 
 type BrowserOptions = Parameters<NextInstance['browser']>[1]
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('i18n Support basePath', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const ctx: Record<string, any> = {
     basePath: '/docs',

--- a/test/e2e/i18n-support-custom-error/i18n-support-custom-error.test.ts
+++ b/test/e2e/i18n-support-custom-error/i18n-support-custom-error.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('Custom routes i18n custom error', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const locales = ['en', 'fr', 'de', 'it']
 

--- a/test/e2e/i18n-support/i18n-support.test.ts
+++ b/test/e2e/i18n-support/i18n-support.test.ts
@@ -9,13 +9,14 @@ import assert from 'assert'
 
 type BrowserOptions = Parameters<NextInstance['browser']>[1]
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('i18n Support', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const ctx: Record<string, any> = {
     basePath: '',

--- a/test/e2e/index-index/index-index.test.ts
+++ b/test/e2e/index-index/index-index.test.ts
@@ -2,15 +2,15 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel's deploy infrastructure normalizes nested `/index/index/index`
+// paths differently from Next.js's local server, so the routing
+// assertions here are local-only.
+// @force-gate !deploy
 describe('nested index.js', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    // Vercel's deploy infrastructure normalizes nested `/index/index/index`
-    // paths differently from Next.js's local server, so the routing
-    // assertions here are local-only.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should ssr page /', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/invalid-custom-routes/invalid-custom-routes.test.ts
+++ b/test/e2e/invalid-custom-routes/invalid-custom-routes.test.ts
@@ -1,13 +1,14 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Errors on invalid custom routes', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const writeConfig = async (routes: any, type = 'redirects') => {
     await next.patchFile(

--- a/test/e2e/invalid-multi-match/invalid-multi-match.test.ts
+++ b/test/e2e/invalid-multi-match/invalid-multi-match.test.ts
@@ -1,18 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// The test asserts on `next.cliOutput`, expecting the local
+// `next build` failure message ("To use a multi-match in the
+// destination..."). In deploy mode `next.cliOutput` contains the
+// Vercel deploy log, which doesn't surface the same Next.js build
+// error string at the top level, so the assertions don't apply.
+// @force-gate !deploy
 describe('Custom routes invalid multi-match', () => {
-  const { next, isNextDeploy, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
-    // The test asserts on `next.cliOutput`, expecting the local
-    // `next build` failure message ("To use a multi-match in the
-    // destination..."). In deploy mode `next.cliOutput` contains the
-    // Vercel deploy log, which doesn't surface the same Next.js build
-    // error string at the top level, so the assertions don't apply.
-    skipDeployment: true,
   })
-  if (skipped) return
-  if (isNextDeploy) return
 
   it('should show error for invalid multi-match', async () => {
     await next.render('/random')

--- a/test/e2e/legacy-link-behavior/index.test.ts
+++ b/test/e2e/legacy-link-behavior/index.test.ts
@@ -5,15 +5,13 @@ import {
   type ErrorSnapshot,
 } from '../../lib/add-redbox-matchers'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('Link with legacyBehavior', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return it('should skip', () => {})
-  }
 
   describe('if the child is an <a> tag', () => {
     it('forwards the href attribute', async () => {

--- a/test/e2e/legacy-link-behavior/validations.console.test.ts
+++ b/test/e2e/legacy-link-behavior/validations.console.test.ts
@@ -4,12 +4,13 @@ import { getDeterministicOutput } from '../app-dir/cache-components-errors/utils
 
 const partialPrefetching = !!process.env.__NEXT_PARTIAL_PREFETCHING
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Validations for <Link legacyBehavior>', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
   let previousOutputIndex = 0
 
   beforeEach(() => {

--- a/test/e2e/manual-client-base-path/index.test.ts
+++ b/test/e2e/manual-client-base-path/index.test.ts
@@ -6,6 +6,7 @@ import assert from 'assert'
 import { check, renderViaHTTP, waitFor } from 'next-test-utils'
 
 describe('manual-client-base-path', () => {
+  // Deploy mode exclusion: This suite runs an in-test HTTP proxy in front of the local Next.js server.
   if ((global as any).isNextDeploy) {
     it('should skip deploy', () => {})
     return

--- a/test/e2e/multi-zone/multi-zone.test.ts
+++ b/test/e2e/multi-zone/multi-zone.test.ts
@@ -2,10 +2,12 @@ import { nextTestSetup } from 'e2e-utils'
 import { check, waitFor } from 'next-test-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('multi-zone', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'app'),
-    skipDeployment: true,
     buildCommand: 'pnpm build',
     startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
     serverReadyPattern: /Next mode: (production|development)/,
@@ -19,10 +21,6 @@ describe('multi-zone', () => {
     },
     dependencies: require('./app/package.json').dependencies,
   })
-
-  if (skipped) {
-    return
-  }
 
   it.each([
     { pathname: '/', content: ['hello from host app'] },

--- a/test/e2e/new-link-behavior/material-ui.test.ts
+++ b/test/e2e/new-link-behavior/material-ui.test.ts
@@ -3,6 +3,8 @@ import path from 'path'
 
 const appDir = path.join(__dirname, 'material-ui')
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('New Link Behavior with material-ui', () => {
   const { next } = nextTestSetup({
     files: {

--- a/test/e2e/new-link-behavior/stitches.test.ts
+++ b/test/e2e/new-link-behavior/stitches.test.ts
@@ -3,6 +3,8 @@ import path from 'path'
 
 const appDir = path.join(__dirname, 'stitches')
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('New Link Behavior with stitches', () => {
   const { next } = nextTestSetup({
     files: {

--- a/test/e2e/next-link-errors/next-link-errors.test.ts
+++ b/test/e2e/next-link-errors/next-link-errors.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('next-link', () => {
-  const { skipped, next, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('errors on invalid href', async () => {
     const browser = await next.browser('/invalid-href')

--- a/test/e2e/next-phase/index.test.ts
+++ b/test/e2e/next-phase/index.test.ts
@@ -1,10 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test is skipped when deployed because it asserts against runtime
+// logs that cannot be queried in a deployed environment.
+// @force-gate !deploy
 describe('next-phase', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
-    // This test is skipped when deployed because it asserts against runtime
-    // logs that cannot be queried in a deployed environment.
-    skipDeployment: true,
+  const { next, isNextDev } = nextTestSetup({
     files: {
       'app/layout.js': `export default function Layout({ children }) {
         return <html><body>{children}</body></html>
@@ -19,8 +20,6 @@ describe('next-phase', () => {
       `,
     },
   })
-
-  if (skipped) return
 
   it('should render page with next phase correctly', async () => {
     await next.fetch('/')

--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('beforeInteractive in document Head', () => {
   const { next } = nextTestSetup({
     files: {

--- a/test/e2e/next-test/next-test.test.ts
+++ b/test/e2e/next-test/next-test.test.ts
@@ -25,18 +25,18 @@ function createTemporaryFixture(fixtureName: string) {
   return dir
 }
 
-describe.skip('next test', () => {
-  const { next: basicExample, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This doesn't need to be deployed as it's using `experimental-test` mode
+// @force-gate !deploy
+// @force-gate TODO
+describe('next test', () => {
+  const { next: basicExample } = nextTestSetup({
     files: new FileRef(join(__dirname, 'basic-example')),
     dependencies: {
       '@playwright/test': '1.43.1',
     },
     skipStart: true,
-    // This doesn't need to be deployed as it's using `experimental-test` mode
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   afterAll(async () => {
     await basicExample.destroy()

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -4,13 +4,13 @@ import { randomUUID } from 'crypto'
 import fs from 'fs-extra'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy || !standaloneOutput
 describe('og-api', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: new FileRef(join(__dirname, 'app')),
-    skipDeployment: process.env.TEST_OUTPUT_STANDALONE === 'true',
   })
-
-  if (skipped) return
 
   it('should respond from index', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/e2e/pages-performance-mark/index.test.ts
+++ b/test/e2e/pages-performance-mark/index.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 
 // This test case doesn't indicate rendering duplicate head in _document is valid,
 // but it's a way to reproduce the performance mark crashing.
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('pages performance mark', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render the page correctly without crashing with performance mark', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/react-current-version/react-current-version.test.ts
+++ b/test/e2e/react-current-version/react-current-version.test.ts
@@ -36,15 +36,13 @@ export const config = {
 
 describe('react-current-version', () => {
   describe('React 18 deprecation warning', () => {
-    const { next, isNextDeploy, skipped } = nextTestSetup({
+    const { next, isNextDeploy } = nextTestSetup({
       files: join(__dirname, 'app'),
       skipStart: true,
     })
 
-    if (skipped) {
-      return
-    }
-
+    // Deploy mode exclusion: This block asserts local build and server CLI
+    // output, which is produced before a deployment is available.
     if (isNextDeploy) {
       it('should skip in deploy mode', () => {})
       return

--- a/test/e2e/react-dnd-compile/react-dnd-compile.test.ts
+++ b/test/e2e/react-dnd-compile/react-dnd-compile.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('react-dnd-compile', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/repeated-slashes/repeated-slashes.test.ts
+++ b/test/e2e/repeated-slashes/repeated-slashes.test.ts
@@ -7,7 +7,7 @@ import {
   fetchViaHTTP,
   retry,
 } from 'next-test-utils'
-import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
+import { nextTestSetup, isNextDev } from 'e2e-utils'
 
 function runTests({
   next,
@@ -418,22 +418,25 @@ function runTests({
 
 describe('404 handling', () => {
   describe('custom _error', () => {
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
+    // @force-gate !deploy
     describe('server mode', () => {
-      const { next, isNextDeploy } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: path.join(__dirname, 'app'),
-        skipDeployment: true,
       })
-      if (isNextDeploy) return
 
       runTests({ next, isDev: isNextDev, isPages404: false })
     })
-    ;(isNextStart ? describe : describe.skip)('export mode', () => {
-      const { next, skipped } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
+    // @force-gate !deploy
+    // @force-gate start
+    describe('export mode', () => {
+      const { next } = nextTestSetup({
         files: path.join(__dirname, 'app'),
         skipStart: true,
-        skipDeployment: true,
       })
-      if (skipped) return
 
       let staticServer: any
       let staticPort: number
@@ -471,13 +474,14 @@ describe('404 handling', () => {
   })
 
   describe('pages/404', () => {
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
+    // @force-gate !deploy
     describe('server mode', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: path.join(__dirname, 'app'),
         skipStart: true,
-        skipDeployment: true,
       })
-      if (skipped) return
 
       beforeAll(async () => {
         await next.deleteFile('pages/_error.js')
@@ -501,13 +505,15 @@ describe('404 handling', () => {
 
       runTests({ next, isDev: isNextDev, isPages404: true })
     })
-    ;(isNextStart ? describe : describe.skip)('pages/404 export mode', () => {
-      const { next, skipped } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
+    // @force-gate !deploy
+    // @force-gate start
+    describe('pages/404 export mode', () => {
+      const { next } = nextTestSetup({
         files: path.join(__dirname, 'app'),
         skipStart: true,
-        skipDeployment: true,
       })
-      if (skipped) return
 
       let staticServer: any
       let staticPort: number

--- a/test/e2e/rewrite-request-smuggling/rewrite-request-smuggling.test.ts
+++ b/test/e2e/rewrite-request-smuggling/rewrite-request-smuggling.test.ts
@@ -4,6 +4,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { findPort, retry } from 'next-test-utils'
 
 describe('rewrite-request-smuggling', () => {
+  // Deploy mode exclusion: This suite opens raw TCP connections to a local backend server.
   if ((global as any).isNextDeploy) {
     it('should skip deploy', () => {})
     return

--- a/test/e2e/rewrite-with-browser-history/rewrite-with-browser-history.test.ts
+++ b/test/e2e/rewrite-with-browser-history/rewrite-with-browser-history.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('rewrites persist with browser history actions', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -7,8 +10,6 @@ describe('rewrites persist with browser history actions', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
 
   it('back-button should go back to rewritten path successfully', async () => {

--- a/test/e2e/rewrites-hostname/rewrites-hostname.test.ts
+++ b/test/e2e/rewrites-hostname/rewrites-hostname.test.ts
@@ -2,16 +2,14 @@ import { nextTestSetup } from 'e2e-utils'
 import { findPort } from 'next-test-utils'
 import createTargetServer from './target-server'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely depends on a local server, proxy, process, or dynamically allocated port.
+// @force-gate !deploy
 describe('rewrites hostname', () => {
-  const { skipped, next } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let targetPort: number | null = null
   let closeTargetServer: (() => Promise<void>) | null = null

--- a/test/e2e/route-index/route-index.test.ts
+++ b/test/e2e/route-index/route-index.test.ts
@@ -1,11 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Pages-router `/index` route resolution differs in Vercel's deploy
+// infrastructure; these assertions are local-only.
+// @force-gate !deploy
 describe('Route index handling', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // Pages-router `/index` route resolution differs in Vercel's deploy
-    // infrastructure; these assertions are local-only.
-    skipDeployment: true,
   })
 
   it('should handle / correctly', async () => {

--- a/test/e2e/route-indexes/route-indexes.test.ts
+++ b/test/e2e/route-indexes/route-indexes.test.ts
@@ -1,11 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Pages-router `/index` route resolution differs in Vercel's deploy
+// infrastructure; these assertions are local-only.
+// @force-gate !deploy
 describe('Route indexes handling', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // Pages-router `/index` route resolution differs in Vercel's deploy
-    // infrastructure; these assertions are local-only.
-    skipDeployment: true,
   })
 
   it('should handle / correctly', async () => {

--- a/test/e2e/router-hash-navigation/router-hash-navigation.test.ts
+++ b/test/e2e/router-hash-navigation/router-hash-navigation.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('router hash navigation', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -7,8 +10,6 @@ describe('router hash navigation', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
 
   it('scrolls to top when href="/" and url already contains a hash', async () => {

--- a/test/e2e/scroll-back-restoration/scroll-back-restoration.test.ts
+++ b/test/e2e/scroll-back-restoration/scroll-back-restoration.test.ts
@@ -1,6 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('Scroll Back Restoration Support', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -8,8 +11,6 @@ describe('Scroll Back Restoration Support', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
 
   it('should restore the scroll position on navigating back', async () => {

--- a/test/e2e/skip-trailing-slash-redirect/index.test.ts
+++ b/test/e2e/skip-trailing-slash-redirect/index.test.ts
@@ -11,6 +11,8 @@ import {
 import { join } from 'path'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('skip-trailing-slash-redirect', () => {
   const { next } = nextTestSetup({
     files: new FileRef(join(__dirname, 'app')),

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -31,6 +31,8 @@ async function testRoute(appPort, url, { isStatic, isEdge }) {
 describe('Switchable runtime', () => {
   let context
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // Prerenders used by this suite are not currently handled by deploy mode.
   if ((global as any).isNextDeploy) {
     // TODO-APP: re-enable after Prerenders are handled on deploy
     it('should skip for deploy temporarily', () => {})

--- a/test/e2e/third-parties/index.test.ts
+++ b/test/e2e/third-parties/index.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('@next/third-parties basic usage', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/trailing-slashes-rewrite/trailing-slashes-rewrite.test.ts
+++ b/test/e2e/trailing-slashes-rewrite/trailing-slashes-rewrite.test.ts
@@ -2,15 +2,15 @@ import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { findPort, initNextServerScript, killApp } from 'next-test-utils'
 
+// Deploy mode exclusion: This suite controls a local server or proxy process.
+// Spawns a custom proxy server in front of `next.start()`; deploy mode
+// doesn't run a local server.
+// @force-gate !deploy
 describe('Trailing Slash Rewrite Proxying', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    // Spawns a custom proxy server in front of `next.start()`; deploy mode
-    // doesn't run a local server.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let proxyServer: any
 

--- a/test/e2e/trailingslash-with-rewrite/index.test.ts
+++ b/test/e2e/trailingslash-with-rewrite/index.test.ts
@@ -3,6 +3,8 @@ import { FileRef, nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('trailingSlash:true with rewrites and getStaticProps', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
   if ((global as any).isNextDeploy) {
     it('should skip for deploy mode for now', () => {})
     return

--- a/test/e2e/url-imports/url-imports.test.ts
+++ b/test/e2e/url-imports/url-imports.test.ts
@@ -8,93 +8,88 @@ import { FileRef, nextTestSetup, isNextDev } from 'e2e-utils'
 import { join } from 'path'
 
 // experimental.urlImports is not implemented in Turbopack
-;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-  `Handle url imports`,
-  () => {
-    let staticServer
-    let staticServerPort
-    beforeAll(async () => {
-      staticServerPort = 12345
-      staticServer = await startStaticServer(
-        join(__dirname, 'source'),
-        undefined,
-        staticServerPort
-      )
-    })
-    afterAll(async () => {
-      await stopApp(staticServer)
-    })
-
-    const { next, skipped } = nextTestSetup({
-      files: isNextDev
-        ? {
-            // exclude next.lock here, should be generated automatically in dev
-            'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
-            pages: new FileRef(join(__dirname, 'pages')),
-            public: new FileRef(join(__dirname, 'public')),
-          }
-        : __dirname,
-      // The staticServer above doesn't work when deployed
-      skipDeployment: true,
-    })
-
-    if (skipped) {
-      return
-    }
-
-    const expectedServer =
-      /Hello <!-- -->42<!-- -->\+<!-- -->42<!-- -->\+<!-- -->\/_next\/static\/(immutable\/)?media\/vercel\.[0-9a-z_-]+\.png<!-- -->\+<!-- -->\/_next\/static\/(immutable\/)?media\/vercel\.[0-9a-z_-]+\.png/
-    const expectedClient = new RegExp(
-      expectedServer.source.replace(/<!-- -->/g, '')
+// Deploy mode exclusion: This suite controls a local server or proxy process.
+// The staticServer above doesn't work when deployed
+// @force-gate !deploy
+// @force-gate !turbopack
+describe(`Handle url imports`, () => {
+  let staticServer
+  let staticServerPort
+  beforeAll(async () => {
+    staticServerPort = 12345
+    staticServer = await startStaticServer(
+      join(__dirname, 'source'),
+      undefined,
+      staticServerPort
     )
+  })
+  afterAll(async () => {
+    await stopApp(staticServer)
+  })
 
-    for (const page of ['/static', '/ssr', '/ssg']) {
-      it(`should render the ${page} page`, async () => {
-        const html = await next.render(page)
-        expect(html).toMatch(expectedServer)
-      })
+  const { next } = nextTestSetup({
+    files: isNextDev
+      ? {
+          // exclude next.lock here, should be generated automatically in dev
+          'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
+          pages: new FileRef(join(__dirname, 'pages')),
+          public: new FileRef(join(__dirname, 'public')),
+        }
+      : __dirname,
+  })
 
-      it(`should client-render the ${page} page`, async () => {
-        const browser = await next.browser(page)
-        await retry(async () =>
-          expect(await getBrowserBodyText(browser)).toMatch(expectedClient)
-        )
-      })
-    }
+  const expectedServer =
+    /Hello <!-- -->42<!-- -->\+<!-- -->42<!-- -->\+<!-- -->\/_next\/static\/(immutable\/)?media\/vercel\.[0-9a-z_-]+\.png<!-- -->\+<!-- -->\/_next\/static\/(immutable\/)?media\/vercel\.[0-9a-z_-]+\.png/
+  const expectedClient = new RegExp(
+    expectedServer.source.replace(/<!-- -->/g, '')
+  )
 
-    it(`should render a static url image import`, async () => {
-      const browser = await next.browser('/image')
-      await browser.waitForElementByCss('#static-image')
-      await retry(async () =>
-        expect(
-          await browser.elementByCss('#static-image').getAttribute('src')
-        ).toMatch(
-          /^\/_next\/image\?url=%2F_next%2Fstatic%2F(immutable%2F)?media%2Fvercel\.[0-9a-z_-]+\.png&/
-        )
-      )
+  for (const page of ['/static', '/ssr', '/ssg']) {
+    it(`should render the ${page} page`, async () => {
+      const html = await next.render(page)
+      expect(html).toMatch(expectedServer)
     })
 
-    it(`should allow url import in css`, async () => {
-      const browser = await next.browser('/css')
-
-      await browser.waitForElementByCss('#static-css')
+    it(`should client-render the ${page} page`, async () => {
+      const browser = await next.browser(page)
       await retry(async () =>
-        expect(
-          await browser
-            .elementByCss('#static-css')
-            .getComputedCss('background-image')
-        ).toMatch(
-          /^url\("http(s)?:\/\/.+\/_next\/static\/(immutable\/)?media\/vercel\.[0-9a-z_-]+\.png(?:\?.*)?"\)$/
-        )
+        expect(await getBrowserBodyText(browser)).toMatch(expectedClient)
       )
-    })
-
-    it('should respond on value api', async () => {
-      const data = await next
-        .fetch('/api/value')
-        .then((res) => res.ok && res.json())
-
-      expect(data).toEqual({ value: 42 })
     })
   }
-)
+
+  it(`should render a static url image import`, async () => {
+    const browser = await next.browser('/image')
+    await browser.waitForElementByCss('#static-image')
+    await retry(async () =>
+      expect(
+        await browser.elementByCss('#static-image').getAttribute('src')
+      ).toMatch(
+        /^\/_next\/image\?url=%2F_next%2Fstatic%2F(immutable%2F)?media%2Fvercel\.[0-9a-z_-]+\.png&/
+      )
+    )
+  })
+
+  it(`should allow url import in css`, async () => {
+    const browser = await next.browser('/css')
+
+    await browser.waitForElementByCss('#static-css')
+    await retry(async () =>
+      expect(
+        await browser
+          .elementByCss('#static-css')
+          .getComputedCss('background-image')
+      ).toMatch(
+        /^url\("http(s)?:\/\/.+\/_next\/static\/(immutable\/)?media\/vercel\.[0-9a-z_-]+\.png(?:\?.*)?"\)$/
+      )
+    )
+  })
+
+  it('should respond on value api', async () => {
+    const data = await next
+      .fetch('/api/value')
+      .then((res) => res.ok && res.json())
+
+    expect(data).toEqual({ value: 42 })
+  })
+})

--- a/test/e2e/url/url.test.ts
+++ b/test/e2e/url/url.test.ts
@@ -10,20 +10,18 @@ import { isNextDev, isNextStart, nextTestSetup } from 'e2e-utils'
 // Webpack has
 // - a bug where App Router API routes (and Metadata) return client assets for `new URL`s.
 // - a bug where Edge Page routes return client assets for `new URL`s.
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe(`Handle new URL asset references`, () => {
-  const { next, skipped, isTurbopack } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     env: {
       // rely on skew protection when deployed
       NEXT_DEPLOYMENT_ID: isNextStart ? 'test-deployment-id' : undefined,
       __NEXT_SUPPORTS_IMMUTABLE_ASSETS: isNextStart ? '1' : undefined,
     },
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   const serverFileRegex = expect.stringMatching(
     /file:.*\/.next(\/dev)?\/server\/.*\/vercel.HASH.png$/

--- a/test/e2e/vary-header/test/index.test.ts
+++ b/test/e2e/vary-header/test/index.test.ts
@@ -2,10 +2,12 @@ import { nextTestSetup } from 'e2e-utils'
 import { expectVaryHeaderToContain } from 'next-test-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('Vary Header Tests', () => {
   const { next } = nextTestSetup({
     files: path.join(__dirname, '../app'),
-    skipDeployment: true,
   })
 
   it('should preserve custom vary header in API routes', async () => {


### PR DESCRIPTION
## Summary

- migrate Pages Router, API route, i18n, custom route, rewrite, redirect, and error-page deployment exclusions to `@force-gate`
- remove the corresponding `skipDeployment` options and `skipped` control flow while preserving each suite's rationale

## Verification

- verified on the combined top-of-stack tree with `pnpm typescript`
- compared ordinary-mode collection before and after: all 4,670 existing test names matched
- collected all 510 affected files in deploy mode: 4,578 skipped tests, zero failures

<!-- NEXT_JS_LLM -->
