### PR TITLE
fix(turbopack): translate group indices in split_module

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/graph.rs
@@ -355,6 +355,7 @@ impl DepGraph {
         };
 
         let mut module_evaluation_ix = None;
+        let mut group_to_module = FxHashMap::<u32, u32>::default();
 
         for (ix, group) in groups.graph_ix.iter().enumerate() {
             let mut chunk = Module {
@@ -717,7 +718,16 @@ impl DepGraph {
                 continue;
             }
 
+            group_to_module.insert(ix as u32, modules.len() as u32);
             modules.push(chunk);
+        }
+
+        translate_entrypoints(&mut outputs, &group_to_module);
+        module_evaluation_ix =
+            module_evaluation_ix.and_then(|ix| group_to_module.get(&ix).copied());
+        translate_part_deps(&mut part_deps, &group_to_module);
+        for module in &mut modules {
+            remap_internal_part_ids_in_module(module, &group_to_module);
         }
 
         outputs.insert(Key::Exports, modules.len() as u32);
@@ -767,6 +777,10 @@ impl DepGraph {
 
             modules.push(module);
         }
+
+        debug_assert!(validate_split_module_indices(
+            &outputs, &part_deps, &modules,
+        ));
 
         SplitModuleResult {
             entrypoints: outputs,
@@ -1648,6 +1662,121 @@ impl DepGraph {
 }
 
 const ASSERT_CHUNK_KEY: &str = "__turbopack_part__";
+
+fn translate_part_id(part_id: PartId, map: &FxHashMap<u32, u32>) -> Option<PartId> {
+    match part_id {
+        PartId::Internal(dep, is_eval) => map.get(&dep).map(|&m| PartId::Internal(m, is_eval)),
+        other => Some(other),
+    }
+}
+
+fn translate_entrypoints(outputs: &mut FxHashMap<Key, u32>, map: &FxHashMap<u32, u32>) {
+    let keys = outputs.keys().cloned().collect::<Vec<_>>();
+    for key in keys {
+        match &key {
+            Key::Export(_) | Key::ModuleEvaluation => {
+                let val = outputs[&key];
+                if let Some(mapped) = map.get(&val) {
+                    outputs.insert(key, *mapped);
+                } else {
+                    outputs.remove(&key);
+                }
+            }
+            Key::Exports | Key::StarExports => {}
+        }
+    }
+}
+
+fn translate_part_deps(deps: &mut FxHashMap<u32, Vec<PartId>>, map: &FxHashMap<u32, u32>) {
+    let old = std::mem::take(deps);
+    for (key, part_ids) in old {
+        let Some(&mapped_key) = map.get(&key) else {
+            continue;
+        };
+        let mut mapped_part_ids = Vec::with_capacity(part_ids.len());
+        for part_id in part_ids {
+            if let Some(mapped) = translate_part_id(part_id, map) {
+                mapped_part_ids.push(mapped);
+            }
+        }
+        if !mapped_part_ids.is_empty() {
+            deps.insert(mapped_key, mapped_part_ids);
+        }
+    }
+}
+
+fn remap_internal_part_ids_in_module(module: &mut Module, map: &FxHashMap<u32, u32>) {
+    module.body.retain_mut(|item| {
+        let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item else {
+            return true;
+        };
+
+        let Some(with) = import.with.as_deref() else {
+            return true;
+        };
+
+        let Some(part_id) = find_turbopack_part_id_in_asserts(with) else {
+            return true;
+        };
+
+        let PartId::Internal(_, _) = part_id else {
+            return true;
+        };
+
+        let Some(translated) = translate_part_id(part_id, map) else {
+            return false;
+        };
+
+        import.with = Some(Box::new(create_turbopack_part_id_assert(translated)));
+        true
+    });
+}
+
+fn validate_split_module_indices(
+    entrypoints: &FxHashMap<Key, u32>,
+    part_deps: &FxHashMap<u32, Vec<PartId>>,
+    modules: &[Module],
+) -> bool {
+    let module_count = modules.len() as u32;
+
+    for &index in entrypoints.values() {
+        if index >= module_count {
+            return false;
+        }
+    }
+
+    for (key, deps) in part_deps {
+        if *key >= module_count {
+            return false;
+        }
+        for dep in deps {
+            if let PartId::Internal(index, _) = dep
+                && *index >= module_count
+            {
+                return false;
+            }
+        }
+    }
+
+    for module in modules {
+        for item in &module.body {
+            let ModuleItem::ModuleDecl(ModuleDecl::Import(import)) = item else {
+                continue;
+            };
+            let Some(with) = import.with.as_deref() else {
+                continue;
+            };
+            let Some(PartId::Internal(index, _)) = find_turbopack_part_id_in_asserts(with) else {
+                continue;
+            };
+            if index >= module_count {
+                return false;
+            }
+        }
+    }
+
+    true
+}
 
 #[derive(Debug, Clone)]
 pub(crate) enum PartId {

--- a/turbopack/crates/turbopack-ecmascript/src/module_fragments/tests.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_fragments/tests.rs
@@ -28,6 +28,72 @@ fn test_fixture(input: PathBuf) {
     run(input);
 }
 
+#[test]
+fn empty_group_fragment_indices_are_in_module_bounds() {
+    let input = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/tree-shaker/analyzer/empty-group-fragment/regression.js");
+
+    testing::run_test(false, |cm, _handler| {
+        let fm = cm.load_file(&input).unwrap();
+        let comments = SingleThreadedComments::default();
+        let module = parse_file_as_module(
+            &fm,
+            swc_core::ecma::parser::Syntax::Es(EsSyntax {
+                jsx: true,
+                ..Default::default()
+            }),
+            EsVersion::latest(),
+            Some(&comments),
+            &mut vec![],
+        )
+        .unwrap();
+
+        let unresolved_mark = Mark::new();
+        let top_level_mark = Mark::new();
+        let unresolved_ctxt = SyntaxContext::empty().apply_mark(unresolved_mark);
+        let top_level_ctxt = SyntaxContext::empty().apply_mark(top_level_mark);
+
+        let mut g = DepGraph::default();
+        let (_, items) = g.init(&module, &comments, unresolved_ctxt, top_level_ctxt);
+        g.handle_weak(Mode::Production);
+
+        let SplitModuleResult {
+            entrypoints,
+            part_deps,
+            modules,
+            ..
+        } = g.split_module(&[], &items);
+
+        let module_count = modules.len() as u32;
+
+        for (key, index) in &entrypoints {
+            assert!(
+                *index < module_count,
+                "entrypoint {key:?} index {index} is out of bounds for {} modules",
+                module_count
+            );
+        }
+
+        for (key, deps) in &part_deps {
+            assert!(
+                *key < module_count,
+                "part_deps key {key} is out of bounds for {module_count} modules"
+            );
+            for dep in deps {
+                if let super::graph::PartId::Internal(index, _) = dep {
+                    assert!(
+                        *index < module_count,
+                        "part_deps Internal({index}) is out of bounds for {module_count} modules"
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    })
+    .unwrap();
+}
+
 #[derive(Deserialize)]
 struct TestConfig {
     /// Enabled exports. This is `Vec<Vec<String>>` because we test multiple

--- a/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/empty-group-fragment/regression.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/tree-shaker/analyzer/empty-group-fragment/regression.js
@@ -1,0 +1,61 @@
+import { createAbortController } from './next-request'
+
+export function isAbortError(e) {
+  return e?.name === 'AbortError'
+}
+
+const HAS_CLIENT_COMPONENT_METRICS_ENABLED =
+  'performance' in globalThis && process.env.NEXT_OTEL_PERFORMANCE_PREFIX
+
+function createWriterFromResponse(res, waitUntilForEnd) {
+  let started = false
+
+  return {
+    write: async (chunk) => {
+      if (!started) {
+        started = true
+        res.flushHeaders()
+      }
+
+      return res.write(chunk)
+    },
+    close: async () => {
+      if (waitUntilForEnd) {
+        await waitUntilForEnd
+      }
+
+      if (!res.writableFinished) {
+        res.end()
+      }
+    },
+  }
+}
+
+export async function pipeToNodeResponse(readable, res, waitUntilForEnd) {
+  const { errored, destroyed } = res
+  if (errored || destroyed) return
+
+  const controller = createAbortController(res)
+  const writer = createWriterFromResponse(res, waitUntilForEnd)
+
+  await readable.pipeTo(writer, { signal: controller.signal })
+}
+
+export async function pipeNodeReadableToNodeResponse(readable, res, waitUntilForEnd) {
+  const { errored, destroyed } = res
+  if (errored || destroyed) return
+
+  readable.on('data', (chunk) => {
+    res.write(chunk)
+  })
+
+  readable.on('end', async () => {
+    if (waitUntilForEnd) {
+      await waitUntilForEnd
+    }
+
+    if (!res.writableFinished) {
+      res.end()
+    }
+  })
+}


### PR DESCRIPTION
## Summary

- Fix an index space mismatch in \split_module\ where group indices were stored in \entrypoints\, \part_deps\, and \module_evaluation_ix\ but read as positions into the compacted \modules\ vector after empty groups were skipped.
- Build a \group_to_module\ map as non-empty chunks are pushed, then translate entrypoints, part_deps keys/values, embedded \PartId::Internal\ import assertions, and \module_evaluation_ix\ before the result is used.
- Add a regression test (\empty_group_fragment_indices_are_in_module_bounds\) using a module shape similar to \pipe-readable.js\.

## Test plan

- [x] Added Rust regression test asserting all entrypoints and part_deps indices are in bounds
- [ ] CI: \cargo test -p turbopack-ecmascript empty_group_fragment\
- [ ] CI: existing \	est_fixture\ snapshot tests
- [ ] Manual repro: https://github.com/benderTheCrime/turbopack-module-fragments-repro with \	urbopackModuleFragments: true\

Fixes #98128

Related: #97811, #86571

Made with [Cursor](https://cursor.com)