### PR TITLE
fix(hmr): only reconnect a closed WebSocket on visibilitychange/online

### DIFF
--- a/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
+++ b/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
@@ -142,10 +142,15 @@ export function createWebSocket(
     return newWebSocket
   }
 
+  // Reconnect when the page becomes visible or the browser comes back online
+  // (e.g. after sleep/wake) and the socket is CLOSED. A socket that is still
+  // CONNECTING must be left alone: closing it would fire its disconnect
+  // handler, which schedules a reconnect that closes the new socket, and so on
+  // (e.g. when a prerendered page is activated while the handshake is pending).
   function handleVisibilityChange() {
     if (
       document.visibilityState === 'visible' &&
-      webSocket.readyState !== WebSocket.OPEN
+      webSocket.readyState === WebSocket.CLOSED
     ) {
       reconnections = 0
       clearTimeout(timer)
@@ -154,7 +159,7 @@ export function createWebSocket(
   }
 
   function handleOnlineEvent() {
-    if (webSocket.readyState !== WebSocket.OPEN) {
+    if (webSocket.readyState === WebSocket.CLOSED) {
       reconnections = 0
       clearTimeout(timer)
       init()

--- a/packages/next/src/client/dev/hot-reloader/pages/websocket.ts
+++ b/packages/next/src/client/dev/hot-reloader/pages/websocket.ts
@@ -95,10 +95,15 @@ export function connectHMR(options: { path: string; assetPrefix: string }) {
     source.onmessage = handleMessage
   }
 
+  // Reconnect when the page becomes visible or the browser comes back online
+  // (e.g. after sleep/wake) and the socket is CLOSED. A socket that is still
+  // CONNECTING must be left alone: closing it would fire its disconnect
+  // handler, which schedules a reconnect that closes the new socket, and so on
+  // (e.g. when a prerendered page is activated while the handshake is pending).
   function handleVisibilityChange() {
     if (
       document.visibilityState === 'visible' &&
-      source.readyState !== WebSocket.OPEN
+      source.readyState === WebSocket.CLOSED
     ) {
       reconnections = 0
       clearTimeout(timer)
@@ -107,7 +112,7 @@ export function connectHMR(options: { path: string; assetPrefix: string }) {
   }
 
   function handleOnlineEvent() {
-    if (source.readyState !== WebSocket.OPEN) {
+    if (source.readyState === WebSocket.CLOSED) {
       reconnections = 0
       clearTimeout(timer)
       init()

--- a/test/development/app-hmr/websocket-reconnect.test.ts
+++ b/test/development/app-hmr/websocket-reconnect.test.ts
@@ -1,0 +1,50 @@
+import { FileRef, nextTestSetup } from 'e2e-utils'
+import { retry, waitFor } from 'next-test-utils'
+import path from 'path'
+
+describe('app-dir HMR WebSocket reconnect', () => {
+  const { next } = nextTestSetup({
+    files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
+  })
+
+  it('should not replace the socket when the page becomes visible while it is connecting', async () => {
+    let hmrSocketCount = 0
+    const browser = await next.browser('/', {
+      async beforePageLoad(page) {
+        page.on('websocket', (webSocket) => {
+          if (webSocket.url().includes('/_next/hmr')) {
+            hmrSocketCount++
+          }
+        })
+        // Fire `visibilitychange` while the HMR WebSocket is still connecting,
+        // as happens when a prerendered page is activated.
+        await page.addInitScript(`(() => {
+          const OriginalWebSocket = window.WebSocket
+          let fired = false
+          window.WebSocket = class extends OriginalWebSocket {
+            constructor(...args) {
+              super(...args)
+              if (!fired && String(args[0]).includes('/_next/hmr')) {
+                fired = true
+                queueMicrotask(() => {
+                  document.dispatchEvent(new Event('visibilitychange'))
+                })
+              }
+            }
+          }
+        })()`)
+      },
+    })
+
+    await retry(async () => {
+      expect(await browser.log()).toContainEqual({
+        source: 'log',
+        message: '[HMR] connected',
+      })
+    })
+    // A faulty client would replace the socket right away, and again after the
+    // one second reconnect delay.
+    await waitFor(2000)
+    expect(hmrSocketCount).toBe(1)
+  })
+})

--- a/test/development/basic/hmr/run-basic-hmr-test.util.ts
+++ b/test/development/basic/hmr/run-basic-hmr-test.util.ts
@@ -105,4 +105,45 @@ export function runBasicHmrTest(nextConfig: {
 
     await reloadPromise
   })
+
+  it('should not replace the HMR socket when the page becomes visible while it is connecting', async () => {
+    let hmrSocketCount = 0
+    const browser = await next.browser(basePath + '/hmr/about', {
+      async beforePageLoad(page) {
+        page.on('websocket', (webSocket) => {
+          if (webSocket.url().includes('/_next/hmr')) {
+            hmrSocketCount++
+          }
+        })
+        // Fire `visibilitychange` while the HMR WebSocket is still connecting,
+        // as happens when a prerendered page is activated.
+        await page.addInitScript(`(() => {
+          const OriginalWebSocket = window.WebSocket
+          let fired = false
+          window.WebSocket = class extends OriginalWebSocket {
+            constructor(...args) {
+              super(...args)
+              if (!fired && String(args[0]).includes('/_next/hmr')) {
+                fired = true
+                queueMicrotask(() => {
+                  document.dispatchEvent(new Event('visibilitychange'))
+                })
+              }
+            }
+          }
+        })()`)
+      },
+    })
+
+    await retry(async () => {
+      expect(await browser.log()).toContainEqual({
+        source: 'log',
+        message: '[HMR] connected',
+      })
+    })
+    // A faulty client would replace the socket right away, and again after the
+    // one second reconnect delay.
+    await waitFor(2000)
+    expect(hmrSocketCount).toBe(1)
+  })
 }


### PR DESCRIPTION
### What?

The `visibilitychange`/`online` handlers in the dev HMR WebSocket clients (App Router and Pages Router) now only reconnect when the socket is `CLOSED`, instead of whenever it is not `OPEN`.

### Why?

#91416 added those handlers so a stale socket reconnects after sleep/wake. But they also fired while the socket was still `CONNECTING`, which `init()` then closed. Closing a connecting socket fires its `onerror`/`onclose` → `handleDisconnect`, which schedules another `init()` one second later, which closes the new (healthy) socket, whose `handleDisconnect` schedules another `init()`… `reconnections` is reset on every `onopen`, so `WEB_SOCKET_MAX_RECONNECTIONS` never trips and the loop never ends.

This is not a rare race: Chrome defers the WebSocket handshake of a prerendered document (Speculation Rules `prerender`, or the "Preload pages" omnibox setting) until activation, and activation fires `visibilitychange`. So every prerendered `next dev` page hit this deterministically. Measured with real prerender activation over CDP (canary `65c832c`): `activationStart` 3330 ms, then a new `/_next/hmr` socket every second (7 sockets / 6× `[HMR] connected` in 6 s). If the first socket had already reached the server it also consumed the React debug channel for the request id (`debug-channel.ts` hands it out once), and the page never hydrated. Same trigger, reproduced synthetically (`visibilitychange` dispatched while `readyState === CONNECTING`): App Router 8 sockets in 6 s and no hydration; Pages Router 3 sockets, two `WebSocket is closed before the connection is established` errors and a 1 s delayed connection.

### How?

`readyState !== WebSocket.OPEN` → `readyState === WebSocket.CLOSED` in both handlers of both clients.

Only `handleDisconnect` and `init()` ever call `close()`, and `readyState` becomes `CLOSED` in the same task that fires `error`/`close`. So whenever a handler observes `CLOSED`, `handleDisconnect` has already run: the socket's handlers are detached and only a retry timer is pending. `init()` from the handler then cancels that timer and reconnects immediately, which is exactly the sleep/wake behaviour #91416 wanted (verified: `online`/`visibilitychange` while `CLOSED` reconnects in ~30 ms instead of waiting for the timer, then stays stable). A `CONNECTING` socket is left alone and either opens or fails into the normal retry path. This restores the pre-#91416 invariant that `init()` only ever runs with no socket or a closed, detached one.

With the fix, the same real-prerender run opens exactly one socket (created during prerendering, opened right after activation) and hydrates.

Regression tests dispatch `visibilitychange` right after the HMR socket is constructed (while it is `CONNECTING`) and assert that exactly one `/_next/hmr` WebSocket is created. Both fail on canary (App Router: 14 sockets, Pages Router: 3) and pass with the fix, in Turbopack and webpack dev modes.

Root-cause analysis and the proposed condition come from @hairywelly's report in #98212.

Fixes #98212
