### PR TITLE
[not for merge] Run CI on Node 24

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,7 +18,7 @@ concurrency:
 # reusable workflows.
 env:
   NODE_MAINTENANCE_VERSION: 20
-  NODE_LTS_VERSION: 22
+  NODE_LTS_VERSION: 24
 
 jobs:
   optimize-ci:
@@ -485,7 +485,7 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
-      nodeVersion: 20.9.0
+      nodeVersion: 24
       afterBuild: |
         export IS_TURBOPACK_TEST=1
         export TURBOPACK_BUILD=1
@@ -525,7 +525,7 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
-      nodeVersion: 20.19.x
+      nodeVersion: 24
       afterBuild: |
         export NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/rspack-dev-tests-manifest.json"
         export NEXT_TEST_MODE=dev
@@ -574,7 +574,7 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
-      nodeVersion: 20.19.x
+      nodeVersion: 24
       afterBuild: |
         export NEXT_EXTERNAL_TESTS_FILTERS="$(pwd)/test/rspack-build-tests-manifest.json"
         export NEXT_TEST_MODE=start
@@ -652,7 +652,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22] # TODO: use env var like [env.NODE_MAINTENANCE_VERSION, env.NODE_LTS_VERSION]
+        node: [24]
 
     permissions:
       contents: read
@@ -675,10 +675,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Playwright hangs on Node 24.16+, we can remove this exact node version
-        # pin once we update to playwright 1.60.0 or newer.
-        # https://github.com/microsoft/playwright/issues/40724
-        node: [22, '24.15.0']
+        node: [24]
 
     permissions:
       contents: read
@@ -686,6 +683,8 @@ jobs:
     uses: ./.github/workflows/build_reusable.yml
     with:
       nodeVersion: ${{ matrix.node }}
+
+      # .test.ts/.test.mts tests
       afterBuild: |
         export __NEXT_NODE_NATIVE_TS_LOADER_ENABLED=true
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
@@ -703,9 +702,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Playwright hangs on Node 24.16+, we can remove this exact node version
-        # pin once we update to playwright 1.60.0 or newer.
-        node: [22, '24.15.0']
+        node: [24]
 
     permissions:
       contents: read
@@ -729,7 +726,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22] # TODO: use env var like [env.NODE_MAINTENANCE_VERSION, env.NODE_LTS_VERSION]
+        node: [24]
 
     permissions:
       contents: read
@@ -981,7 +978,7 @@ jobs:
       id-token: write
     uses: ./.github/workflows/build_reusable.yml
     with:
-      nodeVersion: 20.9.0
+      nodeVersion: 24
       afterBuild: |
         export NEXT_TEST_MODE=start
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -110,7 +110,7 @@ env:
   NAPI_CLI_VERSION: 3.4.1
   TURBO_VERSION: 2.9.4
   TURBO_ARGS: '-v --env-mode loose --remote-cache-timeout 300 --log-order stream'
-  NODE_LTS_VERSION: 20.9.0
+  NODE_LTS_VERSION: 24
   # run-tests.js reads `TEST_CONCURRENCY` if no explicit `--concurrency` or `-c`
   # argument is provided
   TEST_CONCURRENCY: 8


### PR DESCRIPTION
Stacked on top of #98179 to run the same `--trace-deprecation` experiment on Node 24.

This changes the build-and-test workflow so every job runs on Node 24 instead of the current mix of 20 and 22. The default `NODE_LTS_VERSION` in `build_reusable.yml` moves from 20.9.0 to 24, which covers every job without an explicit `nodeVersion` input. The explicit pins for the Turbopack production, rspack, and Windows integration jobs move from 20.9.0/20.19.x to 24, and the unit and next-config-ts matrices collapse to `[24]` so each suite runs once on the new version. The stale Playwright pin comments are removed since the repo already ships playwright 1.61.0, satisfying the `>= 1.60.0` condition they documented. `validate-docs-links` keeps Node 20 because it does not execute Next.js code.

The goal is to surface Node.js deprecation warnings that only fire on newer Node versions, so the traces collected in CI reflect the runtime we are moving toward.

<!-- NEXT_JS_LLM_PR -->