### PR TITLE
fix(hmr): don't reconnect while the HMR socket is still connecting

### DIFF
--- a/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
+++ b/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
@@ -44,6 +44,8 @@ export function createWebSocket(
 
   function init() {
     if (webSocket) {
+      webSocket.onerror = null
+      webSocket.onclose = null
       webSocket.close()
     }
 
@@ -145,7 +147,7 @@ export function createWebSocket(
   function handleVisibilityChange() {
     if (
       document.visibilityState === 'visible' &&
-      webSocket.readyState !== WebSocket.OPEN
+      webSocket.readyState === WebSocket.CLOSED
     ) {
       reconnections = 0
       clearTimeout(timer)
@@ -154,7 +156,7 @@ export function createWebSocket(
   }
 
   function handleOnlineEvent() {
-    if (webSocket.readyState !== WebSocket.OPEN) {
+    if (webSocket.readyState === WebSocket.CLOSED) {
       reconnections = 0
       clearTimeout(timer)
       init()

--- a/packages/next/src/client/dev/hot-reloader/pages/websocket.ts
+++ b/packages/next/src/client/dev/hot-reloader/pages/websocket.ts
@@ -29,10 +29,18 @@ export function connectHMR(options: { path: string; assetPrefix: string }) {
   let timer: ReturnType<typeof setTimeout>
 
   function init() {
-    if (source) source.close()
+    if (source) {
+      source.onerror = null
+      source.onclose = null
+      source.close()
+    }
+
+    const url = getSocketUrl(options.assetPrefix)
+
+    const newSource = new window.WebSocket(`${url}${options.path}`)
 
     function handleOnline() {
-      logQueue.onSocketReady(source)
+      logQueue.onSocketReady(newSource)
       reconnections = 0
       window.console.log('[HMR] connected')
     }
@@ -70,9 +78,9 @@ export function connectHMR(options: { path: string; assetPrefix: string }) {
     }
 
     function handleDisconnect() {
-      source.onerror = null
-      source.onclose = null
-      source.close()
+      newSource.onerror = null
+      newSource.onclose = null
+      newSource.close()
       reconnections++
       // After WEB_SOCKET_MAX_RECONNECTIONS reconnects we'll want to reload the page as it indicates the dev server is no longer running.
       if (reconnections > WEB_SOCKET_MAX_RECONNECTIONS) {
@@ -86,19 +94,18 @@ export function connectHMR(options: { path: string; assetPrefix: string }) {
       timer = setTimeout(init, reconnections > 5 ? 5000 : 1000)
     }
 
-    const url = getSocketUrl(options.assetPrefix)
+    newSource.onopen = handleOnline
+    newSource.onerror = handleDisconnect
+    newSource.onclose = handleDisconnect
+    newSource.onmessage = handleMessage
 
-    source = new window.WebSocket(`${url}${options.path}`)
-    source.onopen = handleOnline
-    source.onerror = handleDisconnect
-    source.onclose = handleDisconnect
-    source.onmessage = handleMessage
+    source = newSource
   }
 
   function handleVisibilityChange() {
     if (
       document.visibilityState === 'visible' &&
-      source.readyState !== WebSocket.OPEN
+      source.readyState === WebSocket.CLOSED
     ) {
       reconnections = 0
       clearTimeout(timer)
@@ -107,7 +114,7 @@ export function connectHMR(options: { path: string; assetPrefix: string }) {
   }
 
   function handleOnlineEvent() {
-    if (source.readyState !== WebSocket.OPEN) {
+    if (source.readyState === WebSocket.CLOSED) {
       reconnections = 0
       clearTimeout(timer)
       init()

--- a/test/development/app-hmr/hmr.test.ts
+++ b/test/development/app-hmr/hmr.test.ts
@@ -91,6 +91,70 @@ describe(`app-dir-hmr`, () => {
       }
     })
 
+    it('does not reconnect in a loop when the page becomes visible while the HMR socket is still connecting', async () => {
+      const componentPath = 'app/hmr-reconnect/page.js'
+      const originalComponent = await next.readFile(componentPath)
+      let hmrConnections = 0
+      let releaseFirstConnection = () => {}
+      const firstConnectionReleased = new Promise<void>((resolve) => {
+        releaseFirstConnection = resolve
+      })
+
+      const getHmrValue = (browser: Playwright<unknown>) =>
+        browser.eval(`document.querySelector('#hmr-value')?.textContent`)
+      const hasConnectedLog = async (browser: Playwright<unknown>) =>
+        (await browser.log()).some((entry) =>
+          entry.message.includes('[HMR] connected')
+        )
+
+      try {
+        const browser = await next.browser('/hmr-reconnect', {
+          async beforePageLoad(page) {
+            await page.routeWebSocket(/\/_next\/hmr/, async (clientSocket) => {
+              hmrConnections++
+              if (hmrConnections === 1) {
+                await firstConnectionReleased
+              }
+              clientSocket.connectToServer()
+            })
+          },
+        })
+
+        await retry(async () => {
+          expect(await getHmrValue(browser)).toBe('Initial')
+        })
+        expect(hmrConnections).toBe(1)
+        expect(await hasConnectedLog(browser)).toBe(false)
+
+        await browser.eval(() => {
+          Object.defineProperty(document, 'visibilityState', {
+            configurable: true,
+            get: () => 'visible',
+          })
+          document.dispatchEvent(new Event('visibilitychange'))
+        })
+
+        await waitFor(2500)
+        expect(hmrConnections).toBe(1)
+
+        releaseFirstConnection()
+        await retry(async () => {
+          expect(await hasConnectedLog(browser)).toBe(true)
+        })
+
+        await next.patchFile(
+          componentPath,
+          originalComponent.replace('Initial', 'Visible edit')
+        )
+        await retry(async () => {
+          expect(await getHmrValue(browser)).toBe('Visible edit')
+        }, 10_000)
+        expect(hmrConnections).toBe(1)
+      } finally {
+        await next.patchFile(componentPath, originalComponent)
+      }
+    })
+
     it('should not continously poll when hitting a not found page', async () => {
       let requestCount = 0
 

--- a/test/development/pages-hmr-reconnect/pages-hmr-reconnect.test.ts
+++ b/test/development/pages-hmr-reconnect/pages-hmr-reconnect.test.ts
@@ -1,0 +1,73 @@
+import { nextTestSetup, Playwright } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+
+describe('pages-hmr-reconnect', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    patchFileDelay: 500,
+  })
+
+  it('does not reconnect in a loop when the page becomes visible while the HMR socket is still connecting', async () => {
+    const componentPath = 'pages/index.tsx'
+    const originalComponent = await next.readFile(componentPath)
+    let hmrConnections = 0
+    let releaseFirstConnection = () => {}
+    const firstConnectionReleased = new Promise<void>((resolve) => {
+      releaseFirstConnection = resolve
+    })
+
+    const getHmrValue = (browser: Playwright<unknown>) =>
+      browser.eval(`document.querySelector('#hmr-value')?.textContent`)
+    const hasConnectedLog = async (browser: Playwright<unknown>) =>
+      (await browser.log()).some((entry) =>
+        entry.message.includes('[HMR] connected')
+      )
+
+    try {
+      const browser = await next.browser('/', {
+        async beforePageLoad(page) {
+          await page.routeWebSocket(/\/_next\/hmr/, async (clientSocket) => {
+            hmrConnections++
+            if (hmrConnections === 1) {
+              await firstConnectionReleased
+            }
+            clientSocket.connectToServer()
+          })
+        },
+      })
+
+      await retry(async () => {
+        expect(await getHmrValue(browser)).toBe('Initial')
+      })
+      expect(hmrConnections).toBe(1)
+      expect(await hasConnectedLog(browser)).toBe(false)
+
+      await browser.eval(() => {
+        Object.defineProperty(document, 'visibilityState', {
+          configurable: true,
+          get: () => 'visible',
+        })
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+
+      await waitFor(2500)
+      expect(hmrConnections).toBe(1)
+
+      releaseFirstConnection()
+      await retry(async () => {
+        expect(await hasConnectedLog(browser)).toBe(true)
+      })
+
+      await next.patchFile(
+        componentPath,
+        originalComponent.replace('Initial', 'Visible edit')
+      )
+      await retry(async () => {
+        expect(await getHmrValue(browser)).toBe('Visible edit')
+      }, 10_000)
+      expect(hmrConnections).toBe(1)
+    } finally {
+      await next.patchFile(componentPath, originalComponent)
+    }
+  })
+})

--- a/test/development/pages-hmr-reconnect/pages/index.tsx
+++ b/test/development/pages-hmr-reconnect/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="hmr-value">Initial</p>
+}


### PR DESCRIPTION
### What?

`next dev` could get stuck in an endless reconnect loop on its HMR WebSocket, retrying once a second forever. It happened when a page became visible while the socket was still connecting — most commonly when Chrome activated a Speculation Rules `prerender`. If the first socket had already reached the server, the page also never hydrated.

### Why?

The dev HMR client's `visibilitychange` and `online` handlers called `init()` any time the socket wasn't `OPEN`. But a socket that's still `CONNECTING` isn't `OPEN` either, so activating a prerendered page mid-handshake killed a perfectly good connection.

From there it snowballed. `init()` never detached the old socket's `onclose`, so that socket's `handleDisconnect` still fired, scheduled another `init()` a second later, and that one killed the next socket the same way. Since `handleOnline` resets the reconnect counter every time a socket opens, `WEB_SOCKET_MAX_RECONNECTIONS` never kicked in to stop it. Server-side, every dropped socket also deleted the React debug channel for that request — which is why hydration could fail.

The Pages Router client had the same bug plus an extra one: `handleDisconnect` read the module-level `source`, so a late `onclose` from an old socket would close whatever socket happened to be current.

### How?

- `handleVisibilityChange` and `handleOnlineEvent` only reconnect when `readyState === WebSocket.CLOSED`. A `CONNECTING` or `CLOSING` socket still has `handleDisconnect` attached and will sort itself out.
- `init()` nulls out `onerror` and `onclose` on the previous socket before closing it.
- The Pages Router client captures each socket in a closure (`newSource`) and only assigns `source` after the handlers are attached.

**Tests:** added a case to `test/development/app-hmr/hmr.test.ts` and a new `test/development/pages-hmr-reconnect` suite. Both hold Playwright's `routeWebSocket` handler open so the page's socket stays `CONNECTING`, fire a synthetic `visibilitychange` with `visibilityState` reporting `visible`, wait past two reconnect ticks, then check that exactly one connection was opened and that HMR still picks up an edit afterwards. On `canary` these fail with 4 connections (App Router) and 3 (Pages Router); with the fix they pass on both Turbopack and webpack. The existing `app-hmr` and Pages Router HMR suites still pass.

Allso hardens the sleep/wake reconnect from #91416.

Fixes #98212