### PR TITLE
docs: clarify ISR with Suspense params

### DIFF
--- a/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
@@ -19,11 +19,14 @@ During build, Partial Prerendering splits each render into two parts:
 
 For a visit to a URL whose params were included in `generateStaticParams`, Next.js serves the fully prerendered page from the cache. For a visit to a URL whose params weren't, Next.js serves the App Shell instantly, then upgrades it in the background with the now-known params. Subsequent visits to that URL get the upgraded result from the cache, skipping the App Shell entirely.
 
-If you have used [ISR](/docs/app/guides/incremental-static-regeneration) or [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) in the Pages Router, this is the Cache Components equivalent.
+If you have used [ISR](/docs/app/guides/incremental-static-regeneration) or [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) in the Pages Router, combining Cache Components with Partial Prefetching provides the equivalent behavior.
 
-Enable both [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) and [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching). Cache Components produces the App Shell, while Partial Prefetching upgrades it to a full route once the params are known.
+Enable both [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) and [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching). Cache Components prerenders a static shell that can contain fallback UI. Partial Prefetching lets Next.js serve that fallback for an unlisted path, then render the route with the known params and store the result in the ISR cache.
 
-> **Good to know:** If you await `params` inside a `<Suspense>` boundary, Partial Prefetching is required for unlisted paths to use ISR. The boundary lets Next.js serve the App Shell as a fallback, and Partial Prefetching upgrades the route for subsequent requests. Without Partial Prefetching, Next.js can still cache data used by the route, but it renders the URL-specific content on each request.
+> **Good to know:** How you access `params` depends on whether Partial Prefetching is enabled:
+>
+> - With Partial Prefetching, you can await `params` inside `<Suspense>`. Next.js serves the fallback while it renders and stores the completed route.
+> - Without Partial Prefetching, await `params` outside any `<Suspense>` boundary, including one created by [`loading.tsx`](/docs/app/api-reference/file-conventions/loading). The request waits for the completed route, which Next.js can then store in the ISR cache. If you await `params` inside a boundary, Next.js keeps serving the shared fallback instead of creating a URL-specific ISR entry.
 
 ```ts filename="next.config.ts" highlight={4-5}
 import type { NextConfig } from 'next'
@@ -213,7 +216,7 @@ Instead, use [`generateStaticParams`](/docs/app/api-reference/functions/generate
 
 If you are migrating from the Pages Router:
 
-- `fallback: true` in `getStaticPaths` is now the default behavior with `cacheComponents`. Visitors get a `<Suspense>` fallback instantly and content streams in.
+- `fallback: true` in `getStaticPaths` maps to Cache Components with Partial Prefetching. Visitors get a `<Suspense>` fallback instantly and content streams in.
 - `router.isFallback` is not needed. The prerendering step generates a static shell, and you can grow it further with `'use cache'`.
 - `getStaticProps` with `revalidate` maps to `'use cache'` with [`cacheLife`](/docs/app/api-reference/functions/cacheLife).
 - `getStaticPaths` maps to [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params).

--- a/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
@@ -23,6 +23,8 @@ If you have used [ISR](/docs/app/guides/incremental-static-regeneration) or [`fa
 
 Enable both [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) and [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching). Cache Components produces the App Shell, while Partial Prefetching upgrades it to a full route once the params are known.
 
