### PR TITLE
Turn on the adapter route collapses by default

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -507,9 +507,7 @@ export interface ExperimentalConfig {
    * A collapsed entry resolves each request to the same output as the entries
    * that it replaces.
    *
-   * The default is `false`, so a build keeps one entry per route.
-   *
-   * @default false
+   * @default true
    */
   collapseAdapterRoutes?: boolean
   useSkewCookie?: boolean
@@ -2279,7 +2277,7 @@ export const defaultConfig = Object.freeze({
   adapterPath: process.env.NEXT_ADAPTER_PATH || undefined,
   experimental: {
     coldCacheBadge: false,
-    collapseAdapterRoutes: false,
+    collapseAdapterRoutes: true,
     devValidationWorker: true,
     useSkewCookie: false,
     cssChunking: true,

--- a/test/production/app-dir/adapter-dynamic-routes/cache-components/next.config.js
+++ b/test/production/app-dir/adapter-dynamic-routes/cache-components/next.config.js
@@ -3,9 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  // The option is off by default. These snapshots pin the collapsed route
-  // table, so the fixture enables it.
-  experimental: { collapseAdapterRoutes: true },
   // A build ID that reaches an entry changes the snapshot on every run. A
   // fixed build ID keeps the snapshot independent of the run.
   generateBuildId: () => 'test-build-id',

--- a/test/production/app-dir/adapter-dynamic-routes/legacy/next.config.js
+++ b/test/production/app-dir/adapter-dynamic-routes/legacy/next.config.js
@@ -7,9 +7,6 @@ const nextConfig = {
   // that variable overrides a config that omits the field. An omitted field
   // would let that matrix turn Cache Components on for this fixture.
   cacheComponents: false,
-  // The option is off by default. These snapshots pin the collapsed route
-  // table, so the fixture enables it.
-  experimental: { collapseAdapterRoutes: true },
   // The source regex of a pages router data route holds the build ID. A fixed
   // build ID keeps the snapshot independent of the run.
   generateBuildId: () => 'test-build-id',

--- a/test/production/app-dir/adapter-dynamic-routes/no-root-params/next.config.js
+++ b/test/production/app-dir/adapter-dynamic-routes/no-root-params/next.config.js
@@ -3,9 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  // The option is off by default. These snapshots pin the collapsed route
-  // table, so the fixture enables it.
-  experimental: { collapseAdapterRoutes: true },
   // A build ID that reaches an entry changes the snapshot on every run. A fixed
   // build ID keeps the snapshot independent of the run.
   generateBuildId: () => 'test-build-id',

--- a/test/production/app-dir/adapter-dynamic-routes/shell-prefixes/next.config.js
+++ b/test/production/app-dir/adapter-dynamic-routes/shell-prefixes/next.config.js
@@ -3,9 +3,6 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  // The option is off by default. These snapshots pin the collapsed route
-  // table, so the fixture enables it.
-  experimental: { collapseAdapterRoutes: true },
   // A build ID that reaches an entry changes the snapshot on every run. A fixed
   // build ID keeps the snapshot independent of the run.
   generateBuildId: () => 'test-build-id',


### PR DESCRIPTION
`experimental.collapseAdapterRoutes` now defaults to `true`, so a build serves several dynamic routes from one entry in the route table that it passes to an adapter. The default started off in #97774 so that the behavior could reach projects one at a time. We have tested this successfully internally, so the default moves back. The option stays in place, so a build that hits a regression can set it to `false` and get the table that a build emitted before the collapses.

The four fixtures under `test/production/app-dir/adapter-dynamic-routes` no longer set the option, because the default now gives them the collapsed table that their snapshots record. The snapshots themselves do not change, since the new default produces what the explicit option produced.

A full deploy test run with the flag on by default was already done as part of #97738.