### PR TITLE
[16.3.X] Emit whole-app server NFTs when `output: 'standalone'` is used with an adapter

### DIFF
--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -74,18 +74,24 @@ enum ServerNftType {
 
 #[turbo_tasks::function]
 pub async fn next_server_nft_assets(project: Vc<Project>) -> Result<Vc<OutputAssets>> {
-    if *project.next_config().is_using_adapter().await? {
+    let is_standalone = *project.next_config().is_standalone().await?;
+
+    if *project.next_config().is_using_adapter().await? && !is_standalone {
         // When using an adapter, `next-server.js.nft.json` / `next-minimal-server.js.nft.json` are
         // not needed: they exist for `output: 'standalone'` (see `copyTracedFiles`), while an
         // adapter assembles the deployment from the per-endpoint NFTs in build-complete.ts. What
         // those two files trace on top of the endpoints - the `styled-jsx` modules the require hook
         // needs at runtime - is part of every endpoint's trace via
         // `Project::additional_traced_modules`, so nothing is lost here.
+        //
+        // The exception is `output: 'standalone'` configured alongside an adapter:
+        // `copyTracedFiles` reads `next-server.js.nft.json` unconditionally whenever standalone
+        // output is requested (adapter or not), so suppressing the pair crashes the build
+        // (see #96646).
         return Ok(Vc::cell(vec![]));
     }
 
     let has_next_support = *project.ci_has_next_support().await?;
-    let is_standalone = *project.next_config().is_standalone().await?;
 
     let minimal = ResolvedVc::upcast(
         ServerNftJsonAsset::new(project, ServerNftType::Minimal)

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -723,5 +723,41 @@ async function readNormalizedNFT(next, name) {
         `)
       })
     })
+
+    describe('with adapters and output:standalone', () => {
+      const { next, skipped } = nextTestSetup({
+        files: __dirname,
+        dependencies: {
+          typescript: '5.9.2',
+        },
+        nextConfig: {
+          output: 'standalone',
+          adapterPath: path.join(__dirname, './my-adapter.mjs'),
+        },
+      })
+
+      if (skipped) {
+        return
+      }
+
+      // Regression test for #96646: with an adapter configured, the whole-app server NFTs were
+      // suppressed while `copyTracedFiles` (which runs for `output: 'standalone'`, adapter or
+      // not) still reads `next-server.js.nft.json` unconditionally — crashing the build with
+      // ENOENT.
+      it('should emit both whole-app server NFTs and complete the build', async () => {
+        const serverTrace = await next.readJSON('.next/next-server.js.nft.json')
+        expect(Array.isArray(serverTrace.files)).toBe(true)
+        expect(serverTrace.files.length).toBeGreaterThan(0)
+
+        const minimalTrace = await next.readJSON(
+          '.next/next-minimal-server.js.nft.json'
+        )
+        expect(Array.isArray(minimalTrace.files)).toBe(true)
+
+        // The adapter still ran (my-adapter.mjs writes build-complete.json).
+        const buildComplete = await next.readJSON('build-complete.json')
+        expect(buildComplete).toBeTruthy()
+      })
+    })
   }
 )


### PR DESCRIPTION
Backports #97287