+> **Good to know:** If you await `params` inside a `<Suspense>` boundary, Partial Prefetching is required for unlisted paths to use ISR. The boundary lets Next.js serve the App Shell as a fallback, and Partial Prefetching upgrades the route for subsequent requests. Without Partial Prefetching, Next.js can still cache data used by the route, but it renders the URL-specific content on each request.
+
 ```ts filename="next.config.ts" highlight={4-5}
 import type { NextConfig } from 'next'
 

--- a/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
@@ -19,14 +19,15 @@ During build, Partial Prerendering splits each render into two parts:
 
 For a visit to a URL whose params were included in `generateStaticParams`, Next.js serves the fully prerendered page from the cache. For a visit to a URL whose params weren't, Next.js serves the App Shell instantly, then upgrades it in the background with the now-known params. Subsequent visits to that URL get the upgraded result from the cache, skipping the App Shell entirely.
 
-If you have used [ISR](/docs/app/guides/incremental-static-regeneration) or [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) in the Pages Router, combining Cache Components with Partial Prefetching provides the equivalent behavior.
+This fallback-first behavior is the Cache Components equivalent of [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) in the Pages Router.
 
 Enable both [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) and [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching). Cache Components prerenders a static shell that can contain fallback UI. Partial Prefetching lets Next.js serve that fallback for an unlisted path, then render the route with the known params and store the result in the ISR cache.
 
 > **Good to know:** How you access `params` depends on whether Partial Prefetching is enabled:
 >
 > - With Partial Prefetching, you can await `params` inside `<Suspense>`. Next.js serves the fallback while it renders and stores the completed route.
-> - Without Partial Prefetching, await `params` outside any `<Suspense>` boundary, including one created by [`loading.tsx`](/docs/app/api-reference/file-conventions/loading). The request waits for the completed route, which Next.js can then store in the ISR cache. If you await `params` inside a boundary, Next.js keeps serving the shared fallback instead of creating a URL-specific ISR entry.
+> - Without Partial Prefetching, ISR still works, but the first request for an unlisted path must wait for the completed route. Await `params` outside any `<Suspense>` boundary, including one created by [`loading.tsx`](/docs/app/api-reference/file-conventions/loading), so Next.js can store the result in the ISR cache.
+> - If you await `params` inside `<Suspense>` without Partial Prefetching, Next.js keeps serving the shared fallback instead of creating a URL-specific ISR entry. Data used by the route can still be cached independently.
 
 ```ts filename="next.config.ts" highlight={4-5}
 import type { NextConfig } from 'next'
