### PR TITLE
fix: compareRouterStates for array queries and formatUrl hash encoding

### DIFF
--- a/packages/next/src/shared/lib/router/utils/compare-states.ts
+++ b/packages/next/src/shared/lib/router/utils/compare-states.ts
@@ -1,5 +1,16 @@
 import type { default as Router } from '../router'
 
+function queryValuesEqual(
+  a: string | string[] | undefined,
+  b: string | string[] | undefined
+): boolean {
+  if (a === b) return true
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((v, i) => v === b[i])
+  }
+  return false
+}
+
 export function compareRouterStates(a: Router['state'], b: Router['state']) {
   const stateKeys = Object.keys(a)
   if (stateKeys.length !== Object.keys(b).length) return false
@@ -15,7 +26,7 @@ export function compareRouterStates(a: Router['state'], b: Router['state']) {
         const queryKey = queryKeys[j]
         if (
           !b.query.hasOwnProperty(queryKey) ||
-          a.query[queryKey] !== b.query[queryKey]
+          !queryValuesEqual(a.query[queryKey], b.query[queryKey])
         ) {
           return false
         }

--- a/packages/next/src/shared/lib/router/utils/format-url.ts
+++ b/packages/next/src/shared/lib/router/utils/format-url.ts
@@ -67,7 +67,7 @@ export function formatUrl(urlObj: UrlObject) {
   if (search && search[0] !== '?') search = '?' + search
 
   pathname = pathname.replace(/[?#]/g, encodeURIComponent)
-  search = search.replace('#', '%23')
+  search = search.replace(/#/g, '%23')
 
   return `${protocol}${host}${pathname}${search}${hash}`
 }


### PR DESCRIPTION
Two fixes in router utilities:

## 1. `compareRouterStates` always returns false for array-valued query params

`compare-states.ts` line 18 uses strict inequality (`!==`) to compare query values. `ParsedUrlQuery` values can be `string | string[] | undefined`. When query parameters are repeated (e.g. `?tag=react&tag=next`), the value is a `string[]`. Two distinct arrays with identical contents are never `===` in JavaScript, so the comparison always reports a difference.

**Impact:** During hydration (`isQueryUpdating` is true), the router checks whether state changed. Since `compareRouterStates` falsely reports a difference, the "skip update" optimization is never taken, causing an unnecessary `this.set()` call and re-render on every page with repeated query params.

**Fix:** Added `queryValuesEqual` helper that handles `string | string[] | undefined` with array-aware deep comparison.

## 2. `formatUrl` only encodes the first `#` in search string

`format-url.ts` line 70 uses `String.prototype.replace` with a string first argument (`'#'`), which replaces only the first occurrence. Line 69 already correctly uses a regex with the global flag for pathname encoding.

**Impact:** Multiple hex color codes in query params (e.g. `?color=#FF0000&bg=#00FF00`) silently lose data -- the second unencoded `#` becomes a hash fragment delimiter, dropping the `bg` parameter value.

**Fix:** Changed `search.replace('#', '%23')` to `search.replace(/#/g, '%23')`.