### PR TITLE
fix(next/image): don't share the requester's socket with the internal image response

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -8,7 +8,7 @@ import type { ImageConfigComplete } from '../shared/lib/image-config'
 import { hasLocalMatch } from '../shared/lib/match-local-pattern'
 import { hasRemoteMatch } from '../shared/lib/match-remote-pattern'
 import type { NextConfigComplete, NextConfigRuntime } from './config-shared'
-import { createRequestResponseMocks } from './lib/mock-request'
+import { MockedRequest, MockedResponse } from './lib/mock-request'
 import type { NextUrlWithParsedQuery } from './request-meta'
 import {
   CachedRouteKind,
@@ -644,12 +644,24 @@ export async function fetchInternalImage(
     // Coerce HEAD to GET to avoid issues with the image optimizer
     const method = !_req.method || _req.method === 'HEAD' ? 'GET' : _req.method
 
-    const mocked = createRequestResponseMocks({
-      url: href,
-      method,
-      socket: _req.socket,
-      maximumResponseBody,
-    })
+    // The mocked request keeps the requester's socket so that protocol and
+    // remote address detection keep working, but the mocked response must not
+    // reference it. `send` (used by `serveStatic`) watches `res.socket` through
+    // `on-finished` and treats the response as finished as soon as that socket
+    // stops being writable. When the requester disconnected mid-transfer this
+    // tore down the file stream without ever ending the mocked response, and
+    // since `ResponseCache` coalesces every request for the same cache key onto
+    // this single fetch, the key stayed pending for every later requester until
+    // the server restarted.
+    const mocked = {
+      req: new MockedRequest({
+        url: href,
+        method,
+        headers: {},
+        socket: _req.socket,
+      }),
+      res: new MockedResponse({ maximumResponseBody }),
+    }
 
     await handleRequest(mocked.req, mocked.res, parseReqUrl(href))
     await mocked.res.hasStreamed

--- a/test/unit/image-optimizer/fetch-internal-image.test.ts
+++ b/test/unit/image-optimizer/fetch-internal-image.test.ts
@@ -3,7 +3,13 @@ import {
   fetchInternalImage,
   ImageError,
 } from 'next/dist/server/image-optimizer'
+import { serveStatic } from 'next/dist/server/serve-static'
+import { EventEmitter } from 'events'
+import { promises as fs } from 'fs'
 import type { IncomingMessage, ServerResponse } from 'http'
+import type { Socket } from 'net'
+import { tmpdir } from 'os'
+import { join } from 'path'
 
 describe('fetchInternalImage', () => {
   describe('non-2xx responses', () => {
@@ -204,6 +210,59 @@ describe('fetchInternalImage', () => {
 
       expect(result.buffer).toBeInstanceOf(Buffer)
       expect(result.buffer.length).toBe(maximumResponseBody)
+    })
+  })
+  describe('when the requesting client disconnects', () => {
+    it('should complete the internal fetch even if the requester socket is no longer writable', async () => {
+      const size = 1024 * 1024
+      const fileName = 'disconnect.png'
+      const dir = await fs.mkdtemp(join(tmpdir(), 'fetch-internal-image-'))
+      await fs.writeFile(join(dir, fileName), Buffer.alloc(size, 1))
+
+      try {
+        // Emulate a requester whose connection already went away. `send`
+        // (used by `serveStatic`) consults `on-finished`, which treats a
+        // response as finished as soon as `res.socket.writable` is false.
+        const closedSocket = Object.assign(new EventEmitter(), {
+          writable: false,
+          destroyed: true,
+        }) as unknown as Socket
+        const mockReq = {
+          method: 'GET',
+          socket: closedSocket,
+        } as unknown as IncomingMessage
+        const mockRes = {} as ServerResponse
+
+        const handleRequest = (req: IncomingMessage, res: ServerResponse) =>
+          serveStatic(req, res, fileName, { root: dir })
+
+        const result = await Promise.race([
+          fetchInternalImage(
+            `/${fileName}`,
+            mockReq,
+            mockRes,
+            300_000_000,
+            handleRequest
+          ),
+          new Promise<never>((_resolve, reject) => {
+            const timer = setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    'fetchInternalImage did not settle after the requester disconnected'
+                  )
+                ),
+              5_000
+            )
+            timer.unref()
+          }),
+        ])
+
+        expect(result.buffer.length).toBe(size)
+        expect(result.contentType).toBe('image/png')
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true })
+      }
     })
   })
 })


