### PR TITLE
[not for merge] run tests with --trace-deprecation

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -689,7 +689,7 @@ jobs:
       afterBuild: |
         export __NEXT_NODE_NATIVE_TS_LOADER_ENABLED=true
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
-        NEXT_TEST_MODE=dev NODE_OPTIONS=--experimental-transform-types node run-tests.js test/e2e/app-dir/next-config-ts-native-ts/**/*.test.ts test/e2e/app-dir/next-config-ts-native-mts/**/*.test.ts
+        NEXT_TEST_MODE=dev NODE_OPTIONS="--experimental-transform-types --trace-deprecation" node run-tests.js test/e2e/app-dir/next-config-ts-native-ts/**/*.test.ts test/e2e/app-dir/next-config-ts-native-mts/**/*.test.ts
       stepName: 'test-next-config-ts-native-ts-dev-${{ matrix.node }}'
 
     secrets: inherit
@@ -716,7 +716,7 @@ jobs:
       afterBuild: |
         export __NEXT_NODE_NATIVE_TS_LOADER_ENABLED=true
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
-        NEXT_TEST_MODE=start NODE_OPTIONS=--experimental-transform-types node run-tests.js test/e2e/app-dir/next-config-ts-native-ts/**/*.test.ts test/e2e/app-dir/next-config-ts-native-mts/**/*.test.ts
+        NEXT_TEST_MODE=start NODE_OPTIONS="--experimental-transform-types --trace-deprecation" node run-tests.js test/e2e/app-dir/next-config-ts-native-ts/**/*.test.ts test/e2e/app-dir/next-config-ts-native-mts/**/*.test.ts
       stepName: 'test-next-config-ts-native-ts-prod-${{ matrix.node }}'
 
     secrets: inherit

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -127,6 +127,9 @@ env:
   TURBO_CACHE: 'local:rw,remote:rw'
 
   NEXT_TELEMETRY_DISABLED: 1
+  # Temporary CI experiment: surface deprecation stack traces from every Node
+  # process in the test suite.
+  NODE_OPTIONS: --trace-deprecation
   # `skipNativeInstall: 'no'` must force the download even though CI otherwise
   # skips it by default (see scripts/install-native.mjs), so emit an explicit
   # '0' rather than an empty value.

--- a/run-tests.js
+++ b/run-tests.js
@@ -418,7 +418,9 @@ async function main() {
     printTests: argv.printTests ?? false,
   }
   let numRetries = options.retries
-  const hideOutput = !options.debug && !options.dry
+  // Temporary CI experiment: stream output of all tests (not just failures)
+  // in CI so the job logs can be searched for --trace-deprecation warnings.
+  const hideOutput = !options.debug && !options.dry && !process.env.CI
 
   let filterTestsBy
 

--- a/test/e2e/app-dir/hello-world/app/page.tsx
+++ b/test/e2e/app-dir/hello-world/app/page.tsx
@@ -1,3 +1,6 @@
 export default function Page() {
+  // Temporary CI experiment: trigger a Node deprecation at request time to
+  // verify --trace-deprecation propagates to the server process.
+  require('sys')
   return <p>hello world</p>
 }

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -729,7 +729,7 @@ export class NextInstance {
       'next'
     )
     const nextBin = existsSync(localNextBin) ? localNextBin : workspaceNextBin
-    const spawnArgs = ['node', '--no-deprecation', nextBin, ...args]
+    const spawnArgs = ['node', nextBin, ...args]
     const spawnOpts: import('child_process').SpawnOptions = {
       cwd: cwd ?? this.testDir,
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -81,7 +81,7 @@ export function initNextServerScript(
   return new Promise((resolve, reject) => {
     const instance = spawn(
       'node',
-      [...((opts && opts.nodeArgs) || []), '--no-deprecation', scriptPath],
+      [...((opts && opts.nodeArgs) || []), scriptPath],
       {
         env: { HOSTNAME: '::', ...env },
         cwd: opts && opts.cwd,
@@ -322,7 +322,7 @@ export function runNextCommand(
     debugPrint(`Running command "next ${argv.join(' ')}"`)
     const instance = spawn(
       'node',
-      [...(options.nodeArgs || []), '--no-deprecation', nextBin, ...argv],
+      [...(options.nodeArgs || []), nextBin, ...argv],
       {
         ...options.spawnOptions,
         cwd,
@@ -444,14 +444,10 @@ export function runNextCommandDev(
 
   const nodeArgs = opts.nodeArgs || []
   return new Promise((resolve, reject) => {
-    const instance = spawn(
-      'node',
-      [...nodeArgs, '--no-deprecation', nextBin, ...argv],
-      {
-        cwd,
-        env,
-      }
-    )
+    const instance = spawn('node', [...nodeArgs, nextBin, ...argv], {
+      cwd,
+      env,
+    })
     let didResolve = false
 
     const bootType =


### PR DESCRIPTION
## Summary

Temporary CI experiment. Sets `NODE_OPTIONS: --trace-deprecation` in `build_reusable.yml` so every Node process in the test suite emits deprecation stack traces, and merges the flag into the two inline `NODE_OPTIONS` overrides in `build_and_test.yml` that would otherwise drop it. Adds a `require('sys')` probe to the hello-world e2e page to confirm propagation end-to-end.

Do not merge. Branch exists to run the full suite in CI with the flag on and inspect which suites emit deprecations.

## Verification

- `next dev` with `NODE_OPTIONS=--trace-deprecation` on the modified hello-world fixture emits `[DEP0025] sys is deprecated` with a full stack trace pointing at the page.
- Through `run-tests.js`, child server stdout/stderr is captured into `cliOutput`, not streamed, in turbopack-dev, webpack-dev, and webpack-prod modes. Deprecation traces land in per-test captured output (surfaced on failure / via artifacts), not the live CI console.

<!-- NEXT_JS_LLM_PR -->