### PR TITLE
test: migrate runtime deploy exclusions to force gates

### DIFF
--- a/.agents/skills/gate-tests/SKILL.md
+++ b/.agents/skills/gate-tests/SKILL.md
@@ -93,8 +93,8 @@ Every name in a pragma must be declared in `test/lib/gate/conditions.ts`
 
 - **static** — the run's shape: `dev`, `start`, `deploy`, `mode`, `turbopack`,
   `rspack`, `webpack`, `bundler`, `react18`, `wasm`, `ci`; specialized CI
-  variants `adapter`, `standaloneOutput`, `turbopackDev`, and `turbopackBuild`;
-  plus the always-false `FIXME`/`TODO`.
+  variants `adapter`, `nodeMiddleware`, `standaloneOutput`, `turbopackDev`, and
+  `turbopackBuild`; plus the always-false `FIXME`/`TODO`.
   `prod` and `prefetching` are semantic aliases for `!dev` — prefer the name
   that states _why_ the suite cannot run.
 - **lazy** — a predicate over the fixture's _resolved_ `next.config`

--- a/test/e2e/app-dir/app-basepath-custom-server/index.test.ts
+++ b/test/e2e/app-dir/app-basepath-custom-server/index.test.ts
@@ -2,20 +2,18 @@ import { nextTestSetup } from 'e2e-utils'
 import { check, retry } from 'next-test-utils'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('custom-app-server-action-redirect', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: join(__dirname, 'custom-server'),
-    skipDeployment: true,
     startCommand: 'node server.js',
     serverReadyPattern: /Next mode: (production|development)/,
     dependencies: {
       'get-port': '5.1.1',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('redirects with basepath properly when server action handler uses `redirect`', async () => {
     const browser = await next.browser('/base')

--- a/test/e2e/app-dir/app-edge-root-layout/index.test.ts
+++ b/test/e2e/app-dir/app-edge-root-layout/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir edge runtime root layout', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not emit metadata files into bad paths', async () => {
     await next.fetch('/favicon.ico')

--- a/test/e2e/app-dir/app-edge/app-edge-invalid-reexport.test.ts
+++ b/test/e2e/app-dir/app-edge/app-edge-invalid-reexport.test.ts
@@ -1,8 +1,11 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('app-dir edge SSR invalid reexport', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: {
       'app/layout.tsx': new FileRef(path.join(__dirname, 'app', 'layout.tsx')),
       'app/export': new FileRef(path.join(__dirname, 'app', 'export')),
@@ -10,12 +13,7 @@ describe('app-dir edge SSR invalid reexport', () => {
         "export { default, runtime, preferredRegion } from '../basic/page'",
     },
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should warn or error about the re-export of a pages runtime/preferredRegion config', async () => {
     try {

--- a/test/e2e/app-dir/app-edge/app-edge.test.ts
+++ b/test/e2e/app-dir/app-edge/app-edge.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('app-dir edge SSR', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should handle edge only routes', async () => {
     const appHtml = await next.render('/edge/basic')

--- a/test/e2e/app-dir/binary/rsc-binary.test.ts
+++ b/test/e2e/app-dir/binary/rsc-binary.test.ts
@@ -1,15 +1,16 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('RSC binary serialization', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: {
       'server-only': 'latest',
     },
   })
-  if (skipped) return
 
   afterEach(async () => {
     await next.stop()

--- a/test/e2e/app-dir/graceful-shutdown-next-after/custom-server/index.test.ts
+++ b/test/e2e/app-dir/graceful-shutdown-next-after/custom-server/index.test.ts
@@ -1,22 +1,21 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// the tests use cli logs and a custom server
+// @force-gate !deploy
 describe('after during server shutdown - custom server', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     startCommand: 'node server.mjs',
     serverReadyPattern: /Custom server started/,
     forcedPort: 'random',
     skipStart: true,
-    skipDeployment: true, // the tests use cli logs and a custom server
     env: {
       NODE_ENV: isNextDev ? 'development' : 'production',
       DEBUG: '1',
     },
   })
-  if (skipped) {
-    return
-  }
 
   beforeEach(async () => {
     await next.start()

--- a/test/e2e/app-dir/graceful-shutdown-next-after/next-start/index.test.ts
+++ b/test/e2e/app-dir/graceful-shutdown-next-after/next-start/index.test.ts
@@ -1,15 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// the tests use cli logs
+// @force-gate !deploy
 describe('after during server shutdown - next start', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true, // the tests use cli logs
     skipStart: true,
   })
-  if (skipped) {
-    return
-  }
 
   beforeEach(async () => {
     await next.start()

--- a/test/e2e/app-dir/instrumentation-order/instrumentation-order.test.ts
+++ b/test/e2e/app-dir/instrumentation-order/instrumentation-order.test.ts
@@ -1,10 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('instrumentation-order', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('should work', async () => {

--- a/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
+++ b/test/e2e/app-dir/interception-middleware-rewrite/interception-middleware-rewrite.test.ts
@@ -1,16 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// TODO: remove after deployment handling is updated
+// @force-gate !deploy
 describe('interception-middleware-rewrite', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // TODO: remove after deployment handling is updated
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should support intercepting routes with a middleware rewrite', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/log-file/log-file.test.ts
+++ b/test/e2e/app-dir/log-file/log-file.test.ts
@@ -3,15 +3,13 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely reads files from the isolated local fixture.
+// @force-gate !deploy
 describe('log-file', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   function getLogFilePath(): string {
     const logFilePath = path.join(

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -43,9 +43,11 @@ function parseLogsFromCli(cliOutput: string) {
   }, [])
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - fetch logging', () => {
   const { next, isNextDev } = nextTestSetup({
-    skipDeployment: true,
     files: __dirname,
   })
 
@@ -79,12 +81,13 @@ describe('app-dir - fetch logging', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - logging', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
-    skipDeployment: true,
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
   })
-  if (skipped) return
   function runTests({
     withFetchesLogging,
     withFullUrlFetches = false,

--- a/test/e2e/app-dir/logging/fetch-warning.test.ts
+++ b/test/e2e/app-dir/logging/fetch-warning.test.ts
@@ -1,15 +1,13 @@
 import { retry } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - fetch warnings', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
-    skipDeployment: true,
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   beforeAll(async () => {
     // we don't need verbose logging (enabled by default in this Next app) for these tests to work

--- a/test/e2e/app-dir/middleware-matching/index.test.ts
+++ b/test/e2e/app-dir/middleware-matching/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - middleware with custom matcher', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should match /:id (without asterisk)', async () => {
     const browser = await next.browser('/chat/123')

--- a/test/e2e/app-dir/middleware-rsc-external-rewrite/middleware-rsc-external-rewrite.test.ts
+++ b/test/e2e/app-dir/middleware-rsc-external-rewrite/middleware-rsc-external-rewrite.test.ts
@@ -1,13 +1,11 @@
 import { findPort } from 'next-test-utils'
-import { isNextDeploy, isNextDev, nextTestSetup } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { startExternalServer } from './external-server.mjs'
 
+// This suite starts an external test server on a local port, which a deployed
+// application could not reach, and owns its production build/start lifecycle.
+// @force-gate start
 describe('middleware RSC external rewrite', () => {
-  if (isNextDev || isNextDeploy) {
-    test('should not run during dev or deploy test runs', () => {})
-    return
-  }
-
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,

--- a/test/e2e/app-dir/next-after-app-api-usage/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-api-usage/index.test.ts
@@ -3,14 +3,14 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { REQUEST_API_NAMES } from './app/request-apis-in-promise/common'
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// reading runtime logs is not supported in deploy tests
+// @force-gate !deploy
 describe('nextjs APIs in after()', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true, // reading runtime logs is not supported in deploy tests
   })
-
-  if (skipped) return
 
   let currentCliOutputIndex = 0
 

--- a/test/e2e/app-dir/next-after-app-deploy/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-deploy/index.test.ts
@@ -21,12 +21,10 @@ const REVALIDATION_RETRY_DURATION =
 const _describe = isNextDev ? describe.skip : describe
 
 _describe.each(runtimes)('after() in %s runtime', (runtimeValue) => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     env: { WAIT_BEFORE_REVALIDATING: WAIT_BEFORE_REVALIDATING + '' },
   })
-
-  if (skipped) return
   const pathPrefix = '/' + runtimeValue
 
   type PageInfo = {

--- a/test/e2e/app-dir/next-after-app-static/build-time-error/build-time-error.test.ts
+++ b/test/e2e/app-dir/next-after-app-static/build-time-error/build-time-error.test.ts
@@ -1,17 +1,14 @@
 /* eslint-env jest */
-import { isNextDev, nextTestSetup } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
-// This test relies on next.build() so it can't work in dev mode.
-const _describe = isNextDev ? describe.skip : describe
-
-_describe('after() in static pages - thrown errors', () => {
-  const { next, skipped } = nextTestSetup({
+// This suite intentionally exercises a failed local build.
+// @force-gate !dev
+// @force-gate !deploy
+describe('after() in static pages - thrown errors', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true, // can't access build errors in deploy tests
   })
-
-  if (skipped) return
 
   it('fails the build if an error is thrown inside after', async () => {
     const buildResult = await next.build()

--- a/test/e2e/app-dir/next-after-app-static/build-time/build-time.test.ts
+++ b/test/e2e/app-dir/next-after-app-static/build-time/build-time.test.ts
@@ -1,19 +1,16 @@
 /* eslint-env jest */
-import { isNextDev, nextTestSetup } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import * as Log from './utils/log'
 import { setTimeout } from 'timers/promises'
 
-// This test relies on next.build() so it can't work in dev mode.
-const _describe = isNextDev ? describe.skip : describe
-
-_describe('after() in static pages', () => {
-  const { next, skipped } = nextTestSetup({
+// This suite relies on next.build() and local CLI logs.
+// @force-gate !dev
+// @force-gate !deploy
+describe('after() in static pages', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true, // reading CLI logs to observe after
     skipStart: true,
   })
-
-  if (skipped) return
 
   let currentCliOutputIndex = 0
   beforeEach(() => {

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params-error/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params-error/index.test.ts
@@ -5,14 +5,14 @@ import {
   getRedboxDescription,
 } from '../../../../lib/next-test-utils'
 
+// Deploy mode exclusion: This suite intentionally exercises a failed local build, so it cannot produce a deployment.
+// can't access build errors in deploy tests
+// @force-gate !deploy
 describe('after() in generateStaticParams - thrown errors', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true, // can't access build errors in deploy tests
   })
-
-  if (skipped) return
 
   if (isNextDev) {
     it('shows the error overlay if an error is thrown inside after', async () => {

--- a/test/e2e/app-dir/next-after-app-static/generate-static-params/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-static/generate-static-params/index.test.ts
@@ -3,14 +3,14 @@ import { nextTestSetup } from 'e2e-utils'
 import * as Log from './utils/log'
 import { waitForNoRedbox, retry } from '../../../../lib/next-test-utils'
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// reading CLI logs to observe after
+// @force-gate !deploy
 describe('after() in generateStaticParams', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true, // reading CLI logs to observe after
     skipStart: true,
   })
-
-  if (skipped) return
 
   let currentCliOutputIndex = 0
   beforeEach(() => {

--- a/test/e2e/app-dir/next-after-app/index.test.ts
+++ b/test/e2e/app-dir/next-after-app/index.test.ts
@@ -7,14 +7,13 @@ import * as Log from './utils/log'
 
 const runtimes = ['nodejs', 'edge']
 
+// This suite patches fixture files and reads process-local runtime logs, which
+// are unavailable after deployment.
+// @force-gate !deploy
 describe.each(runtimes)('after() in %s runtime', (runtimeValue) => {
-  const { next, isNextDeploy, skipped } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    // `patchFile` and reading runtime logs are not supported in a deployed environment
-    skipDeployment: true,
   })
-
-  if (skipped) return
   const pathPrefix = '/' + runtimeValue
 
   let currentCliOutputIndex = 0

--- a/test/e2e/app-dir/node-extensions/node-extensions.random.test.ts
+++ b/test/e2e/app-dir/node-extensions/node-extensions.random.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 
 describe('Node Extensions', () => {
   describe('Random', () => {
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
+    // @force-gate !deploy
     describe('Cache Components', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: __dirname + '/fixtures/random/cache-components',
-        skipDeployment: true,
       })
-
-      if (skipped) {
-        return
-      }
 
       it('should not error when accessing middlware that use Math.random()', async () => {
         let res: Awaited<ReturnType<typeof next.fetch>>,
@@ -147,13 +145,9 @@ describe('Node Extensions', () => {
     })
 
     describe('Legacy', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: __dirname + '/fixtures/random/legacy',
       })
-
-      if (skipped) {
-        return
-      }
 
       it('should not error when accessing middlware that use Math.random()', async () => {
         let res, $

--- a/test/e2e/app-dir/node-worker-threads/node-worker-threads.test.ts
+++ b/test/e2e/app-dir/node-worker-threads/node-worker-threads.test.ts
@@ -1,18 +1,16 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('node-worker-threads', () => {
-  const { next, skipped, isTurbopack } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: {
       pino: '9.6.0',
       jspdf: '4.2.1',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   // These tests are Turbopack-specific since they rely on Turbopack's worker bundling
   if (!isTurbopack) {

--- a/test/e2e/app-dir/otel-parent-span-propagation/otel-parent-span-propagation.test.ts
+++ b/test/e2e/app-dir/otel-parent-span-propagation/otel-parent-span-propagation.test.ts
@@ -4,20 +4,18 @@ import { type Collector, connectCollector } from './collector'
 
 const COLLECTOR_PORT = 9876
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('otel-parent-span-propagation', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: require('./package.json').dependencies,
     env: {
       TEST_OTEL_COLLECTOR_PORT: String(COLLECTOR_PORT),
       NEXT_TELEMETRY_DISABLED: '1',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   let collector: Collector
 

--- a/test/e2e/app-dir/phase-changes/cookies.test.ts
+++ b/test/e2e/app-dir/phase-changes/cookies.test.ts
@@ -3,11 +3,9 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 describe('setting cookies', () => {
-  const { next, isNextDeploy, skipped } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) return
 
   let currentCliOutputIndex = 0
   beforeEach(() => {

--- a/test/e2e/app-dir/proxy-with-middleware/proxy-with-middleware.test.ts
+++ b/test/e2e/app-dir/proxy-with-middleware/proxy-with-middleware.test.ts
@@ -1,16 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('proxy-with-middleware', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should error when both middleware and proxy files are detected', async () => {
     const message =

--- a/test/e2e/app-dir/server-action-logging/server-action-logging.test.ts
+++ b/test/e2e/app-dir/server-action-logging/server-action-logging.test.ts
@@ -2,13 +2,13 @@ import stripAnsi from 'strip-ansi'
 import { retry } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('server-action-logging', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
-    skipDeployment: true,
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) return
 
   if (isNextStart) {
     it('should not log server actions in production mode', async () => {
@@ -188,16 +188,16 @@ describe('server-action-logging', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('server-action-logging when logging.serverFunctions is disabled', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
-    skipDeployment: true,
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     env: {
       NEXT_TEST_SERVER_FUNCTION_LOGGING: 'false',
     },
   })
-
-  if (skipped) return
 
   it('should not log server actions', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
@@ -122,21 +122,21 @@ async function resolveSourceMapLikeADebugger(
   return { sourceMap: JSON.parse(data), mapURL: null }
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - server source maps - fake frame source maps', () => {
   const dependencies = {
     // `link:` simulates a package in a monorepo
     'internal-pkg': `link:./internal-pkg`,
     'external-pkg': `file:./external-pkg`,
   }
-  const { skipped, next, isNextDev, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     dependencies,
     files: path.join(__dirname, 'fixtures/default'),
-    skipDeployment: true,
     // Expose the inspector on a random port.
     startArgs: ['--inspect=0'],
   })
-
-  if (skipped) return
 
   async function findServerInspectorTarget(): Promise<InspectorTarget> {
     const ports = [

--- a/test/e2e/app-dir/server-source-maps/server-source-maps-edge.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps-edge.test.ts
@@ -7,15 +7,14 @@ function normalizeCliOutput(output: string) {
   return stripAnsi(output)
 }
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// Deploy tests don't have access to runtime logs.
+// Manually verify that the runtime logs match.
+// @force-gate !deploy
 describe('app-dir - server source maps edge runtime', () => {
-  const { skipped, next, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures/edge'),
-    // Deploy tests don't have access to runtime logs.
-    // Manually verify that the runtime logs match.
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('logged errors have a sourcemapped stack with a codeframe', async () => {
     const outputIndex = next.cliOutput.length

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -12,21 +12,20 @@ function normalizeCliOutput(output: string) {
   )
 }
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// Deploy tests don't have access to runtime logs.
+// Manually verify that the runtime logs match.
+// @force-gate !deploy
 describe('app-dir - server source maps', () => {
   const dependencies = {
     // `link:` simulates a package in a monorepo
     'internal-pkg': `link:./internal-pkg`,
     'external-pkg': `file:./external-pkg`,
   }
-  const { skipped, next, isNextDev, isTurbopack, isRspack } = nextTestSetup({
+  const { next, isNextDev, isTurbopack, isRspack } = nextTestSetup({
     dependencies,
     files: path.join(__dirname, 'fixtures/default'),
-    // Deploy tests don't have access to runtime logs.
-    // Manually verify that the runtime logs match.
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('logged errors have a sourcemapped stack with a codeframe', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/service-worker-multiple/service-worker-multiple.test.ts
+++ b/test/e2e/app-dir/service-worker-multiple/service-worker-multiple.test.ts
@@ -2,33 +2,28 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 // Compiling `navigator.serviceWorker.register(new URL(...))` is a Turbopack-only feature.
-;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
-  'app dir - service worker (multiple registrations error)',
-  () => {
-    const { next, skipped, isNextDev } = nextTestSetup({
-      files: __dirname,
-      skipStart: true,
-      // This test asserts a build failure.
-      skipDeployment: true,
-    })
+// Deploy mode exclusion: This suite intentionally exercises a failed local build, so it cannot produce a deployment.
+// This test asserts a build failure.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('app dir - service worker (multiple registrations error)', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
 
-    if (skipped) {
-      return
+  it('errors when different service worker files are registered', async () => {
+    // In production `next.start()` runs the build, which fails. In dev the server
+    // boots and the failure surfaces when the registering page is compiled.
+    await next.start().catch(() => {})
+    if (isNextDev) {
+      await next.fetch('/').catch(() => {})
     }
 
-    it('errors when different service worker files are registered', async () => {
-      // In production `next.start()` runs the build, which fails. In dev the server
-      // boots and the failure surfaces when the registering page is compiled.
-      await next.start().catch(() => {})
-      if (isNextDev) {
-        await next.fetch('/').catch(() => {})
-      }
-
-      await retry(async () => {
-        expect(next.cliOutput).toContain(
-          'Multiple service workers with different source files'
-        )
-      })
+    await retry(async () => {
+      expect(next.cliOutput).toContain(
+        'Multiple service workers with different source files'
+      )
     })
-  }
-)
+  })
+})

--- a/test/e2e/app-dir/set-cookies/set-cookies.test.ts
+++ b/test/e2e/app-dir/set-cookies/set-cookies.test.ts
@@ -10,16 +10,13 @@ function getSetCookieHeaders(res: Response): ReadonlyArray<string> {
   )
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// TODO: re-enable once this behavior is corrected on deploy
+// @force-gate !deploy
 describe('set-cookies', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // TODO: re-enable once this behavior is corrected on deploy
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   describe.each([
     { dir: 'pages', runtimes: ['edge', 'experimental-edge', 'node'] },

--- a/test/e2e/app-dir/sub-shell-generation-middleware/sub-shell-generation-middleware.test.ts
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/sub-shell-generation-middleware.test.ts
@@ -3,14 +3,13 @@ import * as cheerio from 'cheerio'
 import { getCacheHeader, retry } from 'next-test-utils'
 import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
 
-const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
-
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The latest changes to support this behavior on deployed infra are available in the adapter,
+// and are not being backported to the CLI
+// @force-gate !deploy || adapter
 describe('middleware-static-rewrite', () => {
   const { next, isNextDeploy, isNextDev } = nextTestSetup({
     files: __dirname,
-    // The latest changes to support this behavior on deployed infra are available in the adapter,
-    // and are not being backported to the CLI
-    skipDeployment: !isAdapterTest,
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/unhandled-rejection-logging/unhandled-rejection-logging.test.ts
+++ b/test/e2e/app-dir/unhandled-rejection-logging/unhandled-rejection-logging.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry, waitFor } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('unhandled-rejection-logging', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('logs an unhandled rejection', async () => {
     const outputIndex = next.cliOutput.length

--- a/test/e2e/app-dir/webpack-loader-binary/webpack-loader-binary.test.ts
+++ b/test/e2e/app-dir/webpack-loader-binary/webpack-loader-binary.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('webpack-loader-ts-transform', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should allow passing binary assets to and from a Webpack loader', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/x-forwarded-headers/x-forwarded-headers.test.ts
+++ b/test/e2e/app-dir/x-forwarded-headers/x-forwarded-headers.test.ts
@@ -1,14 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// Deploy mode exclusion: The assertions exercise behavior specific to the local Next.js server.
+// This test is skipped because it sends requests with manipulated host headers
+// which doesn't work in a deployed environment
+// @force-gate !deploy
 describe('x-forwarded-headers', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // This test is skipped because it sends requests with manipulated host headers
-    // which doesn't work in a deployed environment
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should include x-forwarded-* headers', async () => {
     const res = await next.fetch('/')

--- a/test/e2e/cpu-profiling/cpu-profiling-build.test.ts
+++ b/test/e2e/cpu-profiling/cpu-profiling-build.test.ts
@@ -2,18 +2,19 @@ import { nextTestSetup, isNextDeploy } from 'e2e-utils'
 import { pathExists, readdir, readFile } from 'fs-extra'
 import { join } from 'path'
 
+// Deploy mode exclusion: This suite invokes a local profiled build and
+// inspects the generated profile files.
+// @force-gate !deploy
 describe('CPU Profiling - next build', () => {
-  const { next, isNextDev, skipped, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
     buildCommand: 'pnpm next build --experimental-cpu-prof',
     dependencies: {},
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   // CPU profiling only works with local `next build`, not dev or deploy modes
-  if (isNextDev || isNextDeploy || skipped) {
+  if (isNextDev || isNextDeploy) {
     it('skip for development/deploy mode', () => {})
     return
   }

--- a/test/e2e/cpu-profiling/cpu-profiling.test.ts
+++ b/test/e2e/cpu-profiling/cpu-profiling.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import { retry } from 'next-test-utils'
 
 describe('CPU Profiling - next start', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     startCommand: 'pnpm next start --experimental-cpu-prof',
     dependencies: {},
@@ -12,7 +12,8 @@ describe('CPU Profiling - next start', () => {
   })
 
   // CPU profiling only works with local `next start`, not dev or deploy modes
-  if (isNextDev || isNextDeploy || skipped) {
+  // Deploy mode exclusion: This suite controls a local `next start` process and inspects generated profile files.
+  if (isNextDev || isNextDeploy) {
     it('skip for development/deploy mode', () => {})
     return
   }

--- a/test/e2e/custom-server/custom-server.test.ts
+++ b/test/e2e/custom-server/custom-server.test.ts
@@ -22,17 +22,18 @@ describe.each([
       ? new https.Agent({ rejectUnauthorized: false })
       : undefined
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('with dynamic assetPrefix', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       startCommand: 'node server.js',
       serverReadyPattern: /- Local:/,
       env: { USE_HTTPS: useHttps, NODE_ENV: sharedNodeEnv },
       dependencies: sharedDeps,
-      skipDeployment: true,
       disableAutoSkewProtection: true,
     })
-    if (skipped) return
 
     it('should render the custom 404 page for an unmatched request', async () => {
       const response = await next.fetch('/does-not-exist', { agent })
@@ -147,8 +148,12 @@ describe.each([
       )
     })
   })
-  ;(isNextDev ? describe.skip : describe)('with generateEtags enabled', () => {
-    const { next, skipped } = nextTestSetup({
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
+  // @force-gate !dev
+  describe('with generateEtags enabled', () => {
+    const { next } = nextTestSetup({
       files: __dirname,
       startCommand: 'node server.js',
       serverReadyPattern: /- Local:/,
@@ -158,10 +163,8 @@ describe.each([
         NODE_ENV: sharedNodeEnv,
       },
       dependencies: sharedDeps,
-      skipDeployment: true,
       disableAutoSkewProtection: true,
     })
-    if (skipped) return
 
     it('response includes etag header', async () => {
       const response = await next.fetch('/', { agent })
@@ -169,8 +172,11 @@ describe.each([
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('with generateEtags disabled', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       startCommand: 'node server.js',
       serverReadyPattern: /- Local:/,
@@ -180,10 +186,8 @@ describe.each([
         NODE_ENV: sharedNodeEnv,
       },
       dependencies: sharedDeps,
-      skipDeployment: true,
       disableAutoSkewProtection: true,
     })
-    if (skipped) return
 
     it('response does not include etag header', async () => {
       const response = await next.fetch('/', { agent })
@@ -192,17 +196,19 @@ describe.each([
   })
 
   if (useHttps === 'false') {
-    ;(isNextDev ? describe : describe.skip)('HMR with custom server', () => {
-      const { next, skipped } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely asserts local CLI or runtime output that deploy tests do not expose.
+    // @force-gate !deploy
+    // @force-gate dev
+    describe('HMR with custom server', () => {
+      const { next } = nextTestSetup({
         files: __dirname,
         startCommand: 'node server.js',
         serverReadyPattern: /- Local:/,
         env: { USE_HTTPS: useHttps, NODE_ENV: sharedNodeEnv },
         dependencies: sharedDeps,
-        skipDeployment: true,
         disableAutoSkewProtection: true,
       })
-      if (skipped) return
 
       it('Should support HMR when rendering with /index pathname', async () => {
         const browser = await next.browser('/test-index-hmr')
@@ -237,17 +243,18 @@ describe.each([
     })
   }
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('Error when rendering without starting slash', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       startCommand: 'node server.js',
       serverReadyPattern: /- Local:/,
       env: { USE_HTTPS: useHttps, NODE_ENV: sharedNodeEnv },
       dependencies: sharedDeps,
-      skipDeployment: true,
       disableAutoSkewProtection: true,
     })
-    if (skipped) return
     ;(isNextDev ? it : it.skip)('should warn in development mode', async () => {
       const cliOutputBefore = next.cliOutput.length
       const html = await next.render('/no-slash', undefined, { agent })
@@ -270,8 +277,11 @@ describe.each([
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('with a custom fetch polyfill', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       startCommand: 'node server.js',
       serverReadyPattern: /- Local:/,
@@ -281,10 +291,8 @@ describe.each([
         NODE_ENV: sharedNodeEnv,
       },
       dependencies: { ...sharedDeps, 'node-fetch': '2.6.7' },
-      skipDeployment: true,
       disableAutoSkewProtection: true,
     })
-    if (skipped) return
 
     it('should serve internal file from render', async () => {
       const html = await next.render('/static/hello.txt', undefined, { agent })
@@ -292,17 +300,18 @@ describe.each([
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('unhandled rejection', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       startCommand: 'node server.js',
       serverReadyPattern: /- Local:/,
       env: { USE_HTTPS: useHttps, NODE_ENV: sharedNodeEnv },
       dependencies: sharedDeps,
-      skipDeployment: true,
       disableAutoSkewProtection: true,
     })
-    if (skipped) return
 
     it('stderr should include error message and stack trace', async () => {
       const cliOutputBefore = next.cliOutput.length
@@ -319,17 +328,18 @@ describe.each([
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('legacy NextCustomServer methods', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       startCommand: 'node server.js',
       serverReadyPattern: /- Local:/,
       env: { USE_HTTPS: useHttps, NODE_ENV: sharedNodeEnv },
       dependencies: sharedDeps,
-      skipDeployment: true,
       disableAutoSkewProtection: true,
     })
-    if (skipped) return
 
     it('NextCustomServer.renderToHTML', async () => {
       const rawHTML = await next.render(

--- a/test/e2e/dynamic-routing-middleware/dynamic-routing-middleware.test.ts
+++ b/test/e2e/dynamic-routing-middleware/dynamic-routing-middleware.test.ts
@@ -2,14 +2,15 @@ import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { join } from 'path'
 import { runTests } from '../dynamic-routing/shared'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('Dynamic Routing with Middleware', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: join(__dirname, '../dynamic-routing'),
     skipStart: true,
     disableAutoSkewProtection: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     await next.patchFile(

--- a/test/e2e/edge-compiler-module-exports-preference/index.test.ts
+++ b/test/e2e/edge-compiler-module-exports-preference/index.test.ts
@@ -2,6 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('Edge compiler module exports preference', () => {
+  // Deploy mode exclusion: This suite manually creates a package in the local `node_modules` directory.
   if ((global as any).isNextDeploy) {
     // this test is skipped when deployed because it manually creates a package in the node_modules directory
     // which is unsupported

--- a/test/e2e/edge-configurable-runtime/index.test.ts
+++ b/test/e2e/edge-configurable-runtime/index.test.ts
@@ -1,11 +1,13 @@
-import { isNextDev, isNextStart, nextTestSetup } from 'e2e-utils'
+import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 import stripAnsi from 'strip-ansi'
 
 const pagePath = 'pages/index.jsx'
 const apiPath = 'pages/api/edge.js'
 
-;(process.env.IS_TURBOPACK_TEST ? describe.skip.each : describe.each)([
+// Deploy mode exclusion: This suite mutates fixture files and asserts local build and CLI output.
+// @force-gate !turbopack && !deploy
+describe.each([
   { appDir: join(__dirname, './app/src'), title: 'src/pages and API routes' },
   { appDir: join(__dirname, './app'), title: 'pages and API routes' },
 ])('Configurable runtime for $title', ({ appDir }) => {
@@ -88,7 +90,7 @@ const apiPath = 'pages/api/edge.js'
         expect(next.cliOutput).not.toInclude('warn')
       })
     })
-  } else if (isNextStart) {
+  } else {
     describe('In start mode', () => {
       const { next } = nextTestSetup({
         files: appDir,
@@ -138,7 +140,5 @@ const apiPath = 'pages/api/edge.js'
         )
       })
     })
-  } else {
-    it.skip('no deploy tests', () => {})
   }
 })

--- a/test/e2e/edge-runtime-configurable-guards/edge-runtime-configurable-guards.test.ts
+++ b/test/e2e/edge-runtime-configurable-guards/edge-runtime-configurable-guards.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { shouldUseTurbopack } from 'next-test-utils'
 import { retry } from 'next-test-utils'
 
@@ -14,12 +14,14 @@ const LIB_PATH = 'node_modules/lib/index.js'
 jest.setTimeout(120 * 1000)
 
 describe('Edge runtime configurable guards', () => {
-  ;(isNextDev ? describe : describe.skip)('development mode', () => {
-    const { next, isTurbopack, skipped } = nextTestSetup({
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
+  // @force-gate dev
+  describe('development mode', () => {
+    const { next, isTurbopack } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     let originalApiRoute: string
     let originalMiddleware: string
@@ -341,14 +343,16 @@ describe('Edge runtime configurable guards', () => {
       }
     )
   })
-  ;(isNextStart ? describe : describe.skip)('production mode', () => {
-    const { next, isTurbopack, skipped } = nextTestSetup({
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
+  // @force-gate start
+  describe('production mode', () => {
+    const { next, isTurbopack } = nextTestSetup({
       files: __dirname,
       skipStart: true,
       env: shouldUseTurbopack() ? {} : { NEXT_TELEMETRY_DEBUG: '1' },
-      skipDeployment: true,
     })
-    if (skipped) return
 
     let originalApiRoute: string
     let originalMiddleware: string
@@ -393,7 +397,6 @@ describe('Edge runtime configurable guards', () => {
       }
     })
 
-    // eslint-disable-next-line jest/no-identical-title
     describe('Multiple functions with different configurations', () => {
       it('fails to build because of unallowed code', async () => {
         await next.patchFile(

--- a/test/e2e/edge-runtime-module-errors/edge-runtime-module-errors.test.ts
+++ b/test/e2e/edge-runtime-module-errors/edge-runtime-module-errors.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
@@ -116,8 +116,12 @@ function createVariants(opts: {
 
 describe('Edge runtime module errors', () => {
   // ==================== DEVELOPMENT MODE ====================
-  ;(isNextDev ? describe : describe.skip)('development mode', () => {
-    const { next, isTurbopack, skipped } = nextTestSetup({
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
+  // @force-gate dev
+  describe('development mode', () => {
+    const { next, isTurbopack } = nextTestSetup({
       files: __dirname,
       dependencies: {
         nanoid: 'latest',
@@ -126,9 +130,7 @@ describe('Edge runtime module errors', () => {
       // pushes the initial server startup past the default 10s window on
       // loaded CI hardware.
       startServerTimeout: 30_000,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     // webpack's dev server lazily compiles Edge API routes on demand and
     // keeps serving the last-successful compilation when a later compile
@@ -574,16 +576,18 @@ describe('Edge runtime module errors', () => {
   })
 
   // ==================== PRODUCTION MODE ====================
-  ;(isNextStart ? describe : describe.skip)('production mode', () => {
-    const { next, isTurbopack, skipped } = nextTestSetup({
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
+  // @force-gate start
+  describe('production mode', () => {
+    const { next, isTurbopack } = nextTestSetup({
       files: __dirname,
       skipStart: true,
       dependencies: {
         nanoid: 'latest',
       },
-      skipDeployment: true,
     })
-    if (skipped) return
 
     let originalApi: string
     let originalMiddleware: string

--- a/test/e2e/edge-runtime-response-error/edge-runtime-response-error.test.ts
+++ b/test/e2e/edge-runtime-response-error/edge-runtime-response-error.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('Edge runtime response error', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   describe.each([
     { title: 'Edge API', url: '/api/route' },

--- a/test/e2e/edge-runtime-streaming-error/edge-runtime-streaming-error.test.ts
+++ b/test/e2e/edge-runtime-streaming-error/edge-runtime-streaming-error.test.ts
@@ -2,14 +2,14 @@ import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('edge-runtime-streaming-error', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('logs the error correctly', async () => {
     const res = await next.fetch('/api/test')

--- a/test/e2e/edge-runtime-timer-this/edge-runtime-timer-this.test.ts
+++ b/test/e2e/edge-runtime-timer-this/edge-runtime-timer-this.test.ts
@@ -2,16 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 
 const enableCacheComponents = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
+// Deploy mode exclusion: The assertions exercise behavior specific to the local Next.js server.
+// This is testing the edge runtime sandbox, which is only used in `next start`.
+// @force-gate !deploy
 describe('edge-runtime-timer-this', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // This is testing the edge runtime sandbox, which is only used in `next start`.
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (enableCacheComponents) {
     it.skip('skipped because `runtime = "edge"` is not allowed in cacheComponents', () => {})

--- a/test/e2e/edge-runtime-uses-edge-light-import-specifier-for-packages/edge-runtime-uses-edge-light-import-specifier-for-packages.test.ts
+++ b/test/e2e/edge-runtime-uses-edge-light-import-specifier-for-packages/edge-runtime-uses-edge-light-import-specifier-for-packages.test.ts
@@ -1,7 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('edge-runtime uses edge-light import specifier for packages', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     packageJson: {
       scripts: {
@@ -13,12 +16,7 @@ describe('edge-runtime uses edge-light import specifier for packages', () => {
     installCommand: 'pnpm i',
     startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
     buildCommand: 'pnpm build',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // In case you need to test the response object
   it('pages/api endpoints import the correct module', async () => {

--- a/test/e2e/edge-runtime-with-node.js-apis/edge-runtime-with-node.js-apis.test.ts
+++ b/test/e2e/edge-runtime-with-node.js-apis/edge-runtime-with-node.js-apis.test.ts
@@ -27,18 +27,18 @@ const unsupportedClasses = [
   'WritableStreamDefaultController',
 ]
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('Edge runtime with Node.js APIs', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     // Turbopack builds fail (non-zero exit) when edge code uses Node.js APIs,
     // but the CLI output still contains the warnings we're asserting on. Skip
     // the automatic start so we can run the build manually and ignore the
     // non-zero exit code.
     skipStart: true,
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     if (isNextDev) {

--- a/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
+++ b/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
@@ -2,16 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// don't have access to runtime logs on deploy
+// @force-gate !deploy
 describe('fetch failures have good stack traces in edge runtime', () => {
-  const { next, isNextStart, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextStart, isNextDev } = nextTestSetup({
     files: __dirname,
-    // don't have access to runtime logs on deploy
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // TODO: Failure is not specific to Turbopack, edge runtime errors don't have source maps applied.
   ;(process.env.IS_TURBOPACK_TEST && isNextStart ? it.skip : it)(

--- a/test/e2e/file-serving/file-serving.test.ts
+++ b/test/e2e/file-serving/file-serving.test.ts
@@ -4,17 +4,17 @@ import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel's edge rejects malformed URLs (mixed-encoding traversal,
+// backslash, double-encoded, etc.) before they reach the runtime, and
+// `safeFetch` for those paths uses `localhost:0` which doesn't apply in
+// deploy mode. The traversal protection we want to test here is local to
+// Next.js's server.
+// @force-gate !deploy
 describe('file-serving', () => {
-  const { next, isNextDeploy, skipped } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    // Vercel's edge rejects malformed URLs (mixed-encoding traversal,
-    // backslash, double-encoded, etc.) before they reach the runtime, and
-    // `safeFetch` for those paths uses `localhost:0` which doesn't apply in
-    // deploy mode. The traversal protection we want to test here is local to
-    // Next.js's server.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   // Helper to detect malformed URLs that can't be parsed by the URL constructor
   const isMalformedUrl = (path) => {

--- a/test/e2e/instrumentation-hook-src/instrumentation-hook-src.test.ts
+++ b/test/e2e/instrumentation-hook-src/instrumentation-hook-src.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 describe('instrumentation-hook-rsc', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('instrumentation', () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
+    const { next, isNextDev } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('should run the instrumentation hook', async () => {
       await next.render('/')

--- a/test/e2e/instrumentation-hook/instrumentation-hook.test.ts
+++ b/test/e2e/instrumentation-hook/instrumentation-hook.test.ts
@@ -4,15 +4,12 @@ import path from 'path'
 
 const describeCase = (
   caseName: string,
-  callback: (context: ReturnType<typeof nextTestSetup>) => void,
-  { skipDeployment = false }: { skipDeployment?: boolean } = {}
+  callback: (context: ReturnType<typeof nextTestSetup>) => void
 ) => {
   describe(caseName, () => {
     const context = nextTestSetup({
       files: path.join(__dirname, caseName),
-      skipDeployment,
     })
-    if (context.skipped) return
 
     callback(context)
   })

--- a/test/e2e/instrumentation-hook/register-once/register-once.test.ts
+++ b/test/e2e/instrumentation-hook/register-once/register-once.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('instrumentation-hook - register-once', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should only register once', async () => {
     await next.fetch('/foo')

--- a/test/e2e/invalid-middleware-matchers/invalid-middleware-matchers.test.ts
+++ b/test/e2e/invalid-middleware-matchers/invalid-middleware-matchers.test.ts
@@ -1,13 +1,14 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Errors on invalid custom middleware matchers', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   afterEach(async () => {
     await next.deleteFile('middleware.js').catch(() => {})

--- a/test/e2e/middleware-custom-matchers/test/index.test.ts
+++ b/test/e2e/middleware-custom-matchers/test/index.test.ts
@@ -3,15 +3,10 @@ import { join } from 'path'
 import { fetchViaHTTP } from 'next-test-utils'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
-const itif = (condition: boolean) => (condition ? it : it.skip)
-
-const isModeDeploy = process.env.NEXT_TEST_MODE === 'deploy'
-
+// TODO(deploy-test-completion): Re-enable this suite for deployed Node.js middleware.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy || !nodeMiddleware
 describe('Middleware custom matchers', () => {
-  if ((global as any).isNextDeploy && process.env.TEST_NODE_MIDDLEWARE) {
-    return it('should skip deploy for now', () => {})
-  }
-
   const { next } = nextTestSetup({
     files: new FileRef(join(__dirname, '../app')),
     overrideFiles: process.env.TEST_NODE_MIDDLEWARE
@@ -103,8 +98,9 @@ describe('Middleware custom matchers', () => {
       expect(res2.status).toBe(404)
     })
 
-    // Cannot modify host when testing with real deployment
-    itif(!isModeDeploy)('should match has host', async () => {
+    // Cannot modify host when testing with a real deployment.
+    // @force-gate !deploy
+    it('should match has host', async () => {
       const res1 = await fetchViaHTTP(next.url, '/has-match-4')
       expect(res1.status).toBe(404)
 
@@ -144,37 +140,30 @@ describe('Middleware custom matchers', () => {
 
     // FIXME: Test fails on Vercel deployment for now.
     // See https://linear.app/vercel/issue/EC-160/header-value-set-on-middleware-is-not-propagated-on-client-request-of
-    itif(!isModeDeploy)(
-      'should match has query on client routing',
-      async () => {
-        const browser = await next.browser('/routes')
-        await browser.eval('window.__TEST_NO_RELOAD = true')
-        await browser.elementById('has-match-2').click()
-        const fromMiddleware = await browser
-          .elementById('from-middleware')
-          .text()
-        expect(fromMiddleware).toBe('true')
-        const noReload = await browser.eval('window.__TEST_NO_RELOAD')
-        expect(noReload).toBe(true)
-      }
-    )
+    // @force-gate !deploy
+    it('should match has query on client routing', async () => {
+      const browser = await next.browser('/routes')
+      await browser.eval('window.__TEST_NO_RELOAD = true')
+      await browser.elementById('has-match-2').click()
+      const fromMiddleware = await browser.elementById('from-middleware').text()
+      expect(fromMiddleware).toBe('true')
+      const noReload = await browser.eval('window.__TEST_NO_RELOAD')
+      expect(noReload).toBe(true)
+    })
 
-    itif(!isModeDeploy)(
-      'should match has cookie on client routing',
-      async () => {
-        const browser = await next.browser('/routes')
-        await browser.addCookie({ name: 'loggedIn', value: 'true' })
-        await browser.refresh()
-        await browser.eval('window.__TEST_NO_RELOAD = true')
-        await browser.elementById('has-match-3').click()
-        const fromMiddleware = await browser
-          .elementById('from-middleware')
-          .text()
-        expect(fromMiddleware).toBe('true')
-        const noReload = await browser.eval('window.__TEST_NO_RELOAD')
-        expect(noReload).toBe(true)
-      }
-    )
+    // TODO(deploy-test-completion): The reason for this deploy failure is not documented.
+    // @force-gate !deploy
+    it('should match has cookie on client routing', async () => {
+      const browser = await next.browser('/routes')
+      await browser.addCookie({ name: 'loggedIn', value: 'true' })
+      await browser.refresh()
+      await browser.eval('window.__TEST_NO_RELOAD = true')
+      await browser.elementById('has-match-3').click()
+      const fromMiddleware = await browser.elementById('from-middleware').text()
+      expect(fromMiddleware).toBe('true')
+      const noReload = await browser.eval('window.__TEST_NO_RELOAD')
+      expect(noReload).toBe(true)
+    })
   }
   runTests()
 })

--- a/test/e2e/middleware-matcher/index.test.ts
+++ b/test/e2e/middleware-matcher/index.test.ts
@@ -30,6 +30,8 @@ function normalizeMiddlewareManifest(value: unknown, key?: string): unknown {
   return value
 }
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('Middleware can set the matcher in its config', () => {
   const { next } = nextTestSetup({
     files: new FileRef(join(__dirname, 'app')),

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -6,9 +6,9 @@ import { check, fetchViaHTTP, retry } from 'next-test-utils'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import escapeStringRegexp from 'escape-string-regexp'
 
-const isTurbopackTest = Boolean(process.env.IS_TURBOPACK_TEST)
-const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
-
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// FIXME: Fails to deploy
+// @force-gate !deploy || !adapter || !turbopack
 describe('Middleware Rewrite', () => {
   const { next, isNextDeploy } = nextTestSetup({
     files: {
@@ -16,8 +16,6 @@ describe('Middleware Rewrite', () => {
       'next.config.js': new FileRef(join(__dirname, '../app/next.config.js')),
       'middleware.js': new FileRef(join(__dirname, '../app/middleware.js')),
     },
-    // FIXME: Fails to deploy
-    skipDeployment: isAdapterTest && isTurbopackTest,
   })
 
   function tests() {

--- a/test/e2e/middleware-src-node/middleware-src-node.test.ts
+++ b/test/e2e/middleware-src-node/middleware-src-node.test.ts
@@ -4,13 +4,14 @@ import { retry } from 'next-test-utils'
 const srcHeader = 'X-From-Src-Middleware'
 const rootHeader = 'X-From-Root-Middleware'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('middleware-src-node', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   if (isNextDev) {
     beforeAll(async () => {

--- a/test/e2e/middleware-src/middleware-src.test.ts
+++ b/test/e2e/middleware-src/middleware-src.test.ts
@@ -4,13 +4,14 @@ import { retry } from 'next-test-utils'
 const srcHeader = 'X-From-Src-Middleware'
 const rootHeader = 'X-From-Root-Middleware'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('middleware-src', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   if (isNextDev) {
     beforeAll(async () => {

--- a/test/e2e/node-cli-args/node-cli-args.test.ts
+++ b/test/e2e/node-cli-args/node-cli-args.test.ts
@@ -1,10 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('node-cli-args', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     startCommand: `node --experimental-network-inspection ./node_modules/next/dist/bin/next ${process.env.NEXT_TEST_MODE === 'dev' ? 'dev' : 'start'}`,
-    skipDeployment: true,
     skipStart: true,
   })
 

--- a/test/e2e/node-fetch-keep-alive/node-fetch-keep-alive.test.ts
+++ b/test/e2e/node-fetch-keep-alive/node-fetch-keep-alive.test.ts
@@ -1,16 +1,16 @@
 import { nextTestSetup } from 'e2e-utils'
 import { createServer, Server } from 'http'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('node-fetch-keep-alive', () => {
   let mockServer: Server
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     mockServer = createServer((req, res) => {

--- a/test/e2e/on-request-error/basic/basic.test.ts
+++ b/test/e2e/on-request-error/basic/basic.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { getOutputLogJson } from '../_testing/utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('on-request-error - basic', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   const outputLogPath = 'output-log.json'
 

--- a/test/e2e/on-request-error/client-abort/client-abort.test.ts
+++ b/test/e2e/on-request-error/client-abort/client-abort.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// Deploy mode exclusion: This suite asserts local server CLI output after
+// aborting a response stream.
+// @force-gate !deploy
 describe('on-request-error - client-abort', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not report an aborted RSC stream but still report render errors', async () => {
     const controller = new AbortController()

--- a/test/e2e/on-request-error/dynamic-routes/dynamic-routes.test.ts
+++ b/test/e2e/on-request-error/dynamic-routes/dynamic-routes.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { getOutputLogJson } from '../_testing/utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('on-request-error - dynamic-routes', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   const outputLogPath = 'output-log.json'
 

--- a/test/e2e/on-request-error/isr/isr.test.ts
+++ b/test/e2e/on-request-error/isr/isr.test.ts
@@ -4,15 +4,13 @@ import { getOutputLogJson } from '../_testing/utils'
 
 const outputLogPath = 'output-log.json'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('on-request-error - isr', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     it('should skip in development mode', () => {

--- a/test/e2e/on-request-error/otel/otel.test.ts
+++ b/test/e2e/on-request-error/otel/otel.test.ts
@@ -2,20 +2,18 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { getOutputLogJson } from '../_testing/utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('on-request-error - otel', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     packageJson: {
       dependencies: {
         '@vercel/otel': '^1.13.0',
       },
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   const outputLogPath = 'output-log.json'
 

--- a/test/e2e/on-request-error/server-action-error/server-action-error.test.ts
+++ b/test/e2e/on-request-error/server-action-error/server-action-error.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { getOutputLogJson } from '../_testing/utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('on-request-error - server-action-error', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   const outputLogPath = 'output-log.json'
 

--- a/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
+++ b/test/e2e/on-request-error/skip-next-internal-error/skip-next-internal-error.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('on-request-error - skip-next-internal-error', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   async function assertNoNextjsInternalErrors() {
     const output = next.cliOutput

--- a/test/e2e/opentelemetry/instrumentation/instrumentation-pages-app-only.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/instrumentation-pages-app-only.test.ts
@@ -27,6 +27,9 @@ for (const { app, src, pathname, text } of [
     text: 'Page',
   },
 ]) {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe(`instrumentation ${app ? 'app' : 'pages'}${
     src ? ' src/' : ''
   }`, () => {
@@ -38,7 +41,6 @@ for (const { app, src, pathname, text } of [
       env: {
         NEXT_PUBLIC_SIMPLE_INSTRUMENT: '1',
       },
-      skipDeployment: true,
       packageJson: {
         scripts: {
           'setup-dir': `mv instrumentation-minimal.ts instrumentation.ts; rm -rf ${oppositeDir}${

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -33,7 +33,6 @@ function setup({ useDirectEntrypointHandler, useNodeMiddleware }) {
 
   let next = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: require('./package.json').dependencies,
     ...(!useDirectEntrypointHandler
       ? {
@@ -68,6 +67,9 @@ function setup({ useDirectEntrypointHandler, useNodeMiddleware }) {
   return { next, getCollector }
 }
 
+// This suite starts a process-local telemetry collector and, in one variant,
+// a custom local server entrypoint.
+// @force-gate !deploy
 describe.each(
   [
     { name: 'default' },
@@ -78,16 +80,12 @@ describe.each(
   ].filter(Boolean)
 )('opentelemetry - $name', ({ useDirectEntrypointHandler }) => {
   const {
-    next: { next, skipped, isNextDev },
+    next: { next, isNextDev },
     getCollector,
   } = setup({
     useDirectEntrypointHandler,
     useNodeMiddleware: false,
   })
-
-  if (skipped) {
-    return
-  }
 
   // Edge runtime is currently not implemented in custom-entrypoint-server.ts
   const itEdge = useDirectEntrypointHandler ? it.skip : it
@@ -1536,11 +1534,13 @@ describe.each(
 })
 
 if (isNextStart) {
+  // Deploy mode exclusion: This suite starts a process-local telemetry
+  // collector and controls the server lifecycle.
+  // @force-gate !deploy
   describe('opentelemetry route module preparation with direct entrypoint handler', () => {
     let collector: Collector | undefined
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       skipStart: true,
       dependencies: require('./package.json').dependencies,
       startCommand: 'pnpm start-entrypoint',
@@ -1557,10 +1557,6 @@ if (isNextStart) {
         NODE_ENV: 'production',
       },
     })
-
-    if (skipped) {
-      return
-    }
 
     afterAll(async () => {
       await collector?.shutdown()
@@ -1601,6 +1597,9 @@ if (isNextStart) {
   })
 }
 
+// This suite starts a process-local telemetry collector and controls the local
+// server lifecycle.
+// @force-gate !deploy
 describe.each(
   [
     { name: 'default', useDirectEntrypointHandler: false },
@@ -1613,9 +1612,8 @@ describe.each(
   'opentelemetry App Route module loading - $name',
   ({ useDirectEntrypointHandler }) => {
     let collector: Collector | undefined
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       skipStart: true,
       dependencies: require('./package.json').dependencies,
       ...(!useDirectEntrypointHandler
@@ -1645,10 +1643,6 @@ describe.each(
             },
           }),
     })
-
-    if (skipped) {
-      return
-    }
 
     afterAll(async () => {
       await collector?.shutdown()
@@ -1734,6 +1728,9 @@ describe.each(
   }
 )
 
+// This suite starts a process-local telemetry collector and controls the local
+// server lifecycle.
+// @force-gate !deploy
 describe.each(
   [
     { name: 'default', useDirectEntrypointHandler: false },
@@ -1745,16 +1742,12 @@ describe.each(
 )('opentelemetry - middleware $name', ({ useDirectEntrypointHandler }) => {
   describe.each(['edge', 'nodejs'])('%s runtime', (runtime) => {
     const {
-      next: { next, skipped },
+      next: { next },
       getCollector,
     } = setup({
       useDirectEntrypointHandler,
       useNodeMiddleware: runtime === 'nodejs',
     })
-
-    if (skipped) {
-      return
-    }
 
     if (useDirectEntrypointHandler && runtime === 'edge') {
       it.skip('direct entrypoint handler is not implemented for edge runtime', () => {})
@@ -1831,6 +1824,9 @@ describe.each(
   })
 })
 
+// This suite starts a process-local telemetry collector and controls the local
+// server lifecycle.
+// @force-gate !deploy
 describe.each(
   [
     { name: 'default' },
@@ -1843,9 +1839,8 @@ describe.each(
   'opentelemetry instrumentation startup - $name',
   ({ useDirectEntrypointHandler }) => {
     let collector: Collector | undefined
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       skipStart: true,
       dependencies: require('./package.json').dependencies,
       ...(!useDirectEntrypointHandler
@@ -1875,10 +1870,6 @@ describe.each(
             },
           }),
     })
-
-    if (skipped) {
-      return
-    }
 
     afterAll(async () => {
       await collector?.shutdown()
@@ -1939,89 +1930,83 @@ describe.each(
     })
   }
 )
-;(process.env.__NEXT_CACHE_COMPONENTS ? describe.skip : describe)(
-  'opentelemetry NEXT_OTEL_VERBOSE=1',
-  () => {
-    const { next, skipped } = nextTestSetup({
-      files: __dirname,
-      skipDeployment: true,
-      dependencies: require('./package.json').dependencies,
-      env: {
-        TEST_OTEL_COLLECTOR_PORT: String(COLLECTOR_PORT),
-        NEXT_TELEMETRY_DISABLED: '1',
-        NEXT_OTEL_VERBOSE: '1',
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
+// @force-gate !cacheComponents
+describe('opentelemetry NEXT_OTEL_VERBOSE=1', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    dependencies: require('./package.json').dependencies,
+    env: {
+      TEST_OTEL_COLLECTOR_PORT: String(COLLECTOR_PORT),
+      NEXT_TELEMETRY_DISABLED: '1',
+      NEXT_OTEL_VERBOSE: '1',
+    },
+  })
+
+  let collector: Collector | undefined
+
+  beforeEach(async () => {
+    collector = await connectCollector({ port: COLLECTOR_PORT })
+  })
+
+  afterEach(async () => {
+    await collector?.shutdown()
+    collector = undefined
+  })
+
+  // Regression for https://github.com/vercel/otel/issues/107.
+  it('all spans (including verbose) inherit traceId from incoming traceparent header', async () => {
+    const pathname = '/app/param/rsc-fetch'
+    await next.fetch(pathname, {
+      headers: {
+        traceparent: `00-${EXTERNAL.traceId}-${EXTERNAL.spanId}-01`,
       },
     })
 
-    if (skipped) {
-      return
+    let spans: SavedSpan[] = []
+    await retry(async () => {
+      const all = collector?.getSpans() ?? []
+      const root = all.find(
+        (s) =>
+          s.attributes?.['next.span_type'] === 'BaseServer.handleRequest' &&
+          s.attributes?.['http.target'] === pathname
+      )
+      expect(root).toBeDefined()
+      expect(root!.traceId).toBe(EXTERNAL.traceId)
+
+      spans = all.filter((s) => s.traceId === root!.traceId)
+      expect(spans.length).toBeGreaterThan(1)
+
+      const verbose = spans.find(
+        (s) =>
+          s.attributes?.['next.span_type'] === 'NextServer.getRequestHandler'
+      )
+      expect(verbose).toBeDefined()
+      expect(verbose!.traceId).toBe(EXTERNAL.traceId)
+      const parentSpanId = verbose!.parentId
+      expect(parentSpanId).toBe(EXTERNAL.spanId)
+    })
+
+    for (const span of spans) {
+      expect(span.traceId).toBe(EXTERNAL.traceId)
     }
+  })
+})
 
-    let collector: Collector | undefined
-
-    beforeEach(async () => {
-      collector = await connectCollector({ port: COLLECTOR_PORT })
-    })
-
-    afterEach(async () => {
-      await collector?.shutdown()
-      collector = undefined
-    })
-
-    // Regression for https://github.com/vercel/otel/issues/107.
-    it('all spans (including verbose) inherit traceId from incoming traceparent header', async () => {
-      const pathname = '/app/param/rsc-fetch'
-      await next.fetch(pathname, {
-        headers: {
-          traceparent: `00-${EXTERNAL.traceId}-${EXTERNAL.spanId}-01`,
-        },
-      })
-
-      let spans: SavedSpan[] = []
-      await retry(async () => {
-        const all = collector?.getSpans() ?? []
-        const root = all.find(
-          (s) =>
-            s.attributes?.['next.span_type'] === 'BaseServer.handleRequest' &&
-            s.attributes?.['http.target'] === pathname
-        )
-        expect(root).toBeDefined()
-        expect(root!.traceId).toBe(EXTERNAL.traceId)
-
-        spans = all.filter((s) => s.traceId === root!.traceId)
-        expect(spans.length).toBeGreaterThan(1)
-
-        const verbose = spans.find(
-          (s) =>
-            s.attributes?.['next.span_type'] === 'NextServer.getRequestHandler'
-        )
-        expect(verbose).toBeDefined()
-        expect(verbose!.traceId).toBe(EXTERNAL.traceId)
-        const parentSpanId = verbose!.parentId
-        expect(parentSpanId).toBe(EXTERNAL.spanId)
-      })
-
-      for (const span of spans) {
-        expect(span.traceId).toBe(EXTERNAL.traceId)
-      }
-    })
-  }
-)
-
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('opentelemetry with disabled fetch tracing', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: require('./package.json').dependencies,
     env: {
       NEXT_OTEL_FETCH_DISABLED: '1',
       TEST_OTEL_COLLECTOR_PORT: String(COLLECTOR_PORT),
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   let collector: Collector
 
@@ -2090,10 +2075,12 @@ describe('opentelemetry with disabled fetch tracing', () => {
   )
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('opentelemetry with custom server', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: require('./package.json').dependencies,
     startCommand: 'pnpm start',
     packageJson: {
@@ -2108,10 +2095,6 @@ describe('opentelemetry with custom server', () => {
       NODE_ENV: isNextDev ? 'development' : 'production',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   let collector: Collector
 
@@ -2268,10 +2251,12 @@ describe('opentelemetry with custom server', () => {
 })
 
 if (isNextStart) {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely controls the local Next.js build or server lifecycle.
+  // @force-gate !deploy
   describe('opentelemetry with direct entrypoint handler', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       dependencies: require('./package.json').dependencies,
       startCommand: 'pnpm start-entrypoint',
       packageJson: {
@@ -2286,10 +2271,6 @@ if (isNextStart) {
         NODE_ENV: 'production',
       },
     })
-
-    if (skipped) {
-      return
-    }
 
     let collector: Collector
 

--- a/test/e2e/socket-io/index.test.ts
+++ b/test/e2e/socket-io/index.test.ts
@@ -1,6 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// Deploy mode exclusion: This suite controls a local server or proxy process.
+// the socket.io setup relies on patching next's `http.Server` instance,
+// which we can't do when deployed
+// @force-gate !deploy
 describe('socket-io', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -10,9 +14,6 @@ describe('socket-io', () => {
       'utf-8-validate': '6.0.3',
       bufferutil: '4.0.8',
     },
-    // the socket.io setup relies on patching next's `http.Server` instance,
-    // which we can't do when deployed
-    skipDeployment: true,
   })
 
   it('should support socket.io without falling back to polling', async () => {

--- a/test/e2e/telemetry/config.test.ts
+++ b/test/e2e/telemetry/config.test.ts
@@ -10,13 +10,14 @@ import {
   retry,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('config telemetry', () => {
-  const { next, isNextStart, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   async function launchDevServer(
     port: number,

--- a/test/e2e/telemetry/page-features.test.ts
+++ b/test/e2e/telemetry/page-features.test.ts
@@ -4,14 +4,14 @@ import fs from 'fs-extra'
 import { nextTestSetup } from 'e2e-utils'
 import { findPort, killApp, renderViaHTTP, retry } from 'next-test-utils'
 
+// Deploy mode exclusion: The assertions exercise behavior specific to the local Next.js server.
+// Calls `next.build()` directly which is not supported on `NextDeployInstance`.
+// @force-gate !deploy
 describe('page features telemetry', () => {
-  const { next, isTurbopack, isRspack, isNextStart, skipped } = nextTestSetup({
+  const { next, isTurbopack, isRspack, isNextStart } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    // Calls `next.build()` directly which is not supported on `NextDeployInstance`.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   async function launchDevServer(
     port: number,

--- a/test/e2e/telemetry/telemetry.test.ts
+++ b/test/e2e/telemetry/telemetry.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import fs from 'fs-extra'
-import { isReact18, nextTestSetup } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { findAllTelemetryEvents } from 'next-test-utils'
 
 // The telemetry suite drives multiple consecutive `next build` invocations
@@ -9,13 +9,15 @@ import { findAllTelemetryEvents } from 'next-test-utils'
 // first". The telemetry feature itself is not React-version-specific, so
 // skipping under React 18 is fine until the underlying build/server lifecycle
 // race is fixed.
-;(isReact18 ? describe.skip : describe)('Telemetry CLI', () => {
-  const { next, isNextStart, isTurbopack, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate !react18
+describe('Telemetry CLI', () => {
+  const { next, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('can print telemetry status', async () => {
     const { stdout } = await next.runCommand(['telemetry'])

--- a/test/e2e/testmode/testmode.test.ts
+++ b/test/e2e/testmode/testmode.test.ts
@@ -1,16 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 import { createProxyServer } from 'next/experimental/testmode/proxy'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('testmode', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: require('./package.json').dependencies,
   })
-
-  if (skipped) {
-    return
-  }
 
   let proxyServer: Awaited<ReturnType<typeof createProxyServer>>
 

--- a/test/e2e/worker-react-refresh/worker-react-refresh.test.tsx
+++ b/test/e2e/worker-react-refresh/worker-react-refresh.test.tsx
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('worker-react-refresh', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     dependencies: require('./package.json').dependencies,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('does not cause any runtime errors', async () => {
     const pageErrors: unknown[] = []

--- a/test/lib/gate/README.md
+++ b/test/lib/gate/README.md
@@ -94,8 +94,8 @@ There are two tiers:
   `turbopack`, `rspack`, `webpack`, `bundler`, `react18`, `wasm`, `ci`),
   semantic aliases for `!dev` that state the reason rather than the mode
   (`prod`, `prefetching`), specialized CI variants (`adapter`,
-  `standaloneOutput`, `turbopackDev`, `turbopackBuild`), plus `FIXME` / `TODO`,
-  which are always false.
+  `nodeMiddleware`, `standaloneOutput`, `turbopackDev`, `turbopackBuild`), plus
+  `FIXME` / `TODO`, which are always false.
 - **lazy** — a predicate over the fixture's *resolved* `next.config`
   (`cacheComponents`, `ppr`, `prefetchInlining`, `output`, …), read the first
   time a gate asks for it.

--- a/test/lib/gate/conditions.ts
+++ b/test/lib/gate/conditions.ts
@@ -137,6 +137,10 @@ export const conditions: Record<string, Condition> = {
   adapter: staticCondition('running the adapter test variant', () =>
     Boolean(process.env.NEXT_ENABLE_ADAPTER === '1')
   ),
+  nodeMiddleware: staticCondition(
+    'running the Node.js middleware test variant (`TEST_NODE_MIDDLEWARE`)',
+    () => Boolean(process.env.TEST_NODE_MIDDLEWARE)
+  ),
   standaloneOutput: staticCondition(
     'running the standalone-output test variant (`TEST_OUTPUT_STANDALONE`)',
     () => process.env.TEST_OUTPUT_STANDALONE === 'true'

--- a/test/unit/gate/runtime.test.ts
+++ b/test/unit/gate/runtime.test.ts
@@ -269,6 +269,40 @@ describe('@gate runtime', () => {
       expect(gate.needsResolvedConfig).toBe(false)
     })
 
+    it('skips only the deployed Node.js middleware variant', async () => {
+      const original = process.env.TEST_NODE_MIDDLEWARE
+      const gate = parseGate('!deploy || !nodeMiddleware', true)
+
+      try {
+        for (const [mode, nodeMiddleware, type] of [
+          ['deploy', true, 'force-pass'],
+          ['start', true, 'run'],
+          ['deploy', false, 'run'],
+        ] as const) {
+          if (nodeMiddleware) {
+            process.env.TEST_NODE_MIDDLEWARE = '1'
+          } else {
+            delete process.env.TEST_NODE_MIDDLEWARE
+          }
+          setGateTestContext({
+            mode,
+            bundler: 'webpack',
+            react18: false,
+            wasm: false,
+          })
+          await expect(__testing.decideGates([gate])).resolves.toMatchObject({
+            type,
+          })
+        }
+      } finally {
+        if (original === undefined) {
+          delete process.env.TEST_NODE_MIDDLEWARE
+        } else {
+          process.env.TEST_NODE_MIDDLEWARE = original
+        }
+      }
+    })
+
     it('skips the test for real when the condition is false', () => {
       const body = () => {}
       const fakes = withFakeTestGlobals(() => {


### PR DESCRIPTION
## Summary

- migrate Edge, middleware, instrumentation, telemetry, logging, custom-server, and local-process deployment exclusions to `@force-gate`
- remove the corresponding `skipDeployment` options and `skipped` control flow while preserving each suite's rationale

This groups suites whose exclusions most often depend on runtime topology or access to local processes.

## Verification

- verified on the combined top-of-stack tree with `pnpm typescript`
- compared ordinary-mode collection before and after: all 4,670 existing test names matched
- collected all 510 affected files in deploy mode: 4,578 skipped tests, zero failures

<!-- NEXT_JS_LLM -->
