### PR TITLE
refactor(next-devtools): enforce strict types for middlewareResponse

### DIFF
--- a/packages/next/src/next-devtools/server/middleware-response.ts
+++ b/packages/next/src/next-devtools/server/middleware-response.ts
@@ -2,11 +2,11 @@ import type { ServerResponse } from 'http'
 import { inspect } from 'util'
 
 export const middlewareResponse = {
-  noContent(res: ServerResponse) {
+  noContent(res: ServerResponse): void {
     res.statusCode = 204
     res.end('No Content')
   },
-  badRequest(res: ServerResponse, reason?: string) {
+  badRequest(res: ServerResponse, reason?: string): void {
     res.statusCode = 400
     if (reason !== undefined) {
       res.setHeader('Content-Type', 'text/plain')
@@ -15,15 +15,15 @@ export const middlewareResponse = {
       res.end()
     }
   },
-  notFound(res: ServerResponse) {
+  notFound(res: ServerResponse): void {
     res.statusCode = 404
     res.end('Not Found')
   },
-  methodNotAllowed(res: ServerResponse) {
+  methodNotAllowed(res: ServerResponse): void {
     res.statusCode = 405
     res.end('Method Not Allowed')
   },
-  internalServerError(res: ServerResponse, error?: unknown) {
+  internalServerError(res: ServerResponse, error?: unknown): void {
     res.statusCode = 500
     res.setHeader('Content-Type', 'text/plain')
     res.end(
@@ -32,12 +32,12 @@ export const middlewareResponse = {
         : 'Internal Server Error'
     )
   },
-  json(res: ServerResponse, data: any) {
+  json(res: ServerResponse, data: unknown): void {
     res
       .setHeader('Content-Type', 'application/json')
       .end(Buffer.from(JSON.stringify(data)))
   },
-  jsonString(res: ServerResponse, data: string) {
+  jsonString(res: ServerResponse, data: string): void {
     res.setHeader('Content-Type', 'application/json').end(Buffer.from(data))
   },
 }


### PR DESCRIPTION


<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?
Improves the type-safety of the `middlewareResponse` utility in `next-devtools`.



### How?
Changes:
1. Added explicit `: void` return types to all response handlers.
2. Replaced the `data: any` argument in the `json()` method with `data: unknown` for better strict-mode compliance (since it is safely passed to `JSON.stringify`).
