### PR TITLE
test: migrate mode-specific deploy exclusions to force gates

### DIFF
--- a/test/development/app-dir/cache-indicator-partial-prefetching/cache-indicator-partial-prefetching.test.ts
+++ b/test/development/app-dir/cache-indicator-partial-prefetching/cache-indicator-partial-prefetching.test.ts
@@ -10,13 +10,9 @@ import { retry, waitFor } from 'next-test-utils'
 // the shell. (The static-shell behavior is covered in the `cache-indicator`
 // suite.)
 describe('cache-indicator-partial-prefetching', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('cache after session data triggers cold cache indicator', async () => {
     const browser = await next.browser('/')

--- a/test/development/app-dir/css-parse-error-recovery/css-parse-error-recovery.test.ts
+++ b/test/development/app-dir/css-parse-error-recovery/css-parse-error-recovery.test.ts
@@ -7,7 +7,7 @@ import stripAnsi from 'strip-ansi'
   'css-parse-error-recovery',
   () => {
     describe('with turbopack.ignoreIssue config', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: __dirname,
         nextConfig: {
           turbopack: {
@@ -19,8 +19,6 @@ import stripAnsi from 'strip-ansi'
           },
         },
       })
-
-      if (skipped) return
 
       it('should render page with ignored CSS parse error', async () => {
         const res = await next.fetch('/css-error')
@@ -44,11 +42,9 @@ import stripAnsi from 'strip-ansi'
     })
 
     describe('without turbopack.ignoreIssue config', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: __dirname,
       })
-
-      if (skipped) return
 
       it('should show CSS parse error in cli output when not ignored', async () => {
         const outputIndex = next.cliOutput.length

--- a/test/development/app-dir/dynamic-error-trace/index.test.ts
+++ b/test/development/app-dir/dynamic-error-trace/index.test.ts
@@ -1,10 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('app dir - dynamic error trace', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-  if (skipped) return
 
   it('should show the error trace', async () => {
     const browser = await next.browser('/')

--- a/test/development/app-dir/special-project-paths/special-project-paths.test.ts
+++ b/test/development/app-dir/special-project-paths/special-project-paths.test.ts
@@ -40,8 +40,7 @@ async function assertSymbolicatedSSRError(
 // contains characters that need percent-encoding in URLs.
 describe('special project paths', () => {
   describe('in "space dir"', () => {
-    const { skipped, next } = setup('space dir')
-    if (skipped) return
+    const { next } = setup('space dir')
 
     it('symbolicates thrown SSR errors', async () => {
       await assertSymbolicatedSSRError(next)
@@ -49,8 +48,7 @@ describe('special project paths', () => {
   })
 
   describe('in "ünïcode-dir"', () => {
-    const { skipped, next } = setup('ünïcode-dir')
-    if (skipped) return
+    const { next } = setup('ünïcode-dir')
 
     it('symbolicates thrown SSR errors', async () => {
       await assertSymbolicatedSSRError(next)
@@ -58,8 +56,7 @@ describe('special project paths', () => {
   })
 
   describe('in "bracket [dir]"', () => {
-    const { skipped, next } = setup('bracket [dir]')
-    if (skipped) return
+    const { next } = setup('bracket [dir]')
 
     it('symbolicates thrown SSR errors', async () => {
       await assertSymbolicatedSSRError(next)
@@ -71,8 +68,7 @@ describe('special project paths', () => {
   // passing, `it.failing` will fail and remind us to promote them.
 
   describe('in "percent%20dir"', () => {
-    const { skipped, next } = setup('percent%20dir')
-    if (skipped) return
+    const { next } = setup('percent%20dir')
 
     it.failing('symbolicates thrown SSR errors', async () => {
       await assertSymbolicatedSSRError(next)
@@ -80,8 +76,7 @@ describe('special project paths', () => {
   })
 
   describe('in "hash#dir"', () => {
-    const { skipped, next } = setup('hash#dir')
-    if (skipped) return
+    const { next } = setup('hash#dir')
 
     it.failing('symbolicates thrown SSR errors', async () => {
       await assertSymbolicatedSSRError(next)

--- a/test/development/app-dir/turbopack-ignore-issue/turbopack-ignore-issue.test.ts
+++ b/test/development/app-dir/turbopack-ignore-issue/turbopack-ignore-issue.test.ts
@@ -4,7 +4,7 @@ import stripAnsi from 'strip-ansi'
 
 describe('turbopack-ignore-issue', () => {
   describe('with turbopack.ignoreIssue config', () => {
-    const { next, skipped, isTurbopack } = nextTestSetup({
+    const { next, isTurbopack } = nextTestSetup({
       files: __dirname,
       // turbopack.ignoreIssue is turbopack-only
       nextConfig: {
@@ -33,8 +33,6 @@ describe('turbopack-ignore-issue', () => {
         },
       },
     })
-
-    if (skipped) return
     if (!isTurbopack) {
       it('should skip tests since turbopack.ignoreIssue only works with Turbopack', () => {})
       return
@@ -122,11 +120,9 @@ describe('turbopack-ignore-issue', () => {
   })
 
   describe('without turbopack.ignoreIssue config', () => {
-    const { next, skipped, isTurbopack } = nextTestSetup({
+    const { next, isTurbopack } = nextTestSetup({
       files: __dirname,
     })
-
-    if (skipped) return
 
     it('should show warning in cli output when not ignored', async () => {
       // Trigger compilation of the warning page

--- a/test/development/app-dir/use-cache-custom-handler-dev/use-cache-custom-handler-dev.test.ts
+++ b/test/development/app-dir/use-cache-custom-handler-dev/use-cache-custom-handler-dev.test.ts
@@ -2,13 +2,9 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry, waitFor } from 'next-test-utils'
 
 describe('use-cache-custom-handler-dev', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   // Reads the rendered cache value over HTTP instead of through the browser. A
   // dev page reload costs seconds on a CI runner, almost all of it downloading

--- a/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
+++ b/test/development/app-dir/use-cache-size-zero/use-cache-size-zero.test.ts
@@ -2,13 +2,9 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry, waitFor, waitForNoErrorToast } from 'next-test-utils'
 
 describe('use-cache-size-zero', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('serves the stale cached value on a warm reload, then converges to a fresh one', async () => {
     const browser = await next.browser('/reload', {

--- a/test/development/experimental-https-server/https-server-opengraph-image.test.ts
+++ b/test/development/experimental-https-server/https-server-opengraph-image.test.ts
@@ -1,12 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('experimental-https-server OpenGraph image', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     startCommand: 'pnpm next dev --experimental-https',
     skipStart: !process.env.NEXT_TEST_CI,
   })
-  if (skipped) return
 
   if (!process.env.NEXT_TEST_CI) {
     console.warn('only runs on CI as it requires administrator privileges')

--- a/test/development/experimental-https-server/https-server.generated-key.test.ts
+++ b/test/development/experimental-https-server/https-server.generated-key.test.ts
@@ -3,12 +3,11 @@ import https from 'https'
 import { renderViaHTTP } from 'next-test-utils'
 
 describe('experimental-https-server (generated certificate)', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     startCommand: 'pnpm next dev --experimental-https',
     skipStart: !process.env.NEXT_TEST_CI,
   })
-  if (skipped) return
 
   if (!process.env.NEXT_TEST_CI) {
     console.warn('only runs on CI as it requires administrator privileges')

--- a/test/development/mcp-server/mcp-server-compile-route.test.ts
+++ b/test/development/mcp-server/mcp-server-compile-route.test.ts
@@ -30,13 +30,9 @@ async function callMcpTool(
 ;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
   'mcp-server compile_route tool',
   () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: path.join(__dirname, 'fixtures', 'dynamic-routes-app'),
     })
-
-    if (skipped) {
-      return
-    }
 
     describe('routeSpecifier input', () => {
       it('should compile a valid app router root route', async () => {
@@ -201,13 +197,9 @@ async function callMcpTool(
 ;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
   'mcp-server compile_route with compilation errors',
   () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: path.join(__dirname, 'fixtures', 'compilation-errors-app'),
     })
-
-    if (skipped) {
-      return
-    }
 
     it('should return compilation issues inline in the response', async () => {
       const result = (await callMcpTool(next.url, 'compile_route', {

--- a/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
+++ b/test/development/mcp-server/mcp-server-get-compilation-issues.test.ts
@@ -5,13 +5,9 @@ import { nextTestSetup } from 'e2e-utils'
 ;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
   'mcp-server get_compilation_issues tool',
   () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: path.join(__dirname, 'fixtures', 'compilation-errors-app'),
     })
-
-    if (skipped) {
-      return
-    }
 
     async function callMcpTool() {
       const response = await fetch(`${next.url}/_next/mcp`, {

--- a/test/development/mcp-server/mcp-server-get-logs.test.ts
+++ b/test/development/mcp-server/mcp-server-get-logs.test.ts
@@ -3,13 +3,9 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 describe('get-logs MCP tool', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'log-file-app'),
   })
-
-  if (skipped) {
-    return
-  }
 
   async function callGetLogs(id: string): Promise<string> {
     const response = await fetch(`${next.url}/_next/mcp`, {

--- a/test/development/mcp-server/mcp-server-get-routes.test.ts
+++ b/test/development/mcp-server/mcp-server-get-routes.test.ts
@@ -2,13 +2,9 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
 describe('get_routes MCP tool', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'dynamic-routes-app'),
   })
-
-  if (skipped) {
-    return
-  }
 
   async function callGetRoutes(
     id: string,

--- a/test/development/next-font/deprecated-package.test.ts
+++ b/test/development/next-font/deprecated-package.test.ts
@@ -3,7 +3,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
 describe('Deprecated @next/font warning', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       'pages/index.js': '',
     },
@@ -12,7 +12,6 @@ describe('Deprecated @next/font warning', () => {
     },
     skipStart: true,
   })
-  if (skipped) return
 
   it('should warn if @next/font is in deps', async () => {
     await next.start()

--- a/test/development/sass-error/index.test.ts
+++ b/test/development/sass-error/index.test.ts
@@ -2,16 +2,12 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, getRedboxSource } from 'next-test-utils'
 
 describe('app dir - css', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
       sass: 'latest',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   describe('sass support', () => {
     ;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(

--- a/test/production/500-page/mixed-router-no-custom-pages-error/mixed-router-no-error.test.ts
+++ b/test/production/500-page/mixed-router-no-custom-pages-error/mixed-router-no-error.test.ts
@@ -3,13 +3,9 @@ import fsp from 'fs/promises'
 import path from 'path'
 
 describe('500-page - mixed-router-no-custom-pages-error', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not use app router global-error for 500.html when no pages _error.tsx exists', async () => {
     const $ = await next.render$('/pages-error')

--- a/test/production/500-page/mixed-router-with-custom-pages-error/mixed-router-with-error.test.ts
+++ b/test/production/500-page/mixed-router-with-custom-pages-error/mixed-router-with-error.test.ts
@@ -3,13 +3,9 @@ import fsp from 'fs/promises'
 import path from 'path'
 
 describe('500-page - mixed-router-with-custom-pages-error', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not override 500.html with app router global-error when pages _error.tsx exists', async () => {
     const $ = await next.render$('/pages-error')

--- a/test/production/adapter-styled-jsx/adapter-styled-jsx.test.ts
+++ b/test/production/adapter-styled-jsx/adapter-styled-jsx.test.ts
@@ -6,13 +6,13 @@ import type { NextAdapter } from 'next'
 
 type BuildComplete = Parameters<NextAdapter['onBuildComplete']>[0]
 
+// This asserts on the output an adapter is handed locally (`build-complete.json`) and runs the
+// app with only the files from that output, so it has to build and serve locally.
+// @force-gate !deploy
 describe('adapter output - styled-jsx', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: path.join(__dirname, 'fixture'),
     skipStart: true,
-    // This asserts on the output an adapter is handed locally (`build-complete.json`) and runs the
-    // app with only the files from that output, so it has to build and serve locally.
-    skipDeployment: true,
     dependencies: {
       // A version that does not dedupe with the one Next.js depends on, so the app gets its own
       // copy of styled-jsx next to Next.js' copy. That is the case where the require hook in
@@ -22,8 +22,6 @@ describe('adapter output - styled-jsx', () => {
       'styled-jsx': '5.1.7',
     },
   })
-
-  if (skipped) return
 
   let buildComplete: BuildComplete
   /** Absolute paths of the files the adapter declares for the `/index` pages function. */

--- a/test/production/app-dir/client-components-tree-shaking/index.test.ts
+++ b/test/production/app-dir/client-components-tree-shaking/index.test.ts
@@ -1,10 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('app-dir client-components-tree-shaking', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-  if (skipped) return
 
   it('should only include imported components 3rd party package in browser bundle with direct imports', async () => {
     const $ = await next.render$('/third-party-dep')

--- a/test/production/app-dir/client-page-error-bailout/client-page-error-bailout.test.ts
+++ b/test/production/app-dir/client-page-error-bailout/client-page-error-bailout.test.ts
@@ -1,14 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('app-dir - client-page-error-bailout', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let stderr = ''
   beforeAll(() => {

--- a/test/production/app-dir/dynamic-import-evaluation-only/dynamic-import-evaluation-only.test.ts
+++ b/test/production/app-dir/dynamic-import-evaluation-only/dynamic-import-evaluation-only.test.ts
@@ -2,13 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import fs from 'fs'
 import path from 'path'
 
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('dynamic-import-evaluation-only', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-  if (skipped) return
 
   it('should drop only the side-effect-free targets of evaluation-only dynamic imports', async () => {
     const { exitCode, cliOutput } = await next.build()

--- a/test/production/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
+++ b/test/production/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
@@ -2,12 +2,10 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 describe('empty-generate-static-params', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
-
-  if (skipped) return
 
   // If we're not using cache components, there shouldn't be any build errors!
   if (process.env.__NEXT_CACHE_COMPONENTS !== 'true') {

--- a/test/production/app-dir/empty-resume/empty-resume.test.ts
+++ b/test/production/app-dir/empty-resume/empty-resume.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 import { createNowRouteMatches } from 'next-test-utils'
 
+// This test synthesizes an adapter invocation using private runtime
+// switches; it does not exercise the deployed platform proxy.
+// @force-gate !deploy
 describe('empty resume', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // This test synthesizes an adapter invocation using private runtime
-    // switches; it does not exercise the deployed platform proxy.
-    skipDeployment: true,
     env: {
       NEXT_PRIVATE_TEST_HEADERS: '1',
       NEXT_PRIVATE_MINIMAL_MODE: '1',

--- a/test/production/app-dir/expire-time-infinity/expire-time-infinity.test.ts
+++ b/test/production/app-dir/expire-time-infinity/expire-time-infinity.test.ts
@@ -1,18 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('expire-time-infinity', () => {
   if (process.env.__NEXT_CACHE_COMPONENTS === 'true') {
     it.skip('the route segment config is not compatible with cacheComponents', () => {})
     return
   }
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('serves a well-formed cache-control header for an Infinity expireTime', async () => {
     await next.start()

--- a/test/production/app-dir/instant-navigation-resume/instant-navigation-resume.test.ts
+++ b/test/production/app-dir/instant-navigation-resume/instant-navigation-resume.test.ts
@@ -1,11 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// This test directly emulates the platform's internal resume request using
+// locally generated postponed state and private runtime switches.
+// @force-gate !deploy
 describe('instant-navigation-resume', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // This test directly emulates the platform's internal resume request using
-    // locally generated postponed state and private runtime switches.
-    skipDeployment: true,
     env: {
       NEXT_PRIVATE_TEST_HEADERS: '1',
       NEXT_PRIVATE_MINIMAL_MODE: '1',

--- a/test/production/app-dir/instrumentation-client-dce/instrumentation-client-dce.test.ts
+++ b/test/production/app-dir/instrumentation-client-dce/instrumentation-client-dce.test.ts
@@ -8,13 +8,12 @@ import { nextTestSetup } from 'e2e-utils'
 // appears only inside that gated branch, and object keys survive minification.
 describe('instrumentation client router transition events - dead code elimination', () => {
   describe('when the experimental flag is enabled', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       nextConfig: {
         experimental: { instrumentationClientRouterTransitionEvents: true },
       },
     })
-    if (skipped) return
 
     it('keeps the transition event payload in the client bundle', async () => {
       const $ = await next.render$('/')
@@ -31,10 +30,9 @@ describe('instrumentation client router transition events - dead code eliminatio
   })
 
   describe('when the experimental flag is disabled', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
     })
-    if (skipped) return
 
     it('removes the transition event payload from the client bundle', async () => {
       const $ = await next.render$('/')

--- a/test/production/app-dir/next-types-plugin/basic/index.test.ts
+++ b/test/production/app-dir/next-types-plugin/basic/index.test.ts
@@ -2,11 +2,9 @@ import { nextTestSetup } from 'e2e-utils'
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'next-types-plugin',
   () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
     })
-
-    if (skipped) return
 
     it('should have type for root page', async () => {
       expect(await next.hasFile('app/page.tsx')).toBe(true)

--- a/test/production/app-dir/next-types-plugin/private-folder-convention/index.test.ts
+++ b/test/production/app-dir/next-types-plugin/private-folder-convention/index.test.ts
@@ -2,11 +2,9 @@ import { nextTestSetup } from 'e2e-utils'
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'next-types-plugin private-folder-convention',
   () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
     })
-
-    if (skipped) return
 
     it('should have type for root page', async () => {
       expect(await next.hasFile('app/page.tsx')).toBe(true)

--- a/test/production/app-dir/not-found-non-document-minimal/not-found-non-document-adapter.test.ts
+++ b/test/production/app-dir/not-found-non-document-minimal/not-found-non-document-adapter.test.ts
@@ -3,16 +3,13 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { findPort, retry } from 'next-test-utils'
 
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('not-found-non-document-adapter', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let launcher: ChildProcess
   let port: number

--- a/test/production/app-dir/not-found-non-document-minimal/not-found-non-document-minimal.test.ts
+++ b/test/production/app-dir/not-found-non-document-minimal/not-found-non-document-minimal.test.ts
@@ -1,11 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// This test synthesizes an adapter invocation using private runtime
+// switches; it does not exercise the deployed platform proxy.
+// @force-gate !deploy
 describe('not-found-non-document-minimal', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // This test synthesizes an adapter invocation using private runtime
-    // switches; it does not exercise the deployed platform proxy.
-    skipDeployment: true,
     env: {
       NEXT_PRIVATE_TEST_HEADERS: '1',
       NEXT_PRIVATE_MINIMAL_MODE: '1',

--- a/test/production/app-dir/post-build/post-build.test.ts
+++ b/test/production/app-dir/post-build/post-build.test.ts
@@ -8,15 +8,13 @@ describe('post-build', () => {
     return
   }
 
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
     env: {
       NEXT_USE_POST_BUILD: '1',
     },
   })
-
-  if (skipped) return
 
   it('should run post-build compaction on the turbopack cache', async () => {
     if (!isTurbopack) {

--- a/test/production/app-dir/postponed-resume-incomplete/postponed-resume-incomplete.test.ts
+++ b/test/production/app-dir/postponed-resume-incomplete/postponed-resume-incomplete.test.ts
@@ -24,12 +24,12 @@ function validResumeDataCacheTail(): string {
 // failure is logged with content-free structural diagnostics that identify
 // *how* the state was malformed, so the otherwise-opaque error is actionable in
 // production.
+// Synthesizes the minimal-mode resume path locally; does not exercise the
+// deployed platform proxy.
+// @force-gate !deploy
 describe('postponed resume - parse failure diagnostics', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // Synthesizes the minimal-mode resume path locally; does not exercise the
-    // deployed platform proxy.
-    skipDeployment: true,
     env: {
       NEXT_PRIVATE_TEST_HEADERS: '1',
       NEXT_PRIVATE_MINIMAL_MODE: '1',

--- a/test/production/app-dir/revalidate/revalidate.test.ts
+++ b/test/production/app-dir/revalidate/revalidate.test.ts
@@ -1,13 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('app-dir revalidate', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should be able to revalidate the cache via pages/api', async () => {
     const $ = await next.render$('/')

--- a/test/production/app-dir/route-handler-manifest-size/route-handler-manifest-size.test.ts
+++ b/test/production/app-dir/route-handler-manifest-size/route-handler-manifest-size.test.ts
@@ -3,11 +3,9 @@ import { getClientReferenceManifest } from 'next-test-utils'
 import type { ClientReferenceManifest } from 'next/dist/build/webpack/plugins/flight-manifest-plugin'
 
 describe('route-handler-manifest-size', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) return
 
   /**
    * Gets the module paths from clientModules

--- a/test/production/app-dir/ssg-single-pass/ssg-single-pass.test.ts
+++ b/test/production/app-dir/ssg-single-pass/ssg-single-pass.test.ts
@@ -2,13 +2,9 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 describe('ssg-single-pass', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should only render the page once during build', async () => {
     expect(next.cliOutput).toIncludeRepeated('home page rendered', 1)

--- a/test/production/app-dir/types-gen-nounuselocal/types-gen-nounuselocal.test.ts
+++ b/test/production/app-dir/types-gen-nounuselocal/types-gen-nounuselocal.test.ts
@@ -6,13 +6,9 @@ const strictRouteTypes =
   process.env.__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES === 'true'
 
 describe('types-gen-nounuselocal', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should build successfully', async () => {
     const $ = await next.render$('/')

--- a/test/production/app-dir/typescript-cli/typescript-cli.test.ts
+++ b/test/production/app-dir/typescript-cli/typescript-cli.test.ts
@@ -15,17 +15,16 @@ const typeError = `export const invalidValue: number = 'not a number'
 `
 
 describe('TypeScript CLI backend', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('TypeScript 7', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
       dependencies: {
         typescript: '7.0.2',
       },
     })
-
-    if (skipped) return
 
     let originalTsConfig: string
 
@@ -122,17 +121,16 @@ describe('TypeScript CLI backend', () => {
     })
   })
 
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('TypeScript 7 with the CLI disabled', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
       dependencies: {
         typescript: '7.0.2',
       },
     })
-
-    if (skipped) return
 
     it('fails with actionable API compatibility guidance', async () => {
       await next.patchFile('next.config.js', apiConfig)
@@ -150,17 +148,16 @@ describe('TypeScript CLI backend', () => {
     })
   })
 
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('TypeScript 6', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
       dependencies: {
         typescript: '6.0.2',
       },
     })
-
-    if (skipped) return
 
     it('uses the same project-local tsc entry point', async () => {
       const result = await next.build()
@@ -170,17 +167,16 @@ describe('TypeScript CLI backend', () => {
     })
   })
 
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('TypeScript 6 npm alias', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
       dependencies: {
         typescript: 'npm:@typescript/typescript6@6.0.1',
       },
     })
-
-    if (skipped) return
 
     it('builds with the versioned tsc6 entry point', async () => {
       const result = await next.build()

--- a/test/production/app-dir/upload-trace/upload-trace.test.ts
+++ b/test/production/app-dir/upload-trace/upload-trace.test.ts
@@ -3,20 +3,19 @@ import http from 'http'
 import path from 'path'
 import fs from 'fs'
 
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('upload-trace', () => {
   if (!isNextStart) {
     it('skipped for non-start mode', () => {})
     return
   }
 
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     buildCommand: 'pnpm next build --experimental-cpu-prof --internal-trace',
   })
-
-  if (skipped) return
 
   it('should upload profiles and trace to the mock endpoint after build', async () => {
     const buildResult = await next.build()

--- a/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
@@ -167,13 +167,11 @@ async function execute(next: NextInstance, envKey: string, id: string) {
 describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
   'use-cache-cross-deployment with %s',
   (envKey) => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       disableAutoSkewProtection: true,
       skipStart: true,
     })
-
-    if (skipped) return
 
     // In the future, this assertion can be relaxed to only prevent sharing if the implementation
     // changed.
@@ -207,14 +205,12 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
 ;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
   'use-cache-cross-deployment with durableUseCacheEntries',
   () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       disableAutoSkewProtection: true,
       skipStart: true,
       env: { DURABLE_USE_CACHE_ENTRIES: '1' },
     })
-
-    if (skipped) return
 
     beforeEach(async () => {
       await next.deleteFile('handler-remote-data.json')

--- a/test/production/app-dir/use-cache-invalid-cache-life/use-cache-invalid-cache-life.test.ts
+++ b/test/production/app-dir/use-cache-invalid-cache-life/use-cache-invalid-cache-life.test.ts
@@ -4,14 +4,13 @@ const validPage = `export default function Page() {
   return <p>hello</p>
 }`
 
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('use-cache-invalid-cache-life', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('fails the build for a config profile with a non-finite value other than Infinity', async () => {
     await next.patchFile(

--- a/test/production/app-dynamic-error/app-dynamic-error.test.ts
+++ b/test/production/app-dynamic-error/app-dynamic-error.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('app-dynamic-error', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('throws an error when prerendering a page with config dynamic error', async () => {
       const { exitCode } = await next.build()

--- a/test/production/auto-export-error-bail/auto-export-error-bail.test.ts
+++ b/test/production/auto-export-error-bail/auto-export-error-bail.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('Auto Export _error bail', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should not opt-out of auto static optimization from invalid _error', async () => {
     const { exitCode, cliOutput } = await next.build()

--- a/test/production/build-trace-extra-entries-monorepo/build-trace-extra-entries-monorepo.test.ts
+++ b/test/production/build-trace-extra-entries-monorepo/build-trace-extra-entries-monorepo.test.ts
@@ -2,13 +2,13 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
 describe('build trace with extra entries in monorepo', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should build and trace correctly', async () => {
       const appDir = path.join(next.testDir, 'app')

--- a/test/production/build-trace-extra-entries-turbo/build-trace-extra-entries-turbo.test.ts
+++ b/test/production/build-trace-extra-entries-turbo/build-trace-extra-entries-turbo.test.ts
@@ -2,13 +2,13 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
 describe('build trace with extra entries', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack } = nextTestSetup({
       files: path.join(__dirname, 'app'),
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should build and trace correctly', async () => {
       const { exitCode } = await next.build()

--- a/test/production/clean-distdir/index.test.ts
+++ b/test/production/clean-distdir/index.test.ts
@@ -3,12 +3,10 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Cleaning distDir', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
-
-  if (skipped) return
 
   beforeEach(async () => {
     await next.stop()

--- a/test/production/config-evaluation-error/config-evaluation-error.test.ts
+++ b/test/production/config-evaluation-error/config-evaluation-error.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('next.config evaluation error', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     async function buildAndGetOutput(): Promise<string> {
       const start = next.cliOutput.length

--- a/test/production/config-syntax-error/config-syntax-error.test.ts
+++ b/test/production/config-syntax-error/config-syntax-error.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Invalid config syntax', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should error when next.config.js contains syntax error', async () => {
       await next.patchFile(

--- a/test/production/config-validation/config-validation.test.ts
+++ b/test/production/config-validation/config-validation.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('next.config.js validation', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it.each([
       {

--- a/test/production/conflicting-ssg-paths/conflicting-ssg-paths.test.ts
+++ b/test/production/conflicting-ssg-paths/conflicting-ssg-paths.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Conflicting SSG paths', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     afterEach(async () => {
       await next.deleteFile('pages')

--- a/test/production/document-file-dependencies/document-file-dependencies.test.ts
+++ b/test/production/document-file-dependencies/document-file-dependencies.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('File Dependencies', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should apply styles defined in global and module css files in a standard page.', async () => {
       const browser = await next.browser('/')

--- a/test/production/export/index.test.ts
+++ b/test/production/export/index.test.ts
@@ -10,14 +10,10 @@ import { AddressInfo, Server } from 'net'
 import cheerio from 'cheerio'
 
 describe('static export', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   const nextConfigPath = 'next.config.js'
   const outdir = 'out'

--- a/test/production/gsp-extension/gsp-extension.test.ts
+++ b/test/production/gsp-extension/gsp-extension.test.ts
@@ -3,12 +3,13 @@ import { nextTestSetup } from 'e2e-utils'
 const fileNames = ['1', '2.ext', '3.html']
 
 describe('GS(S)P with file extension', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should support slug with different extensions', async () => {
       for (const name of fileNames) {

--- a/test/production/hydrate-then-render/hydrate-then-render.test.ts
+++ b/test/production/hydrate-then-render/hydrate-then-render.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('hydrate/render ordering', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('correctly measures hydrate followed by render', async () => {
       const browser = await next.browser('/')

--- a/test/production/jsconfig-empty/jsconfig-empty.test.ts
+++ b/test/production/jsconfig-empty/jsconfig-empty.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Empty JSConfig Support', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should compile successfully', async () => {
       const { exitCode, cliOutput } = await next.build()

--- a/test/production/json-serialize-original-error/json-serialize-original-error.test.ts
+++ b/test/production/json-serialize-original-error/json-serialize-original-error.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('JSON Serialization', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     test('should fail with original error', async () => {
       const { exitCode } = await next.build()

--- a/test/production/middleware-build-errors/middleware-build-errors.test.ts
+++ b/test/production/middleware-build-errors/middleware-build-errors.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Middleware validation during build', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     const middlewareError = 'Middleware is returning a response body'
 

--- a/test/production/mixed-ssg-serverprops-error/mixed-ssg-serverprops-error.test.ts
+++ b/test/production/mixed-ssg-serverprops-error/mixed-ssg-serverprops-error.test.ts
@@ -3,15 +3,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { SERVER_PROPS_SSG_CONFLICT } from 'next/dist/lib/constants'
 
 describe('Mixed getStaticProps and getServerSideProps error', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, isTurbopack, skipped } = nextTestSetup({
+    const { next, isTurbopack } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) {
-      return
-    }
 
     // Uses Babel, not supported in Turbopack.
     ;(isTurbopack ? it.skip : it)(

--- a/test/production/next-image-legacy/react-virtualized/react-virtualized.test.ts
+++ b/test/production/next-image-legacy/react-virtualized/react-virtualized.test.ts
@@ -3,17 +3,17 @@ import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('react-virtualized wrapping next/legacy/image', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     dependencies: {
       'react-virtualized': 'latest',
       'http-proxy': '1.18.1',
     },
   })
-  if (skipped) return
 
   let proxyChild: ChildProcess
   let proxyPort: number

--- a/test/production/next-image-new/react-virtualized/react-virtualized.test.ts
+++ b/test/production/next-image-new/react-virtualized/react-virtualized.test.ts
@@ -3,17 +3,17 @@ import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('react-virtualized wrapping next/image', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     dependencies: {
       'react-virtualized': 'latest',
       'http-proxy': '1.18.1',
     },
   })
-  if (skipped) return
 
   let proxyChild: ChildProcess
   let proxyPort: number

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -75,7 +75,7 @@ async function readNormalizedNFT(next, name) {
   'next-server-nft',
   () => {
     describe('with output:standalone', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: __dirname,
         dependencies: {
           typescript: '5.9.2',
@@ -84,10 +84,6 @@ async function readNormalizedNFT(next, name) {
           output: 'standalone',
         },
       })
-
-      if (skipped) {
-        return
-      }
 
       it('should not trace too many files in next-server.js.nft.json', async () => {
         const trace = await readNormalizedNFT(
@@ -417,16 +413,12 @@ async function readNormalizedNFT(next, name) {
     })
 
     describe('default mode', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: __dirname,
         dependencies: {
           typescript: '5.9.2',
         },
       })
-
-      if (skipped) {
-        return
-      }
 
       it('should not include .next directory in traces despite dynamic fs operations', async () => {
         // This test verifies that the denied_path feature prevents the .next directory
@@ -534,7 +526,7 @@ async function readNormalizedNFT(next, name) {
     })
 
     describe('with adapters', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: __dirname,
         dependencies: {
           typescript: '5.9.2',
@@ -543,10 +535,6 @@ async function readNormalizedNFT(next, name) {
           adapterPath: path.join(__dirname, './my-adapter.mjs'),
         },
       })
-
-      if (skipped) {
-        return
-      }
 
       it('should not include .next directory in traces despite dynamic fs operations', async () => {
         // This test verifies that the denied_path feature prevents the .next directory
@@ -729,7 +717,7 @@ async function readNormalizedNFT(next, name) {
     })
 
     describe('with adapters and output:standalone', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: __dirname,
         dependencies: {
           typescript: '5.9.2',
@@ -739,10 +727,6 @@ async function readNormalizedNFT(next, name) {
           adapterPath: path.join(__dirname, './my-adapter.mjs'),
         },
       })
-
-      if (skipped) {
-        return
-      }
 
       // Regression test for #96646: with an adapter configured, the whole-app server NFTs were
       // suppressed while `copyTracedFiles` (which runs for `output: 'standalone'`, adapter or

--- a/test/production/non-next-dist-exclude/non-next-dist-exclude.test.ts
+++ b/test/production/non-next-dist-exclude/non-next-dist-exclude.test.ts
@@ -2,13 +2,13 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Non-Next externalization', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: path.join(__dirname, 'app'),
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('Externalized non-Next dist-using package', async () => {
       await next.build()

--- a/test/production/numeric-sep/numeric-sep.test.ts
+++ b/test/production/numeric-sep/numeric-sep.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Numeric Separator Support', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should successfully build for a JavaScript file', async () => {
       expect(next.cliOutput).toContain('Compiled successfully')

--- a/test/production/page-extensions/page-extensions.test.ts
+++ b/test/production/page-extensions/page-extensions.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Page Extensions', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should use the default pageExtensions if set to undefined', async () => {
       await next.patchFile(

--- a/test/production/polyfilling-minimal/polyfilling-minimal.test.ts
+++ b/test/production/polyfilling-minimal/polyfilling-minimal.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Polyfilling (minimal)', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should compile successfully', async () => {
       const { exitCode, cliOutput } = await next.build()

--- a/test/production/preload-viewport/preload-viewport.test.ts
+++ b/test/production/preload-viewport/preload-viewport.test.ts
@@ -8,16 +8,16 @@ import {
   getClientBuildManifestLoaderChunkUrlPath,
 } from 'next-test-utils'
 
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('Prefetching Links in viewport', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     dependencies: {
       'http-proxy': '1.18.1',
     },
   })
-  if (skipped) return
 
   let proxyChild: ChildProcess
   let proxyPort: number

--- a/test/production/prerender-export/prerender-export.test.ts
+++ b/test/production/prerender-export/prerender-export.test.ts
@@ -3,16 +3,16 @@ import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP, startStaticServer, waitFor } from 'next-test-utils'
 import { AddressInfo, Server } from 'net'
 
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('SSG Prerender export', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     dependencies: {
       firebase: '7.14.5',
     },
   })
-  if (skipped) return
 
   let server: Server
   let appPort: number

--- a/test/production/prerender-invalid-catchall-params/index.test.ts
+++ b/test/production/prerender-invalid-catchall-params/index.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('Invalid Prerender Catchall Params', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   describe('production mode', () => {
     it('should fail the build', async () => {

--- a/test/production/prerender-invalid-paths/prerender-invalid-paths.test.ts
+++ b/test/production/prerender-invalid-paths/prerender-invalid-paths.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Legacy Prerender', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       skipStart: true,
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     describe('handles old getStaticParams', () => {
       it('should fail the build', async () => {

--- a/test/production/production-browser-sourcemaps/index.test.ts
+++ b/test/production/production-browser-sourcemaps/index.test.ts
@@ -55,16 +55,12 @@ describe('Production browser sourcemaps', () => {
   describe.each([false, true] as const)(
     'productionBrowserSourceMaps = %s',
     (productionBrowserSourceMaps) => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: __dirname,
         nextConfig: {
           productionBrowserSourceMaps,
         },
       })
-
-      if (skipped) {
-        return
-      }
 
       it('check sourcemaps for all browser files', async () => {
         const buildManifest = getBuildManifest(next.testDir)

--- a/test/production/production-build-dir/production-build-dir.test.ts
+++ b/test/production/production-build-dir/production-build-dir.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Production Custom Build Directory', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should render the page', async () => {
       const result = await next.build()

--- a/test/production/production-config/production-config.test.ts
+++ b/test/production/production-config/production-config.test.ts
@@ -2,13 +2,14 @@ import { nextTestSetup } from 'e2e-utils'
 
 describe('Production Config Usage', () => {
   describe('production mode', () => {
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
+    // @force-gate !deploy
     describe('with generateBuildId', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: __dirname + '/fixture-generateBuildId',
         disableAutoSkewProtection: true,
-        skipDeployment: true,
       })
-      if (skipped) return
 
       it('should add the custom buildid', async () => {
         const browser = await next.browser('/')
@@ -21,13 +22,13 @@ describe('Production Config Usage', () => {
       })
     })
 
+    // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+    // @force-gate !deploy
     describe('env', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: __dirname,
         skipStart: true,
-        skipDeployment: true,
       })
-      if (skipped) return
 
       it('should fail with leading __ in env key', async () => {
         const start = next.cliOutput.length

--- a/test/production/production-nav/production-nav.test.ts
+++ b/test/production/production-nav/production-nav.test.ts
@@ -2,12 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 describe('Production Usage', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should navigate forward and back correctly', async () => {
       const browser = await next.browser('/')

--- a/test/production/production-start-no-build/production-start-no-build.test.ts
+++ b/test/production/production-start-no-build/production-start-no-build.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('Production Usage without production build', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should show error when there is no production build', async () => {
     await next.start({ skipBuild: true }).catch(() => {})

--- a/test/production/query-with-encoding/query-with-encoding.test.ts
+++ b/test/production/query-with-encoding/query-with-encoding.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Query String with Encoding', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     describe('new line', () => {
       it('should have correct query on SSR', async () => {

--- a/test/production/remove-unused-imports/remove-unused-imports.test.ts
+++ b/test/production/remove-unused-imports/remove-unused-imports.test.ts
@@ -1,13 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('remove-unused-imports', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should remove unused imports', async () => {
     const browser = await next.browser('/')

--- a/test/production/render-error-on-module-error/render-error-on-module-error.test.ts
+++ b/test/production/render-error-on-module-error/render-error-on-module-error.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Module Init Error', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should render error page', async () => {
       const browser = await next.browser('/')

--- a/test/production/render-error-on-top-level-error/render-error-on-top-level-error.test.ts
+++ b/test/production/render-error-on-top-level-error/render-error-on-top-level-error.test.ts
@@ -3,12 +3,13 @@ import { join } from 'path'
 
 describe('Top Level Error', () => {
   describe('production mode', () => {
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
+    // @force-gate !deploy
     describe('with getInitialProps', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: join(__dirname, 'with-get-initial-props'),
-        skipDeployment: true,
       })
-      if (skipped) return
 
       it('should render error page with getInitialProps', async () => {
         const browser = await next.browser('/')
@@ -17,12 +18,13 @@ describe('Top Level Error', () => {
       })
     })
 
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // No deploy-specific incompatibility is documented.
+    // @force-gate !deploy
     describe('without getInitialProps', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: join(__dirname, 'without-get-initial-props'),
-        skipDeployment: true,
       })
-      if (skipped) return
 
       it('should render error page', async () => {
         const browser = await next.browser('/')

--- a/test/production/root-catchall-cache/root-catchall-cache.test.ts
+++ b/test/production/root-catchall-cache/root-catchall-cache.test.ts
@@ -2,12 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 
 describe('Root Catch-all Cache', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     const getRandom = async (path: string) => {
       const $ = await next.render$(path)

--- a/test/production/root-optional-revalidate/root-optional-revalidate.test.ts
+++ b/test/production/root-optional-revalidate/root-optional-revalidate.test.ts
@@ -3,12 +3,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry, waitFor } from 'next-test-utils'
 
 describe('Root Optional Catch-all Revalidate', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     const getProps = async (path: string) => {
       const html = await next.render(path)

--- a/test/production/route-load-cancel-css/route-load-cancel-css.test.ts
+++ b/test/production/route-load-cancel-css/route-load-cancel-css.test.ts
@@ -2,12 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 
 describe('route cancel via CSS', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should cancel slow page loads on re-navigation', async () => {
       const browser = await next.browser('/')

--- a/test/production/scss-invalid-module/invalid-module.test.ts
+++ b/test/production/scss-invalid-module/invalid-module.test.ts
@@ -2,13 +2,14 @@
 
 import { nextTestSetup } from 'e2e-utils'
 
-describe.skip('Invalid CSS Module Usage in node_modules', () => {
-  const { next, skipped } = nextTestSetup({
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
+// @force-gate TODO
+describe('Invalid CSS Module Usage in node_modules', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should fail to build', async () => {
     const { exitCode, cliOutput } = await next.build()

--- a/test/production/standalone-mode/tracing-side-effects-false/tracing-side-effects-false.test.ts
+++ b/test/production/standalone-mode/tracing-side-effects-false/tracing-side-effects-false.test.ts
@@ -3,15 +3,11 @@ import { nextTestSetup } from 'e2e-utils'
 describe('standalone mode - tracing-side-effects-false', () => {
   const dependencies = require('./package.json').dependencies
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should trace sideeffect imports even when sideEffects is false', async () => {
     let { exitCode } = await next.build()

--- a/test/production/standalone-mode/tracing-static-files/tracing-static-files.test.ts
+++ b/test/production/standalone-mode/tracing-static-files/tracing-static-files.test.ts
@@ -3,15 +3,11 @@ import { nextTestSetup } from 'e2e-utils'
 describe('standalone mode - tracing-static-files', () => {
   const dependencies = require('./package.json').dependencies
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should trace process.cwd calls in node_modules', async () => {
     let { exitCode } = await next.build()

--- a/test/production/standalone-mode/tracing-unparsable/tracing-unparsable.test.ts
+++ b/test/production/standalone-mode/tracing-unparsable/tracing-unparsable.test.ts
@@ -3,15 +3,11 @@ import { nextTestSetup } from 'e2e-utils'
 describe('standalone mode - tracing-unparsable', () => {
   const dependencies = require('./package.json').dependencies
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not error when dynamic require includes non-JS files', async () => {
     let { exitCode } = await next.build()

--- a/test/production/static-routes-info/static-routes-info.test.ts
+++ b/test/production/static-routes-info/static-routes-info.test.ts
@@ -60,12 +60,10 @@ describe('next internal static-routes-info', () => {
     return
   }
 
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
-
-  if (skipped) return
 
   beforeAll(async () => {
     const buildResult = await next.build()

--- a/test/production/tsconfig-verifier/tsconfig-verifier.test.ts
+++ b/test/production/tsconfig-verifier/tsconfig-verifier.test.ts
@@ -3,8 +3,10 @@ import { nextTestSetup } from 'e2e-utils'
 const strictRouteTypes =
   process.env.__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES === 'true'
 
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('tsconfig.json verifier', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     nextConfig: {
       experimental: { useTypeScriptCli: false },
@@ -13,9 +15,7 @@ describe('tsconfig.json verifier', () => {
       NEXT_PRIVATE_LOCAL_DEV: '',
     },
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeEach(async () => {
     await next.deleteFile('tsconfig.json')
@@ -1133,8 +1133,10 @@ describe('tsconfig.json verifier', () => {
 // `module: commonjs` forces Next.js to emit `moduleResolution: node`, which
 // TypeScript 6 deprecates (TS5107). Pin TypeScript 5.9 for this case until we
 // stop emitting the deprecated resolution.
+// This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+// @force-gate !deploy
 describe('tsconfig.json verifier 5.x', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     nextConfig: {
       experimental: { useTypeScriptCli: false },
@@ -1146,9 +1148,7 @@ describe('tsconfig.json verifier 5.x', () => {
     dependencies: {
       typescript: '5.9.3',
     },
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeEach(async () => {
     await next.deleteFile('tsconfig.json')

--- a/test/production/turborepo-access-trace/turborepo-access-trace.test.ts
+++ b/test/production/turborepo-access-trace/turborepo-access-trace.test.ts
@@ -2,13 +2,13 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
 describe('build with proxy trace', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: path.join(__dirname, 'app'),
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should build and output trace correctly', async () => {
       const { exitCode } = await next.build({

--- a/test/production/turbotrace-with-webpack-worker/turbotrace-with-webpack-worker.test.ts
+++ b/test/production/turbotrace-with-webpack-worker/turbotrace-with-webpack-worker.test.ts
@@ -2,79 +2,75 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
 describe('build trace with extra entries', () => {
-  ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-    'production mode',
-    () => {
-      const { next, skipped } = nextTestSetup({
-        files: path.join(__dirname, 'app'),
-        skipStart: true,
-        skipDeployment: true,
-      })
-      if (skipped) return
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
+  // @force-gate !turbopack
+  describe('production mode', () => {
+    const { next } = nextTestSetup({
+      files: path.join(__dirname, 'app'),
+      skipStart: true,
+    })
 
-      it('should build and trace correctly', async () => {
-        const { exitCode } = await next.build()
-        console.log(next.cliOutput)
-        expect(exitCode).toBe(0)
+    it('should build and trace correctly', async () => {
+      const { exitCode } = await next.build()
+      console.log(next.cliOutput)
+      expect(exitCode).toBe(0)
 
-        const appTrace = JSON.parse(
-          await next.readFile('.next/server/pages/_app.js.nft.json')
-        )
-        const indexTrace = JSON.parse(
-          await next.readFile('.next/server/pages/index.js.nft.json')
-        )
-        const anotherTrace = JSON.parse(
-          await next.readFile('.next/server/pages/another.js.nft.json')
-        )
-        const imageTrace = JSON.parse(
-          await next.readFile('.next/server/pages/image-import.js.nft.json')
-        )
+      const appTrace = JSON.parse(
+        await next.readFile('.next/server/pages/_app.js.nft.json')
+      )
+      const indexTrace = JSON.parse(
+        await next.readFile('.next/server/pages/index.js.nft.json')
+      )
+      const anotherTrace = JSON.parse(
+        await next.readFile('.next/server/pages/another.js.nft.json')
+      )
+      const imageTrace = JSON.parse(
+        await next.readFile('.next/server/pages/image-import.js.nft.json')
+      )
 
-        const tracedFiles = [
-          ...appTrace.files,
-          ...indexTrace.files,
-          ...anotherTrace.files,
-          ...imageTrace.files,
-        ]
+      const tracedFiles = [
+        ...appTrace.files,
+        ...indexTrace.files,
+        ...anotherTrace.files,
+        ...imageTrace.files,
+      ]
 
-        expect(tracedFiles.some((file) => file.endsWith('hello.json'))).toBe(
-          true
+      expect(tracedFiles.some((file) => file.endsWith('hello.json'))).toBe(true)
+      expect(
+        tracedFiles.some((file) => file.includes('some-cms/index.js'))
+      ).toBe(true)
+      expect(
+        tracedFiles.some((file) => file === '../../../include-me/hello.txt')
+      ).toBe(true)
+      expect(
+        tracedFiles.some((file) => file === '../../../include-me/second.txt')
+      ).toBe(true)
+      expect(indexTrace.files.some((file) => file.includes('exclude-me'))).toBe(
+        false
+      )
+
+      expect(
+        tracedFiles.some((file) =>
+          file.includes('nested-structure/constants/package.json')
         )
-        expect(
-          tracedFiles.some((file) => file.includes('some-cms/index.js'))
-        ).toBe(true)
-        expect(
-          tracedFiles.some((file) => file === '../../../include-me/hello.txt')
-        ).toBe(true)
-        expect(
-          tracedFiles.some((file) => file === '../../../include-me/second.txt')
-        ).toBe(true)
-        expect(
-          indexTrace.files.some((file) => file.includes('exclude-me'))
-        ).toBe(false)
-
-        expect(
-          tracedFiles.some((file) =>
-            file.includes('nested-structure/constants/package.json')
-          )
-        ).toBe(true)
-        expect(
-          tracedFiles.some((file) =>
-            file.includes('nested-structure/package.json')
-          )
-        ).toBe(true)
-        expect(
-          tracedFiles.some((file) =>
-            file.includes('nested-structure/lib/constants.js')
-          )
-        ).toBe(true)
-        expect(
-          tracedFiles.some((file) => file.includes('public/another.jpg'))
-        ).toBe(true)
-        expect(
-          tracedFiles.some((file) => file.includes('public/test.jpg'))
-        ).toBe(false)
-      })
-    }
-  )
+      ).toBe(true)
+      expect(
+        tracedFiles.some((file) =>
+          file.includes('nested-structure/package.json')
+        )
+      ).toBe(true)
+      expect(
+        tracedFiles.some((file) =>
+          file.includes('nested-structure/lib/constants.js')
+        )
+      ).toBe(true)
+      expect(
+        tracedFiles.some((file) => file.includes('public/another.jpg'))
+      ).toBe(true)
+      expect(tracedFiles.some((file) => file.includes('public/test.jpg'))).toBe(
+        false
+      )
+    })
+  })
 })

--- a/test/production/typeof-window-replace/typeof-window-replace.test.ts
+++ b/test/production/typeof-window-replace/typeof-window-replace.test.ts
@@ -3,13 +3,13 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
 describe('typeof window replace', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: path.join(__dirname, 'app'),
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     let buildManifest: any
 

--- a/test/production/typescript-build-output/typescript-build-output.test.ts
+++ b/test/production/typescript-build-output/typescript-build-output.test.ts
@@ -1,14 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('typescript-build-output', () => {
-  const { next, isNextDeploy, skipped } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDeploy) {
     it('should skip', () => {})

--- a/test/production/typescript-checked-side-effect-imports/index.test.ts
+++ b/test/production/typescript-checked-side-effect-imports/index.test.ts
@@ -1,12 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Side-effect imports with noUncheckedSideEffectImports', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies: { sass: '1.54.0' },
     skipStart: true,
   })
-  if (skipped) return
 
   let buildResult: Awaited<ReturnType<(typeof next)['build']>>
   beforeAll(async () => {

--- a/test/production/typescript-custom-tsconfig/typescript-custom-tsconfig.test.ts
+++ b/test/production/typescript-custom-tsconfig/typescript-custom-tsconfig.test.ts
@@ -3,20 +3,18 @@ import { nextTestSetup } from 'e2e-utils'
 const warnMessage = /Using tsconfig file:/
 
 describe('Custom TypeScript Config', () => {
-  ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-    'production mode',
-    () => {
-      const { next, skipped } = nextTestSetup({
-        files: __dirname,
-        skipStart: true,
-        skipDeployment: true,
-      })
-      if (skipped) return
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
+  // @force-gate !turbopack
+  describe('production mode', () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      skipStart: true,
+    })
 
-      it('should warn when using custom typescript path', async () => {
-        await next.build()
-        expect(next.cliOutput).toMatch(warnMessage)
-      })
-    }
-  )
+    it('should warn when using custom typescript path', async () => {
+      await next.build()
+      expect(next.cliOutput).toMatch(warnMessage)
+    })
+  })
 })

--- a/test/production/typescript-filtered-files/typescript-filtered-files.test.ts
+++ b/test/production/typescript-filtered-files/typescript-filtered-files.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('TypeScript filtered files', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should fail to build the app with a file named con*test*.js', async () => {
       const { exitCode } = await next.build()

--- a/test/production/typescript-ignore-errors/typescript-ignore-errors.test.ts
+++ b/test/production/typescript-ignore-errors/typescript-ignore-errors.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('TypeScript with error handling options', () => {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     for (const incremental of [false, true]) {
       for (const ignoreBuildErrors of [false, true]) {

--- a/test/production/typescript-paths-baseUrl/typescript-paths-baseUrl-inherited.test.ts
+++ b/test/production/typescript-paths-baseUrl/typescript-paths-baseUrl-inherited.test.ts
@@ -2,9 +2,11 @@ import path from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
 // Reproduces https://github.com/vercel/next.js/issues/93336
+// Only next-build is interesting here.
+// @force-gate !deploy
 describe('typescript paths with deprecated, inherited baseUrl', () => {
   const fixtureDir = path.join(__dirname, 'fixtures/inherited')
-  const { skipped, next } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       '../pnpm-workspace.yaml': new FileRef(
         path.join(fixtureDir, 'pnpm-workspace.yaml')
@@ -25,13 +27,7 @@ describe('typescript paths with deprecated, inherited baseUrl', () => {
       // This test would fail in 7.0
       typescript: '^6.0.0',
     },
-    // Only next-build is interesting here.
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render the page that uses the aliased module', async () => {
     const html = await next.render('/')


### PR DESCRIPTION
## Summary

- migrate the remaining development- and production-mode deployment exclusions to `@force-gate`
- remove the corresponding `skipDeployment` options and `skipped` control flow while preserving each suite's rationale

These suites are grouped by their test-runner mode because their exclusions primarily concern local dev-server or build output.

## Verification

- verified on the combined top-of-stack tree with `pnpm typescript`
- compared ordinary-mode collection before and after: all 4,670 existing test names matched
- collected all 510 affected files in deploy mode: 4,578 skipped tests, zero failures

<!-- NEXT_JS_LLM -->
