### PR TITLE
fix(after): make cookies() in after() reflect Route Handler mutations

### DIFF
--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -12,7 +12,10 @@ import {
   type RouteModuleHandleContext,
   type RouteModuleOptions,
 } from '../route-module'
-import { createRequestStoreForAPI } from '../../async-storage/request-store'
+import {
+  createRequestStoreForAPI,
+  synchronizeMutableCookies,
+} from '../../async-storage/request-store'
 import {
   createPrerenderWorkStore,
   createWorkStore,
@@ -839,6 +842,13 @@ export class AppRouteRouteModule extends RouteModule<
         requestStore,
         context
       )
+    } finally {
+      // `after()` callbacks run once the response is done, when `cookies()`
+      // returns the immutable `cookies` snapshot instead of the mutable
+      // cookies. Synchronize them so that the callbacks see any cookies the
+      // handler set, like `executeActionAndPrepareForRender` does for Server
+      // Actions.
+      synchronizeMutableCookies(requestStore)
     }
 
     return this.finalizeResponse(

--- a/test/e2e/app-dir/next-after-app-api-usage/app/cookies-mutation/route-handler/route.js
+++ b/test/e2e/app-dir/next-after-app-api-usage/app/cookies-mutation/route-handler/route.js
@@ -1,0 +1,16 @@
+import { cookies } from 'next/headers'
+import { after } from 'next/server'
+
+export async function GET() {
+  const path = '/cookies-mutation/route-handler'
+
+  const cookieStore = await cookies()
+  cookieStore.set('test-cookie', 'mutated')
+
+  after(async () => {
+    const value = (await cookies()).get('test-cookie')?.value
+    console.log(`[${path}] cookies() in after(): test-cookie=${value}`)
+  })
+
+  return new Response()
+}

--- a/test/e2e/app-dir/next-after-app-api-usage/app/cookies-mutation/server-action/page.js
+++ b/test/e2e/app-dir/next-after-app-api-usage/app/cookies-mutation/server-action/page.js
@@ -1,0 +1,23 @@
+import { cookies } from 'next/headers'
+import { after } from 'next/server'
+
+export default async function Page() {
+  return (
+    <form
+      action={async () => {
+        'use server'
+        const path = '/cookies-mutation/server-action'
+
+        const cookieStore = await cookies()
+        cookieStore.set('test-cookie', 'mutated')
+
+        after(async () => {
+          const value = (await cookies()).get('test-cookie')?.value
+          console.log(`[${path}] cookies() in after(): test-cookie=${value}`)
+        })
+      }}
+    >
+      <button type="submit">Submit</button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/next-after-app-api-usage/index.test.ts
+++ b/test/e2e/app-dir/next-after-app-api-usage/index.test.ts
@@ -428,6 +428,30 @@ describe('nextjs APIs in after()', () => {
       )
     })
   })
+
+  describe('cookies() inside after() reflects cookie mutations', () => {
+    it('in a route handler', async () => {
+      const path = '/cookies-mutation/route-handler'
+      await next.fetch(path, { headers: { cookie: 'test-cookie=initial' } })
+      await retry(() => {
+        expect(getLogs()).toContain(
+          `[${path}] cookies() in after(): test-cookie=mutated`
+        )
+      })
+    })
+
+    it('in a server action', async () => {
+      const path = '/cookies-mutation/server-action'
+      const browser = await next.browser(path)
+      await using _ = defer(() => browser.deleteCookies())
+      await browser.elementByCss('button[type="submit"]').click()
+      await retry(() => {
+        expect(getLogs()).toContain(
+          `[${path}] cookies() in after(): test-cookie=mutated`
+        )
+      })
+    })
+  })
 })
 
 function defer(callback: () => void | Promise<void>): AsyncDisposable {


### PR DESCRIPTION
### What?

`cookies()` called inside `after()` in a Route Handler returned the inbound request cookies, ignoring any `cookies().set()` / `.delete()` the handler performed. Server Actions already returned the post-mutation values in the same scenario.

```ts
export async function GET() {
  const store = await cookies()
  store.set('session', 'NEW')

  after(async () => {
    // before: 'OLD' (inbound cookie), even though the response sends `Set-Cookie: session=NEW`
    // after:  'NEW'
    console.log((await cookies()).get('session')?.value)
  })

  return Response.json({ ok: true })
}
```

### Why?

The `after()` docs recommend reading `cookies()` inside the callback in Route Handlers "for logging activity after a mutation", but the callback saw pre-mutation values.

While a Route Handler runs, `cookies()` returns `requestStore.userspaceMutableCookies`, which reflects mutations. `after()` callbacks run once the response is done, when the request store is in the `'after'` phase and `cookies()` returns the immutable snapshot `requestStore.cookies`, which is still the inbound jar.

Server Actions don't hit this because `executeActionAndPrepareForRender` calls `synchronizeMutableCookies()` once the action body has finished, so the snapshot reflects the mutations. Route Handlers never did that.

### How?

Call the same `synchronizeMutableCookies()` in `AppRouteRouteModule.renderToResponse` once the handler has run (in a `finally`, so it also covers handlers that end with `redirect()` / `notFound()`). `requestStore.mutableCookies` is also what `finalizeResponse` and `handleHandlerError` use to emit `Set-Cookie`, so `after()` now sees exactly what the response sent.

Added e2e tests for a Route Handler (fails before this change) and a Server Action (control, passes before and after).

Fixes #98222