### PR DESCRIPTION
### What?

A client that disconnects right after starting a cold `/_next/image` transform leaves that exact transform URL (`url` + `w` + `q`) unresponsive for every other client until the server process restarts. Nothing is logged. This affects both `next start` and `next dev`.

This PR builds the internal (mocked) response for `fetchInternalImage` without a reference to the requester's socket, so one client going away can no longer wedge the shared transform.

Fixes #96538

### Why?

`fetchInternalImage` serves the source image by running an internal request through the server with a mocked request/response pair, and that mocked response carried the requester's real socket. `serveStatic` pipes the file with `send`, which watches the response through `on-finished`:

```js
// on-finished
function isFinished(msg) {
  var socket = msg.socket
  if (typeof msg.finished === 'boolean') {
    return Boolean(msg.finished || (socket && !socket.writable))
  }
  ...
}
```

As soon as the requester's socket stops being writable, `send` considers the response finished, destroys the file read stream, and never calls `res.end()` on the mock. From there:

- `serveStatic` only resolves on the response's `finish` event, so `await handleRequest(...)` in `fetchInternalImage` never returns (this also means a timeout placed around `hasStreamed` alone cannot catch this case).
- `ResponseCache.get` coalesces every request for the same cache key through `Batcher`, which only releases the key in a `finally` after the generator settles. The generator never settles, so every later request for that key joins the pending promise forever.

Cached keys are immune because `ResponseCache` resolves them early from the previous entry (even when stale), which is why the failure only shows up on cold transforms.

### How?

`fetchInternalImage` now constructs `MockedRequest` and `MockedResponse` directly instead of going through `createRequestResponseMocks`:

- The **request** keeps the requester's socket. Two places read it on the internal path: `resolve-routes` uses `req.socket.encrypted` for protocol detection, and `base-server` uses `req.socket.remoteAddress` to fill `x-forwarded-for`. Dropping the socket from the request would change both for internal fetches that reach the render path (for example `url=/api/og`). The `MockedRequest` fallback socket is also a `Proxy` that throws for any property other than those two, so keeping the real socket is the safer default.
- The **response** no longer references it. Nothing in the internal path needs `res.socket`; it only served as the trigger for `on-finished`.

This differs from #96542 and #97490 (thanks to both authors for the diagnosis), which remove the socket from both mocks; #97490 additionally adds a 30 s timeout around `hasStreamed`, which cannot fire for this bug because the hang happens one `await` earlier, inside `serveStatic`.

### Testing

- Added a unit test in `test/unit/image-optimizer/fetch-internal-image.test.ts` that pipes a real file through `serveStatic` with a request whose socket is already non-writable and races it against a 5 s timer. It fails on `canary` with `fetchInternalImage did not settle after the requester disconnected` and passes with this change.
- Reproduced end to end with a minimal app (`app/page.tsx` + three PNGs in `public/`) and a script that opens a raw TCP connection, writes the `GET /_next/image?...` request, destroys the socket 0–20 ms later, then probes the same URL:

| Build | Uncached keys probed | Keys hung forever |
| --- | --- | --- |
| published npm `next@16.3.3` (`next dev`) | 24 | 7 |
| published npm `next@16.4.0-canary.14` (`next dev`) | 24 | 16 |
| `canary` HEAD 8ea76d64 + this change (`pnpm next dev`) | 24 | 0 |

- Cached keys: 81 aborts across 9 cached keys, 0 hangs (before and after), consistent with the early-resolve path described above.
- `pnpm exec jest test/unit/image-optimizer/`: all suites pass. `tsc --noEmit` for `packages/next`, `eslint` and `prettier --check` on the touched files are clean.

We originally hit this in CI: Playwright closes the browser context when a scenario ends, which aborts any lazy-loaded image request that started a few milliseconds earlier, and from then on every scenario asserting that image failed until the dev server was restarted.
