### PR TITLE
Fix Turbopack HMR subscription initialization race

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -2558,13 +2558,12 @@ impl Project {
         }
         let version_op = hmr_version_operation(self, chunk_name.clone(), target);
 
-        // INVALIDATION: This is intentionally untracked to avoid invalidating this
-        // function completely. We want to initialize the VersionState with the
-        // first seen version of the session.
-        let initial_version = version_op
-            .read_trait_strongly_consistent()
-            .untracked()
-            .await?;
+        // INVALIDATION: This is intentionally eventual and untracked. The baseline
+        // must remain the first version observed when the subscription starts. A
+        // strongly consistent read can restart after an invalidation and instead
+        // adopt the post-edit version. The following update then appears empty even
+        // though an already-loaded browser still has the pre-edit output.
+        let initial_version = version_op.connect().into_trait_ref().untracked().await?;
         if tracing::enabled!(target: "turbopack_hmr_diagnostics", tracing::Level::INFO) {
             let version_id = TraitRef::cell(initial_version.clone())
                 .id()

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -40,7 +40,7 @@ use tracing::{Instrument, field::Empty};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, Completions, FxIndexMap, NonLocalValue, OperationValue, OperationVc, ReadRef,
-    ResolvedVc, State, TransientInstance, TryFlatJoinIterExt, TryJoinIterExt, Vc,
+    ResolvedVc, State, TraitRef, TransientInstance, TryFlatJoinIterExt, TryJoinIterExt, Vc,
     debug::ValueDebugFormat, fxindexmap, trace::TraceRawVcs,
 };
 use turbo_tasks_env::{EnvMap, ProcessEnv};
@@ -2518,6 +2518,13 @@ impl Project {
 
     /// Get the version state for an HMR session. Initialized with the first seen
     /// version in that session.
+    #[tracing::instrument(
+        target = "turbopack_hmr_diagnostics",
+        level = "info",
+        name = "initialize HMR version state",
+        skip_all,
+        fields(chunk_name = %chunk_name, target = %target),
+    )]
     #[turbo_tasks::function]
     pub async fn hmr_version_state(
         self: ResolvedVc<Self>,
@@ -2549,18 +2556,32 @@ impl Project {
                 Ok(Vc::upcast(NotFoundVersion::new()))
             }
         }
-        let version_op = hmr_version_operation(self, chunk_name, target);
+        let version_op = hmr_version_operation(self, chunk_name.clone(), target);
 
         // INVALIDATION: This is intentionally untracked to avoid invalidating this
         // function completely. We want to initialize the VersionState with the
         // first seen version of the session.
-        let state = VersionState::new(
-            version_op
-                .read_trait_strongly_consistent()
+        let initial_version = version_op
+            .read_trait_strongly_consistent()
+            .untracked()
+            .await?;
+        if tracing::enabled!(target: "turbopack_hmr_diagnostics", tracing::Level::INFO) {
+            let version_id = TraitRef::cell(initial_version.clone())
+                .id()
                 .untracked()
-                .await?,
-        )
-        .await?;
+                .owned()
+                .await?;
+            tracing::info_span!(
+                target: "turbopack_hmr_diagnostics",
+                parent: None,
+                "hmr version baseline",
+                chunk_name = %chunk_name,
+                target = %target,
+                version_id = %version_id,
+            )
+            .in_scope(|| {});
+        }
+        let state = VersionState::new(initial_version).await?;
         Ok(state)
     }
 

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -1804,6 +1804,39 @@ struct HmrUpdateWithIssues {
     effects: Arc<Effects>,
 }
 
