### PR TITLE
Key the Pages Router app route prefetch marker by the `as` path

### DIFF
--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -171,6 +171,34 @@ function resolveDynamicRoute(pathname: string, pages: string[]) {
   return removeTrailingSlash(pathname)
 }
 
+/**
+ * Key under which `prefetch()` stores the `{ __appRouter: true }` marker in
+ * `router.components` when the client router filter matches an `as` path, and
+ * under which `change()` looks it up again.
+ *
+ * The filter is evaluated against the `as` path, so the marker has to be keyed
+ * by the `as` pathname as well. `href` and `as` can differ (e.g. `href` is the
+ * current route with an extra query param and `as` is a different URL), and
+ * keying the marker by the `href` pathname would replace the cached route info
+ * of a pages route the filter never matched.
+ *
+ * Returns `null` for non-local URLs (e.g. `mailto:`), which can never be an
+ * App Router path.
+ */
+function getAppRouterMarkerKey(router: NextRouter, as: string): string | null {
+  if (!isLocalURL(as)) {
+    return null
+  }
+
+  let { pathname } = parseRelativeUrl(hasBasePath(as) ? removeBasePath(as) : as)
+
+  if (process.env.__NEXT_I18N_SUPPORT) {
+    pathname = normalizeLocalePath(pathname, router.locales).pathname
+  }
+
+  return removeTrailingSlash(pathname)
+}
+
 function getMiddlewareData<T extends FetchDataOutput>(
   source: string,
   response: Response,
@@ -1446,9 +1474,13 @@ export default class Router implements BaseRouter {
     let route = removeTrailingSlash(pathname)
     const parsedAsPathname = as.startsWith('/') && parseRelativeUrl(as).pathname
 
-    // if we detected the path as app route during prefetching
+    // if we detected the `as` path as app route during prefetching
     // trigger hard navigation
-    if ((this.components[pathname] as any)?.__appRouter) {
+    const appRouterMarkerKey = getAppRouterMarkerKey(this, cleanedAs)
+    if (
+      appRouterMarkerKey !== null &&
+      (this.components[appRouterMarkerKey] as any)?.__appRouter
+    ) {
       handleHardNavigation({ url: as, router: this })
       return new Promise(() => {})
     }
@@ -2073,6 +2105,15 @@ export default class Router implements BaseRouter {
 
     try {
       let existingInfo: PrivateRouteInfo | undefined = this.components[route]
+
+      // `prefetch()` stores an `__appRouter` marker in `this.components` when
+      // the client router filter matches a path. It is not route info (it has
+      // no `Component` and no `props`), so treat it as a cache miss and load
+      // the route again instead of rendering it.
+      if ((existingInfo as any)?.__appRouter) {
+        existingInfo = undefined
+      }
+
       if (routeProps.shallow && existingInfo && this.route === route) {
         return existingInfo
       }
@@ -2173,6 +2214,9 @@ export default class Router implements BaseRouter {
 
           // Check again the cache with the new destination.
           existingInfo = this.components[route]
+          if ((existingInfo as any)?.__appRouter) {
+            existingInfo = undefined
+          }
           if (
             routeProps.shallow &&
             existingInfo &&
@@ -2416,7 +2460,6 @@ export default class Router implements BaseRouter {
       return
     }
     let parsed = parseRelativeUrl(url)
-    const urlPathname = parsed.pathname
 
     let { pathname, query } = parsed
     const originalPathname = pathname
@@ -2553,8 +2596,12 @@ export default class Router implements BaseRouter {
 
     const route = removeTrailingSlash(pathname)
 
-    if (await this._bfl(asPath, resolvedAs, options.locale, true)) {
-      this.components[urlPathname] = { __appRouter: true } as any
+    const appRouterMarkerKey = getAppRouterMarkerKey(this, asPath)
+    if (
+      appRouterMarkerKey !== null &&
+      (await this._bfl(asPath, resolvedAs, options.locale, true))
+    ) {
+      this.components[appRouterMarkerKey] = { __appRouter: true } as any
     }
 
     await Promise.all([

--- a/test/e2e/app-dir/pages-to-app-routing/fixtures/prefetch-marker/app/dashboard/page.tsx
+++ b/test/e2e/app-dir/pages-to-app-routing/fixtures/prefetch-marker/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1 id="page-title">App Dashboard</h1>
+}

--- a/test/e2e/app-dir/pages-to-app-routing/fixtures/prefetch-marker/app/layout.tsx
+++ b/test/e2e/app-dir/pages-to-app-routing/fixtures/prefetch-marker/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/pages-to-app-routing/fixtures/prefetch-marker/next.config.js
+++ b/test/e2e/app-dir/pages-to-app-routing/fixtures/prefetch-marker/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/pages-to-app-routing/fixtures/prefetch-marker/pages/blog/[slug].js
+++ b/test/e2e/app-dir/pages-to-app-routing/fixtures/prefetch-marker/pages/blog/[slug].js
@@ -1,0 +1,45 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+export async function getServerSideProps({ params }) {
+  return {
+    props: {
+      slug: params.slug,
+    },
+  }
+}
+
+export default function Page({ slug }) {
+  const router = useRouter()
+  return (
+    <>
+      <h1 id="page-title">Pages Blog: {slug}</h1>
+      <p id="tab">{router.query.tab || 'a'}</p>
+      <Link id="tab-b-link" href={`/blog/${slug}?tab=b`} shallow>
+        Tab B
+      </Link>
+      <Link
+        id="to-second-link"
+        href={{ pathname: '/blog/[slug]', query: { slug: 'second' } }}
+      >
+        To Second
+      </Link>
+      {/*
+        "Route as modal": `href` is the current dynamic route pattern with an
+        extra query param and `as` shows a different URL, here an App Router
+        route.
+      */}
+      <Link
+        id="to-dashboard-link"
+        href={{
+          pathname: router.pathname,
+          query: { ...router.query, modal: 1 },
+        }}
+        as="/dashboard"
+        shallow
+      >
+        To Dashboard
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/pages-to-app-routing/fixtures/prefetch-marker/pages/index.js
+++ b/test/e2e/app-dir/pages-to-app-routing/fixtures/prefetch-marker/pages/index.js
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+export default function Page() {
+  const router = useRouter()
+  return (
+    <>
+      <h1 id="page-title">Pages Home</h1>
+      <p id="tab">{router.query.tab || 'a'}</p>
+      <Link id="tab-b-link" href="/?tab=b" shallow>
+        Tab B
+      </Link>
+      {/*
+        "Route as modal": `href` stays on the current pages route and `as`
+        shows a different URL, here an App Router route.
+      */}
+      <Link id="to-dashboard-link" href="/?modal=1" as="/dashboard" shallow>
+        To Dashboard
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts
+++ b/test/e2e/app-dir/pages-to-app-routing/pages-to-app-routing.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { nextTestSetup, type NextInstance } from 'e2e-utils'
+import { nextTestSetup, type NextInstance, type Playwright } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 // In dev the first request to a not-yet-registered dynamic route can return a
@@ -264,4 +264,115 @@ describe('pages-to-app-routing with a pages optional catch-all owning the root',
       expect(didHardNavigateToRoot).toBe(false)
     }
   )
+})
+
+// While prefetching a link, the Pages Router checks the link's `as` path
+// against the client router filter and, on a match, records
+// `{ __appRouter: true }` in `router.components` so that clicking the link
+// hard-navigates right away. That marker has to be keyed by the `as` pathname
+// the filter was checked against. `href` and `as` differ for "route as modal"
+// links, where `href` stays on the current pages route and `as` is a
+// different URL: keyed by `href`, the marker replaced the cached route info of
+// the current pages route, so the next shallow navigation hard-navigated
+// (static route) or rendered the page without its props (dynamic route), and
+// every navigation through the dynamic route pattern hard-navigated.
+describe('pages-to-app-routing with a prefetched link whose `as` is an app route', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: join(__dirname, 'fixtures', 'prefetch-marker'),
+  })
+
+  it('should not render an app router marker as route info on a shallow navigation', async () => {
+    const browser = await next.browser('/blog/first')
+    expect(await browser.elementByCss('#page-title').text()).toBe(
+      'Pages Blog: first'
+    )
+
+    // Plant the marker `prefetch()` writes under the current route directly
+    // so this does not depend on the client router filter (and on prefetching
+    // being enabled, which it is not in dev).
+    await browser.eval(
+      "window.next.router.components['/blog/[slug]'] = { __appRouter: true }"
+    )
+    await browser.eval(
+      "window.next.router.push('/blog/first?tab=b', undefined, { shallow: true })"
+    )
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#tab').text()).toBe('b')
+    })
+    expect(await browser.elementByCss('#page-title').text()).toBe(
+      'Pages Blog: first'
+    )
+  })
+
+  // Prefetching is a no-op in development, so the marker is only ever written
+  // in production.
+  ;(isNextDev ? describe.skip : describe)('in production', () => {
+    async function waitForPrefetchedAppRoute(browser: Playwright) {
+      await browser.eval('window.beforeNav = 1')
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            'Object.values(window.next.router.components).some((c) => c && c.__appRouter)'
+          )
+        ).toBe(true)
+      })
+    }
+
+    it('should hard-navigate to the app route when the link is clicked', async () => {
+      const browser = await next.browser('/')
+      await waitForPrefetchedAppRoute(browser)
+
+      await browser.elementByCss('#to-dashboard-link').click()
+
+      await retry(async () => {
+        expect(await browser.elementByCss('#page-title').text()).toBe(
+          'App Dashboard'
+        )
+      })
+      expect(await browser.eval('window.beforeNav')).toBeUndefined()
+    })
+
+    it('should keep a shallow navigation on the static pages route client-side', async () => {
+      const browser = await next.browser('/')
+      await waitForPrefetchedAppRoute(browser)
+
+      await browser.elementByCss('#tab-b-link').click()
+
+      await retry(async () => {
+        expect(await browser.elementByCss('#tab').text()).toBe('b')
+      })
+      expect(await browser.eval('window.beforeNav')).toBe(1)
+    })
+
+    it('should keep a shallow navigation on the dynamic pages route client-side', async () => {
+      const browser = await next.browser('/blog/first')
+      await waitForPrefetchedAppRoute(browser)
+
+      await browser.elementByCss('#tab-b-link').click()
+
+      await retry(async () => {
+        expect(await browser.elementByCss('#tab').text()).toBe('b')
+      })
+      expect(await browser.eval('window.beforeNav')).toBe(1)
+      // A shallow navigation keeps the page's props.
+      expect(await browser.elementByCss('#page-title').text()).toBe(
+        'Pages Blog: first'
+      )
+    })
+
+    it('should keep a navigation within the dynamic pages route client-side', async () => {
+      const browser = await next.browser('/blog/first')
+      await waitForPrefetchedAppRoute(browser)
+
+      await browser.elementByCss('#to-second-link').click()
+
+      await retry(async () => {
+        expect(await browser.elementByCss('#page-title').text()).toBe(
+          'Pages Blog: second'
+        )
+      })
+      expect(await browser.eval('window.beforeNav')).toBe(1)
+    })
+  })
 })


### PR DESCRIPTION
### What?

`Router.prefetch()` in the Pages Router checks the client router filter against a link's `as` path and, on a match, records `{ __appRouter: true }` in `router.components` so that clicking the link hard-navigates right away. That marker was stored under the `href` pathname and looked up by the `href` pathname in `Router.change()`. This PR keys it by the normalized `as` pathname in both places, and makes `Router.getRouteInfo()` treat a marker as a cache miss so it can never be handed to `_app` as route info.

### Why?

`href` and `as` are the same URL for most links, so the mismatch was invisible. They differ for "route as modal" links (`href={{ pathname: router.pathname, query: { ...router.query, modal: id } }}` with `as="/pretty/url"`, see `examples/with-route-as-modal`). When the filter matches `as`, or hits one of its false positives (0.01% per checked path by default; every hover/touch checks a path), the marker replaced the cached route info of the page the user is currently on:

- on a static route the `change()` guard then fired for every later navigation to that route, so a shallow query change hard-navigated;
- on a dynamic route the marker sat under the pattern (`/blog/[slug]`) but was looked up by the concrete `href` (`/blog/first`), so the guard missed and the shallow `getRouteInfo()` early return handed the marker to `_app`: `Component` and `props` are `undefined`, which renders the page without its props or crashes a custom `_app` that reads `pageProps`. Every object-form `<Link href={{ pathname: '/blog/[slug]', ... }}>` through that pattern also hard-navigated.

Fixes #98180
Fixes #98181

This consolidates the fixes proposed by @Stanzilla in #98182 and #98187 (thanks for the detailed report and reproduction) into one change with a single fixture in the existing `pages-to-app-routing` suite; Benjamin is credited as co-author.

### How?

- `getAppRouterMarkerKey(router, as)` strips `basePath` and the locale prefix from `as`, takes the pathname and removes the trailing slash. It returns `null` for non-local URLs (`mailto:` etc.), which can never be an App Router path. This mirrors the normalisation `change()` already applies to `href` before the lookup.
- `prefetch()` writes the marker under `getAppRouterMarkerKey(this, asPath)`; `change()` reads it with `getAppRouterMarkerKey(this, cleanedAs)`. For `href === as` links nothing changes.
- `getRouteInfo()` resets `existingInfo` when it carries `__appRouter` (both the initial lookup and the re-check after a middleware rewrite), so the shallow early return does not fire and `cachedRouteInfo` is not the marker; the route is loaded again instead.

### Tests

New `prefetch-marker` fixture in `test/e2e/app-dir/pages-to-app-routing` (pages `/` and `/blog/[slug]` with a shallow tab link and a route-as-modal link whose `as` is `app/dashboard`):

- planting the marker under the current dynamic route and doing a shallow `router.push()` re-renders with the new query and keeps the page's props (dev + prod);
- after the route-as-modal link has been prefetched (prod only, prefetch is a no-op in dev): clicking it still hard-navigates to the app route; a shallow navigation on the static route stays client-side; a shallow navigation on the dynamic route stays client-side and keeps its props; an object-form navigation to another slug stays client-side.

All four navigation tests fail on `canary` (hard navigation, or `Pages Blog:` rendered without `slug`); the marker still hard-navigates the app-route link before and after.

Also verified on the same build: full `pages-to-app-routing` (prod + dev, incl. the `basePath` fixture), `app-dir/app` "should successfully detect app route during prefetch" (the original #47761 test), `invalid-href` (prod + dev, covers external `as`), `client-shallow-routing`, `middleware-shallow-link`, `dynamic-route-interpolation`, `basepath` (35), `i18n-support` (103), plus `basePath: '/base'` and `i18n` variants of the new fixture.

x-ref: #47761 (introduced the marker), #47949