@@ -216,7 +217,8 @@ Instead, use [`generateStaticParams`](/docs/app/api-reference/functions/generate
 
 If you are migrating from the Pages Router:
 
-- `fallback: true` in `getStaticPaths` maps to Cache Components with Partial Prefetching. Visitors get a `<Suspense>` fallback instantly and content streams in.
+- `fallback: true` in `getStaticPaths` maps to Cache Components with Partial Prefetching. Visitors get a `<Suspense>` fallback instantly, and Next.js stores the completed route for subsequent visits.
+- [`fallback: 'blocking'`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-blocking) maps to Cache Components without Partial Prefetching. Await `params` outside `<Suspense>` so the first request waits for the completed route, which Next.js then stores for subsequent visits.
 - `router.isFallback` is not needed. The prerendering step generates a static shell, and you can grow it further with `'use cache'`.
 - `getStaticProps` with `revalidate` maps to `'use cache'` with [`cacheLife`](/docs/app/api-reference/functions/cacheLife).
 - `getStaticPaths` maps to [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params).

--- a/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
@@ -21,12 +21,16 @@ For a visit to a URL whose params were included in `generateStaticParams`, Next.
 
 If you have used [ISR](/docs/app/guides/incremental-static-regeneration) or [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) in the Pages Router, this is the Cache Components equivalent.
 
-Enable both [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) and [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching). Cache Components prerenders a static shell that can contain fallback UI. Partial Prefetching lets Next.js serve that fallback for an unlisted path, then render the route with the known params and store the result in the ISR cache.
+Enable both [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) and [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching).
 
-> **Good to know:** To create URL-specific ISR entries for paths not returned by `generateStaticParams`:
->
-> - With Partial Prefetching, you can await `params` inside `<Suspense>`. Next.js serves the fallback while it renders and stores the completed route.
-> - Without Partial Prefetching, ISR still works, but the first request for an unlisted path must wait for the completed route. Await `params` outside any `<Suspense>` boundary, including one created by [`loading.tsx`](/docs/app/api-reference/file-conventions/loading), so Next.js can store the result in the ISR cache. If you await `params` inside `<Suspense>` instead, Next.js keeps serving the shared fallback rather than creating a URL-specific ISR entry. Data used by the route can still be cached independently.
+Cache Components prerenders a static shell that can include fallback UI. For paths not returned by `generateStaticParams`, Next.js can render the path on demand and store the completed result in the ISR cache.
+
+Partial Prefetching determines whether the fallback is served before the URL-specific render completes:
+
+- **With Partial Prefetching:** You can await `params` inside `<Suspense>`. Next.js can immediately serve the fallback for an unlisted path, render the URL-specific content, and store the completed result in the ISR cache.
+- **Without Partial Prefetching:** The first request for an unlisted path must wait for the URL-specific render to complete. Await `params` outside any `<Suspense>` boundary, including one created by [`loading.tsx`](/docs/app/api-reference/file-conventions/loading), so Next.js creates an ISR entry for that URL.
+
+> **Good to know:** Without Partial Prefetching, awaiting `params` inside `<Suspense>` causes Next.js to keep serving the shared fallback instead of creating a URL-specific ISR entry. Data fetched by the route can still be cached independently.
 
 ```ts filename="next.config.ts" highlight={4-5}
 import type { NextConfig } from 'next'

--- a/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
@@ -23,11 +23,10 @@ This fallback-first behavior is the Cache Components equivalent of [`fallback: t
 
 Enable both [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) and [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching). Cache Components prerenders a static shell that can contain fallback UI. Partial Prefetching lets Next.js serve that fallback for an unlisted path, then render the route with the known params and store the result in the ISR cache.
 
-> **Good to know:** How you access `params` depends on whether Partial Prefetching is enabled:
+> **Good to know:** To create URL-specific ISR entries for paths not returned by `generateStaticParams`:
 >
 > - With Partial Prefetching, you can await `params` inside `<Suspense>`. Next.js serves the fallback while it renders and stores the completed route.
-> - Without Partial Prefetching, ISR still works, but the first request for an unlisted path must wait for the completed route. Await `params` outside any `<Suspense>` boundary, including one created by [`loading.tsx`](/docs/app/api-reference/file-conventions/loading), so Next.js can store the result in the ISR cache.
-> - If you await `params` inside `<Suspense>` without Partial Prefetching, Next.js keeps serving the shared fallback instead of creating a URL-specific ISR entry. Data used by the route can still be cached independently.
+> - Without Partial Prefetching, ISR still works, but the first request for an unlisted path must wait for the completed route. Await `params` outside any `<Suspense>` boundary, including one created by [`loading.tsx`](/docs/app/api-reference/file-conventions/loading), so Next.js can store the result in the ISR cache. If you await `params` inside `<Suspense>` instead, Next.js keeps serving the shared fallback rather than creating a URL-specific ISR entry. Data used by the route can still be cached independently.
 
 ```ts filename="next.config.ts" highlight={4-5}
 import type { NextConfig } from 'next'

--- a/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
+++ b/docs/01-app/02-guides/incremental-static-regeneration-cache-components.mdx
@@ -19,7 +19,7 @@ During build, Partial Prerendering splits each render into two parts:
 
 For a visit to a URL whose params were included in `generateStaticParams`, Next.js serves the fully prerendered page from the cache. For a visit to a URL whose params weren't, Next.js serves the App Shell instantly, then upgrades it in the background with the now-known params. Subsequent visits to that URL get the upgraded result from the cache, skipping the App Shell entirely.
 
-This fallback-first behavior is the Cache Components equivalent of [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) in the Pages Router.
+If you have used [ISR](/docs/app/guides/incremental-static-regeneration) or [`fallback: true`](https://nextjs.org/docs/pages/api-reference/functions/get-static-paths#fallback-true) in the Pages Router, this is the Cache Components equivalent.
 
 Enable both [`cacheComponents`](/docs/app/api-reference/config/next-config-js/cacheComponents) and [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching). Cache Components prerenders a static shell that can contain fallback UI. Partial Prefetching lets Next.js serve that fallback for an unlisted path, then render the route with the known params and store the result in the ISR cache.
 

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -603,6 +603,8 @@ export async function generateStaticParams() {
 
 Paths you don't return are still served. Next.js prerenders a static shell for the unknown params and streams the rest at request time. See [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) for the full prerender-a-subset workflow.
 
+> **Good to know:** If you await `params` inside a `<Suspense>` boundary without [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), unlisted paths do not use ISR. Learn more in [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components).
+
 ### `dynamicParams` is not supported
 
 **Delete the export.** With Cache Components enabled, exporting `dynamicParams` fails the build with this error message:

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -603,7 +603,7 @@ export async function generateStaticParams() {
 
 Paths you don't return are still served. Next.js prerenders a static shell for the unknown params and streams the rest at request time. See [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) for the full prerender-a-subset workflow.
 
-> **Good to know:** If you await `params` inside a `<Suspense>` boundary without [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), unlisted paths do not use ISR. Learn more in [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components).
+> **Good to know:** With Cache Components, awaiting `params` inside `<Suspense>` can unintentionally disable ISR for unlisted paths. To use ISR for these paths, either await `params` outside `<Suspense>` or enable [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching). Partial Prefetching lets Next.js serve the fallback and upgrade it to a full route. Learn more in [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components).
 
 ### `dynamicParams` is not supported
 

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -601,7 +601,14 @@ export async function generateStaticParams() {
 }
 ```
 
-Paths you don't return are still served. Next.js prerenders a static shell for the unknown params and streams the rest at request time. See [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) for the full prerender-a-subset workflow.
+Paths you don't return are still served at request time.
+
+### Preserve ISR for unlisted paths
+
+- Without Partial Prefetching, don't await `params` inside `<Suspense>`. Await it outside the boundary so the first request renders the complete route and stores it in the ISR cache.
+- To serve fallback UI while an unlisted path renders, enable [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching) and await `params` inside `<Suspense>`.
+
+See [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) for the complete behavior.
 
 ### `dynamicParams` is not supported
 
@@ -611,67 +618,9 @@ Paths you don't return are still served. Next.js prerenders a static shell for t
 
 Params not returned by `generateStaticParams` are rendered on request. If you used `dynamicParams: false` to reject them, call [`notFound()`](/docs/app/api-reference/functions/not-found) in the page when the param doesn't resolve to real data.
 
-### Await `params` inside `<Suspense>`
+### Wrap client route hooks in `<Suspense>`
 
-To produce the static shell, pass the `params` promise into a [`<Suspense>`](/docs/app/api-reference/file-conventions/loading) boundary instead of awaiting it at the top of the component, so unknown params can still prerender.
-
-```tsx filename="app/blog/[slug]/page.tsx" switcher
-// Before - awaiting params at the top blocks the shell
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ slug: string }>
-}) {
-  const { slug } = await params
-  return <Post slug={slug} />
-}
-```
-
-```jsx filename="app/blog/[slug]/page.js" switcher
-// Before - awaiting params at the top blocks the shell
-export default async function Page({ params }) {
-  const { slug } = await params
-  return <Post slug={slug} />
-}
-```
-
-```tsx filename="app/blog/[slug]/page.tsx" switcher
-import { Suspense } from 'react'
-
-// After - await inside Suspense so the shell can prerender
-export default function Page({ params }: PageProps<'/blog/[slug]'>) {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <Post params={params} />
-    </Suspense>
-  )
-}
-
-async function Post({ params }: Pick<PageProps<'/blog/[slug]'>, 'params'>) {
-  const { slug } = await params
-  // ...
-}
-```
-
-```jsx filename="app/blog/[slug]/page.js" switcher
-import { Suspense } from 'react'
-
-// After - await inside Suspense so the shell can prerender
-export default function Page({ params }) {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <Post params={params} />
-    </Suspense>
-  )
-}
-
-async function Post({ params }) {
-  const { slug } = await params
-  // ...
-}
-```
-
-The same applies to client hooks that read the route. When the route's pathname is fully known, they resolve during prerendering and need no boundary. When it depends on dynamic params not yet known, they suspend, wherever the component sits. A nav or breadcrumb in a shared layout, for instance, suspends while Next.js generates the static shell for any route below it that has dynamic params. Wrap the component that reads the hook in `<Suspense>` (push the read down to the smallest leaf so the rest stays prerendered), or the build fails:
+When the route's pathname is fully known, client hooks that read the route resolve during prerendering and need no boundary. When the pathname depends on dynamic params not yet known, the hooks suspend wherever the component sits. A nav or breadcrumb in a shared layout, for instance, suspends while Next.js generates the static shell for any route below it that has dynamic params. Wrap the component that reads the hook in `<Suspense>` (push the read down to the smallest leaf so the rest stays prerendered), or the build fails:
 
 - [`usePathname`](/docs/app/api-reference/functions/use-pathname)
 - [`useParams`](/docs/app/api-reference/functions/use-params)

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -603,7 +603,7 @@ export async function generateStaticParams() {
 
 Paths you don't return are still served. Next.js prerenders a static shell for the unknown params and streams the rest at request time. See [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) for the full prerender-a-subset workflow.
 
-> **Good to know:** With Cache Components, awaiting `params` inside `<Suspense>` can unintentionally disable ISR for unlisted paths. To use ISR for these paths, either await `params` outside `<Suspense>` or enable [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching). Partial Prefetching lets Next.js serve the fallback and upgrade it to a full route. Learn more in [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components).
+> **Good to know:** Without [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), awaiting `params` inside `<Suspense>` prevents unlisted paths from creating URL-specific ISR entries. Next.js can keep serving the shared fallback, while data used by the route remains cached independently. To create an ISR entry, await `params` outside `<Suspense>` so the first request waits for the completed route. Alternatively, enable Partial Prefetching to serve the fallback immediately and upgrade it to a full route. Learn more in [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components).
 
 ### `dynamicParams` is not supported
 
@@ -613,12 +613,15 @@ Paths you don't return are still served. Next.js prerenders a static shell for t
 
 Params not returned by `generateStaticParams` are rendered on request. If you used `dynamicParams: false` to reject them, call [`notFound()`](/docs/app/api-reference/functions/not-found) in the page when the param doesn't resolve to real data.
 
-### Await `params` inside `<Suspense>`
+### Choose where to await `params`
 
-To produce the static shell, pass the `params` promise into a [`<Suspense>`](/docs/app/api-reference/file-conventions/loading) boundary instead of awaiting it at the top of the component, so unknown params can still prerender.
+Where you await `params` determines how unlisted paths behave:
+
+- With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), pass the `params` promise into a [`<Suspense>`](/docs/app/api-reference/file-conventions/loading) boundary. Unknown params can produce a shared fallback, and Next.js upgrades the result into a URL-specific ISR entry.
+- Without Partial Prefetching, await `params` outside `<Suspense>`. The first request for an unlisted path blocks until the route finishes rendering, then Next.js stores the result in the ISR cache.
 
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
-// Before - awaiting params at the top blocks the shell
+// Without Partial Prefetching - block before rendering the shell
 export default async function Page({
   params,
 }: {
@@ -630,7 +633,7 @@ export default async function Page({
 ```
 
 ```jsx filename="app/blog/[slug]/page.js" switcher
-// Before - awaiting params at the top blocks the shell
+// Without Partial Prefetching - block before rendering the shell
 export default async function Page({ params }) {
   const { slug } = await params
   return <Post slug={slug} />
@@ -640,7 +643,7 @@ export default async function Page({ params }) {
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
 import { Suspense } from 'react'
 
-// After - await inside Suspense so the shell can prerender
+// With Partial Prefetching - await inside Suspense so the shell can prerender
 export default function Page({ params }: PageProps<'/blog/[slug]'>) {
   return (
     <Suspense fallback={<div>Loading...</div>}>
@@ -658,7 +661,7 @@ async function Post({ params }: Pick<PageProps<'/blog/[slug]'>, 'params'>) {
 ```jsx filename="app/blog/[slug]/page.js" switcher
 import { Suspense } from 'react'
 
-// After - await inside Suspense so the shell can prerender
+// With Partial Prefetching - await inside Suspense so the shell can prerender
 export default function Page({ params }) {
   return (
     <Suspense fallback={<div>Loading...</div>}>

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -603,12 +603,7 @@ export async function generateStaticParams() {
 
 Paths you don't return are still served at request time.
 
-### Preserve ISR for unlisted paths
-
-- Without Partial Prefetching, don't await `params` inside `<Suspense>`. Await it outside the boundary so the first request renders the complete route and stores it in the ISR cache.
-- To serve fallback UI while an unlisted path renders, enable [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching) and await `params` inside `<Suspense>`.
-
-See [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) for the complete behavior.
+> **Good to know:** When you use `generateStaticParams` without Partial Prefetching, await `params` outside `<Suspense>` to preserve ISR for unlisted paths. To serve a fallback while an unlisted path renders, enable [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching) and await `params` inside `<Suspense>`. See [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) for details.
 
 ### `dynamicParams` is not supported
 
@@ -618,9 +613,67 @@ See [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration
 
 Params not returned by `generateStaticParams` are rendered on request. If you used `dynamicParams: false` to reject them, call [`notFound()`](/docs/app/api-reference/functions/not-found) in the page when the param doesn't resolve to real data.
 
-### Wrap client route hooks in `<Suspense>`
+### Await `params` inside `<Suspense>`
 
-When the route's pathname is fully known, client hooks that read the route resolve during prerendering and need no boundary. When the pathname depends on dynamic params not yet known, the hooks suspend wherever the component sits. A nav or breadcrumb in a shared layout, for instance, suspends while Next.js generates the static shell for any route below it that has dynamic params. Wrap the component that reads the hook in `<Suspense>` (push the read down to the smallest leaf so the rest stays prerendered), or the build fails:
+For routes that don't use `generateStaticParams`, pass the `params` promise into a [`<Suspense>`](/docs/app/api-reference/file-conventions/loading) boundary instead of awaiting it at the top of the component. This lets Next.js prerender a static shell while the params remain unknown. For routes that use `generateStaticParams`, follow the ISR guidance above.
+
+```tsx filename="app/blog/[slug]/page.tsx" switcher
+// Before - awaiting params at the top blocks the shell
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <Post slug={slug} />
+}
+```
+
+```jsx filename="app/blog/[slug]/page.js" switcher
+// Before - awaiting params at the top blocks the shell
+export default async function Page({ params }) {
+  const { slug } = await params
+  return <Post slug={slug} />
+}
+```
+
+```tsx filename="app/blog/[slug]/page.tsx" switcher
+import { Suspense } from 'react'
+
+// After - await inside Suspense so the shell can prerender
+export default function Page({ params }: PageProps<'/blog/[slug]'>) {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Post params={params} />
+    </Suspense>
+  )
+}
+
+async function Post({ params }: Pick<PageProps<'/blog/[slug]'>, 'params'>) {
+  const { slug } = await params
+  // ...
+}
+```
+
+```jsx filename="app/blog/[slug]/page.js" switcher
+import { Suspense } from 'react'
+
+// After - await inside Suspense so the shell can prerender
+export default function Page({ params }) {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Post params={params} />
+    </Suspense>
+  )
+}
+
+async function Post({ params }) {
+  const { slug } = await params
+  // ...
+}
+```
+
+Client hooks that read the route follow the same Suspense pattern. When the route's pathname is fully known, they resolve during prerendering and need no boundary. When the pathname depends on dynamic params not yet known, the hooks suspend wherever the component sits. A nav or breadcrumb in a shared layout, for instance, suspends while Next.js generates the static shell for any route below it that has dynamic params. Wrap the component that reads the hook in `<Suspense>` (push the read down to the smallest leaf so the rest stays prerendered), or the build fails:
 
 - [`usePathname`](/docs/app/api-reference/functions/use-pathname)
 - [`useParams`](/docs/app/api-reference/functions/use-params)

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -569,7 +569,7 @@ Cache Components changes how [dynamic routes](/docs/app/api-reference/file-conve
 
 **Returning an empty array now errors.** Without Cache Components, returning `[]` defers every path to the first runtime visit. With Cache Components, [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) must return at least one param so Next.js can prerender the route and validate it produces a non-empty [static shell](/docs/app/glossary#static-shell). An empty array raises [`empty-generate-static-params`](/docs/messages/empty-generate-static-params).
 
-Keep `generateStaticParams` and return at least one real param. Removing the export opts the route out of ISR, so Next.js renders it on every request, even when it uses `use cache` for data. Read [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) to learn how `generateStaticParams` prerenders dynamic routes and upgrades unlisted paths after their first visit.
+Keep `generateStaticParams` and return at least one real param. Removing the export opts the route out of ISR, so Next.js renders it on every request, even when it uses `use cache` for data. Read [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) to learn how `generateStaticParams` prerenders dynamic routes and how unlisted paths behave.
 
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
 // Before - defer all paths to runtime
@@ -603,8 +603,6 @@ export async function generateStaticParams() {
 
 Paths you don't return are still served. Next.js prerenders a static shell for the unknown params and streams the rest at request time. See [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) for the full prerender-a-subset workflow.
 
-> **Good to know:** Without [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), awaiting `params` inside `<Suspense>` prevents unlisted paths from creating URL-specific ISR entries. Next.js can keep serving the shared fallback, while data used by the route remains cached independently. To create an ISR entry, await `params` outside `<Suspense>` so the first request waits for the completed route. Alternatively, enable Partial Prefetching to serve the fallback immediately and upgrade it to a full route. Learn more in [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components).
-
 ### `dynamicParams` is not supported
 
 **Delete the export.** With Cache Components enabled, exporting `dynamicParams` fails the build with this error message:
@@ -613,15 +611,12 @@ Paths you don't return are still served. Next.js prerenders a static shell for t
 
 Params not returned by `generateStaticParams` are rendered on request. If you used `dynamicParams: false` to reject them, call [`notFound()`](/docs/app/api-reference/functions/not-found) in the page when the param doesn't resolve to real data.
 
-### Choose where to await `params`
+### Await `params` inside `<Suspense>`
 
-Where you await `params` determines how unlisted paths behave:
-
-- With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching), pass the `params` promise into a [`<Suspense>`](/docs/app/api-reference/file-conventions/loading) boundary. Unknown params can produce a shared fallback, and Next.js upgrades the result into a URL-specific ISR entry.
-- Without Partial Prefetching, await `params` outside `<Suspense>`. The first request for an unlisted path blocks until the route finishes rendering, then Next.js stores the result in the ISR cache.
+To produce the static shell, pass the `params` promise into a [`<Suspense>`](/docs/app/api-reference/file-conventions/loading) boundary instead of awaiting it at the top of the component, so unknown params can still prerender.
 
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
-// Without Partial Prefetching - block before rendering the shell
+// Before - awaiting params at the top blocks the shell
 export default async function Page({
   params,
 }: {
@@ -633,7 +628,7 @@ export default async function Page({
 ```
 
 ```jsx filename="app/blog/[slug]/page.js" switcher
-// Without Partial Prefetching - block before rendering the shell
+// Before - awaiting params at the top blocks the shell
 export default async function Page({ params }) {
   const { slug } = await params
   return <Post slug={slug} />
@@ -643,7 +638,7 @@ export default async function Page({ params }) {
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
 import { Suspense } from 'react'
 
-// With Partial Prefetching - await inside Suspense so the shell can prerender
+// After - await inside Suspense so the shell can prerender
 export default function Page({ params }: PageProps<'/blog/[slug]'>) {
   return (
     <Suspense fallback={<div>Loading...</div>}>
@@ -661,7 +656,7 @@ async function Post({ params }: Pick<PageProps<'/blog/[slug]'>, 'params'>) {
 ```jsx filename="app/blog/[slug]/page.js" switcher
 import { Suspense } from 'react'
 
-// With Partial Prefetching - await inside Suspense so the shell can prerender
+// After - await inside Suspense so the shell can prerender
 export default function Page({ params }) {
   return (
     <Suspense fallback={<div>Loading...</div>}>


### PR DESCRIPTION
## Summary

- warn that awaiting params inside Suspense without Partial Prefetching prevents unlisted paths from using ISR
- clarify that route data may still be cached even though the URL-specific route renders on each request
- link the migration warning to the ISR with Cache Components guide

## Why

This follows up on #98209. The migration eval showed that an agent can preserve generateStaticParams but move params beneath Suspense while Partial Prefetching is disabled. That produces a fallback shell, but unlisted paths do not use ISR.

Context: https://github.com/vercel/next.js/discussions/98177#discussioncomment-18252316

## Testing

- git diff --check
- Prettier check for both changed guides
- commit hooks: Prettier and ESLint