### PR TITLE
[16.3.x] next/image: reject empty image on read/write to disk cache

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1466,5 +1466,7 @@
   "1465": "\\`experimental.useCache\\` cannot be disabled when \\`cacheComponents\\` is enabled, because Cache Components relies on the \\`\"use cache\"\\` directive. Please remove it from %s.",
   "1466": "TypeScript %s does not provide the compiler API required by Next.js. Set %s to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
   "1467": "TypeScript %s does not provide the compiler API required by Next.js. Set %s back to true in your Next.js config to use the TypeScript CLI, or install TypeScript 6 instead.",
-  "1468": "Invalid file path: %s"
+  "1468": "Invalid file path: %s",
+  "1469": "Invariant: image cache entry \"%s\" is empty",
+  "1470": "Invariant: cannot write an empty buffer to the image cache"
 }

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -188,6 +188,12 @@ async function writeToCacheDir(
   etag: string,
   upstreamEtag: string
 ) {
+  if (buffer.byteLength === 0) {
+    throw new Error(
+      'Invariant: cannot write an empty buffer to the image cache'
+    )
+  }
+
   const dir = join(/* turbopackIgnore: true */ cacheDir, cacheKey)
   const filename = join(
     /* turbopackIgnore: true */
@@ -216,6 +222,9 @@ async function readFromCacheDir(cacheDir: string, cacheKey: string) {
   )
   const filePath = join(/* turbopackIgnore: true */ dir, file)
   const buffer = await promises.readFile(/* turbopackIgnore: true */ filePath)
+  if (buffer.byteLength === 0) {
+    throw new Error(`Invariant: image cache entry "${cacheKey}" is empty`)
+  }
   const expireAt = Number(expireAtSt)
   const maxAge = Number(maxAgeSt)
   return { maxAge, expireAt, etag, upstreamEtag, buffer, extension }


### PR DESCRIPTION
Backports https://github.com/vercel/next.js/pull/97278 to 16.3