### PR TITLE
Fix config redirects matching `_next/data` requests when middleware is present

### DIFF
--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -83,11 +83,16 @@ export function getResolveRoutes(
   let routes: Route[] | null = null
   const calculateRoutes = () => {
     return [
-      // _next/data with middleware handling
+      // detect _next/data requests so config headers/redirects can match
+      // against the request before any middleware-specific normalization
       { match: () => ({}), name: 'middleware_next_data' },
 
       ...(opts.minimalMode ? [] : fsChecker.headers),
       ...(opts.minimalMode ? [] : fsChecker.redirects),
+
+      // normalize _next/data requests to their underlying page path so the
+      // middleware matcher below evaluates against the real route
+      { match: () => ({}), name: 'middleware_next_data_normalize' },
 
       // check middleware (using matchers)
       { match: () => ({}), name: 'middleware' },
@@ -429,70 +434,84 @@ export function getResolveRoutes(
         }
 
         if (route.name === 'middleware_next_data' && parsedUrl.pathname) {
-          if (fsChecker.getMiddlewareMatchers()?.length) {
-            let normalized = parsedUrl.pathname
+          let normalized = parsedUrl.pathname
 
-            // Remove the base path if it exists.
-            const hadBasePath = normalizers.basePath?.match(parsedUrl.pathname)
-            if (hadBasePath && normalizers.basePath) {
-              normalized = normalizers.basePath.normalize(normalized, true)
-            }
+          // Remove the base path if it exists.
+          const hadBasePath = normalizers.basePath?.match(parsedUrl.pathname)
+          if (hadBasePath && normalizers.basePath) {
+            normalized = normalizers.basePath.normalize(normalized, true)
+          }
 
-            const isNextDataPath =
-              pathHasPrefix(normalized, '/_next/data') &&
-              normalized.endsWith('.json')
-            const hasCurrentBuildIdDataPath = normalizers.data.match(normalized)
+          const isNextDataPath =
+            pathHasPrefix(normalized, '/_next/data') &&
+            normalized.endsWith('.json')
 
-            let updated = false
-            if (hasCurrentBuildIdDataPath) {
-              updated = true
-              normalized = normalizers.data.normalize(normalized, true)
-            }
-            if (isNextDataPath) {
-              setIsNextDataRequest()
-            }
+          if (isNextDataPath) {
+            setIsNextDataRequest()
+          }
+        }
 
-            if (config.i18n) {
-              const curLocaleResult = normalizeLocalePath(
-                normalized,
-                config.i18n.locales
+        if (
+          route.name === 'middleware_next_data_normalize' &&
+          parsedUrl.pathname &&
+          fsChecker.getMiddlewareMatchers()?.length
+        ) {
+          let normalized = parsedUrl.pathname
+
+          // Remove the base path if it exists.
+          const hadBasePath = normalizers.basePath?.match(parsedUrl.pathname)
+          if (hadBasePath && normalizers.basePath) {
+            normalized = normalizers.basePath.normalize(normalized, true)
+          }
+
+          const hasCurrentBuildIdDataPath = normalizers.data.match(normalized)
+
+          let updated = false
+          if (hasCurrentBuildIdDataPath) {
+            updated = true
+            normalized = normalizers.data.normalize(normalized, true)
+          }
+
+          if (config.i18n) {
+            const curLocaleResult = normalizeLocalePath(
+              normalized,
+              config.i18n.locales
+            )
+
+            if (curLocaleResult.detectedLocale) {
+              addRequestMeta(req, 'locale', curLocaleResult.detectedLocale)
+            } else if (
+              defaultLocale &&
+              !curLocaleResult.pathname.startsWith('/_next/')
+            ) {
+              // Match normalized _next/data requests against the same
+              // locale-prefixed internal pathname shape used by direct page
+              // requests when the default locale was inferred.
+              normalized = addPathPrefix(
+                curLocaleResult.pathname === '/'
+                  ? `/${defaultLocale}`
+                  : addPathPrefix(
+                      curLocaleResult.pathname || '',
+                      `/${defaultLocale}`
+                    )
               )
+            }
+          }
 
-              if (curLocaleResult.detectedLocale) {
-                addRequestMeta(req, 'locale', curLocaleResult.detectedLocale)
-              } else if (
-                defaultLocale &&
-                !curLocaleResult.pathname.startsWith('/_next/')
-              ) {
-                // Match normalized _next/data requests against the same
-                // locale-prefixed internal pathname shape used by direct page
-                // requests when the default locale was inferred.
-                normalized = addPathPrefix(
-                  curLocaleResult.pathname === '/'
-                    ? `/${defaultLocale}`
-                    : addPathPrefix(
-                        curLocaleResult.pathname || '',
-                        `/${defaultLocale}`
-                      )
-                )
-              }
+          // If we updated the pathname, and it had a base path, re-add the
+          // base path.
+          if (updated) {
+            if (hadBasePath) {
+              normalized =
+                normalized === '/'
+                  ? config.basePath
+                  : path.posix.join(config.basePath, normalized)
             }
 
-            // If we updated the pathname, and it had a base path, re-add the
-            // base path.
-            if (updated) {
-              if (hadBasePath) {
-                normalized =
-                  normalized === '/'
-                    ? config.basePath
-                    : path.posix.join(config.basePath, normalized)
-              }
+            // Re-add the trailing slash (if required).
+            normalized = maybeAddTrailingSlash(normalized)
 
-              // Re-add the trailing slash (if required).
-              normalized = maybeAddTrailingSlash(normalized)
-
-              parsedUrl.pathname = normalized
-            }
+            parsedUrl.pathname = normalized
           }
         }
 

--- a/test/e2e/config-redirect-next-data-middleware/config-redirect-next-data-middleware.test.ts
+++ b/test/e2e/config-redirect-next-data-middleware/config-redirect-next-data-middleware.test.ts
@@ -1,0 +1,28 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('config-redirect-next-data-middleware', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should still redirect a full navigation to a matching page', async () => {
+    const res = await next.fetch('/foo/details', { redirect: 'manual' })
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toMatch(/\/$/)
+  })
+
+  it('should not redirect the _next/data request for that same page', async () => {
+    // the page above is only ever redirected away from, so this is the
+    // first request that actually compiles it in dev mode
+    await retry(async () => {
+      const res = await next.fetch(
+        `/_next/data/${next.buildId}/foo/details.json`,
+        { redirect: 'manual' }
+      )
+      expect(res.status).toBe(200)
+      const data = await res.json()
+      expect(data.pageProps.routeType).toBe('foo')
+    })
+  })
+})

--- a/test/e2e/config-redirect-next-data-middleware/middleware.ts
+++ b/test/e2e/config-redirect-next-data-middleware/middleware.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+
+export function middleware() {
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/middleware-does-not-match-anything'],
+}

--- a/test/e2e/config-redirect-next-data-middleware/next.config.js
+++ b/test/e2e/config-redirect-next-data-middleware/next.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  async redirects() {
+    return [
+      {
+        source: '/:type/details',
+        destination: '/',
+        permanent: false,
+      },
+    ]
+  },
+}

--- a/test/e2e/config-redirect-next-data-middleware/pages/[type]/details.tsx
+++ b/test/e2e/config-redirect-next-data-middleware/pages/[type]/details.tsx
@@ -1,0 +1,11 @@
+export default function Details({ routeType }: { routeType: string }) {
+  return <p id="route-type">{routeType}</p>
+}
+
+export async function getStaticProps({ params }: { params: { type: string } }) {
+  return { props: { routeType: params.type } }
+}
+
+export async function getStaticPaths() {
+  return { paths: [{ params: { type: 'foo' } }], fallback: false }
+}

--- a/test/e2e/config-redirect-next-data-middleware/pages/index.tsx
+++ b/test/e2e/config-redirect-next-data-middleware/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}


### PR DESCRIPTION
**What?**
Fixes config redirects incorrectly matching _next/data requests when middleware is present.

**Why?**
_next/data requests were being normalized to their underlying page pathname before config headers and redirects were evaluated whenever middleware existed. This caused redirects intended for full page navigations to incorrectly match internal data requests.

**How?**
Splits _next/data handling into two stages:

Detect _next/data requests before headers and redirects without modifying the pathname.
Normalize the pathname only afterward, when evaluating middleware matchers.

Adds an e2e test to verify that full page navigations still redirect while the corresponding _next/data request returns the page data successfully.

Fixes #98142