### PR TITLE
fix(telemetry): use the native AbortController so submissions are not refused on Node 24+

### DIFF
--- a/packages/next/src/telemetry/storage.ts
+++ b/packages/next/src/telemetry/storage.ts
@@ -9,7 +9,6 @@ import { getAnonymousMeta } from './anonymous-meta'
 import * as ciEnvironment from '../server/ci-info'
 import { postNextTelemetryPayload } from './post-telemetry-payload'
 import { getRawProjectId } from './project-id'
-import { AbortController } from 'next/dist/compiled/@edge-runtime/ponyfill'
 import fs from 'fs'
 
 // This is the key that stores whether or not telemetry is enabled or disabled.

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -165,7 +165,6 @@ async function readNormalizedNFT(next, name) {
            "/node_modules/next/dist/cli/next-test.js",
            "/node_modules/next/dist/client/*",
            "/node_modules/next/dist/compiled/@edge-runtime/cookies/index.js",
-           "/node_modules/next/dist/compiled/@edge-runtime/ponyfill/index.js",
            "/node_modules/next/dist/compiled/@edge-runtime/primitives/abort-controller.js.text.js",
            "/node_modules/next/dist/compiled/@edge-runtime/primitives/console.js.text.js",
            "/node_modules/next/dist/compiled/@edge-runtime/primitives/events.js.text.js",


### PR DESCRIPTION
### What?
Remove the `ponyfill import` line from `telemetry/storage.ts` and use the global `AbortController` instead. The line will also be removed from the NFT trace snapshot.

### Why?
Since Node 24, global fetch rejects ponyfill's AbortSignal during RequestInit validation. It's thrown before network I/O and suppressed by .catch(() => {}) in post-telemetry-payload.ts. As a result, no telemetry has been received from users on Node 24 or newer. This applies to both next build and next dev.

Measured across a stable and a canary release
([CI run](https://github.com/refirst11/nextjs-turbopack-feature-usage-repro/actions/runs/33553358480)):

| next | node | signal accepted | `postNextTelemetryPayload` returns after |
|---|---|---|---|
| 16.3.3 | v22.23.2 / v23.11.1 | yes | — |
| 16.3.3 | v24.19.0 / v25.9.0 / v26.8.1 | **no** | 500.7 / 502.2 / 501.8 ms |
| 16.4.0-canary.8 | v22.23.2 / v23.11.1 | yes | — |
| 16.4.0-canary.8 | v24.19.0 / v25.9.0 / v26.8.1 | **no** | 501.8 / 502.2 / 501.3 ms |

Verifiable in about ten seconds, without building Next.js:

```shell
git clone -b probe/abortsignal https://github.com/refirst11/nextjs-turbopack-feature-usage-repro
cd nextjs-turbopack-feature-usage-repro
pnpm install
node scripts/abortsignal-probe.mjs   # on Node 24 or newer
```

The polyfill was needed when it arrived in #44614 (Jan 2023): `engines.node`
was `>=14.6.0` then, and Node 14 had no global `AbortController`. #49092 later
rewrote the import path as part of an `@edge-runtime/*` suite bump without
revisiting whether it was still needed. `engines.node` is now `>=20.9.0`, and
the global has existed since Node 15.


### How?
1. `packages/next/src/telemetry/storage.ts`: remove the ponyfill import, so
   `AbortController` resolves to the global.
2. `test/production/next-server-nft/next-server-nft.test.ts`: drop the ponyfill
   from the expected trace — `storage.ts` was its only importer.
   
No behavioural test: asserting the submission path would need network mocking.
The NFT snapshot change acts as the structural guard — if the ponyfill comes
back, that test fails. Happy to add a mocked test if you would rather have one.

Related to #97929 and #97981.