+fn trace_hmr_update_boundary(
+    stage: &'static str,
+    resource: &str,
+    target: HmrTarget,
+    update: &Update,
+    issue_count: usize,
+) {
+    if !tracing::enabled!(target: "turbopack_hmr_diagnostics", tracing::Level::INFO) {
+        return;
+    }
+    let (update_kind, instruction_kind) = match update {
+        Update::Missing => ("missing", None),
+        Update::None => ("none", None),
+        Update::Total(_) => ("total", None),
+        Update::Partial(PartialUpdate { instruction, .. }) => (
+            "partial",
+            instruction.get("type").and_then(|value| value.as_str()),
+        ),
+    };
+    tracing::info_span!(
+        target: "turbopack_hmr_diagnostics",
+        parent: None,
+        "hmr update boundary",
+        stage,
+        resource,
+        target = %target,
+        update_kind,
+        instruction_kind = instruction_kind.unwrap_or("none"),
+        issue_count,
+    )
+    .in_scope(|| {});
+}
+
 #[turbo_tasks::function(operation, root)]
 fn project_hmr_update_operation(
     project: ResolvedVc<Project>,
@@ -1815,6 +1848,7 @@ fn project_hmr_update_operation(
 }
 
 #[tracing::instrument(
+    target = "turbopack_hmr_diagnostics",
     level = "info",
     name = "hmr subscription",
     skip_all,
@@ -1828,7 +1862,7 @@ async fn hmr_update_with_issues_operation(
     target: HmrTarget,
 ) -> Result<Vc<HmrUpdateWithIssues>> {
     tracing::info!(chunk_name = %chunk_name, target = %target, "hmr subscription");
-    let update_op = project_hmr_update_operation(project, chunk_name, target, state);
+    let update_op = project_hmr_update_operation(project, chunk_name.clone(), target, state);
     // NOTE: we do not use `strongly_consistent_catch_collectables` here. The JS HMR
     // consumers in `hot-reloader-turbopack.ts` (`subscribeToServerHmr` and
     // `subscribeToClientHmrEvents`) rely on this read *throwing* on build-graph
@@ -1837,6 +1871,7 @@ async fn hmr_update_with_issues_operation(
     let filter = project.issue_filter().await?;
     let issues = get_issues(update_op, &filter).await?;
     let effects = Arc::new(take_effects(update_op).await?);
+    trace_hmr_update_boundary("computed", &chunk_name, target, &update, issues.len());
     Ok(HmrUpdateWithIssues {
         update,
         issues,
@@ -1857,6 +1892,7 @@ fn project_all_hmr_update_operation(
 
 /// Aggregate counterpart to [`hmr_update_with_issues_operation`].
 #[tracing::instrument(
+    target = "turbopack_hmr_diagnostics",
     level = "info",
     name = "aggregate hmr subscription",
     skip_all,
@@ -1879,6 +1915,13 @@ async fn all_hmr_update_with_issues_operation(
     let filter = project.issue_filter().await?;
     let issues = get_issues(update_op, &filter).await?;
     let effects = Arc::new(take_effects(update_op).await?);
+    trace_hmr_update_boundary(
+        "computed",
+        "__next_all_hmr__",
+        target,
+        &update,
+        issues.len(),
+    );
     Ok(HmrUpdateWithIssues {
         update,
         issues,
@@ -1887,7 +1930,7 @@ async fn all_hmr_update_with_issues_operation(
     .cell())
 }
 
-#[tracing::instrument(level = "info", name = "get all HMR events", skip(project, func), fields(target = %target))]
+#[tracing::instrument(target = "turbopack_hmr_diagnostics", level = "info", name = "get all HMR events", skip(project, func), fields(target = %target))]
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn project_all_hmr_events(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
@@ -1926,6 +1969,13 @@ pub fn project_all_hmr_events(
             unmark_top_level_task_may_leak_eventually_consistent_state();
 
             let HmrUpdateWithIssues { update, issues, .. } = &*read;
+            trace_hmr_update_boundary(
+                "subscription-cycle",
+                "__next_all_hmr__",
+                hmr_target,
+                update,
+                issues.len(),
+            );
             match &**update {
                 Update::Missing | Update::None => {}
                 Update::Total(TotalUpdate { to }) => {
@@ -1939,6 +1989,16 @@ pub fn project_all_hmr_events(
         },
         move |ctx| {
             let (update, issues) = ctx.value;
+
+            if let Some(update) = update.as_deref() {
+                trace_hmr_update_boundary(
+                    "napi-mapper",
+                    "__next_all_hmr__",
+                    hmr_target,
+                    update,
+                    issues.len(),
+                );
+            }
 
             let napi_issues = issues
                 .iter()
@@ -1973,7 +2033,7 @@ pub fn project_all_hmr_events(
     )
 }
 
-#[tracing::instrument(level = "info", name = "get HMR events", skip(project, func), fields(target = %target, chunk_name = %chunk_name))]
+#[tracing::instrument(target = "turbopack_hmr_diagnostics", level = "info", name = "get HMR events", skip(project, func), fields(target = %target, chunk_name = %chunk_name))]
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn project_hmr_events(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
@@ -2019,6 +2079,13 @@ pub fn project_hmr_events(
                     // HACK(bgw): Remove this unmark call
                     unmark_top_level_task_may_leak_eventually_consistent_state();
                     let HmrUpdateWithIssues { update, issues, .. } = &*read;
+                    trace_hmr_update_boundary(
+                        "subscription-cycle",
+                        &chunk_name,
+                        hmr_target,
+                        update,
+                        issues.len(),
+                    );
                     match &**update {
                         Update::Missing | Update::None => {}
                         Update::Total(TotalUpdate { to }) => {
@@ -2034,6 +2101,16 @@ pub fn project_hmr_events(
         },
         move |ctx| {
             let (update, issues) = ctx.value;
+
+            if let Some(update) = update.as_deref() {
+                trace_hmr_update_boundary(
+                    "napi-mapper",
+                    &chunk_name,
+                    hmr_target,
+                    update,
+                    issues.len(),
+                );
+            }
 
             let napi_issues = issues
                 .iter()

--- a/crates/next-napi-bindings/src/next_api/utils.rs
+++ b/crates/next-napi-bindings/src/next_api/utils.rs
@@ -446,7 +446,16 @@ pub fn subscribe<T: 'static + Send + Sync, F: Future<Output = Result<T>> + Send,
                     .or_else(|e| ctx.throw_turbopack_internal_result(&e))
                     .await;
 
+                let result_is_ok = result.is_ok();
                 let status = func.call(result, ThreadsafeFunctionCallMode::NonBlocking);
+                tracing::info_span!(
+                    target: "turbopack_hmr_diagnostics",
+                    parent: None,
+                    "napi subscription dispatch",
+                    result_is_ok,
+                    status = ?status,
+                )
+                .in_scope(|| {});
                 if !matches!(status, Status::Ok) {
                     let error = anyhow!("Error calling JS function: {}", status);
                     eprintln!("{error}");

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1050,8 +1050,10 @@ export async function createHotReloaderTurbopack(
     state.subscriptions.set(id, subscription)
     hmrDiagnostic('client-subscription-created', { id })
 
-    // The subscription will always emit once, which is the initial
-    // computation. This is not a change, so swallow it.
+    // The subscription always emits once for its initial computation. Usually
+    // that is issues-only, but an edit can land while the baseline is being
+    // established. In that case the first emission is already a real update
+    // and must be forwarded to the browser.
     try {
       const initial = await subscription.next()
       hmrDiagnostic('client-subscription-initial', {
@@ -1059,6 +1061,23 @@ export async function createHotReloaderTurbopack(
         done: initial.done,
         updateType: initial.value?.type,
       })
+      if (initial.done) {
+        return
+      }
+
+      const initialData = initial.value
+      processIssues(state.clientIssues, key, initialData, false, true)
+      if (initialData.type !== 'issues') {
+        hmrDiagnostic('client-subscription-initial-update', {
+          id,
+          updateType: initialData.type,
+          instructionType:
+            'instruction' in initialData
+              ? (initialData.instruction as { type?: string } | undefined)?.type
+              : undefined,
+        })
+        sendTurbopackMessage(initialData as TurbopackUpdate)
+      }
 
       for await (const data of subscription) {
         hmrDiagnostic('client-subscription-update', {

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -156,6 +156,14 @@ const isTestMode = !!(
   process.env.__NEXT_TEST_MODE ||
   process.env.DEBUG
 )
+const isHmrDiagnosticsEnabled =
+  process.env.NEXT_TURBOPACK_HMR_DIAGNOSTICS === '1'
+
+function hmrDiagnostic(event: string, details: Record<string, unknown> = {}) {
+  if (isHmrDiagnosticsEnabled) {
+    console.log(`[Turbopack HMR diagnostic] ${event}`, details)
+  }
+}
 
 const sessionId = Math.floor(Number.MAX_SAFE_INTEGER * Math.random())
 
@@ -218,25 +226,37 @@ function setupServerHmr(
 ) {
   async function runSubscription() {
     const subscription = project.allHmrEvents(HmrTarget.Server)
+    hmrDiagnostic('server-subscription-created')
 
     // Subscribing immediately emits one event describing the current state.
     // There's no previous state to diff it against, so it never carries anything
     // to apply. Drop it; real updates start with the second event.
-    await subscription.next()
+    const initial = await subscription.next()
+    hmrDiagnostic('server-subscription-initial', {
+      done: initial.done,
+      updateType: initial.value?.type,
+    })
 
     for await (const result of subscription) {
       const update = result as NodeJsHmrUpdate
+      hmrDiagnostic('server-subscription-update', {
+        updateType: update.type,
+        instructionType:
+          update.type === 'partial' ? update.instruction?.type : undefined,
+      })
 
       // A 'restart' from the wire protocol means the update can't be applied
       // incrementally, so we must fully re-evaluate all chunks from disk. This
       // clears the module cache and notifies browsers to refetch RSC.
       const requiresFullReEvaluation = update.type === 'restart'
       if (requiresFullReEvaluation) {
+        hmrDiagnostic('server-update-full-re-evaluation')
         await reEvaluateAllModulesExpensive()
         continue
       }
 
       if (update.type !== 'partial') {
+        hmrDiagnostic('server-update-ignored', { updateType: update.type })
         continue
       }
 
@@ -259,16 +279,23 @@ function setupServerHmr(
       // until the next request.
       const handlers = globalThis.__turbopack_server_hmr_handlers__
       if (!handlers || handlers.size === 0) {
+        hmrDiagnostic('server-update-no-handlers')
         continue
       }
 
       if (typeof __turbopack_server_hmr_apply__ === 'function') {
         try {
           __turbopack_server_hmr_apply__(update)
+          hmrDiagnostic('server-update-applied', {
+            handlerCount: handlers.size,
+          })
           // The validation worker keeps its own copy of the module graph, and
           // applies the same update to it.
           mirrorModuleStateToDevValidationWorker({ type: 'apply', update })
-        } catch {
+        } catch (error) {
+          hmrDiagnostic('server-update-apply-failed', {
+            error: error instanceof Error ? error.message : String(error),
+          })
           // A matching runtime tried the apply and threw. Evict require.cache
           // so the next request loads fresh, then skip onApplied. (A no-match
           // update is a no-op and does not throw.)
@@ -281,9 +308,15 @@ function setupServerHmr(
         // transition or a new endpoint); nothing changed on disk, so don't
         // invalidate manifests or ping browsers to refetch RSC.
         if (updatedChunkPaths.length > 0) {
+          hmrDiagnostic('server-update-notifying', {
+            updatedChunkCount: updatedChunkPaths.length,
+          })
           await onApplied(updatedChunkPaths)
+        } else {
+          hmrDiagnostic('server-update-empty-partial')
         }
       } else {
+        hmrDiagnostic('server-update-runtime-missing')
         await reEvaluateAllModulesExpensive()
       }
     }
@@ -814,6 +847,11 @@ export async function createHotReloaderTurbopack(
         ? createBinaryHmrMessageData(message)
         : JSON.stringify(message)
 
+    hmrDiagnostic('websocket-send', {
+      messageType: message.type,
+      byteLength:
+        typeof data === 'string' ? Buffer.byteLength(data) : data.byteLength,
+    })
     client.send(data)
   }
 
@@ -851,6 +889,7 @@ export async function createHotReloaderTurbopack(
   function sendEnqueuedMessages() {
     if (hasCompilationErrors()) {
       // During compilation errors we want to delay the HMR events until errors are fixed
+      hmrDiagnostic('client-flush-blocked-project-errors')
       return
     }
 
@@ -860,6 +899,7 @@ export async function createHotReloaderTurbopack(
     ]) {
       const state = clientStates.get(client)
       if (!state) {
+        hmrDiagnostic('client-flush-skipped-missing-state')
         continue
       }
 
@@ -869,10 +909,15 @@ export async function createHotReloaderTurbopack(
             .length > 0
         ) {
           // During compilation errors we want to delay the HMR events until errors are fixed
+          hmrDiagnostic('client-flush-blocked-client-errors')
           return
         }
       }
 
+      hmrDiagnostic('client-flush', {
+        messageCount: state.messages.size,
+        turbopackUpdateCount: state.turbopackUpdates.length,
+      })
       for (const message of state.messages.values()) {
         sendToClient(client, message)
       }
@@ -909,6 +954,18 @@ export async function createHotReloaderTurbopack(
     payload.diagnostics = []
     payload.issues = []
     pendingBuilding.flush()
+
+    const diagnosticPayload = payload as TurbopackUpdate & {
+      resource?: { path?: string }
+      instruction?: { type?: string }
+    }
+    hmrDiagnostic('client-update-enqueued', {
+      updateType: payload.type,
+      resource: diagnosticPayload.resource?.path,
+      instructionType: diagnosticPayload.instruction?.type,
+      clientCount:
+        clientsWithoutHtmlRequestId.size + clientsByHtmlRequestId.size,
+    })
 
     for (const client of [
       ...clientsWithoutHtmlRequestId,
@@ -976,29 +1033,54 @@ export async function createHotReloaderTurbopack(
     const key = getEntryKey('assets', 'client', id)
     if (!hasEntrypointForKey(currentEntrypoints, key, assetMapper)) {
       // maybe throw an error / force the client to reload?
+      hmrDiagnostic('client-subscription-rejected-missing-entrypoint', { id })
       return
     }
 
     const state = clientStates.get(client)
     if (!state || state.subscriptions.has(id)) {
+      hmrDiagnostic('client-subscription-rejected', {
+        id,
+        reason: !state ? 'missing-state' : 'already-subscribed',
+      })
       return
     }
 
     const subscription = project!.hmrEvents(id, HmrTarget.Client)
     state.subscriptions.set(id, subscription)
+    hmrDiagnostic('client-subscription-created', { id })
 
     // The subscription will always emit once, which is the initial
     // computation. This is not a change, so swallow it.
     try {
-      await subscription.next()
+      const initial = await subscription.next()
+      hmrDiagnostic('client-subscription-initial', {
+        id,
+        done: initial.done,
+        updateType: initial.value?.type,
+      })
 
       for await (const data of subscription) {
+        hmrDiagnostic('client-subscription-update', {
+          id,
+          updateType: data.type,
+          instructionType:
+            'instruction' in data
+              ? (data.instruction as { type?: string } | undefined)?.type
+              : undefined,
+        })
         processIssues(state.clientIssues, key, data, false, true)
         if (data.type !== 'issues') {
           sendTurbopackMessage(data as TurbopackUpdate)
+        } else {
+          hmrDiagnostic('client-update-issues-only', { id })
         }
       }
     } catch (e) {
+      hmrDiagnostic('client-subscription-error', {
+        id,
+        error: e instanceof Error ? e.message : String(e),
+      })
       // The client might be using an HMR session from a previous server, tell them
       // to fully reload the page to resolve the issue. We can't use
       // `hotReloader.send` since that would force every connected client to

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -27,7 +27,7 @@ use parking_lot::Mutex;
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 use smallvec::{SmallVec, smallvec};
 use tokio::time::{Duration, Instant};
-use tracing::{Span, field::display, trace_span};
+use tracing::{Instrument, Span, field::display, trace_span};
 use turbo_bincode::{TurboBincodeBuffer, new_turbo_bincode_decoder, new_turbo_bincode_encoder};
 use turbo_tasks::{
     CellId, DynTaskInputsStorage, RawVc, RawVcUnpacked, ReadCellOptions, ReadCellTracking,
@@ -1947,6 +1947,23 @@ impl TurboTasksBackend {
             }
         }
 
+        let diagnostic_recomputation = matches!(
+            execution_reason,
+            TaskExecutionReason::Invalidated
+                | TaskExecutionReason::ActivateDirty
+                | TaskExecutionReason::Stale
+        );
+        let diagnostic_reason = execution_reason.as_str();
+        let diagnostic_task_name = (diagnostic_recomputation
+            && tracing::enabled!(
+                target: "turbopack_hmr_diagnostics",
+                tracing::Level::INFO
+            ))
+        .then(|| match &task_type {
+            TaskType::Cached(task_type) => task_type.get_name(),
+            TaskType::Transient(_) => "transient root task",
+        });
+
         let (span, future) = match task_type {
             TaskType::Cached(task_type) => {
                 let CachedTaskType {
@@ -1974,6 +1991,30 @@ impl TurboTasksBackend {
                 (span, future)
             }
         };
+        let future: Pin<Box<dyn Future<Output = Result<RawVc>> + Send + '_>> =
+            if let Some(task_name) = diagnostic_task_name {
+                let diagnostic_span = tracing::info_span!(
+                    target: "turbopack_hmr_diagnostics",
+                    parent: None,
+                    "turbo task recomputation",
+                    task_id = task_id.to_primitive(),
+                    task_name,
+                    reason = diagnostic_reason,
+                    priority = ?priority,
+                    result = tracing::field::Empty,
+                );
+                let result_span = diagnostic_span.clone();
+                Box::pin(
+                    async move {
+                        let result = future.await;
+                        result_span.record("result", if result.is_ok() { "ok" } else { "error" });
+                        result
+                    }
+                    .instrument(diagnostic_span),
+                )
+            } else {
+                future
+            };
         Some(TaskExecutionSpec { future, span })
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -17,6 +17,30 @@ use crate::{
     data::{Dirtyness, InProgressState, InProgressStateInner},
 };
 
+fn trace_task_invalidation_outcome(
+    task_id: TaskId,
+    task_description: Option<&str>,
+    outcome: &'static str,
+    made_stale: bool,
+    had_in_progress: bool,
+    has_activeness: bool,
+) {
+    let Some(task_description) = task_description else {
+        return;
+    };
+    tracing::info_span!(
+        target: "turbopack_hmr_diagnostics",
+        "turbo task invalidation outcome",
+        task_id = task_id.to_primitive(),
+        task_description,
+        outcome,
+        made_stale,
+        had_in_progress,
+        has_activeness,
+    )
+    .in_scope(|| {});
+}
+
 #[derive(Encode, Decode, Clone, Default)]
 #[allow(clippy::large_enum_variant)]
 pub enum InvalidateOperation {
@@ -129,6 +153,13 @@ pub fn make_task_dirty_internal(
         );
     }
 
+    let diagnostic_task_description = tracing::Span::current()
+        .metadata()
+        .is_some_and(|metadata| metadata.name() == "external invalidator dispatch")
+        .then(|| task.get_task_description());
+    let had_in_progress = task.has_in_progress();
+    let mut made_stale = false;
+
     #[cfg(feature = "trace_task_dirty")]
     let task_name = task.get_task_name();
     if make_stale
@@ -145,6 +176,7 @@ pub fn make_task_dirty_internal(
         )
         .entered();
         *stale = true;
+        made_stale = true;
     }
     let current = task.get_dirty();
     let parent_priority = ctx.get_current_task_priority();
@@ -181,6 +213,14 @@ pub fn make_task_dirty_internal(
                     cause,
                 });
             }
+            trace_task_invalidation_outcome(
+                task_id,
+                diagnostic_task_description.as_deref(),
+                "already_dirty",
+                made_stale,
+                had_in_progress,
+                task.has_activeness(),
+            );
             return;
         }
         Some(Dirtyness::SessionDependent) => {
@@ -205,6 +245,14 @@ pub fn make_task_dirty_internal(
                 )
                 .entered();
                 // already dirty
+                trace_task_invalidation_outcome(
+                    task_id,
+                    diagnostic_task_description.as_deref(),
+                    "session_dependent_already_dirty",
+                    made_stale,
+                    had_in_progress,
+                    task.has_activeness(),
+                );
                 return;
             }
         }
@@ -259,14 +307,37 @@ pub fn make_task_dirty_internal(
         ));
     }
 
-    let should_schedule = !ctx.should_track_activeness() || task.has_activeness();
+    let has_activeness = task.has_activeness();
+    let should_schedule = !ctx.should_track_activeness() || has_activeness;
 
     if should_schedule {
         let description = EventDescription::new(|| task.get_task_desc_fn());
-        if task.add_scheduled(TaskExecutionReason::Invalidated, description) {
+        let scheduled = task.add_scheduled(TaskExecutionReason::Invalidated, description);
+        trace_task_invalidation_outcome(
+            task_id,
+            diagnostic_task_description.as_deref(),
+            if scheduled {
+                "scheduled"
+            } else {
+                "already_scheduled_or_in_progress"
+            },
+            made_stale,
+            had_in_progress,
+            has_activeness,
+        );
+        if scheduled {
             drop(task);
             let task = ctx.task(task_id, TaskDataCategory::All);
             ctx.schedule_task(task, parent_priority);
         }
+    } else {
+        trace_task_invalidation_outcome(
+            task_id,
+            diagnostic_task_description.as_deref(),
+            "inactive",
+            made_stale,
+            had_in_progress,
+            has_activeness,
+        );
     }
 }

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -101,6 +101,7 @@ fn trace_raw_event(event: &notify::Event, watcher_backend: WatcherBackend) {
         && matches!(watcher_backend, WatcherBackend::Recommended)
         && rescan;
     let span = tracing::info_span!(
+        target: "turbopack_hmr_diagnostics",
         parent: None,
         "watcher raw event",
         watcher_backend = watcher_backend.as_str(),
@@ -119,6 +120,7 @@ fn trace_raw_event(event: &notify::Event, watcher_backend: WatcherBackend) {
         .enumerate()
     {
         let _path_span = tracing::info_span!(
+            target: "turbopack_hmr_diagnostics",
             "watcher raw event path",
             path_index,
             path = %path.display(),
@@ -131,6 +133,7 @@ fn trace_watcher_error(kind: &notify::ErrorKind, paths: &[PathBuf]) {
     let path_count = paths.len();
     let paths_truncated = path_count.saturating_sub(MAX_DIAGNOSTIC_EVENT_PATHS);
     let span = tracing::info_span!(
+        target: "turbopack_hmr_diagnostics",
         parent: None,
         "watcher error",
         kind = ?kind,
@@ -140,6 +143,7 @@ fn trace_watcher_error(kind: &notify::ErrorKind, paths: &[PathBuf]) {
     let _entered = span.enter();
     for (path_index, path) in paths.iter().take(MAX_DIAGNOSTIC_EVENT_PATHS).enumerate() {
         let _path_span = tracing::info_span!(
+            target: "turbopack_hmr_diagnostics",
             "watcher error path",
             path_index,
             path = %path.display(),
@@ -638,6 +642,7 @@ impl DiskWatcher {
                             let directory_invalidator_path_count =
                                 fs_inner.dir_invalidator_map.lock().unwrap().len();
                             let _rescan_span = tracing::info_span!(
+                                target: "turbopack_hmr_diagnostics",
                                 parent: None,
                                 "watcher rescan",
                                 watcher_backend = watcher_backend.as_str(),
@@ -686,6 +691,7 @@ impl DiskWatcher {
                         // `BATCH_DELAY`.
                         let retained = batch.add_event(event);
                         tracing::info_span!(
+                            target: "turbopack_hmr_diagnostics",
                             parent: None,
                             "watcher event classification",
                             retained,
@@ -766,6 +772,7 @@ impl DiskWatcher {
             );
             for summary in summaries {
                 tracing::info_span!(
+                    target: "turbopack_hmr_diagnostics",
                     parent: None,
                     "watcher invalidator map summary",
                     map = summary.map_kind.as_str(),
@@ -918,6 +925,7 @@ impl BatchedInvalidations {
         let path_count = self.paths.len();
         let paths_truncated = path_count.saturating_sub(MAX_DIAGNOSTIC_BATCH_PATHS);
         let span = tracing::info_span!(
+            target: "turbopack_hmr_diagnostics",
             parent: None,
             "watcher invalidation batch",
             path_count,
@@ -932,6 +940,7 @@ impl BatchedInvalidations {
             .enumerate()
         {
             let _path_span = tracing::info_span!(
+                target: "turbopack_hmr_diagnostics",
                 "watcher batched path",
                 path_index,
                 path = %path.display(),
@@ -1103,6 +1112,7 @@ impl BatchedInvalidations {
                 summary.invalidator_count += invalidator_count;
                 if path_index < MAX_DIAGNOSTIC_BATCH_PATHS {
                     tracing::info_span!(
+                        target: "turbopack_hmr_diagnostics",
                         parent: None,
                         "watcher invalidator lookup",
                         map = summary.map_kind.as_str(),
@@ -1121,13 +1131,6 @@ impl BatchedInvalidations {
     }
 }
 
-#[instrument(
-    parent = None,
-    level = "info",
-    name = "file change",
-    skip_all,
-    fields(name = %invalidation_reason_path.display())
-)]
 fn invalidate(
     inner: &DiskFileSystemInner,
     turbo_tasks: &dyn TurboTasksApi,
@@ -1135,6 +1138,13 @@ fn invalidate(
     invalidation_reason_path: &Path,
     invalidator: Invalidator,
 ) {
+    let _span = tracing::info_span!(
+        target: "turbopack_hmr_diagnostics",
+        parent: None,
+        "file change",
+        name = %invalidation_reason_path.display(),
+    )
+    .entered();
     if report_invalidation_reason
         && let Some(path) =
             format_absolute_fs_path(invalidation_reason_path, &inner.name, inner.root_path())

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -71,6 +71,83 @@ const BATCH_DELAY: Duration = Duration::from_millis(10);
 #[cfg(not(target_os = "linux"))]
 const BATCH_DELAY: Duration = Duration::from_millis(1);
 
+/// Avoid making a single watcher event or invalidation batch arbitrarily large in diagnostic
+/// traces. The total event and batch counts are still recorded when paths are truncated.
+const MAX_DIAGNOSTIC_EVENT_PATHS: usize = 32;
+const MAX_DIAGNOSTIC_BATCH_PATHS: usize = 256;
+
+#[derive(Clone, Copy, Debug)]
+enum WatcherBackend {
+    Recommended,
+    Polling,
+}
+
+impl WatcherBackend {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Recommended => "recommended",
+            Self::Polling => "polling",
+        }
+    }
+}
+
+fn trace_raw_event(event: &notify::Event, watcher_backend: WatcherBackend) {
+    let path_count = event.paths.len();
+    let paths_truncated = path_count.saturating_sub(MAX_DIAGNOSTIC_EVENT_PATHS);
+    let rescan = event.need_rescan();
+    // notify's Linux inotify backend translates IN_Q_OVERFLOW to Flag::Rescan. Keep both fields
+    // so traces distinguish that concrete backend failure from rescan signals on other backends.
+    let inotify_queue_overflow = cfg!(target_os = "linux")
+        && matches!(watcher_backend, WatcherBackend::Recommended)
+        && rescan;
+    let span = tracing::info_span!(
+        parent: None,
+        "watcher raw event",
+        watcher_backend = watcher_backend.as_str(),
+        kind = ?event.kind,
+        flag = ?event.flag(),
+        rescan,
+        inotify_queue_overflow,
+        path_count,
+        paths_truncated,
+    );
+    let _entered = span.enter();
+    for (path_index, path) in event
+        .paths
+        .iter()
+        .take(MAX_DIAGNOSTIC_EVENT_PATHS)
+        .enumerate()
+    {
+        let _path_span = tracing::info_span!(
+            "watcher raw event path",
+            path_index,
+            path = %path.display(),
+        )
+        .entered();
+    }
+}
+
+fn trace_watcher_error(kind: &notify::ErrorKind, paths: &[PathBuf]) {
+    let path_count = paths.len();
+    let paths_truncated = path_count.saturating_sub(MAX_DIAGNOSTIC_EVENT_PATHS);
+    let span = tracing::info_span!(
+        parent: None,
+        "watcher error",
+        kind = ?kind,
+        path_count,
+        paths_truncated,
+    );
+    let _entered = span.enter();
+    for (path_index, path) in paths.iter().take(MAX_DIAGNOSTIC_EVENT_PATHS).enumerate() {
+        let _path_span = tracing::info_span!(
+            "watcher error path",
+            path_index,
+            path = %path.display(),
+        )
+        .entered();
+    }
+}
+
 #[derive(Encode, Decode)]
 pub(crate) struct DiskWatcher {
     #[bincode(skip)]
@@ -403,11 +480,17 @@ impl DiskWatcher {
         // turbo-tasks-fs
         let config = config.with_follow_symlinks(false);
 
-        let mut notify_watcher = if let Some(poll_interval) = poll_interval {
+        let (mut notify_watcher, watcher_backend) = if let Some(poll_interval) = poll_interval {
             let config = config.with_poll_interval(poll_interval);
-            NotifyWatcher::Polling(PollWatcher::new(tx, config)?)
+            (
+                NotifyWatcher::Polling(PollWatcher::new(tx, config)?),
+                WatcherBackend::Polling,
+            )
         } else {
-            NotifyWatcher::Recommended(RecommendedWatcher::new(tx, config)?)
+            (
+                NotifyWatcher::Recommended(RecommendedWatcher::new(tx, config)?),
+                WatcherBackend::Recommended,
+            )
         };
 
         // TOCTOU: we must watch `root_path` before calling any invalidators and setting up the
@@ -454,10 +537,12 @@ impl DiskWatcher {
         }
 
         spawn_thread(move || {
-            fs_inner
-                .clone()
-                .watcher
-                .watch_thread(rx, fs_inner, report_invalidation_reason)
+            fs_inner.clone().watcher.watch_thread(
+                rx,
+                fs_inner,
+                report_invalidation_reason,
+                watcher_backend,
+            )
         });
 
         // Updating `self.state` is done last. If we panic while setting up the watcher, it'll
@@ -497,6 +582,7 @@ impl DiskWatcher {
         rx: Receiver<notify::Result<notify::Event>>,
         fs_inner: Arc<DiskFileSystemInner>,
         report_invalidation_reason: bool,
+        watcher_backend: WatcherBackend,
     ) {
         let mut batch = BatchedInvalidations::new(self.state.recursive_mode());
 
@@ -511,6 +597,7 @@ impl DiskWatcher {
                 };
                 match event_result {
                     Ok(Ok(event)) => {
+                        trace_raw_event(&event, watcher_backend);
                         // TODO: We might benefit from some user-facing diagnostics if it rescans
                         // occur frequently (i.e. more than X times in Y minutes)
                         //
@@ -525,7 +612,45 @@ impl DiskWatcher {
 
                             // flush the whole mpsc queue, we're about to rescan, we don't need to
                             // process any other update events that have already happened
-                            while rx.try_recv().is_ok() {}
+                            let mut drained_message_count = 0usize;
+                            let mut drained_notify_event_count = 0usize;
+                            let mut drained_rescan_event_count = 0usize;
+                            let mut drained_error_count = 0usize;
+                            while let Ok(drained) = rx.try_recv() {
+                                drained_message_count += 1;
+                                match drained {
+                                    Ok(event) => {
+                                        drained_notify_event_count += 1;
+                                        if event.need_rescan() {
+                                            drained_rescan_event_count += 1;
+                                        }
+                                        trace_raw_event(&event, watcher_backend);
+                                    }
+                                    Err(notify::Error { kind, paths }) => {
+                                        drained_error_count += 1;
+                                        trace_watcher_error(&kind, &paths);
+                                    }
+                                }
+                            }
+
+                            let file_invalidator_path_count =
+                                fs_inner.invalidator_map.lock().unwrap().len();
+                            let directory_invalidator_path_count =
+                                fs_inner.dir_invalidator_map.lock().unwrap().len();
+                            let _rescan_span = tracing::info_span!(
+                                parent: None,
+                                "watcher rescan",
+                                watcher_backend = watcher_backend.as_str(),
+                                inotify_queue_overflow = cfg!(target_os = "linux")
+                                    && matches!(watcher_backend, WatcherBackend::Recommended),
+                                drained_message_count,
+                                drained_notify_event_count,
+                                drained_rescan_event_count,
+                                drained_error_count,
+                                file_invalidator_path_count,
+                                directory_invalidator_path_count,
+                            )
+                            .entered();
 
                             if let State::NonRecursive(non_recursive) = &self.state {
                                 // we can't narrow this down to a smaller set of paths: Rescan
@@ -559,13 +684,23 @@ impl DiskWatcher {
 
                         // Only an event that contributes to the batch keeps it open for another
                         // `BATCH_DELAY`.
-                        if batch.add_event(event) {
+                        let retained = batch.add_event(event);
+                        tracing::info_span!(
+                            parent: None,
+                            "watcher event classification",
+                            retained,
+                            batched_path_count = batch.paths.len(),
+                            batched_new_path_count = batch.new_path_count(),
+                        )
+                        .in_scope(|| {});
+                        if retained {
                             deadline = Some(Instant::now() + BATCH_DELAY);
                         }
                     }
                     // Error raised by notify watcher itself
                     Ok(Err(notify::Error { kind, paths })) => {
                         println!("watch error ({paths:?}): {kind:?} ");
+                        trace_watcher_error(&kind, &paths);
 
                         let flags = InvalidationFlags::PATH_AND_CHILDREN
                             | InvalidationFlags::PATH_AND_CHILDREN_DIR;
@@ -590,6 +725,8 @@ impl DiskWatcher {
                 }
             }
 
+            batch.trace();
+
             // We need to start watching first before invalidating the changed paths...
             // This is only needed on platforms we don't do recursive watching on.
             if let State::NonRecursive(non_recursive) = &self.state {
@@ -613,7 +750,8 @@ impl DiskWatcher {
             let _guard = fs_inner.tokio_handle.enter();
 
             let _lock = fs_inner.invalidation_lock.blocking_write();
-            batch.execute(
+            let lookup_count = batch.paths.len();
+            let summaries = batch.execute(
                 &fs_inner.invalidator_map,
                 &fs_inner.dir_invalidator_map,
                 |invalidation_reason_path, invalidator| {
@@ -626,6 +764,20 @@ impl DiskWatcher {
                     )
                 },
             );
+            for summary in summaries {
+                tracing::info_span!(
+                    parent: None,
+                    "watcher invalidator map summary",
+                    map = summary.map_kind.as_str(),
+                    requested_path_count = summary.requested_path_count,
+                    matched_batched_path_count = summary.matched_batched_path_count,
+                    matched_map_path_count = summary.matched_map_path_count,
+                    invalidator_count = summary.invalidator_count,
+                    lookup_count,
+                    lookups_truncated = lookup_count.saturating_sub(MAX_DIAGNOSTIC_BATCH_PATHS),
+                )
+                .in_scope(|| {});
+            }
         }
     }
 
@@ -661,6 +813,42 @@ bitflags! {
         const PATH_AND_CHILDREN = 1 << 2;
         /// Invalidate this path and all of its children in the directory-listing invalidator map.
         const PATH_AND_CHILDREN_DIR = 1 << 3;
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InvalidatorMapKind {
+    File,
+    Directory,
+}
+
+impl InvalidatorMapKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::File => "file",
+            Self::Directory => "directory",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct InvalidatorMapSummary {
+    map_kind: InvalidatorMapKind,
+    requested_path_count: usize,
+    matched_batched_path_count: usize,
+    matched_map_path_count: usize,
+    invalidator_count: usize,
+}
+
+impl InvalidatorMapSummary {
+    fn new(map_kind: InvalidatorMapKind) -> Self {
+        Self {
+            map_kind,
+            requested_path_count: 0,
+            matched_batched_path_count: 0,
+            matched_map_path_count: 0,
+            invalidator_count: 0,
+        }
     }
 }
 
@@ -720,6 +908,37 @@ impl BatchedInvalidations {
     /// there). Always empty in recursive mode.
     fn new_paths(&self) -> impl Iterator<Item = &Path> {
         self.new_paths.iter().flatten().map(|path| &**path)
+    }
+
+    fn new_path_count(&self) -> usize {
+        self.new_paths.as_ref().map_or(0, FxHashSet::len)
+    }
+
+    fn trace(&self) {
+        let path_count = self.paths.len();
+        let paths_truncated = path_count.saturating_sub(MAX_DIAGNOSTIC_BATCH_PATHS);
+        let span = tracing::info_span!(
+            parent: None,
+            "watcher invalidation batch",
+            path_count,
+            new_path_count = self.new_path_count(),
+            paths_truncated,
+        );
+        let _entered = span.enter();
+        for (path_index, (path, flags)) in self
+            .paths
+            .iter()
+            .take(MAX_DIAGNOSTIC_BATCH_PATHS)
+            .enumerate()
+        {
+            let _path_span = tracing::info_span!(
+                "watcher batched path",
+                path_index,
+                path = %path.display(),
+                flags = ?flags,
+            )
+            .entered();
+        }
     }
 
     /// Updates the batch to contain updated paths from the given event. Does not perform any
@@ -827,37 +1046,78 @@ impl BatchedInvalidations {
         invalidator_map: &InvalidatorMap,
         dir_invalidator_map: &InvalidatorMap,
         invalidate: impl Fn(&Path, Invalidator),
-    ) {
-        for (map, exact_flag, recursive_flag) in [
+    ) -> [InvalidatorMapSummary; 2] {
+        let mut summaries = [
+            InvalidatorMapSummary::new(InvalidatorMapKind::File),
+            InvalidatorMapSummary::new(InvalidatorMapKind::Directory),
+        ];
+        let [file_summary, directory_summary] = &mut summaries;
+        for (summary, map, exact_flag, recursive_flag) in [
             (
+                file_summary,
                 invalidator_map,
                 InvalidationFlags::PATH,
                 InvalidationFlags::PATH_AND_CHILDREN,
             ),
             (
+                directory_summary,
                 dir_invalidator_map,
                 InvalidationFlags::PATH_DIR,
                 InvalidationFlags::PATH_AND_CHILDREN_DIR,
             ),
         ] {
             let mut map = map.lock().unwrap();
-            for (path, flags) in &self.paths {
-                if flags.contains(recursive_flag) {
+            for (path_index, (path, flags)) in self.paths.iter().enumerate() {
+                let mut matched_path_count = 0usize;
+                let mut invalidator_count = 0usize;
+                let lookup_kind = if flags.contains(recursive_flag) {
+                    summary.requested_path_count += 1;
                     for (_, invalidators) in map.extract_path_with_children(path) {
+                        matched_path_count += 1;
+                        invalidator_count += invalidators.len();
                         for invalidator in invalidators {
                             invalidate(path, invalidator);
                         }
                     }
+                    "recursive"
                 } else if flags.contains(exact_flag)
                     && let Some(invalidators) = map.remove(&**path)
                 {
+                    summary.requested_path_count += 1;
+                    matched_path_count = 1;
+                    invalidator_count = invalidators.len();
                     for invalidator in invalidators {
                         invalidate(path, invalidator);
                     }
+                    "exact"
+                } else if flags.contains(exact_flag) {
+                    summary.requested_path_count += 1;
+                    "exact"
+                } else {
+                    "not-requested"
+                };
+                if matched_path_count > 0 {
+                    summary.matched_batched_path_count += 1;
+                }
+                summary.matched_map_path_count += matched_path_count;
+                summary.invalidator_count += invalidator_count;
+                if path_index < MAX_DIAGNOSTIC_BATCH_PATHS {
+                    tracing::info_span!(
+                        parent: None,
+                        "watcher invalidator lookup",
+                        map = summary.map_kind.as_str(),
+                        path = %path.display(),
+                        flags = ?flags,
+                        lookup = lookup_kind,
+                        matched_path_count,
+                        invalidator_count,
+                    )
+                    .in_scope(|| {});
                 }
             }
         }
         self.clear();
+        summaries
     }
 }
 
@@ -926,5 +1186,79 @@ impl InvalidationReasonKind for InvalidateRescanKind {
                 .unwrap()
                 .path
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use notify::event::{CreateKind, DataChange};
+
+    use super::*;
+
+    #[test]
+    fn retains_modified_path_for_file_invalidation() {
+        let path = PathBuf::from("/project/app/page.tsx");
+        let mut batch = BatchedInvalidations::new(RecursiveMode::NonRecursive);
+
+        let retained = batch.add_event(
+            notify::Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Content)))
+                .add_path(path.clone()),
+        );
+
+        assert!(retained);
+        assert_eq!(
+            batch.paths.get(path.as_path()),
+            Some(&InvalidationFlags::PATH)
+        );
+        assert_eq!(batch.new_paths().count(), 0);
+    }
+
+    #[test]
+    fn retains_create_flags_and_new_path() {
+        let path = PathBuf::from("/project/app/new-page.tsx");
+        let parent = path.parent().unwrap();
+        let mut batch = BatchedInvalidations::new(RecursiveMode::NonRecursive);
+
+        let retained = batch.add_event(
+            notify::Event::new(EventKind::Create(CreateKind::File)).add_path(path.clone()),
+        );
+
+        assert!(retained);
+        assert_eq!(
+            batch.paths.get(path.as_path()),
+            Some(
+                &(InvalidationFlags::PATH_AND_CHILDREN | InvalidationFlags::PATH_AND_CHILDREN_DIR)
+            )
+        );
+        assert_eq!(batch.paths.get(parent), Some(&InvalidationFlags::PATH_DIR));
+        assert_eq!(batch.new_paths().collect::<Vec<_>>(), vec![path.as_path()]);
+    }
+
+    #[test]
+    fn reports_missing_file_invalidator() {
+        let path = PathBuf::from("/project/app/page.tsx");
+        let mut batch = BatchedInvalidations::new(RecursiveMode::NonRecursive);
+        batch.mark(path.clone().into_boxed_path(), InvalidationFlags::PATH);
+        let invalidator_map = InvalidatorMap::new();
+        let dir_invalidator_map = InvalidatorMap::new();
+
+        let summaries = batch.execute(&invalidator_map, &dir_invalidator_map, |_, _| {
+            panic!("empty invalidator maps must not invoke invalidators")
+        });
+
+        assert_eq!(
+            summaries,
+            [
+                InvalidatorMapSummary {
+                    map_kind: InvalidatorMapKind::File,
+                    requested_path_count: 1,
+                    matched_batched_path_count: 0,
+                    matched_map_path_count: 0,
+                    invalidator_count: 0,
+                },
+                InvalidatorMapSummary::new(InvalidatorMapKind::Directory),
+            ]
+        );
+        assert!(batch.paths.is_empty());
     }
 }

--- a/turbopack/crates/turbo-tasks/src/invalidation.rs
+++ b/turbopack/crates/turbo-tasks/src/invalidation.rs
@@ -34,7 +34,17 @@ pub struct Invalidator {
 
 impl Invalidator {
     pub fn invalidate(self, turbo_tasks: &dyn TurboTasksApi) {
-        turbo_tasks.invalidate(self.task);
+        if tracing::enabled!(target: "turbopack_hmr_diagnostics", tracing::Level::INFO) {
+            tracing::info_span!(
+                target: "turbopack_hmr_diagnostics",
+                "external invalidator dispatch",
+                task_id = self.task.to_primitive(),
+                has_reason = false,
+            )
+            .in_scope(|| turbo_tasks.invalidate(self.task));
+        } else {
+            turbo_tasks.invalidate(self.task);
+        }
     }
 
     pub fn invalidate_with_reason<T: InvalidationReason>(
@@ -42,10 +52,18 @@ impl Invalidator {
         turbo_tasks: &dyn TurboTasksApi,
         reason: T,
     ) {
-        turbo_tasks.invalidate_with_reason(
-            self.task,
-            (Arc::new(reason) as Arc<dyn InvalidationReason>).into(),
-        );
+        let reason = (Arc::new(reason) as Arc<dyn InvalidationReason>).into();
+        if tracing::enabled!(target: "turbopack_hmr_diagnostics", tracing::Level::INFO) {
+            tracing::info_span!(
+                target: "turbopack_hmr_diagnostics",
+                "external invalidator dispatch",
+                task_id = self.task.to_primitive(),
+                has_reason = true,
+            )
+            .in_scope(|| turbo_tasks.invalidate_with_reason(self.task, reason));
+        } else {
+            turbo_tasks.invalidate_with_reason(self.task, reason);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fix a Turbopack client HMR subscription race and add bounded diagnostics that prove where an edit travels through the watcher, invalidation, native subscription, and browser-delivery pipeline.

The fix does two things:

- Initialize each client HMR `VersionState` from the first eventually-consistent version observed by that subscription. A strongly consistent read can restart across a concurrent edit and incorrectly adopt the post-edit version as its baseline.
- Treat the subscription's first emission as issues-only only when it actually has type `issues`. If the edit races initialization and the first emission is already a real update, forward it to the browser.

The diagnostics are opt-in under `turbopack_hmr_diagnostics`; they do not add retry writes, polling, or full-reload behavior.

## Root cause

The watcher did not miss the event.

- `run-87e6e09b-3f64-4090-afb3-7da2578aaf9b` failed edit 1 in all three boots. The target file produced two `Modify(Data(Any))` events, was retained in `BatchedInvalidations`, matched one exact file invalidator, and invoked it. There was no rescan or inotify queue overflow.
- `run-2c72798c-62df-48a1-a8ad-6eaf51a59dcc` exposed the downstream race. Both browser subscriptions were sent before the edit. The watcher received and invalidated `templates-header.tsx` at trace time ~4.002 s, but the target client chunk did not establish its baseline until ~4.117 s, after invalidation. That baseline was therefore already the post-edit version. Its initial native update was `None`, the JS layer discarded it as the expected initial emission, and the browser received only `serverComponentChanges`, never a client `turbopack-message`; the pre-edit client module remained installed.

The strongly consistent baseline read was the critical detail: invalidation restarted it and collapsed the pre-edit and post-edit states into the same version. This made a real client change look empty.

## Fix verification

- Hosted regression `run-c95b7976-5341-410a-9411-40ed1fe7cedc` against signed commit `99b5c80367f1225dd2e9d1a023d09115b4c443c0`: 126/126 samples valid, 42/42 metrics valid, and 4/4 correctness checks passed across validation plus three independent measured boots.
- Every retained browser artifact contains a real `turbopack-message` with a `partial ChunkListUpdate`; the first two edits include the changed `templates-header.tsx` client module, and the style edits include the CSS chunk. No HMR capture events were dropped or truncated.
- The passing native trace shows the target client baseline established before the edit, an initial `None`, and a later `partial ChunkListUpdate`, rather than a late post-edit baseline.
- Local Dify runtime verification observed the marker update with the same page `timeOrigin` and one navigation entry; `/_next/mcp` reported no compilation issues before or after the edit.
- `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-dev-turbo test/development/app-hmr/hmr.test.ts` (5/5 passed).
- `cargo fmt --all -- --check`
- `cargo check -p next-api -p next-napi-bindings`
- `cargo clippy -p next-api -p next-napi-bindings --all-targets -- -D warnings`
- `cargo test -p turbo-tasks-fs` (117 passed)
- Prettier and ESLint on `hot-reloader-turbopack.ts`
- `pnpm build-all` (18/18 tasks successful)
- Commit preview build-and-deploy and preview-tarball upload workflows passed.

The corresponding benchmark observability changes are in vercel/next-benchmarks#279.

<!-- NEXT_JS_LLM -->
