### PR TITLE
Enable hourly next-maintainer auto-close workflow

### DIFF
--- a/.github/workflows/next-maintainer-auto-close.yml
+++ b/.github/workflows/next-maintainer-auto-close.yml
@@ -1,8 +1,8 @@
 name: Next Maintainer Auto Close
 
 on:
-  # schedule:
-  #   - cron: '0 * * * *'
+  schedule:
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Summary

- enable the existing auto-close workflow once per hour
- keep manual dispatch available
- leave the workflow logic and permissions unchanged

## Verification

- production `workflow_dispatch` succeeded end to end: https://github.com/vercel/next.js/actions/runs/33788887152
- production returned a clean empty-queue response after OIDC authentication and Vercel Trusted Sources validation
- Prettier and `git diff --check` pass