### PR TITLE
test: migrate asset deploy exclusions to force gates

### DIFF
--- a/test/e2e/app-dir/app-css-pageextensions/index.test.ts
+++ b/test/e2e/app-dir/app-css-pageextensions/index.test.ts
@@ -1,18 +1,16 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - css with pageextensions', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: {
       '@picocss/pico': '1.5.7',
       sass: 'latest',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   describe('css support with pageextensions', () => {
     describe('page in app directory with pageextention, css should work', () => {

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -1,20 +1,18 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('app dir - css', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: {
       '@picocss/pico': '1.5.7',
       sass: 'latest',
       '@next/mdx': 'workspace:*',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   describe('css support', () => {
     describe('server layouts', () => {

--- a/test/e2e/app-dir/css-order/css-order.test.ts
+++ b/test/e2e/app-dir/css-order/css-order.test.ts
@@ -339,7 +339,6 @@ const options = (value: CssChunkingValue) => ({
   dependencies: {
     sass: 'latest',
   },
-  skipDeployment: true,
 })
 
 /**
@@ -379,11 +378,13 @@ function shouldSkipConflict(ordering: readonly string[]): boolean {
     )
 }
 
+// TODO(deploy-test-completion): No deploy-specific incompatibility is
+// documented.
+// @force-gate !deploy
 describe.each(process.env.IS_TURBOPACK_TEST ? TURBO_MODES : WEBPACK_MODES_TRUE)(
   'css-order %s',
   (_label: string, value: CssChunkingValue) => {
-    const { next, isNextDev, skipped } = nextTestSetup(options(value))
-    if (skipped) return
+    const { next, isNextDev } = nextTestSetup(options(value))
     for (const ordering of allPairs) {
       const name = `should load correct styles navigating back again ${ordering.join(
         ' -> '
@@ -433,6 +434,9 @@ describe.each(process.env.IS_TURBOPACK_TEST ? TURBO_MODES : WEBPACK_MODES_TRUE)(
     }
   }
 )
+// TODO(deploy-test-completion): No deploy-specific incompatibility is
+// documented.
+// @force-gate !deploy
 describe.each(
   process.env.IS_TURBOPACK_TEST ? TURBO_MODES : WEBPACK_MODES_LOOSE
 )('css-order %s', (_label: string, value: CssChunkingValue) => {
@@ -476,6 +480,9 @@ describe.each(
     })
   }
 })
+// TODO(deploy-test-completion): No deploy-specific incompatibility is
+// documented.
+// @force-gate !deploy
 describe.each(
   process.env.IS_TURBOPACK_TEST ? TURBO_MODES : WEBPACK_MODES_LOOSE
 )('css-order %s', (_label: string, value: CssChunkingValue) => {

--- a/test/e2e/app-dir/css-server-chunks/css-server-chunks.test.ts
+++ b/test/e2e/app-dir/css-server-chunks/css-server-chunks.test.ts
@@ -3,15 +3,13 @@ import { listClientChunks } from 'next-test-utils'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely reads files from the isolated local fixture.
+// @force-gate !deploy
 describe('css-server-chunks', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not write CSS chunks for the server', async () => {
     // Fetch all routes to compile them in development

--- a/test/e2e/app-dir/dynamic-css/index.test.ts
+++ b/test/e2e/app-dir/dynamic-css/index.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app dir - dynamic css', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should preload all chunks of dynamic component during SSR', async () => {
     const $ = await next.render$('/ssr')

--- a/test/e2e/app-dir/emotion-js/index.test.ts
+++ b/test/e2e/app-dir/emotion-js/index.test.ts
@@ -1,19 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - emotion-js', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: {
       '@emotion/react': 'latest',
       '@emotion/cache': 'latest',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render emotion-js css with compiler.emotion option correctly', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/global-error/with-style-import/index.test.ts
+++ b/test/e2e/app-dir/global-error/with-style-import/index.test.ts
@@ -6,15 +6,13 @@ async function testDev(browser, errorRegex) {
   expect(await getRedboxHeader(browser)).toMatch(errorRegex)
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - global error - with style import', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render global error with correct styles', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/metadata-invalid-image-file/metadata-invalid-image-file.test.ts
+++ b/test/e2e/app-dir/metadata-invalid-image-file/metadata-invalid-image-file.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('metadata-invalid-image-file', () => {
-  const { next, isTurbopack, isNextDev, skipped, isRspack } = nextTestSetup({
+  const { next, isTurbopack, isNextDev, isRspack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) return
 
   it('should error on invalid metadata image file', async () => {
     // In dev, it needs to render the page first

--- a/test/e2e/app-dir/next-font/next-font.test.ts
+++ b/test/e2e/app-dir/next-font/next-font.test.ts
@@ -18,12 +18,11 @@ const getAttrs = (elems: Cheerio) =>
     .sort((a, b) => (a.href < b.href ? -1 : 1))
 
 describe('app dir - next/font', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely mutates files in the isolated local fixture after setup.
+  // @force-gate !deploy
   describe('app dir - next-font', () => {
-    const {
-      next,
-      isNextDev: isDev,
-      skipped,
-    } = nextTestSetup({
+    const { next, isNextDev: isDev } = nextTestSetup({
       files: {
         app: new FileRef(join(__dirname, 'app')),
         fonts: new FileRef(join(__dirname, 'fonts')),
@@ -33,12 +32,7 @@ describe('app dir - next/font', () => {
       dependencies: {
         '@next/font': 'workspace:*',
       },
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     describe('import values', () => {
       it('should have correct values at /', async () => {

--- a/test/e2e/app-dir/next-image-legacy-src-with-query-without-local-patterns/next-image-legacy-src-with-query-without-local-patterns.test.ts
+++ b/test/e2e/app-dir/next-image-legacy-src-with-query-without-local-patterns/next-image-legacy-src-with-query-without-local-patterns.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-image-legacy-src-with-query-without-local-patterns', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw error for relative image with query without localPatterns for legacy Image', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/next-image-src-with-query-without-local-patterns/next-image-src-with-query-without-local-patterns.test.ts
+++ b/test/e2e/app-dir/next-image-src-with-query-without-local-patterns/next-image-src-with-query-without-local-patterns.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-image-src-with-query-without-local-patterns', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw error for relative image with query without localPatterns', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/next-image/next-image-https.test.ts
+++ b/test/e2e/app-dir/next-image/next-image-https.test.ts
@@ -1,16 +1,15 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // TODO: Test didn't (or maybe) never ran in CI but it should.
-describe.skip('app dir - next-image (with https)', () => {
-  const { next, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
+// @force-gate TODO
+describe('app dir - next-image (with https)', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     startCommand: `pnpm next dev --experimental-https`,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('loads images without any errors', async () => {
     let failCount = 0

--- a/test/e2e/app-dir/next-image/next-image-proxy.test.ts
+++ b/test/e2e/app-dir/next-image/next-image-proxy.test.ts
@@ -8,14 +8,13 @@ import { nextTestSetup } from 'e2e-utils'
 let proxyPort
 let proxyServer: https.Server
 
+// Deploy mode exclusion: This suite controls a local server or proxy process.
+// This test is skipped when deployed because it relies on a proxy server
+// @force-gate !deploy
 describe('next-image-proxy', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // This test is skipped when deployed because it relies on a proxy server
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   beforeAll(async () => {
     proxyPort = await findPort()

--- a/test/e2e/app-dir/no-double-tailwind-execution/no-double-tailwind-execution.test.ts
+++ b/test/e2e/app-dir/no-double-tailwind-execution/no-double-tailwind-execution.test.ts
@@ -1,10 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('no-double-tailwind-execution', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: {
       '@tailwindcss/postcss': '^4',
       tailwindcss: '^4',
@@ -14,10 +16,6 @@ describe('no-double-tailwind-execution', () => {
       ...process.env,
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should run tailwind only once initially and per change', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/not-found/css-precedence/index.test.ts
+++ b/test/e2e/app-dir/not-found/css-precedence/index.test.ts
@@ -1,18 +1,16 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('not-found app dir css', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: {
       sass: 'latest',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should load css while navigation between not-found and page', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/scss/compilation-and-prefixing/compilation-and-prefixing.test.ts
+++ b/test/e2e/app-dir/scss/compilation-and-prefixing/compilation-and-prefixing.test.ts
@@ -6,6 +6,8 @@ const nextConfig = {
   productionBrowserSourceMaps: true,
 }
 
+// This suite reads emitted CSS and source maps from the local build output.
+// @force-gate !deploy
 describe.each([
   { dependencies: { sass: '1.54.0' }, nextConfig },
   {
@@ -18,17 +20,15 @@ describe.each([
     },
   },
 ])('SCSS Support ($dependencies)', ({ dependencies, nextConfig }) => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // This test is skipped because it is reading files in the `.next` file which
-    // isn't available/necessary in a deployment environment.
-    skipDeployment: true,
     dependencies,
     nextConfig,
   })
 
-  if (skipped) return // TODO: Figure out this test for dev and Turbopack
-  ;(isNextDev ? describe.skip : describe)('Production only', () => {
+  // This section only asserts production build output.
+  // @force-gate !dev
+  describe('Production only', () => {
     describe('CSS Compilation and Prefixing', () => {
       it(`should've compiled and prefixed`, async () => {
         const $ = await next.render$('/')

--- a/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
@@ -3,17 +3,15 @@
 import { isNextStart, nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, getRedboxSource } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Invalid Global CSS with Custom App', () => {
-  const { next, skipped, isTurbopack, isRspack } = nextTestSetup({
+  const { next, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: isNextStart,
-    skipDeployment: true,
     dependencies: { sass: '1.54.0' },
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextStart) {
     it('should fail to build', async () => {

--- a/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
@@ -3,17 +3,15 @@
 import { isNextStart, nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, getRedboxSource } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Invalid Global CSS', () => {
-  const { next, skipped, isTurbopack, isRspack } = nextTestSetup({
+  const { next, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: isNextStart,
-    skipDeployment: true,
     dependencies: { sass: '1.54.0' },
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextStart) {
     it('should fail to build', async () => {

--- a/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
+++ b/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
@@ -4,54 +4,50 @@ import { isNextStart, nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, getRedboxSource } from 'next-test-utils'
 
 // Importing module CSS in _document is allowed in Turbopack
-;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-  'Invalid SCSS in _document',
-  () => {
-    const { next, skipped, isRspack } = nextTestSetup({
-      files: __dirname,
-      skipStart: isNextStart,
-      skipDeployment: true,
-      dependencies: { sass: '1.54.0' },
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
+// @force-gate !turbopack
+describe('Invalid SCSS in _document', () => {
+  const { next, isRspack } = nextTestSetup({
+    files: __dirname,
+    skipStart: isNextStart,
+    dependencies: { sass: '1.54.0' },
+  })
+
+  if (isNextStart) {
+    it('should fail to build', async () => {
+      const { exitCode, cliOutput } = await next.build()
+      expect(exitCode).not.toBe(0)
+      expect(cliOutput).toContain('Failed to compile')
+      expect(cliOutput).toContain('styles.module.scss')
+      expect(cliOutput).toMatch(
+        /CSS.*cannot.*be imported within.*pages[\\/]_document\.js/
+      )
+      // Skip: Rspack loaders cannot access module issuer info for location details
+      if (!process.env.NEXT_RSPACK) {
+        expect(cliOutput).toMatch(/Location:.*pages[\\/]_document\.js/)
+      }
     })
+  } else {
+    it('should show a build error', async () => {
+      const browser = await next.browser('/')
 
-    if (skipped) {
-      return
-    }
+      await waitForRedbox(browser)
+      const errorSource = await getRedboxSource(browser)
 
-    if (isNextStart) {
-      it('should fail to build', async () => {
-        const { exitCode, cliOutput } = await next.build()
-        expect(exitCode).not.toBe(0)
-        expect(cliOutput).toContain('Failed to compile')
-        expect(cliOutput).toContain('styles.module.scss')
-        expect(cliOutput).toMatch(
-          /CSS.*cannot.*be imported within.*pages[\\/]_document\.js/
-        )
-        // Skip: Rspack loaders cannot access module issuer info for location details
-        if (!process.env.NEXT_RSPACK) {
-          expect(cliOutput).toMatch(/Location:.*pages[\\/]_document\.js/)
-        }
-      })
-    } else {
-      it('should show a build error', async () => {
-        const browser = await next.browser('/')
-
-        await waitForRedbox(browser)
-        const errorSource = await getRedboxSource(browser)
-
-        if (isRspack) {
-          expect(errorSource).toMatchInlineSnapshot(`
+      if (isRspack) {
+        expect(errorSource).toMatchInlineSnapshot(`
            "./styles.module.scss
              │ CSS cannot be imported within pages/_document.js. Please move global styles to pages/_app.js."
           `)
-        } else {
-          expect(errorSource).toMatchInlineSnapshot(`
+      } else {
+        expect(errorSource).toMatchInlineSnapshot(`
            "./styles.module.scss
            CSS cannot be imported within pages/_document.js. Please move global styles to pages/_app.js.
            Location: pages/_document.js"
           `)
-        }
-      })
-    }
+      }
+    })
   }
-)
+})

--- a/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
+++ b/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
@@ -3,17 +3,15 @@
 import { isNextStart, nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, getRedboxSource } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('CSS Import from node_modules', () => {
-  const { next, skipped, isTurbopack, isRspack } = nextTestSetup({
+  const { next, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: isNextStart,
-    skipDeployment: true,
     dependencies: { sass: '1.54.0' },
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextStart) {
     it('should fail the build', async () => {

--- a/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
@@ -3,17 +3,15 @@
 import { isNextStart, nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, getRedboxSource } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Valid and Invalid Global CSS with Custom App', () => {
-  const { next, skipped, isTurbopack, isRspack } = nextTestSetup({
+  const { next, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: isNextStart,
-    skipDeployment: true,
     dependencies: { sass: '1.54.0' },
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextStart) {
     it('should fail to build', async () => {

--- a/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
+++ b/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
@@ -1,11 +1,13 @@
 /* eslint-env jest */
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('SCSS Support', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
   // Production only test
   ;(isNextDev ? describe.skip : describe)('Friendly Webpack Error', () => {

--- a/test/e2e/app-dir/turbopack-postcss-multiple-configs/turbopack-postcss-multiple-configs.test.ts
+++ b/test/e2e/app-dir/turbopack-postcss-multiple-configs/turbopack-postcss-multiple-configs.test.ts
@@ -1,16 +1,16 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('turbopack-postcss-multiple-configs', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     // Per-directory PostCSS config resolution is a Turbopack-only feature
     // (turbopackLocalPostcssConfig). Webpack does not support this feature and
     // does not accept function-valued PostCSS plugins, so skip non-Turbopack runs.
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   if (!isTurbopack) {
     it('should only run with Turbopack', () => {})

--- a/test/e2e/css-client-nav/css-client-nav.test.ts
+++ b/test/e2e/css-client-nav/css-client-nav.test.ts
@@ -5,16 +5,16 @@ import cheerio from 'cheerio'
 import { findPort } from 'next-test-utils'
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 
+// Deploy mode exclusion: This suite controls a local server or proxy process.
+// Calls `next.build()` and uses an in-test proxy in front of the Next
+// server; both rely on the local-process model and are not applicable to
+// deploy mode.
+// @force-gate !deploy
 describe('CSS Module client-side navigation', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    // Calls `next.build()` and uses an in-test proxy in front of the Next
-    // server; both rely on the local-process model and are not applicable to
-    // deploy mode.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let proxyServer: http.Server
   let proxyPort: number

--- a/test/e2e/css-features/css-modules-ordering.test.ts
+++ b/test/e2e/css-features/css-modules-ordering.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable jest/no-standalone-expect */
-/* eslint-disable jest/no-identical-title */
+
 import cheerio from 'cheerio'
 import {
   isNextDev,
@@ -12,149 +12,152 @@ import path from 'path'
 
 // https://github.com/vercel/next.js/issues/12343
 describe('Basic CSS Modules Ordering', () => {
-  ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-    'useLightningcss(true)',
-    () => {
-      const { next } = nextTestSetup({
-        files: path.join(__dirname, 'fixtures', 'next-issue-12343'),
-        nextConfig: {
-          experimental: {
-            useLightningcss: true,
-          },
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
+  // @force-gate !turbopack
+  describe('useLightningcss(true)', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures', 'next-issue-12343'),
+      nextConfig: {
+        experimental: {
+          useLightningcss: true,
         },
-        skipDeployment: true,
+      },
+    })
+
+    async function checkGreenButton(browser: Playwright) {
+      await browser.elementByCss('#link-other')
+      const titleColor = await browser.eval(() => {
+        const el = document.querySelector('#link-other')
+        return el ? window.getComputedStyle(el).backgroundColor : ''
       })
-
-      async function checkGreenButton(browser: Playwright) {
-        await browser.elementByCss('#link-other')
-        const titleColor = await browser.eval(() => {
-          const el = document.querySelector('#link-other')
-          return el ? window.getComputedStyle(el).backgroundColor : ''
-        })
-        expect(titleColor).toBe('rgb(0, 255, 0)')
-      }
-
-      async function checkPinkButton(browser: Playwright) {
-        await browser.elementByCss('#link-index')
-        const titleColor = await browser.eval(() => {
-          const el = document.querySelector('#link-index')
-          return el ? window.getComputedStyle(el).backgroundColor : ''
-        })
-        expect(titleColor).toBe('rgb(255, 105, 180)')
-      }
-
-      it('should have correct color on index page (on load)', async () => {
-        const browser = await next.browser('/')
-        try {
-          await checkGreenButton(browser)
-        } finally {
-          await browser.close()
-        }
-      })
-
-      it('should have correct color on index page (on hover)', async () => {
-        const browser = await next.browser('/')
-        try {
-          await checkGreenButton(browser)
-          await browser.elementByCss('#link-other').moveTo()
-          await retry(async () => {
-            await checkGreenButton(browser)
-          })
-        } finally {
-          await browser.close()
-        }
-      })
-
-      it('should have correct color on index page (on nav)', async () => {
-        const browser = await next.browser('/')
-        try {
-          await checkGreenButton(browser)
-          await browser.elementByCss('#link-other').click()
-
-          await browser.elementByCss('#link-index')
-          await checkPinkButton(browser)
-
-          await browser.elementByCss('#link-index').click()
-          await checkGreenButton(browser)
-        } finally {
-          await browser.close()
-        }
-      })
+      expect(titleColor).toBe('rgb(0, 255, 0)')
     }
-  )
-  ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-    'useLightningcss(false)',
-    () => {
-      const { next } = nextTestSetup({
-        files: path.join(__dirname, 'fixtures', 'next-issue-12343'),
-        nextConfig: {
-          experimental: {
-            useLightningcss: false,
-          },
+
+    async function checkPinkButton(browser: Playwright) {
+      await browser.elementByCss('#link-index')
+      const titleColor = await browser.eval(() => {
+        const el = document.querySelector('#link-index')
+        return el ? window.getComputedStyle(el).backgroundColor : ''
+      })
+      expect(titleColor).toBe('rgb(255, 105, 180)')
+    }
+
+    it('should have correct color on index page (on load)', async () => {
+      const browser = await next.browser('/')
+      try {
+        await checkGreenButton(browser)
+      } finally {
+        await browser.close()
+      }
+    })
+
+    it('should have correct color on index page (on hover)', async () => {
+      const browser = await next.browser('/')
+      try {
+        await checkGreenButton(browser)
+        await browser.elementByCss('#link-other').moveTo()
+        await retry(async () => {
+          await checkGreenButton(browser)
+        })
+      } finally {
+        await browser.close()
+      }
+    })
+
+    it('should have correct color on index page (on nav)', async () => {
+      const browser = await next.browser('/')
+      try {
+        await checkGreenButton(browser)
+        await browser.elementByCss('#link-other').click()
+
+        await browser.elementByCss('#link-index')
+        await checkPinkButton(browser)
+
+        await browser.elementByCss('#link-index').click()
+        await checkGreenButton(browser)
+      } finally {
+        await browser.close()
+      }
+    })
+  })
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
+  // @force-gate !turbopack
+  describe('useLightningcss(false)', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures', 'next-issue-12343'),
+      nextConfig: {
+        experimental: {
+          useLightningcss: false,
         },
-        skipDeployment: true,
+      },
+    })
+
+    async function checkGreenButton(browser: Playwright) {
+      await browser.elementByCss('#link-other')
+      const titleColor = await browser.eval(() => {
+        const el = document.querySelector('#link-other')
+        return el ? window.getComputedStyle(el).backgroundColor : ''
       })
-
-      async function checkGreenButton(browser: Playwright) {
-        await browser.elementByCss('#link-other')
-        const titleColor = await browser.eval(() => {
-          const el = document.querySelector('#link-other')
-          return el ? window.getComputedStyle(el).backgroundColor : ''
-        })
-        expect(titleColor).toBe('rgb(0, 255, 0)')
-      }
-
-      async function checkPinkButton(browser: Playwright) {
-        await browser.elementByCss('#link-index')
-        const titleColor = await browser.eval(() => {
-          const el = document.querySelector('#link-index')
-          return el ? window.getComputedStyle(el).backgroundColor : ''
-        })
-        expect(titleColor).toBe('rgb(255, 105, 180)')
-      }
-
-      it('should have correct color on index page (on load)', async () => {
-        const browser = await next.browser('/')
-        try {
-          await checkGreenButton(browser)
-        } finally {
-          await browser.close()
-        }
-      })
-
-      it('should have correct color on index page (on hover)', async () => {
-        const browser = await next.browser('/')
-        try {
-          await checkGreenButton(browser)
-          await browser.elementByCss('#link-other').moveTo()
-          await retry(async () => {
-            await checkGreenButton(browser)
-          })
-        } finally {
-          await browser.close()
-        }
-      })
-
-      it('should have correct color on index page (on nav)', async () => {
-        const browser = await next.browser('/')
-        try {
-          await checkGreenButton(browser)
-          await browser.elementByCss('#link-other').click()
-
-          await browser.elementByCss('#link-index')
-          await checkPinkButton(browser)
-
-          await browser.elementByCss('#link-index').click()
-          await checkGreenButton(browser)
-        } finally {
-          await browser.close()
-        }
-      })
+      expect(titleColor).toBe('rgb(0, 255, 0)')
     }
-  )
+
+    async function checkPinkButton(browser: Playwright) {
+      await browser.elementByCss('#link-index')
+      const titleColor = await browser.eval(() => {
+        const el = document.querySelector('#link-index')
+        return el ? window.getComputedStyle(el).backgroundColor : ''
+      })
+      expect(titleColor).toBe('rgb(255, 105, 180)')
+    }
+
+    it('should have correct color on index page (on load)', async () => {
+      const browser = await next.browser('/')
+      try {
+        await checkGreenButton(browser)
+      } finally {
+        await browser.close()
+      }
+    })
+
+    it('should have correct color on index page (on hover)', async () => {
+      const browser = await next.browser('/')
+      try {
+        await checkGreenButton(browser)
+        await browser.elementByCss('#link-other').moveTo()
+        await retry(async () => {
+          await checkGreenButton(browser)
+        })
+      } finally {
+        await browser.close()
+      }
+    })
+
+    it('should have correct color on index page (on nav)', async () => {
+      const browser = await next.browser('/')
+      try {
+        await checkGreenButton(browser)
+        await browser.elementByCss('#link-other').click()
+
+        await browser.elementByCss('#link-index')
+        await checkPinkButton(browser)
+
+        await browser.elementByCss('#link-index').click()
+        await checkGreenButton(browser)
+      } finally {
+        await browser.close()
+      }
+    })
+  })
 })
 
 describe('Ordering with Global CSS and Modules', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('useLightningcss(true)', () => {
     const { next } = nextTestSetup({
       files: path.join(__dirname, 'fixtures', 'global-and-module-ordering'),
@@ -163,7 +166,6 @@ describe('Ordering with Global CSS and Modules', () => {
           useLightningcss: true,
         },
       },
-      skipDeployment: true,
     })
 
     ;(isNextDev ? it : it.skip)(
@@ -244,6 +246,9 @@ describe('Ordering with Global CSS and Modules', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('useLightningcss(false)', () => {
     const { next } = nextTestSetup({
       files: path.join(__dirname, 'fixtures', 'global-and-module-ordering'),
@@ -252,7 +257,6 @@ describe('Ordering with Global CSS and Modules', () => {
           useLightningcss: false,
         },
       },
-      skipDeployment: true,
     })
 
     ;(isNextDev ? it : it.skip)(
@@ -337,47 +341,62 @@ describe('Ordering with Global CSS and Modules', () => {
 // https://github.com/vercel/next.js/issues/12445
 // This feature is not supported in Turbopack
 describe('CSS Modules Composes Ordering', () => {
-  ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-    'useLightningcss(true)',
-    () => {
-      const { next } = nextTestSetup({
-        files: path.join(__dirname, 'fixtures', 'composes-ordering'),
-        nextConfig: {
-          experimental: {
-            useLightningcss: true,
-          },
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
+  // @force-gate !turbopack
+  describe('useLightningcss(true)', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures', 'composes-ordering'),
+      nextConfig: {
+        experimental: {
+          useLightningcss: true,
         },
-        skipDeployment: true,
+      },
+    })
+
+    async function checkBlackTitle(browser: Playwright) {
+      await browser.elementByCss('#black-title')
+      const titleColor = await browser.eval(() => {
+        const el = document.querySelector('#black-title')
+        return el ? window.getComputedStyle(el).color : ''
       })
+      expect(titleColor).toBe('rgb(17, 17, 17)')
+    }
 
-      async function checkBlackTitle(browser: Playwright) {
-        await browser.elementByCss('#black-title')
-        const titleColor = await browser.eval(() => {
-          const el = document.querySelector('#black-title')
-          return el ? window.getComputedStyle(el).color : ''
-        })
-        expect(titleColor).toBe('rgb(17, 17, 17)')
+    async function checkRedTitle(browser: Playwright) {
+      await browser.elementByCss('#red-title')
+      const titleColor = await browser.eval(() => {
+        const el = document.querySelector('#red-title')
+        return el ? window.getComputedStyle(el).color : ''
+      })
+      expect(titleColor).toBe('rgb(255, 0, 0)')
+    }
+
+    it('should have correct color on index page (on load)', async () => {
+      const browser = await next.browser('/')
+      try {
+        await checkBlackTitle(browser)
+      } finally {
+        await browser.close()
       }
+    })
 
-      async function checkRedTitle(browser: Playwright) {
-        await browser.elementByCss('#red-title')
-        const titleColor = await browser.eval(() => {
-          const el = document.querySelector('#red-title')
-          return el ? window.getComputedStyle(el).color : ''
-        })
-        expect(titleColor).toBe('rgb(255, 0, 0)')
-      }
-
-      it('should have correct color on index page (on load)', async () => {
-        const browser = await next.browser('/')
-        try {
+    it('should have correct color on index page (on hover)', async () => {
+      const browser = await next.browser('/')
+      try {
+        await checkBlackTitle(browser)
+        await browser.elementByCss('#link-other').moveTo()
+        await retry(async () => {
           await checkBlackTitle(browser)
-        } finally {
-          await browser.close()
-        }
-      })
-
-      it('should have correct color on index page (on hover)', async () => {
+        })
+      } finally {
+        await browser.close()
+      }
+    })
+    ;(isNextStart ? it : it.skip)(
+      'should not change color on hover',
+      async () => {
         const browser = await next.browser('/')
         try {
           await checkBlackTitle(browser)
@@ -388,156 +407,155 @@ describe('CSS Modules Composes Ordering', () => {
         } finally {
           await browser.close()
         }
-      })
-      ;(isNextStart ? it : it.skip)(
-        'should not change color on hover',
-        async () => {
-          const browser = await next.browser('/')
-          try {
-            await checkBlackTitle(browser)
-            await browser.elementByCss('#link-other').moveTo()
-            await retry(async () => {
-              await checkBlackTitle(browser)
-            })
-          } finally {
-            await browser.close()
-          }
-        }
-      )
-      ;(isNextStart ? it : it.skip)(
-        'should have correct CSS injection order',
-        async () => {
-          const browser = await next.browser('/')
-          try {
-            await checkBlackTitle(browser)
-
-            const prevSiblingHref = await browser.eval(() => {
-              const el = document.querySelector(
-                'link[rel=stylesheet][data-n-p]'
-              )?.previousSibling as Element | null
-              return el?.getAttribute('href') ?? null
-            })
-            const currentPageHref = await browser.eval(() => {
-              return document
-                .querySelector('link[rel=stylesheet][data-n-p]')
-                ?.getAttribute('href')
-            })
-            expect(prevSiblingHref).toBeDefined()
-            expect(prevSiblingHref).toBe(currentPageHref)
-
-            await browser.elementByCss('#link-other').click()
-            await checkRedTitle(browser)
-
-            const newPrevSibling = await browser.eval(() => {
-              const el = document.querySelector('style[data-n-href]')
-                ?.previousSibling as Element | null
-              return el?.getAttribute('data-n-css') ?? null
-            })
-            const newPageHref = await browser.eval(() => {
-              return document
-                .querySelector('style[data-n-href]')
-                ?.getAttribute('data-n-href')
-            })
-            expect(newPrevSibling).toBe('')
-            expect(newPageHref).toBeDefined()
-            expect(newPageHref).not.toBe(currentPageHref)
-
-            await browser.elementByCss('#link-index').click()
-            await checkBlackTitle(browser)
-
-            const newPrevSibling2 = await browser.eval(() => {
-              const el = document.querySelector('style[data-n-href]')
-                ?.previousSibling as Element | null
-              return el?.getAttribute('data-n-css') ?? null
-            })
-            const newPageHref2 = await browser.eval(() => {
-              return document
-                .querySelector('style[data-n-href]')
-                ?.getAttribute('data-n-href')
-            })
-            expect(newPrevSibling2).toBe('')
-            expect(newPageHref2).toBeDefined()
-            expect(newPageHref2).toBe(currentPageHref)
-          } finally {
-            await browser.close()
-          }
-        }
-      )
-
-      it('should have correct color on index page (on nav from index)', async () => {
+      }
+    )
+    ;(isNextStart ? it : it.skip)(
+      'should have correct CSS injection order',
+      async () => {
         const browser = await next.browser('/')
         try {
           await checkBlackTitle(browser)
-          await browser.elementByCss('#link-other').click()
 
-          await browser.elementByCss('#link-index')
-          await checkRedTitle(browser)
-
-          await browser.elementByCss('#link-index').click()
-          await checkBlackTitle(browser)
-        } finally {
-          await browser.close()
-        }
-      })
-
-      it('should have correct color on index page (on nav from other)', async () => {
-        const browser = await next.browser('/other')
-        try {
-          await checkRedTitle(browser)
-          await browser.elementByCss('#link-index').click()
-
-          await browser.elementByCss('#link-other')
-          await checkBlackTitle(browser)
+          const prevSiblingHref = await browser.eval(() => {
+            const el = document.querySelector('link[rel=stylesheet][data-n-p]')
+              ?.previousSibling as Element | null
+            return el?.getAttribute('href') ?? null
+          })
+          const currentPageHref = await browser.eval(() => {
+            return document
+              .querySelector('link[rel=stylesheet][data-n-p]')
+              ?.getAttribute('href')
+          })
+          expect(prevSiblingHref).toBeDefined()
+          expect(prevSiblingHref).toBe(currentPageHref)
 
           await browser.elementByCss('#link-other').click()
           await checkRedTitle(browser)
+
+          const newPrevSibling = await browser.eval(() => {
+            const el = document.querySelector('style[data-n-href]')
+              ?.previousSibling as Element | null
+            return el?.getAttribute('data-n-css') ?? null
+          })
+          const newPageHref = await browser.eval(() => {
+            return document
+              .querySelector('style[data-n-href]')
+              ?.getAttribute('data-n-href')
+          })
+          expect(newPrevSibling).toBe('')
+          expect(newPageHref).toBeDefined()
+          expect(newPageHref).not.toBe(currentPageHref)
+
+          await browser.elementByCss('#link-index').click()
+          await checkBlackTitle(browser)
+
+          const newPrevSibling2 = await browser.eval(() => {
+            const el = document.querySelector('style[data-n-href]')
+              ?.previousSibling as Element | null
+            return el?.getAttribute('data-n-css') ?? null
+          })
+          const newPageHref2 = await browser.eval(() => {
+            return document
+              .querySelector('style[data-n-href]')
+              ?.getAttribute('data-n-href')
+          })
+          expect(newPrevSibling2).toBe('')
+          expect(newPageHref2).toBeDefined()
+          expect(newPageHref2).toBe(currentPageHref)
         } finally {
           await browser.close()
         }
-      })
-    }
-  )
-  ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-    'useLightningcss(false)',
-    () => {
-      const { next } = nextTestSetup({
-        files: path.join(__dirname, 'fixtures', 'composes-ordering'),
-        nextConfig: {
-          experimental: {
-            useLightningcss: false,
-          },
+      }
+    )
+
+    it('should have correct color on index page (on nav from index)', async () => {
+      const browser = await next.browser('/')
+      try {
+        await checkBlackTitle(browser)
+        await browser.elementByCss('#link-other').click()
+
+        await browser.elementByCss('#link-index')
+        await checkRedTitle(browser)
+
+        await browser.elementByCss('#link-index').click()
+        await checkBlackTitle(browser)
+      } finally {
+        await browser.close()
+      }
+    })
+
+    it('should have correct color on index page (on nav from other)', async () => {
+      const browser = await next.browser('/other')
+      try {
+        await checkRedTitle(browser)
+        await browser.elementByCss('#link-index').click()
+
+        await browser.elementByCss('#link-other')
+        await checkBlackTitle(browser)
+
+        await browser.elementByCss('#link-other').click()
+        await checkRedTitle(browser)
+      } finally {
+        await browser.close()
+      }
+    })
+  })
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
+  // @force-gate !turbopack
+  describe('useLightningcss(false)', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'fixtures', 'composes-ordering'),
+      nextConfig: {
+        experimental: {
+          useLightningcss: false,
         },
-        skipDeployment: true,
+      },
+    })
+
+    async function checkBlackTitle(browser: Playwright) {
+      await browser.elementByCss('#black-title')
+      const titleColor = await browser.eval(() => {
+        const el = document.querySelector('#black-title')
+        return el ? window.getComputedStyle(el).color : ''
       })
+      expect(titleColor).toBe('rgb(17, 17, 17)')
+    }
 
-      async function checkBlackTitle(browser: Playwright) {
-        await browser.elementByCss('#black-title')
-        const titleColor = await browser.eval(() => {
-          const el = document.querySelector('#black-title')
-          return el ? window.getComputedStyle(el).color : ''
-        })
-        expect(titleColor).toBe('rgb(17, 17, 17)')
+    async function checkRedTitle(browser: Playwright) {
+      await browser.elementByCss('#red-title')
+      const titleColor = await browser.eval(() => {
+        const el = document.querySelector('#red-title')
+        return el ? window.getComputedStyle(el).color : ''
+      })
+      expect(titleColor).toBe('rgb(255, 0, 0)')
+    }
+
+    it('should have correct color on index page (on load)', async () => {
+      const browser = await next.browser('/')
+      try {
+        await checkBlackTitle(browser)
+      } finally {
+        await browser.close()
       }
+    })
 
-      async function checkRedTitle(browser: Playwright) {
-        await browser.elementByCss('#red-title')
-        const titleColor = await browser.eval(() => {
-          const el = document.querySelector('#red-title')
-          return el ? window.getComputedStyle(el).color : ''
-        })
-        expect(titleColor).toBe('rgb(255, 0, 0)')
-      }
-
-      it('should have correct color on index page (on load)', async () => {
-        const browser = await next.browser('/')
-        try {
+    it('should have correct color on index page (on hover)', async () => {
+      const browser = await next.browser('/')
+      try {
+        await checkBlackTitle(browser)
+        await browser.elementByCss('#link-other').moveTo()
+        await retry(async () => {
           await checkBlackTitle(browser)
-        } finally {
-          await browser.close()
-        }
-      })
-
-      it('should have correct color on index page (on hover)', async () => {
+        })
+      } finally {
+        await browser.close()
+      }
+    })
+    ;(isNextStart ? it : it.skip)(
+      'should not change color on hover',
+      async () => {
         const browser = await next.browser('/')
         try {
           await checkBlackTitle(browser)
@@ -548,113 +566,97 @@ describe('CSS Modules Composes Ordering', () => {
         } finally {
           await browser.close()
         }
-      })
-      ;(isNextStart ? it : it.skip)(
-        'should not change color on hover',
-        async () => {
-          const browser = await next.browser('/')
-          try {
-            await checkBlackTitle(browser)
-            await browser.elementByCss('#link-other').moveTo()
-            await retry(async () => {
-              await checkBlackTitle(browser)
-            })
-          } finally {
-            await browser.close()
-          }
-        }
-      )
-      ;(isNextStart ? it : it.skip)(
-        'should have correct CSS injection order',
-        async () => {
-          const browser = await next.browser('/')
-          try {
-            await checkBlackTitle(browser)
-
-            const prevSiblingHref = await browser.eval(() => {
-              const el = document.querySelector(
-                'link[rel=stylesheet][data-n-p]'
-              )?.previousSibling as Element | null
-              return el?.getAttribute('href') ?? null
-            })
-            const currentPageHref = await browser.eval(() => {
-              return document
-                .querySelector('link[rel=stylesheet][data-n-p]')
-                ?.getAttribute('href')
-            })
-            expect(prevSiblingHref).toBeDefined()
-            expect(prevSiblingHref).toBe(currentPageHref)
-
-            await browser.elementByCss('#link-other').click()
-            await checkRedTitle(browser)
-
-            const newPrevSibling = await browser.eval(() => {
-              const el = document.querySelector('style[data-n-href]')
-                ?.previousSibling as Element | null
-              return el?.getAttribute('data-n-css') ?? null
-            })
-            const newPageHref = await browser.eval(() => {
-              return document
-                .querySelector('style[data-n-href]')
-                ?.getAttribute('data-n-href')
-            })
-            expect(newPrevSibling).toBe('')
-            expect(newPageHref).toBeDefined()
-            expect(newPageHref).not.toBe(currentPageHref)
-
-            await browser.elementByCss('#link-index').click()
-            await checkBlackTitle(browser)
-
-            const newPrevSibling2 = await browser.eval(() => {
-              const el = document.querySelector('style[data-n-href]')
-                ?.previousSibling as Element | null
-              return el?.getAttribute('data-n-css') ?? null
-            })
-            const newPageHref2 = await browser.eval(() => {
-              return document
-                .querySelector('style[data-n-href]')
-                ?.getAttribute('data-n-href')
-            })
-            expect(newPrevSibling2).toBe('')
-            expect(newPageHref2).toBeDefined()
-            expect(newPageHref2).toBe(currentPageHref)
-          } finally {
-            await browser.close()
-          }
-        }
-      )
-
-      it('should have correct color on index page (on nav from index)', async () => {
+      }
+    )
+    ;(isNextStart ? it : it.skip)(
+      'should have correct CSS injection order',
+      async () => {
         const browser = await next.browser('/')
         try {
           await checkBlackTitle(browser)
-          await browser.elementByCss('#link-other').click()
 
-          await browser.elementByCss('#link-index')
-          await checkRedTitle(browser)
-
-          await browser.elementByCss('#link-index').click()
-          await checkBlackTitle(browser)
-        } finally {
-          await browser.close()
-        }
-      })
-
-      it('should have correct color on index page (on nav from other)', async () => {
-        const browser = await next.browser('/other')
-        try {
-          await checkRedTitle(browser)
-          await browser.elementByCss('#link-index').click()
-
-          await browser.elementByCss('#link-other')
-          await checkBlackTitle(browser)
+          const prevSiblingHref = await browser.eval(() => {
+            const el = document.querySelector('link[rel=stylesheet][data-n-p]')
+              ?.previousSibling as Element | null
+            return el?.getAttribute('href') ?? null
+          })
+          const currentPageHref = await browser.eval(() => {
+            return document
+              .querySelector('link[rel=stylesheet][data-n-p]')
+              ?.getAttribute('href')
+          })
+          expect(prevSiblingHref).toBeDefined()
+          expect(prevSiblingHref).toBe(currentPageHref)
 
           await browser.elementByCss('#link-other').click()
           await checkRedTitle(browser)
+
+          const newPrevSibling = await browser.eval(() => {
+            const el = document.querySelector('style[data-n-href]')
+              ?.previousSibling as Element | null
+            return el?.getAttribute('data-n-css') ?? null
+          })
+          const newPageHref = await browser.eval(() => {
+            return document
+              .querySelector('style[data-n-href]')
+              ?.getAttribute('data-n-href')
+          })
+          expect(newPrevSibling).toBe('')
+          expect(newPageHref).toBeDefined()
+          expect(newPageHref).not.toBe(currentPageHref)
+
+          await browser.elementByCss('#link-index').click()
+          await checkBlackTitle(browser)
+
+          const newPrevSibling2 = await browser.eval(() => {
+            const el = document.querySelector('style[data-n-href]')
+              ?.previousSibling as Element | null
+            return el?.getAttribute('data-n-css') ?? null
+          })
+          const newPageHref2 = await browser.eval(() => {
+            return document
+              .querySelector('style[data-n-href]')
+              ?.getAttribute('data-n-href')
+          })
+          expect(newPrevSibling2).toBe('')
+          expect(newPageHref2).toBeDefined()
+          expect(newPageHref2).toBe(currentPageHref)
         } finally {
           await browser.close()
         }
-      })
-    }
-  )
+      }
+    )
+
+    it('should have correct color on index page (on nav from index)', async () => {
+      const browser = await next.browser('/')
+      try {
+        await checkBlackTitle(browser)
+        await browser.elementByCss('#link-other').click()
+
+        await browser.elementByCss('#link-index')
+        await checkRedTitle(browser)
+
+        await browser.elementByCss('#link-index').click()
+        await checkBlackTitle(browser)
+      } finally {
+        await browser.close()
+      }
+    })
+
+    it('should have correct color on index page (on nav from other)', async () => {
+      const browser = await next.browser('/other')
+      try {
+        await checkRedTitle(browser)
+        await browser.elementByCss('#link-index').click()
+
+        await browser.elementByCss('#link-other')
+        await checkBlackTitle(browser)
+
+        await browser.elementByCss('#link-other').click()
+        await checkRedTitle(browser)
+      } finally {
+        await browser.close()
+      }
+    })
+  })
 })

--- a/test/e2e/geist-font/geist-font.test.ts
+++ b/test/e2e/geist-font/geist-font.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// `geist@latest` has a peer dependency issue with the latest Next.js.
+// see: https://github.com/vercel/geist-font/pull/117
+// @force-gate !deploy
 describe('geist-font', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // `geist@latest` has a peer dependency issue with the latest Next.js.
-    // see: https://github.com/vercel/geist-font/pull/117
-    skipDeployment: true,
     dependencies: {
       geist: 'latest',
     },

--- a/test/e2e/image-optimizer/image-optimizer.test.ts
+++ b/test/e2e/image-optimizer/image-optimizer.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { cleanImagesDir, expectWidth, fsToJson } from './util'
 
@@ -14,13 +14,14 @@ function toQueryString(query: Record<string, any>): string {
 const largeSize = 1080
 
 describe('Image Optimizer', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('config checks', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: join(__dirname, 'app'),
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     const configChecks: Array<{
       name: string
@@ -262,8 +263,11 @@ describe('Image Optimizer', () => {
       })
     }
   })
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('Server support for trailingSlash in next.config.js', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: join(__dirname, 'app'),
       nextConfig: {
         trailingSlash: true,
@@ -272,9 +276,7 @@ describe('Image Optimizer', () => {
           qualities: [70, 75],
         },
       },
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should return successful response for original loader', async () => {
       const query = { url: '/test.png', w: 8, q: 70 }
@@ -282,20 +284,20 @@ describe('Image Optimizer', () => {
       expect(res.status).toBe(200)
     })
   })
-  ;(isNextStart ? describe : describe.skip)(
-    'Server support for headers in next.config.js',
-    () => {
-      const size = 96
-      const { next, skipped } = nextTestSetup({
-        files: join(__dirname, 'app'),
-        skipDeployment: true,
-      })
-      if (skipped) return
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
+  // @force-gate start
+  describe('Server support for headers in next.config.js', () => {
+    const size = 96
+    const { next } = nextTestSetup({
+      files: join(__dirname, 'app'),
+    })
 
-      beforeAll(async () => {
-        await next.patchFile(
-          'next.config.js',
-          `module.exports = {
+    beforeAll(async () => {
+      await next.patchFile(
+        'next.config.js',
+        `module.exports = {
         async headers() {
           return [
             {
@@ -310,225 +312,194 @@ describe('Image Optimizer', () => {
           ]
         },
       }`
-        )
-      })
-      afterAll(async () => {
-        await next.patchFile(
-          'next.config.js',
-          '// prettier-ignore\nmodule.exports = { /* replaceme */ }'
-        )
-      })
+      )
+    })
+    afterAll(async () => {
+      await next.patchFile(
+        'next.config.js',
+        '// prettier-ignore\nmodule.exports = { /* replaceme */ }'
+      )
+    })
 
-      it('should set max-age header', async () => {
-        const query = { url: '/test.png', w: size, q: 75 }
-        const opts = { headers: { accept: 'image/webp' } }
-        const res = await next.fetch(
-          `/_next/image?${toQueryString(query)}`,
-          opts
-        )
-        expect(res.status).toBe(200)
-        expect(res.headers.get('Cache-Control')).toBe(
-          'public, max-age=14400, must-revalidate'
-        )
-        expect(res.headers.get('Content-Disposition')).toBe(
-          'attachment; filename="test.webp"'
-        )
+    it('should set max-age header', async () => {
+      const query = { url: '/test.png', w: size, q: 75 }
+      const opts = { headers: { accept: 'image/webp' } }
+      const res = await next.fetch(`/_next/image?${toQueryString(query)}`, opts)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Cache-Control')).toBe(
+        'public, max-age=14400, must-revalidate'
+      )
+      expect(res.headers.get('Content-Disposition')).toBe(
+        'attachment; filename="test.webp"'
+      )
 
-        const imagesDir = join(next.testDir, '.next', 'cache', 'images')
-        await check(async () => {
-          const files = await fsToJson(imagesDir)
-          let found = false
-          const maxAge = '14400'
-          Object.keys(files).forEach((dir) => {
-            if (
-              Object.keys(files[dir]).some((file) =>
-                file.includes(`${maxAge}.`)
-              )
-            ) {
-              found = true
-            }
-          })
-          return found ? 'success' : 'failed'
-        }, 'success')
-      })
+      const imagesDir = join(next.testDir, '.next', 'cache', 'images')
+      await check(async () => {
+        const files = await fsToJson(imagesDir)
+        let found = false
+        const maxAge = '14400'
+        Object.keys(files).forEach((dir) => {
+          if (
+            Object.keys(files[dir]).some((file) => file.includes(`${maxAge}.`))
+          ) {
+            found = true
+          }
+        })
+        return found ? 'success' : 'failed'
+      }, 'success')
+    })
 
-      it('should not set max-age header when not matching next.config.js', async () => {
-        const query = { url: '/test.jpg', w: size, q: 75 }
-        const opts = { headers: { accept: 'image/webp' } }
-        const res = await next.fetch(
-          `/_next/image?${toQueryString(query)}`,
-          opts
-        )
-        expect(res.status).toBe(200)
-        expect(res.headers.get('Cache-Control')).toBe(
-          'public, max-age=14400, must-revalidate'
-        )
-        expect(res.headers.get('Content-Disposition')).toBe(
-          'attachment; filename="test.webp"'
-        )
-      })
-    }
-  )
-  ;(isNextDev ? describe : describe.skip)(
-    'dev support next.config.js cloudinary loader',
-    () => {
-      const { next, skipped } = nextTestSetup({
-        files: join(__dirname, 'app'),
-        nextConfig: {
-          images: {
-            loader: 'cloudinary',
-            path: 'https://example.com/act123/',
-          },
+    it('should not set max-age header when not matching next.config.js', async () => {
+      const query = { url: '/test.jpg', w: size, q: 75 }
+      const opts = { headers: { accept: 'image/webp' } }
+      const res = await next.fetch(`/_next/image?${toQueryString(query)}`, opts)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Cache-Control')).toBe(
+        'public, max-age=14400, must-revalidate'
+      )
+      expect(res.headers.get('Content-Disposition')).toBe(
+        'attachment; filename="test.webp"'
+      )
+    })
+  })
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
+  // @force-gate dev
+  describe('dev support next.config.js cloudinary loader', () => {
+    const { next } = nextTestSetup({
+      files: join(__dirname, 'app'),
+      nextConfig: {
+        images: {
+          loader: 'cloudinary',
+          path: 'https://example.com/act123/',
         },
-        skipDeployment: true,
-      })
-      if (skipped) return
+      },
+    })
 
-      it('should 404 when loader is not default', async () => {
-        const size = 384
-        const query = { w: size, q: 90, url: '/test.svg' }
-        const opts = { headers: { accept: 'image/webp' } }
-        const res = await next.fetch(
-          `/_next/image?${toQueryString(query)}`,
-          opts
-        )
-        expect(res.status).toBe(404)
-      })
-    }
-  )
-  ;(isNextDev ? describe : describe.skip)(
-    'images.unoptimized in next.config.js',
-    () => {
-      const { next, skipped } = nextTestSetup({
-        files: join(__dirname, 'app'),
-        nextConfig: {
-          images: { unoptimized: true },
+    it('should 404 when loader is not default', async () => {
+      const size = 384
+      const query = { w: size, q: 90, url: '/test.svg' }
+      const opts = { headers: { accept: 'image/webp' } }
+      const res = await next.fetch(`/_next/image?${toQueryString(query)}`, opts)
+      expect(res.status).toBe(404)
+    })
+  })
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
+  // @force-gate dev
+  describe('images.unoptimized in next.config.js', () => {
+    const { next } = nextTestSetup({
+      files: join(__dirname, 'app'),
+      nextConfig: {
+        images: { unoptimized: true },
+      },
+    })
+
+    it('should 404 when unoptimized', async () => {
+      const size = 384
+      const query = { w: size, q: 75, url: '/test.jpg' }
+      const opts = { headers: { accept: 'image/webp' } }
+      const res = await next.fetch(`/_next/image?${toQueryString(query)}`, opts)
+      expect(res.status).toBe(404)
+    })
+  })
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
+  // @force-gate dev
+  describe('experimental.imgOptMaxInputPixels in next.config.js', () => {
+    const { next } = nextTestSetup({
+      files: join(__dirname, 'app'),
+      nextConfig: {
+        experimental: { imgOptMaxInputPixels: 100 },
+      },
+    })
+
+    it('should fallback to source image when input exceeds imgOptMaxInputPixels', async () => {
+      const size = 256
+      const query = { w: size, q: 75, url: '/test.jpg' }
+      const opts = { headers: { accept: 'image/webp' } }
+      const res = await next.fetch(`/_next/image?${toQueryString(query)}`, opts)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Content-Type')).toBe('image/jpeg')
+    })
+  })
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
+  // @force-gate start
+  describe('External rewrite support with for serving static content in images', () => {
+    const { next } = nextTestSetup({
+      files: join(__dirname, 'app'),
+      nextConfig: {
+        async rewrites() {
+          return [
+            {
+              source: '/:base(next-js)/:rest*',
+              destination:
+                'https://assets.vercel.com/image/upload/v1538361091/repositories/:base/:rest*',
+            },
+          ]
         },
-        skipDeployment: true,
-      })
-      if (skipped) return
+      },
+    })
 
-      it('should 404 when unoptimized', async () => {
-        const size = 384
-        const query = { w: size, q: 75, url: '/test.jpg' }
-        const opts = { headers: { accept: 'image/webp' } }
-        const res = await next.fetch(
-          `/_next/image?${toQueryString(query)}`,
-          opts
-        )
-        expect(res.status).toBe(404)
-      })
-    }
-  )
-  ;(isNextDev ? describe : describe.skip)(
-    'experimental.imgOptMaxInputPixels in next.config.js',
-    () => {
-      const { next, skipped } = nextTestSetup({
-        files: join(__dirname, 'app'),
-        nextConfig: {
-          experimental: { imgOptMaxInputPixels: 100 },
+    it('should return response when image is served from an external rewrite', async () => {
+      const imagesDir = join(next.testDir, '.next', 'cache', 'images')
+      await cleanImagesDir(imagesDir)
+
+      const query = { url: '/next-js/next-js-bg.png', w: 64, q: 75 }
+      const opts = { headers: { accept: 'image/webp' } }
+      const res = await next.fetch(`/_next/image?${toQueryString(query)}`, opts)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('Content-Type')).toBe('image/webp')
+      expect(res.headers.get('Cache-Control')).toBe(
+        'public, max-age=31536000, must-revalidate'
+      )
+      expect(res.headers.get('Vary')).toBe('Accept')
+      expect(res.headers.get('Content-Disposition')).toBe(
+        'attachment; filename="next-js-bg.webp"'
+      )
+
+      await check(async () => {
+        const files = await fsToJson(imagesDir)
+        let found = false
+        const maxAge = '31536000'
+        Object.keys(files).forEach((dir) => {
+          if (
+            Object.keys(files[dir]).some((file) => file.includes(`${maxAge}.`))
+          ) {
+            found = true
+          }
+        })
+        return found ? 'success' : 'failed'
+      }, 'success')
+      await expectWidth(res, 64)
+    })
+  })
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
+  // @force-gate dev
+  describe('dev support for dynamic blur placeholder', () => {
+    const { next } = nextTestSetup({
+      files: join(__dirname, 'app'),
+      nextConfig: {
+        images: {
+          deviceSizes: [largeSize],
+          imageSizes: [],
         },
-        skipDeployment: true,
-      })
-      if (skipped) return
+      },
+    })
 
-      it('should fallback to source image when input exceeds imgOptMaxInputPixels', async () => {
-        const size = 256
-        const query = { w: size, q: 75, url: '/test.jpg' }
-        const opts = { headers: { accept: 'image/webp' } }
-        const res = await next.fetch(
-          `/_next/image?${toQueryString(query)}`,
-          opts
-        )
-        expect(res.status).toBe(200)
-        expect(res.headers.get('Content-Type')).toBe('image/jpeg')
-      })
-    }
-  )
-  ;(isNextStart ? describe : describe.skip)(
-    'External rewrite support with for serving static content in images',
-    () => {
-      const { next, skipped } = nextTestSetup({
-        files: join(__dirname, 'app'),
-        nextConfig: {
-          async rewrites() {
-            return [
-              {
-                source: '/:base(next-js)/:rest*',
-                destination:
-                  'https://assets.vercel.com/image/upload/v1538361091/repositories/:base/:rest*',
-              },
-            ]
-          },
-        },
-        skipDeployment: true,
-      })
-      if (skipped) return
-
-      it('should return response when image is served from an external rewrite', async () => {
-        const imagesDir = join(next.testDir, '.next', 'cache', 'images')
-        await cleanImagesDir(imagesDir)
-
-        const query = { url: '/next-js/next-js-bg.png', w: 64, q: 75 }
-        const opts = { headers: { accept: 'image/webp' } }
-        const res = await next.fetch(
-          `/_next/image?${toQueryString(query)}`,
-          opts
-        )
-        expect(res.status).toBe(200)
-        expect(res.headers.get('Content-Type')).toBe('image/webp')
-        expect(res.headers.get('Cache-Control')).toBe(
-          'public, max-age=31536000, must-revalidate'
-        )
-        expect(res.headers.get('Vary')).toBe('Accept')
-        expect(res.headers.get('Content-Disposition')).toBe(
-          'attachment; filename="next-js-bg.webp"'
-        )
-
-        await check(async () => {
-          const files = await fsToJson(imagesDir)
-          let found = false
-          const maxAge = '31536000'
-          Object.keys(files).forEach((dir) => {
-            if (
-              Object.keys(files[dir]).some((file) =>
-                file.includes(`${maxAge}.`)
-              )
-            ) {
-              found = true
-            }
-          })
-          return found ? 'success' : 'failed'
-        }, 'success')
-        await expectWidth(res, 64)
-      })
-    }
-  )
-  ;(isNextDev ? describe : describe.skip)(
-    'dev support for dynamic blur placeholder',
-    () => {
-      const { next, skipped } = nextTestSetup({
-        files: join(__dirname, 'app'),
-        nextConfig: {
-          images: {
-            deviceSizes: [largeSize],
-            imageSizes: [],
-          },
-        },
-        skipDeployment: true,
-      })
-      if (skipped) return
-
-      it('should support width 8 per BLUR_IMG_SIZE with next dev', async () => {
-        const query = { url: '/test.png', w: 8, q: 70 }
-        const opts = { headers: { accept: 'image/webp' } }
-        const res = await next.fetch(
-          `/_next/image?${toQueryString(query)}`,
-          opts
-        )
-        expect(res.status).toBe(200)
-        await expectWidth(res, 320)
-      })
-    }
-  )
+    it('should support width 8 per BLUR_IMG_SIZE with next dev', async () => {
+      const query = { url: '/test.png', w: 8, q: 70 }
+      const opts = { headers: { accept: 'image/webp' } }
+      const res = await next.fetch(`/_next/image?${toQueryString(query)}`, opts)
+      expect(res.status).toBe(200)
+      await expectWidth(res, 320)
+    })
+  })
 })

--- a/test/e2e/image-optimizer/util.ts
+++ b/test/e2e/image-optimizer/util.ts
@@ -10,7 +10,6 @@ import {
   getDistDir,
   listClientChunks,
   retry,
-  shouldUseTurbopack,
   waitFor,
 } from 'next-test-utils'
 import { nextTestSetup, isNextDev } from 'e2e-utils'
@@ -1753,25 +1752,19 @@ export function runTests(ctx: RunTestsCtx) {
 }
 
 export const setupTests = (ctx: SetupTestsCtx) => {
-  const maybeSkipTurbopackProd =
-    shouldUseTurbopack() && !isNextDev ? describe.skip : describe
-
   if (!ctx.nextConfigImages) {
-    maybeSkipTurbopackProd('w/o next.config.js', () => {
+    // The suite exercises the local image pipeline, while deployments use the
+    // Vercel image CDN with different headers and cache behavior.
+    // @force-gate !deploy
+    // @force-gate dev || !turbopack
+    describe('w/o next.config.js', () => {
       const size = 384
-      const { next, isNextDeploy } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: join(__dirname, 'app'),
         nextConfig: ctx.nextConfigExperimental
           ? { experimental: ctx.nextConfigExperimental }
           : undefined,
-        // The image optimizer suite asserts on the local Next.js image
-        // pipeline (custom upstream HTTP server, on-disk cache, response
-        // headers from `/_next/image`). Vercel's deploy serves images
-        // through its own image CDN with different headers, paths, and
-        // cache semantics, so these assertions don't apply.
-        skipDeployment: true,
       })
-      if (isNextDeploy) return
 
       runTests({
         next,
@@ -1782,7 +1775,11 @@ export const setupTests = (ctx: SetupTestsCtx) => {
     })
   }
 
-  maybeSkipTurbopackProd('with next.config.js', () => {
+  // The suite exercises the local image pipeline, while deployments use the
+  // Vercel image CDN with different headers and cache behavior.
+  // @force-gate !deploy
+  // @force-gate dev || !turbopack
+  describe('with next.config.js', () => {
     const w = isNextDev ? 400 : 399
     const mergedImages = {
       dangerouslyAllowLocalIP: true,
@@ -1800,7 +1797,7 @@ export const setupTests = (ctx: SetupTestsCtx) => {
       ...ctx.nextConfigImages,
     }
 
-    const { next, isNextDeploy } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: join(__dirname, 'app'),
       nextConfig: {
         images: mergedImages,
@@ -1808,14 +1805,7 @@ export const setupTests = (ctx: SetupTestsCtx) => {
           ? { experimental: ctx.nextConfigExperimental }
           : {}),
       },
-      // The image optimizer suite asserts on the local Next.js image
-      // pipeline (custom upstream HTTP server, on-disk cache, response
-      // headers from `/_next/image`). Vercel's deploy serves images
-      // through its own image CDN with different headers, paths, and
-      // cache semantics, so these assertions don't apply.
-      skipDeployment: true,
     })
-    if (isNextDeploy) return
 
     runTests({
       next,

--- a/test/e2e/next-dynamic-css-asset-prefix/next-dynamic-css-asset-prefix.test.ts
+++ b/test/e2e/next-dynamic-css-asset-prefix/next-dynamic-css-asset-prefix.test.ts
@@ -3,16 +3,17 @@ import type { Server } from 'http'
 import { findPort } from 'next-test-utils'
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('next/dynamic with assetPrefix', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
     dependencies: {
       sass: '1.54.0',
     },
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let cdnPort: number
   let cdn: Server

--- a/test/e2e/next-font/basepath.test.ts
+++ b/test/e2e/next-font/basepath.test.ts
@@ -8,6 +8,7 @@ const mockedGoogleFontResponses = require.resolve(
 )
 
 describe('next/font/google basepath', () => {
+  // Deploy mode exclusion: This suite passes an absolute local mocked-font-response path into the build.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return

--- a/test/e2e/next-font/google-fetch-error.test.ts
+++ b/test/e2e/next-font/google-fetch-error.test.ts
@@ -9,6 +9,7 @@ describe('next/font/google fetch error', () => {
   const isDev = (global as any).isNextDev
   const isTurbopack = !!process.env.IS_TURBOPACK_TEST
 
+  // Deploy mode exclusion: This suite intentionally fails the build, so there is no successful deployment to exercise.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return

--- a/test/e2e/next-font/index.test.ts
+++ b/test/e2e/next-font/index.test.ts
@@ -36,6 +36,7 @@ function hrefMatchesFontWithoutSizeAdjust(href: string) {
 }
 
 describe('next/font', () => {
+  // Deploy mode exclusion: This suite passes an absolute local mocked-font-response path into the build.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return

--- a/test/e2e/next-font/with-font-declarations-file.test.ts
+++ b/test/e2e/next-font/with-font-declarations-file.test.ts
@@ -10,6 +10,7 @@ const mockedGoogleFontResponses = require.resolve(
 const isDev = (global as any).isNextDev
 
 describe('next/font/google with-font-declarations-file', () => {
+  // Deploy mode exclusion: This suite passes an absolute local mocked-font-response path into the build.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return

--- a/test/e2e/next-font/with-proxy.test.ts
+++ b/test/e2e/next-font/with-proxy.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import spawn from 'cross-spawn'
 
 describe('next/font/google with proxy', () => {
+  // Deploy mode exclusion: This suite spawns a local proxy process.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy', () => {})
     return

--- a/test/e2e/next-font/without-preloaded-fonts.test.ts
+++ b/test/e2e/next-font/without-preloaded-fonts.test.ts
@@ -8,6 +8,7 @@ const mockedGoogleFontResponses = require.resolve(
 )
 
 describe('next/font/google without-preloaded-fonts without _app', () => {
+  // Deploy mode exclusion: This suite passes an absolute local mocked-font-response path into the build.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return
@@ -54,6 +55,7 @@ describe('next/font/google without-preloaded-fonts without _app', () => {
 })
 
 describe('next/font/google no preloads with _app', () => {
+  // Deploy mode exclusion: This suite passes an absolute local mocked-font-response path into the build.
   if ((global as any).isNextDeploy) {
     it('should skip next deploy for now', () => {})
     return

--- a/test/e2e/next-image-forward-ref/index.test.ts
+++ b/test/e2e/next-image-forward-ref/index.test.ts
@@ -2,6 +2,8 @@ import { FileRef, nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('next-image-forward-ref', () => {
   const appDir = path.join(__dirname, 'app')
 

--- a/test/e2e/next-image-legacy-src-with-query-without-local-patterns/next-image-legacy-src-with-query-without-local-patterns.test.ts
+++ b/test/e2e/next-image-legacy-src-with-query-without-local-patterns/next-image-legacy-src-with-query-without-local-patterns.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-image-legacy-src-with-query-without-local-patterns', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw error for relative image with query without localPatterns for legacy Image', async () => {
     if (isNextDev) {

--- a/test/e2e/next-image-legacy/base-path/base-path-static.test.ts
+++ b/test/e2e/next-image-legacy/base-path/base-path-static.test.ts
@@ -1,10 +1,12 @@
 import { nextTestSetup, isNextDev, type Playwright } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Build Error Tests for basePath', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
 
   if (isNextDev) {
@@ -31,12 +33,13 @@ describe('Build Error Tests for basePath', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Static Image Component Tests for basePath', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let browser: Playwright
   let html: string

--- a/test/e2e/next-image-legacy/base-path/base-path.test.ts
+++ b/test/e2e/next-image-legacy/base-path/base-path.test.ts
@@ -7,20 +7,20 @@ import {
   retry,
 } from 'next-test-utils'
 
+// Deploy mode exclusion: This suite reads local build artifacts that deployments do not expose.
+// Image URL assertions construct expected URLs via
+// `getDeploymentId(next.testDir, ...)`, which reads the local
+// `.next/required-server-files.json`. In deploy mode that file lives on
+// Vercel's infrastructure (not on disk locally), so the constructed
+// expected URL omits the `&dpl=...` query that Vercel injects at
+// runtime. The assertions are about local-build URL shape, not deploy
+// CDN URLs, so skip in deploy.
+// @force-gate !deploy
 describe('Legacy Image Component basePath Tests', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
-    // Image URL assertions construct expected URLs via
-    // `getDeploymentId(next.testDir, ...)`, which reads the local
-    // `.next/required-server-files.json`. In deploy mode that file lives on
-    // Vercel's infrastructure (not on disk locally), so the constructed
-    // expected URL omits the `&dpl=...` query that Vercel injects at
-    // runtime. The assertions are about local-build URL shape, not deploy
-    // CDN URLs, so skip in deploy.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let dpl: string
   beforeAll(() => {

--- a/test/e2e/next-image-legacy/default/default-static.test.ts
+++ b/test/e2e/next-image-legacy/default/default-static.test.ts
@@ -7,13 +7,14 @@ import {
 } from 'e2e-utils'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Build Error Tests', () => {
-  const { next, isTurbopack, isRspack, isNextDeploy } = nextTestSetup({
+  const { next, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (isNextDeploy) return
   ;(isNextStart ? it : it.skip)(
     'should throw build error when import statement is used with missing file',
     async () => {
@@ -43,12 +44,13 @@ describe('Build Error Tests', () => {
   )
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Static Image Component Tests', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let browser: Playwright
   let html: string

--- a/test/e2e/next-image-legacy/typescript/typescript.test.ts
+++ b/test/e2e/next-image-legacy/typescript/typescript.test.ts
@@ -2,13 +2,18 @@ import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import fs from 'fs-extra'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('TypeScript Image Component', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
+
+  if (isNextDeploy) {
+    it('is excluded from deploy testing by @force-gate', () => {})
+  }
 
   if (isNextStart) {
     it('should fail to build invalid usage of the Image component', async () => {

--- a/test/e2e/next-image-new/app-dir-localpatterns/app-dir-localpatterns.test.ts
+++ b/test/e2e/next-image-new/app-dir-localpatterns/app-dir-localpatterns.test.ts
@@ -5,10 +5,12 @@ import {
   waitForRedbox,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('Image localPatterns config', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   async function getSrc(browser: Playwright, id: string) {

--- a/test/e2e/next-image-new/app-dir-qualities/app-dir-qualities.test.ts
+++ b/test/e2e/next-image-new/app-dir-qualities/app-dir-qualities.test.ts
@@ -1,10 +1,12 @@
 import { nextTestSetup, isNextDev, type Playwright } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('Image qualities config', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   async function getSrc(browser: Playwright, id: string) {

--- a/test/e2e/next-image-new/app-dir/app-dir-static.test.ts
+++ b/test/e2e/next-image-new/app-dir/app-dir-static.test.ts
@@ -5,268 +5,267 @@ import cheerio from 'cheerio'
 // without a Suspense boundary so that the priority image preload is committed
 // into <head>. That pattern is incompatible with cache components mode, which
 // errors on uncached runtime data outside of a Suspense boundary.
-;(process.env.__NEXT_CACHE_COMPONENTS === 'true' ? describe.skip : describe)(
-  'Build Error Tests',
-  () => {
-    const { next, isTurbopack, isRspack } = nextTestSetup({
-      files: __dirname,
-      skipStart: true,
-      skipDeployment: true,
-    })
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
+// @force-gate !cacheComponents
+describe('Build Error Tests', () => {
+  const { next, isTurbopack, isRspack } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
 
-    if (isNextDev) {
-      it('no-op in dev', () => {})
-      return
-    }
-
-    it('should throw build error when import statement is used with missing file', async () => {
-      await next.patchFile(
-        'app/static-img/page.js',
-        (content) =>
-          content.replace(
-            '../../public/foo/test-rect.jpg',
-            '../../public/foo/test-rect-broken.jpg'
-          ),
-        async () => {
-          const { cliOutput } = await next.build()
-          expect(cliOutput).toContain(
-            "Module not found: Can't resolve '../../public/foo/test-rect-broken.jpg"
-          )
-          if (isTurbopack) {
-            expect(cliOutput).toContain('app/static-img/page.js')
-          } else {
-            expect(cliOutput).toContain('./app/static-img/page.js')
-          }
-          if (!isRspack) {
-            expect(cliOutput).not.toContain('Import trace for requested module')
-          }
-        }
-      )
-    })
+  if (isNextDev) {
+    it('no-op in dev', () => {})
+    return
   }
-)
-;(process.env.__NEXT_CACHE_COMPONENTS === 'true' ? describe.skip : describe)(
-  'Static Image Component Tests',
-  () => {
-    const { next, isTurbopack, skipped } = nextTestSetup({
-      files: __dirname,
-      skipDeployment: true,
-    })
-    if (skipped) return
 
-    let browser: Playwright
-    let $: ReturnType<typeof cheerio.load>
-
-    beforeAll(async () => {
-      const html = await next.render('/static-img')
-      $ = cheerio.load(html)
-      browser = await next.browser('/static-img')
-    })
-
-    it('Should allow an image with a static src to omit height and width', async () => {
-      expect(await browser.elementById('basic-static')).toBeTruthy()
-      expect(await browser.elementById('blur-png')).toBeTruthy()
-      expect(await browser.elementById('blur-webp')).toBeTruthy()
-      expect(await browser.elementById('blur-avif')).toBeTruthy()
-      expect(await browser.elementById('blur-jpg')).toBeTruthy()
-      expect(await browser.elementById('static-svg')).toBeTruthy()
-      expect(await browser.elementById('static-gif')).toBeTruthy()
-      expect(await browser.elementById('static-bmp')).toBeTruthy()
-      expect(await browser.elementById('static-ico')).toBeTruthy()
-      expect(await browser.elementById('static-svg-fill')).toBeTruthy()
-      expect(await browser.elementById('static-gif-fill')).toBeTruthy()
-      expect(await browser.elementById('static-bmp-fill')).toBeTruthy()
-      expect(await browser.elementById('static-ico-fill')).toBeTruthy()
-      expect(await browser.elementById('static-unoptimized')).toBeTruthy()
-    })
-
-    if (!isNextDev) {
-      it('Should use immutable cache-control header for static import', async () => {
-        await browser.eval(
-          `document.getElementById("basic-static").scrollIntoView()`
+  it('should throw build error when import statement is used with missing file', async () => {
+    await next.patchFile(
+      'app/static-img/page.js',
+      (content) =>
+        content.replace(
+          '../../public/foo/test-rect.jpg',
+          '../../public/foo/test-rect-broken.jpg'
+        ),
+      async () => {
+        const { cliOutput } = await next.build()
+        expect(cliOutput).toContain(
+          "Module not found: Can't resolve '../../public/foo/test-rect-broken.jpg"
         )
-        await new Promise((resolve) => setTimeout(resolve, 1000))
-        const url = await browser.eval(
-          `document.getElementById("basic-static").src`
-        )
-        const res = await fetch(url)
-        expect(res.status).toBe(200)
-        expect(res.headers.get('content-type')).toStartWith('image/')
-        expect(res.headers.get('cache-control')).toBe(
-          'public, max-age=315360000, immutable'
-        )
-      })
-
-      it('Should use immutable cache-control header even when unoptimized', async () => {
-        await browser.eval(
-          `document.getElementById("static-unoptimized").scrollIntoView()`
-        )
-        await new Promise((resolve) => setTimeout(resolve, 1000))
-        const url = await browser.eval(
-          `document.getElementById("static-unoptimized").src`
-        )
-        const res = await fetch(url)
-        expect(res.status).toBe(200)
-        expect(res.headers.get('content-type')).toStartWith('image/')
-        expect(res.headers.get('cache-control')).toBe(
-          'public, max-age=31536000, immutable'
-        )
-      })
-    }
-
-    it('should have <head> containing <meta name="viewport"> followed by <link rel="preload"> for priority image', async () => {
-      let metaViewport = { index: 0, attribs: {} as any }
-      let linkPreload = { index: 0, attribs: {} as any }
-      $('head')
-        .children()
-        .toArray()
-        .forEach((child, index) => {
-          const { tagName, attribs } = child
-          if (tagName === 'meta' && attribs.name === 'viewport') {
-            metaViewport = { index, attribs }
-          } else if (
-            tagName === 'link' &&
-            attribs.rel === 'preload' &&
-            attribs.as === 'image'
-          ) {
-            linkPreload = { index, attribs }
-          }
-        })
-      expect(metaViewport.attribs.content).toContain('width=device-width')
-      expect(linkPreload.attribs.imagesrcset).toMatch(
-        /%2F_next%2Fstatic%2F(immutable%2F)?media%2Ftest-rect\.(.*)\.jpg/g
-      )
-      expect(metaViewport.index).toBeLessThan(linkPreload.index)
-    })
-
-    it('Should automatically provide an image height and width', async () => {
-      const img = $('#basic-non-static')
-      expect(img.attr('width')).toBe('400')
-      expect(img.attr('height')).toBe('300')
-    })
-
-    it('should use width and height prop to override import', async () => {
-      const img = $('#defined-width-and-height')
-      expect(img.attr('width')).toBe('150')
-      expect(img.attr('height')).toBe('150')
-    })
-
-    it('should use height prop to adjust both width and height', async () => {
-      const img = $('#defined-height-only')
-      expect(img.attr('width')).toBe('600')
-      expect(img.attr('height')).toBe('350')
-    })
-
-    it('should use width prop to adjust both width and height', async () => {
-      const img = $('#defined-width-only')
-      expect(img.attr('width')).toBe('400')
-      expect(img.attr('height')).toBe('233')
-    })
-
-    it('should add a data URL placeholder to an image', async () => {
-      const style = $('#data-url-placeholder').attr('style')
-      expect(style).toBe(
-        `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml;base64,Cjxzdmcgd2lkdGg9IjIwMCIgaGVpZ2h0PSIyMDAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgPGRlZnM+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImciPgogICAgICA8c3RvcCBzdG9wLWNvbG9yPSIjMzMzIiBvZmZzZXQ9IjIwJSIgLz4KICAgICAgPHN0b3Agc3RvcC1jb2xvcj0iIzIyMiIgb2Zmc2V0PSI1MCUiIC8+CiAgICAgIDxzdG9wIHN0b3AtY29sb3I9IiMzMzMiIG9mZnNldD0iNzAlIiAvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHJlY3Qgd2lkdGg9IjIwMCIgaGVpZ2h0PSIyMDAiIGZpbGw9IiMzMzMiIC8+CiAgPHJlY3QgaWQ9InIiIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiBmaWxsPSJ1cmwoI2cpIiAvPgogIDxhbmltYXRlIHhsaW5rOmhyZWY9IiNyIiBhdHRyaWJ1dGVOYW1lPSJ4IiBmcm9tPSItMjAwIiB0bz0iMjAwIiBkdXI9IjFzIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSIgIC8+Cjwvc3ZnPg==")`
-      )
-    })
-
-    it('should add a blur placeholder a statically imported jpg', async () => {
-      const style = $('#basic-static').attr('style')
-      if (isNextDev) {
         if (isTurbopack) {
-          expect(style).toContain(
-            `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml`
-          )
+          expect(cliOutput).toContain('app/static-img/page.js')
         } else {
-          expect(style).toBe(
-            `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest-rect.f323a148.jpg&w=8&q=70")`
-          )
+          expect(cliOutput).toContain('./app/static-img/page.js')
         }
-      } else {
-        if (isTurbopack) {
-          expect(style).toContain(
-            `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml`
-          )
-        } else {
-          expect(style).toBe(
-            `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 240'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3CfeColorMatrix values='1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 100 -1' result='s'/%3E%3CfeFlood x='0' y='0' width='100%25' height='100%25'/%3E%3CfeComposite operator='out' in='s'/%3E%3CfeComposite in2='SourceGraphic'/%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage width='100%25' height='100%25' x='0' y='0' preserveAspectRatio='none' style='filter: url(%23b);' href='data:image/jpeg;base64,/9j/2wBDAAoKCgoKCgsMDAsPEA4QDxYUExMUFiIYGhgaGCIzICUgICUgMy03LCksNy1RQDg4QFFeT0pPXnFlZXGPiI+7u/v/2wBDAQoKCgoKCgsMDAsPEA4QDxYUExMUFiIYGhgaGCIzICUgICUgMy03LCksNy1RQDg4QFFeT0pPXnFlZXGPiI+7u/v/wgARCAAGAAgDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAf/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAACUg//EABwQAAICAgMAAAAAAAAAAAAAABITERQAAwUVIv/aAAgBAQABPwB3H9YmrsuvN5+VxADn/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAgEBPwB//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAwEBPwB//9k='/%3E%3C/svg%3E")`
-          )
+        if (!isRspack) {
+          expect(cliOutput).not.toContain('Import trace for requested module')
         }
       }
-    })
+    )
+  })
+})
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
+// @force-gate !cacheComponents
+describe('Static Image Component Tests', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
 
-    it('should add a blur placeholder a statically imported png', async () => {
-      const style = $('#blur-png').attr('style')
-      if (isNextDev) {
-        if (isTurbopack) {
-          expect(style).toContain(
-            `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml`
-          )
-        } else {
-          expect(style).toBe(
-            `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=8&q=70")`
-          )
-        }
-      } else {
-        if (isTurbopack) {
-          expect(style).toContain(
-            `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml`
-          )
-        } else {
-          expect(style).toBe(
-            `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 320'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3CfeColorMatrix values='1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 100 -1' result='s'/%3E%3CfeFlood x='0' y='0' width='100%25' height='100%25'/%3E%3CfeComposite operator='out' in='s'/%3E%3CfeComposite in2='SourceGraphic'/%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage width='100%25' height='100%25' x='0' y='0' preserveAspectRatio='none' style='filter: url(%23b);' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAMAAADz0U65AAAAElBMVEUAAAA6OjolJSWwsLAfHx/9/f2oxsg2AAAACXBIWXMAAAsSAAALEgHS3X78AAAAH0lEQVQImWNgwAaYmKAMZmYIzcjKyghmsDAysmDTAQAEXAAh8CaqOAAAAABJRU5ErkJggg=='/%3E%3C/svg%3E")`
-          )
-        }
-      }
-    })
+  let browser: Playwright
+  let $: ReturnType<typeof cheerio.load>
 
-    it('should add a blur placeholder a statically imported png with fill', async () => {
-      const style = $('#blur-png-fill').attr('style')
-      if (isNextDev) {
-        if (isTurbopack) {
-          expect(style).toContain(
-            `position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml`
-          )
-        } else {
-          expect(style).toBe(
-            `position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=8&q=70")`
-          )
-        }
-      } else {
-        if (isTurbopack) {
-          expect(style).toContain(
-            `position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml`
-          )
-        } else {
-          expect(style).toBe(
-            `position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 320'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3CfeColorMatrix values='1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 100 -1' result='s'/%3E%3CfeFlood x='0' y='0' width='100%25' height='100%25'/%3E%3CfeComposite operator='out' in='s'/%3E%3CfeComposite in2='SourceGraphic'/%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage width='100%25' height='100%25' x='0' y='0' preserveAspectRatio='none' style='filter: url(%23b);' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAMAAADz0U65AAAAElBMVEUAAAA6OjolJSWwsLAfHx/9/f2oxsg2AAAACXBIWXMAAAsSAAALEgHS3X78AAAAH0lEQVQImWNgwAaYmKAMZmYIzcjKyghmsDAysmDTAQAEXAAh8CaqOAAAAABJRU5ErkJggg=='/%3E%3C/svg%3E")`
-          )
-        }
-      }
-    })
+  beforeAll(async () => {
+    const html = await next.render('/static-img')
+    $ = cheerio.load(html)
+    browser = await next.browser('/static-img')
+  })
 
-    it('should add placeholder with blurDataURL and fill', async () => {
-      const style = $('#blurdataurl-fill').attr('style')
-      expect(style).toBe(
-        `position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3CfeColorMatrix values='1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 100 -1' result='s'/%3E%3CfeFlood x='0' y='0' width='100%25' height='100%25'/%3E%3CfeComposite operator='out' in='s'/%3E%3CfeComposite in2='SourceGraphic'/%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage width='100%25' height='100%25' x='0' y='0' preserveAspectRatio='none' style='filter: url(%23b);' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNM/s/wBwAFjwJgf8HDLgAAAABJRU5ErkJggg=='/%3E%3C/svg%3E")`
+  it('Should allow an image with a static src to omit height and width', async () => {
+    expect(await browser.elementById('basic-static')).toBeTruthy()
+    expect(await browser.elementById('blur-png')).toBeTruthy()
+    expect(await browser.elementById('blur-webp')).toBeTruthy()
+    expect(await browser.elementById('blur-avif')).toBeTruthy()
+    expect(await browser.elementById('blur-jpg')).toBeTruthy()
+    expect(await browser.elementById('static-svg')).toBeTruthy()
+    expect(await browser.elementById('static-gif')).toBeTruthy()
+    expect(await browser.elementById('static-bmp')).toBeTruthy()
+    expect(await browser.elementById('static-ico')).toBeTruthy()
+    expect(await browser.elementById('static-svg-fill')).toBeTruthy()
+    expect(await browser.elementById('static-gif-fill')).toBeTruthy()
+    expect(await browser.elementById('static-bmp-fill')).toBeTruthy()
+    expect(await browser.elementById('static-ico-fill')).toBeTruthy()
+    expect(await browser.elementById('static-unoptimized')).toBeTruthy()
+  })
+
+  if (!isNextDev) {
+    it('Should use immutable cache-control header for static import', async () => {
+      await browser.eval(
+        `document.getElementById("basic-static").scrollIntoView()`
       )
-    })
-
-    it('should add placeholder even when blurDataURL aspect ratio does not match width/height ratio', async () => {
-      const style = $('#blurdataurl-ratio').attr('style')
-      expect(style).toBe(
-        `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 200'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3CfeColorMatrix values='1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 100 -1' result='s'/%3E%3CfeFlood x='0' y='0' width='100%25' height='100%25'/%3E%3CfeComposite operator='out' in='s'/%3E%3CfeComposite in2='SourceGraphic'/%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage width='100%25' height='100%25' x='0' y='0' preserveAspectRatio='none' style='filter: url(%23b);' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNM/s/wBwAFjwJgf8HDLgAAAABJRU5ErkJggg=='/%3E%3C/svg%3E")`
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      const url = await browser.eval(
+        `document.getElementById("basic-static").src`
       )
-    })
-
-    it('should load direct imported image', async () => {
-      const src = await browser.elementById('basic-static').getAttribute('src')
-      expect(src).toMatch(
-        /_next\/image\?url=%2F_next%2Fstatic(%2Fimmutable)?%2Fmedia%2Ftest-rect(.+)\.jpg&w=828&q=75/
-      )
-      const fullSrc = new URL(src, next.url)
-      const res = await fetch(fullSrc)
+      const res = await fetch(url)
       expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toStartWith('image/')
+      expect(res.headers.get('cache-control')).toBe(
+        'public, max-age=315360000, immutable'
+      )
+    })
+
+    it('Should use immutable cache-control header even when unoptimized', async () => {
+      await browser.eval(
+        `document.getElementById("static-unoptimized").scrollIntoView()`
+      )
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+      const url = await browser.eval(
+        `document.getElementById("static-unoptimized").src`
+      )
+      const res = await fetch(url)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toStartWith('image/')
+      expect(res.headers.get('cache-control')).toBe(
+        'public, max-age=31536000, immutable'
+      )
     })
   }
-)
+
+  it('should have <head> containing <meta name="viewport"> followed by <link rel="preload"> for priority image', async () => {
+    let metaViewport = { index: 0, attribs: {} as any }
+    let linkPreload = { index: 0, attribs: {} as any }
+    $('head')
+      .children()
+      .toArray()
+      .forEach((child, index) => {
+        const { tagName, attribs } = child
+        if (tagName === 'meta' && attribs.name === 'viewport') {
+          metaViewport = { index, attribs }
+        } else if (
+          tagName === 'link' &&
+          attribs.rel === 'preload' &&
+          attribs.as === 'image'
+        ) {
+          linkPreload = { index, attribs }
+        }
+      })
+    expect(metaViewport.attribs.content).toContain('width=device-width')
+    expect(linkPreload.attribs.imagesrcset).toMatch(
+      /%2F_next%2Fstatic%2F(immutable%2F)?media%2Ftest-rect\.(.*)\.jpg/g
+    )
+    expect(metaViewport.index).toBeLessThan(linkPreload.index)
+  })
+
+  it('Should automatically provide an image height and width', async () => {
+    const img = $('#basic-non-static')
+    expect(img.attr('width')).toBe('400')
+    expect(img.attr('height')).toBe('300')
+  })
+
+  it('should use width and height prop to override import', async () => {
+    const img = $('#defined-width-and-height')
+    expect(img.attr('width')).toBe('150')
+    expect(img.attr('height')).toBe('150')
+  })
+
+  it('should use height prop to adjust both width and height', async () => {
+    const img = $('#defined-height-only')
+    expect(img.attr('width')).toBe('600')
+    expect(img.attr('height')).toBe('350')
+  })
+
+  it('should use width prop to adjust both width and height', async () => {
+    const img = $('#defined-width-only')
+    expect(img.attr('width')).toBe('400')
+    expect(img.attr('height')).toBe('233')
+  })
+
+  it('should add a data URL placeholder to an image', async () => {
+    const style = $('#data-url-placeholder').attr('style')
+    expect(style).toBe(
+      `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml;base64,Cjxzdmcgd2lkdGg9IjIwMCIgaGVpZ2h0PSIyMDAiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgPGRlZnM+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImciPgogICAgICA8c3RvcCBzdG9wLWNvbG9yPSIjMzMzIiBvZmZzZXQ9IjIwJSIgLz4KICAgICAgPHN0b3Agc3RvcC1jb2xvcj0iIzIyMiIgb2Zmc2V0PSI1MCUiIC8+CiAgICAgIDxzdG9wIHN0b3AtY29sb3I9IiMzMzMiIG9mZnNldD0iNzAlIiAvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHJlY3Qgd2lkdGg9IjIwMCIgaGVpZ2h0PSIyMDAiIGZpbGw9IiMzMzMiIC8+CiAgPHJlY3QgaWQ9InIiIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiBmaWxsPSJ1cmwoI2cpIiAvPgogIDxhbmltYXRlIHhsaW5rOmhyZWY9IiNyIiBhdHRyaWJ1dGVOYW1lPSJ4IiBmcm9tPSItMjAwIiB0bz0iMjAwIiBkdXI9IjFzIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSIgIC8+Cjwvc3ZnPg==")`
+    )
+  })
+
+  it('should add a blur placeholder a statically imported jpg', async () => {
+    const style = $('#basic-static').attr('style')
+    if (isNextDev) {
+      if (isTurbopack) {
+        expect(style).toContain(
+          `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml`
+        )
+      } else {
+        expect(style).toBe(
+          `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest-rect.f323a148.jpg&w=8&q=70")`
+        )
+      }
+    } else {
+      if (isTurbopack) {
+        expect(style).toContain(
+          `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml`
+        )
+      } else {
+        expect(style).toBe(
+          `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 240'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3CfeColorMatrix values='1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 100 -1' result='s'/%3E%3CfeFlood x='0' y='0' width='100%25' height='100%25'/%3E%3CfeComposite operator='out' in='s'/%3E%3CfeComposite in2='SourceGraphic'/%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage width='100%25' height='100%25' x='0' y='0' preserveAspectRatio='none' style='filter: url(%23b);' href='data:image/jpeg;base64,/9j/2wBDAAoKCgoKCgsMDAsPEA4QDxYUExMUFiIYGhgaGCIzICUgICUgMy03LCksNy1RQDg4QFFeT0pPXnFlZXGPiI+7u/v/2wBDAQoKCgoKCgsMDAsPEA4QDxYUExMUFiIYGhgaGCIzICUgICUgMy03LCksNy1RQDg4QFFeT0pPXnFlZXGPiI+7u/v/wgARCAAGAAgDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAf/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAACUg//EABwQAAICAgMAAAAAAAAAAAAAABITERQAAwUVIv/aAAgBAQABPwB3H9YmrsuvN5+VxADn/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAgEBPwB//8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAgBAwEBPwB//9k='/%3E%3C/svg%3E")`
+        )
+      }
+    }
+  })
+
+  it('should add a blur placeholder a statically imported png', async () => {
+    const style = $('#blur-png').attr('style')
+    if (isNextDev) {
+      if (isTurbopack) {
+        expect(style).toContain(
+          `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml`
+        )
+      } else {
+        expect(style).toBe(
+          `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=8&q=70")`
+        )
+      }
+    } else {
+      if (isTurbopack) {
+        expect(style).toContain(
+          `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml`
+        )
+      } else {
+        expect(style).toBe(
+          `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 320'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3CfeColorMatrix values='1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 100 -1' result='s'/%3E%3CfeFlood x='0' y='0' width='100%25' height='100%25'/%3E%3CfeComposite operator='out' in='s'/%3E%3CfeComposite in2='SourceGraphic'/%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage width='100%25' height='100%25' x='0' y='0' preserveAspectRatio='none' style='filter: url(%23b);' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAMAAADz0U65AAAAElBMVEUAAAA6OjolJSWwsLAfHx/9/f2oxsg2AAAACXBIWXMAAAsSAAALEgHS3X78AAAAH0lEQVQImWNgwAaYmKAMZmYIzcjKyghmsDAysmDTAQAEXAAh8CaqOAAAAABJRU5ErkJggg=='/%3E%3C/svg%3E")`
+        )
+      }
+    }
+  })
+
+  it('should add a blur placeholder a statically imported png with fill', async () => {
+    const style = $('#blur-png-fill').attr('style')
+    if (isNextDev) {
+      if (isTurbopack) {
+        expect(style).toContain(
+          `position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml`
+        )
+      } else {
+        expect(style).toBe(
+          `position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=8&q=70")`
+        )
+      }
+    } else {
+      if (isTurbopack) {
+        expect(style).toContain(
+          `position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml`
+        )
+      } else {
+        expect(style).toBe(
+          `position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 320'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3CfeColorMatrix values='1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 100 -1' result='s'/%3E%3CfeFlood x='0' y='0' width='100%25' height='100%25'/%3E%3CfeComposite operator='out' in='s'/%3E%3CfeComposite in2='SourceGraphic'/%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage width='100%25' height='100%25' x='0' y='0' preserveAspectRatio='none' style='filter: url(%23b);' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAMAAADz0U65AAAAElBMVEUAAAA6OjolJSWwsLAfHx/9/f2oxsg2AAAACXBIWXMAAAsSAAALEgHS3X78AAAAH0lEQVQImWNgwAaYmKAMZmYIzcjKyghmsDAysmDTAQAEXAAh8CaqOAAAAABJRU5ErkJggg=='/%3E%3C/svg%3E")`
+        )
+      }
+    }
+  })
+
+  it('should add placeholder with blurDataURL and fill', async () => {
+    const style = $('#blurdataurl-fill').attr('style')
+    expect(style).toBe(
+      `position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' %3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3CfeColorMatrix values='1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 100 -1' result='s'/%3E%3CfeFlood x='0' y='0' width='100%25' height='100%25'/%3E%3CfeComposite operator='out' in='s'/%3E%3CfeComposite in2='SourceGraphic'/%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage width='100%25' height='100%25' x='0' y='0' preserveAspectRatio='none' style='filter: url(%23b);' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNM/s/wBwAFjwJgf8HDLgAAAABJRU5ErkJggg=='/%3E%3C/svg%3E")`
+    )
+  })
+
+  it('should add placeholder even when blurDataURL aspect ratio does not match width/height ratio', async () => {
+    const style = $('#blurdataurl-ratio').attr('style')
+    expect(style).toBe(
+      `color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 200'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3CfeColorMatrix values='1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 100 -1' result='s'/%3E%3CfeFlood x='0' y='0' width='100%25' height='100%25'/%3E%3CfeComposite operator='out' in='s'/%3E%3CfeComposite in2='SourceGraphic'/%3E%3CfeGaussianBlur stdDeviation='20'/%3E%3C/filter%3E%3Cimage width='100%25' height='100%25' x='0' y='0' preserveAspectRatio='none' style='filter: url(%23b);' href='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNM/s/wBwAFjwJgf8HDLgAAAABJRU5ErkJggg=='/%3E%3C/svg%3E")`
+    )
+  })
+
+  it('should load direct imported image', async () => {
+    const src = await browser.elementById('basic-static').getAttribute('src')
+    expect(src).toMatch(
+      /_next\/image\?url=%2F_next%2Fstatic(%2Fimmutable)?%2Fmedia%2Ftest-rect(.+)\.jpg&w=828&q=75/
+    )
+    const fullSrc = new URL(src, next.url)
+    const res = await fetch(fullSrc)
+    expect(res.status).toBe(200)
+  })
+})

--- a/test/e2e/next-image-new/app-dir/app-dir.test.ts
+++ b/test/e2e/next-image-new/app-dir/app-dir.test.ts
@@ -11,13 +11,14 @@ import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { existsSync } from 'fs'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('Image Component App Dir Tests', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     disableAutoSkewProtection: true,
   })
-  if (skipped) return
 
   let dpl: string
   let assetDpl: string

--- a/test/e2e/next-image-new/base-path/base-path-static.test.ts
+++ b/test/e2e/next-image-new/base-path/base-path-static.test.ts
@@ -1,13 +1,14 @@
 import { nextTestSetup, isNextDev, type Playwright } from 'e2e-utils'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Build Error Tests', () => {
-  const { next, isTurbopack, isRspack, isNextDeploy } = nextTestSetup({
+  const { next, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (isNextDeploy) return
 
   if (isNextDev) {
     it('no-op in dev', () => {})
@@ -40,12 +41,13 @@ describe('Build Error Tests', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Static Image Component Tests for basePath', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let browser: Playwright
   let $: ReturnType<typeof cheerio.load>

--- a/test/e2e/next-image-new/base-path/base-path.test.ts
+++ b/test/e2e/next-image-new/base-path/base-path.test.ts
@@ -7,20 +7,20 @@ import {
   retry,
 } from 'next-test-utils'
 
+// Deploy mode exclusion: This suite reads local build artifacts that deployments do not expose.
+// Image URL assertions construct expected URLs via
+// `getDeploymentId(next.testDir, ...)`, which reads the local
+// `.next/required-server-files.json`. In deploy mode that file lives on
+// Vercel's infrastructure (not on disk locally), so the constructed
+// expected URL omits the `&dpl=...` query that Vercel injects at
+// runtime. The assertions are about local-build URL shape, not deploy
+// CDN URLs, so skip in deploy.
+// @force-gate !deploy
 describe('Image Component basePath Tests', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
-    // Image URL assertions construct expected URLs via
-    // `getDeploymentId(next.testDir, ...)`, which reads the local
-    // `.next/required-server-files.json`. In deploy mode that file lives on
-    // Vercel's infrastructure (not on disk locally), so the constructed
-    // expected URL omits the `&dpl=...` query that Vercel injects at
-    // runtime. The assertions are about local-build URL shape, not deploy
-    // CDN URLs, so skip in deploy.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let dpl: string
   beforeAll(() => {

--- a/test/e2e/next-image-new/both-basepath-trailingslash/both-basepath-trailingslash.test.ts
+++ b/test/e2e/next-image-new/both-basepath-trailingslash/both-basepath-trailingslash.test.ts
@@ -1,20 +1,20 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { getDeploymentId } from 'next-test-utils'
 
+// Deploy mode exclusion: This suite reads local build artifacts that deployments do not expose.
+// Image URL assertions construct expected URLs via
+// `getDeploymentId(next.testDir, ...)`, which reads the local
+// `.next/required-server-files.json`. In deploy mode that file lives on
+// Vercel's infrastructure (not on disk locally), so the constructed
+// expected URL omits the `&dpl=...` query that Vercel injects at
+// runtime. The assertions are about local-build URL shape, not deploy
+// CDN URLs, so skip in deploy.
+// @force-gate !deploy
 describe('Image Component basePath + trailingSlash Tests', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
-    // Image URL assertions construct expected URLs via
-    // `getDeploymentId(next.testDir, ...)`, which reads the local
-    // `.next/required-server-files.json`. In deploy mode that file lives on
-    // Vercel's infrastructure (not on disk locally), so the constructed
-    // expected URL omits the `&dpl=...` query that Vercel injects at
-    // runtime. The assertions are about local-build URL shape, not deploy
-    // CDN URLs, so skip in deploy.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let dpl: string
   let assetDpl: string

--- a/test/e2e/next-image-new/default/default-static.test.ts
+++ b/test/e2e/next-image-new/default/default-static.test.ts
@@ -1,14 +1,15 @@
 import { nextTestSetup, isNextDev, type Playwright } from 'e2e-utils'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Build Error Tests', () => {
-  const { next, isNextDeploy, isRspack } = nextTestSetup({
+  const { next, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     disableAutoSkewProtection: true,
   })
-  if (isNextDeploy) return
 
   if (isNextDev) {
     it('no-op in dev', () => {})
@@ -37,13 +38,14 @@ describe('Build Error Tests', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Static Image Component Tests', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     disableAutoSkewProtection: true,
   })
-  if (skipped) return
 
   let browser: Playwright
   let $: ReturnType<typeof cheerio.load>

--- a/test/e2e/next-image-new/default/default.test.ts
+++ b/test/e2e/next-image-new/default/default.test.ts
@@ -12,16 +12,16 @@ import { isReact18, nextTestSetup, isNextDev } from 'e2e-utils'
 import { existsSync } from 'fs'
 import { join } from 'path'
 
+// Deploy mode exclusion: This suite reads local build artifacts that deployments do not expose.
+// Image URL assertions assume local-relative `/_next/image?url=...`
+// paths and access to `.next/static` on disk; deploy mode rewrites URLs
+// through the Vercel hostname and has no on-disk `.next/`.
+// @force-gate !deploy
 describe('Image Component Default Tests', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
-    // Image URL assertions assume local-relative `/_next/image?url=...`
-    // paths and access to `.next/static` on disk; deploy mode rewrites URLs
-    // through the Vercel hostname and has no on-disk `.next/`.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let dpl: string
   let assetDpl: string

--- a/test/e2e/next-image-new/typescript/typescript.test.ts
+++ b/test/e2e/next-image-new/typescript/typescript.test.ts
@@ -1,6 +1,9 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('TypeScript Image Component Build Errors', () => {
   if (isNextDev) {
     it('no-op in dev', () => {})
@@ -10,7 +13,6 @@ describe('TypeScript Image Component Build Errors', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
 
   it('should fail to build invalid usage of the Image component', async () => {
@@ -39,6 +41,9 @@ describe('TypeScript Image Component Build Errors', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('TypeScript Image Component Dev', () => {
   if (!isNextDev) {
     it('no-op in prod', () => {})
@@ -47,7 +52,6 @@ describe('TypeScript Image Component Dev', () => {
 
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('should have image types when enabled', async () => {

--- a/test/e2e/next-image-new/unicode/unicode.test.ts
+++ b/test/e2e/next-image-new/unicode/unicode.test.ts
@@ -1,9 +1,11 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('Image Component Unicode Image URL', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('should load static unicode image', async () => {

--- a/test/e2e/next-image-new/unoptimized/unoptimized.test.ts
+++ b/test/e2e/next-image-new/unoptimized/unoptimized.test.ts
@@ -1,10 +1,12 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('Unoptimized Image Tests', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   function runTests(url: string) {

--- a/test/e2e/next-image-src-with-query-without-local-patterns/next-image-src-with-query-without-local-patterns.test.ts
+++ b/test/e2e/next-image-src-with-query-without-local-patterns/next-image-src-with-query-without-local-patterns.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-image-src-with-query-without-local-patterns', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw error for relative image with query without localPatterns', async () => {
     if (isNextDev) {

--- a/test/e2e/next-image-svgo-webpack/svgo-webpack.test.ts
+++ b/test/e2e/next-image-svgo-webpack/svgo-webpack.test.ts
@@ -1,9 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('svgo-webpack loader', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: {
       '@svgr/webpack': '8.1.0',
     },

--- a/test/e2e/postcss-config-cjs/index.test.ts
+++ b/test/e2e/postcss-config-cjs/index.test.ts
@@ -1,6 +1,8 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('postcss-config-cjs', () => {
   const { next } = nextTestSetup({
     files: new FileRef(join(__dirname, 'app')),

--- a/test/e2e/script-loader/partytown-missing.test.ts
+++ b/test/e2e/script-loader/partytown-missing.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('script-loader - partytown-missing', () => {
   const { next, isNextDev } = nextTestSetup({
     files: join(__dirname, 'partytown-missing'),
     skipStart: true,
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
 
   it('Error message is shown if Partytown is not installed locally', async () => {

--- a/test/e2e/styled-jsx-dynamic/index.test.ts
+++ b/test/e2e/styled-jsx-dynamic/index.test.ts
@@ -1,9 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('styled-jsx dynamic styles SSR', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   // Dynamic styled-jsx (with interpolated expressions) produces numeric class

--- a/test/e2e/styled-jsx/index.test.ts
+++ b/test/e2e/styled-jsx/index.test.ts
@@ -1,17 +1,15 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('styled-jsx', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: {
       'styled-jsx': '5.0.0', // styled-jsx on user side
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should contain styled-jsx styles during SSR', async () => {
     const html = await next.render('/')

--- a/test/e2e/turbopack-worker-asset-prefix/turbopack-worker-asset-prefix.test.ts
+++ b/test/e2e/turbopack-worker-asset-prefix/turbopack-worker-asset-prefix.test.ts
@@ -1,10 +1,5 @@
-import { isNextDeploy, nextTestSetup } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
-
-// `experimental.turbopackWorkerAssetPrefix` is turbopack-only.
-const isTurbopack = !process.env.IS_WEBPACK_TEST && !process.env.NEXT_RSPACK
-const describeTurbopack =
-  isTurbopack && !isNextDeploy ? describe : describe.skip
 
 // CORS so cross-origin script tags from `assetPrefix` can be fetched. Workers
 // are NOT covered by CORS — `new Worker(crossOriginUrl)` is rejected
@@ -29,7 +24,10 @@ const corsHeadersConfig = `
  * runtime helper resolved from `turbopackWorkerAssetPrefix`, so each test
  * can assert on that URL directly.
  */
-describeTurbopack('turbopack-worker-asset-prefix', () => {
+// `experimental.turbopackWorkerAssetPrefix` is turbopack-only.
+// Deploy mode exclusion: This suite models cross-origin loading with `localhost` and `127.0.0.1` on a local port.
+// @force-gate turbopack && !deploy
+describe('turbopack-worker-asset-prefix', () => {
   describe('without turbopackWorkerAssetPrefix (cross-origin assetPrefix)', () => {
     const { next } = nextTestSetup({
       files: __dirname,


### PR DESCRIPTION
## Summary

- migrate image, font, CSS, Sass, styled-jsx, and other asset integration deployment exclusions to `@force-gate`
- remove the corresponding `skipDeployment` options and `skipped` control flow while preserving each suite's rationale

## Verification

- verified on the combined top-of-stack tree with `pnpm typescript`
- compared ordinary-mode collection before and after: all 4,670 existing test names matched
- collected all 510 affected files in deploy mode: 4,578 skipped tests, zero failures

<!-- NEXT_JS_LLM -->
