### PR TITLE
Do not error when a cached page forwards its props to a child component

### DIFF
--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -42,6 +42,7 @@ import {
 import {
   throwWithStaticGenerationBailoutErrorWithDynamicError,
   throwForSearchParamsAccessInUseCache,
+  throwForSearchParamsEnumerationInUseCache,
 } from './utils'
 
 export type SearchParams = { [key: string]: string | string[] | undefined }
@@ -522,7 +523,34 @@ export function makeErroringSearchParamsForUseCache(): Promise<SearchParams> {
     return cachedSearchParams
   }
 
-  const promise = Promise.resolve({})
+  // The error is triggered when a search param is read from the resolved
+  // object, and not when the promise itself is awaited. Merely touching the
+  // promise must stay side-effect free, because React's dev-only debug info
+  // serializer probes every prop of a rendered Server Component for
+  // thenability by reading `.then`. Otherwise a cached page that only forwards
+  // its props to a child Server Component would error without reading any
+  // search param.
+  const underlyingSearchParams = new Proxy({} as SearchParams, {
+    get: function get(target, prop, receiver) {
+      if (typeof prop === 'string' && !wellKnownProperties.has(prop)) {
+        throwForSearchParamsAccessInUseCache(workStore, get)
+      }
+
+      return ReflectAdapter.get(target, prop, receiver)
+    },
+    has: function has(target, prop) {
+      if (typeof prop === 'string' && !wellKnownProperties.has(prop)) {
+        throwForSearchParamsAccessInUseCache(workStore, has)
+      }
+
+      return Reflect.has(target, prop)
+    },
+    ownKeys: function ownKeys() {
+      throwForSearchParamsEnumerationInUseCache(workStore, ownKeys)
+    },
+  })
+
+  const promise = Promise.resolve(underlyingSearchParams)
 
   const proxiedPromise = new Proxy(promise, {
     get: function get(target, prop, receiver) {
@@ -534,10 +562,8 @@ export function makeErroringSearchParamsForUseCache(): Promise<SearchParams> {
         return ReflectAdapter.get(target, prop, receiver)
       }
 
-      if (
-        typeof prop === 'string' &&
-        (prop === 'then' || !wellKnownProperties.has(prop))
-      ) {
+      if (typeof prop === 'string' && !wellKnownProperties.has(prop)) {
+        // Sync access of a search param on the unawaited promise.
         throwForSearchParamsAccessInUseCache(workStore, get)
       }
 

--- a/packages/next/src/server/request/utils.ts
+++ b/packages/next/src/server/request/utils.ts
@@ -26,6 +26,25 @@ export function throwForSearchParamsAccessInUseCache(
   throw error
 }
 
+/**
+ * Same as `throwForSearchParamsAccessInUseCache`, except that the error is not
+ * recorded as an invalid dynamic usage. This is used for enumerating the search
+ * params, which React's dev-only debug info serializer does itself when it
+ * serializes them as a component prop. Recording it would report an error for a
+ * cached page that never read a search param. An enumeration in user code is
+ * still surfaced, because the thrown error propagates through the render.
+ */
+export function throwForSearchParamsEnumerationInUseCache(
+  workStore: WorkStore,
+  constructorOpt: Function
+): never {
+  const error = createSearchParamsInUseCacheError(workStore.route)
+
+  Error.captureStackTrace(error, constructorOpt)
+
+  throw error
+}
+
 export function isRequestApiAllowedInCurrentPhase(
   workUnitStore: WorkUnitStore
 ): boolean {

--- a/test/e2e/app-dir/use-cache-search-params/app/search-params-enumerated/page.tsx
+++ b/test/e2e/app-dir/use-cache-search-params/app/search-params-enumerated/page.tsx
@@ -1,0 +1,11 @@
+'use cache'
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
+  const params = { ...(await searchParams) }
+
+  return <p>params: {JSON.stringify(params)}</p>
+}

--- a/test/e2e/app-dir/use-cache-search-params/app/search-params-forwarded/page.tsx
+++ b/test/e2e/app-dir/use-cache-search-params/app/search-params-forwarded/page.tsx
@@ -1,0 +1,19 @@
+'use cache'
+
+type Props = {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}
+
+export default async function Page(props: Props) {
+  // Forwarding the page props to a child Server Component must not be treated
+  // as a `searchParams` access.
+  return <Inner {...props} />
+}
+
+async function Inner(props: Props) {
+  return (
+    <p>
+      Page: <span id="page-date">{new Date().toISOString()}</span>
+    </p>
+  )
+}

--- a/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
+++ b/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
@@ -34,11 +34,11 @@ describe('use-cache-search-params', () => {
          Learn more: https://nextjs.org/docs/messages/next-request-in-use-cache",
            "environmentLabel": "Cache",
            "label": "Runtime Error",
-           "source": "app/search-params-used/page.tsx (8:17) @ Page
+           "source": "app/search-params-used/page.tsx (8:38) @ Page
          >  8 |   const param = (await searchParams).foo
-              |                 ^",
+              |                                      ^",
            "stack": [
-             "Page app/search-params-used/page.tsx (8:17)",
+             "Page app/search-params-used/page.tsx (8:38)",
            ],
          }
         `)
@@ -46,7 +46,7 @@ describe('use-cache-search-params', () => {
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
         expect(cliOutput).toContain(`Error: ${getExpectedErrorMessage(route)}
-    at Page (app/search-params-used/page.tsx:8:17)`)
+    at Page (app/search-params-used/page.tsx:8:38)`)
       })
     })
 
@@ -65,11 +65,11 @@ describe('use-cache-search-params', () => {
          Learn more: https://nextjs.org/docs/messages/next-request-in-use-cache",
            "environmentLabel": "Server",
            "label": "Console Error",
-           "source": "app/search-params-caught/page.tsx (11:5) @ Page
+           "source": "app/search-params-caught/page.tsx (11:34) @ Page
          > 11 |     param = (await searchParams).foo
-              |     ^",
+              |                                  ^",
            "stack": [
-             "Page app/search-params-caught/page.tsx (11:5)",
+             "Page app/search-params-caught/page.tsx (11:34)",
            ],
          }
         `)
@@ -77,7 +77,7 @@ describe('use-cache-search-params', () => {
         const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
 
         expect(cliOutput).toContain(`Error: ${getExpectedErrorMessage(route)}
-    at Page (app/search-params-caught/page.tsx:11:5)`)
+    at Page (app/search-params-caught/page.tsx:11:34)`)
       })
 
       it('should also show an error after the second reload', async () => {
@@ -94,11 +94,11 @@ describe('use-cache-search-params', () => {
          Learn more: https://nextjs.org/docs/messages/next-request-in-use-cache",
            "environmentLabel": "Server",
            "label": "Console Error",
-           "source": "app/search-params-caught/page.tsx (11:5) @ Page
+           "source": "app/search-params-caught/page.tsx (11:34) @ Page
          > 11 |     param = (await searchParams).foo
-              |     ^",
+              |                                  ^",
            "stack": [
-             "Page app/search-params-caught/page.tsx (11:5)",
+             "Page app/search-params-caught/page.tsx (11:34)",
            ],
          }
         `)
@@ -108,6 +108,53 @@ describe('use-cache-search-params', () => {
     describe('when searchParams are unused inside of "use cache"', () => {
       beforeAll(() => {
         route = '/search-params-unused'
+      })
+
+      it('should not show an error', async () => {
+        const outputIndex = next.cliOutput.length
+        const browser = await next.browser(`${route}?foo=1`)
+
+        await waitForNoRedbox(browser)
+
+        const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+        expect(cliOutput).not.toContain(getExpectedErrorMessage(route))
+      })
+    })
+
+    describe('when searchParams are enumerated inside of "use cache"', () => {
+      beforeAll(() => {
+        route = '/search-params-enumerated'
+      })
+
+      it('should show an error', async () => {
+        const outputIndex = next.cliOutput.length
+        const browser = await next.browser(`${route}?foo=1`)
+
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "Route "/search-params-enumerated": \`searchParams\` can't be read inside \`"use cache"\`. Await it outside the cached function and pass what you need as an argument.
+         Learn more: https://nextjs.org/docs/messages/next-request-in-use-cache",
+           "environmentLabel": "Cache",
+           "label": "Runtime Error",
+           "source": "app/search-params-enumerated/page.tsx (8:24) @ Page
+         >  8 |   const params = { ...(await searchParams) }
+              |                        ^",
+           "stack": [
+             "Page app/search-params-enumerated/page.tsx (8:24)",
+           ],
+         }
+        `)
+
+        const cliOutput = stripAnsi(next.cliOutput.slice(outputIndex))
+
+        expect(cliOutput).toContain(getExpectedErrorMessage(route))
+      })
+    })
+
+    describe('when searchParams are forwarded to a child Server Component inside of "use cache"', () => {
+      beforeAll(() => {
+        route = '/search-params-forwarded'
       })
 
       it('should not show an error', async () => {
@@ -133,11 +180,11 @@ describe('use-cache-search-params', () => {
        Learn more: https://nextjs.org/docs/messages/next-request-in-use-cache",
          "environmentLabel": "Cache",
          "label": "Runtime Error",
-         "source": "app/search-params-used-generate-metadata/page.tsx (9:17) @ generateMetadata
+         "source": "app/search-params-used-generate-metadata/page.tsx (9:38) @ generateMetadata
        >  9 |   const title = (await searchParams).title
-            |                 ^",
+            |                                      ^",
          "stack": [
-           "generateMetadata app/search-params-used-generate-metadata/page.tsx (9:17)",
+           "generateMetadata app/search-params-used-generate-metadata/page.tsx (9:38)",
          ],
        }
       `)
@@ -154,11 +201,11 @@ describe('use-cache-search-params', () => {
        Learn more: https://nextjs.org/docs/messages/next-request-in-use-cache",
          "environmentLabel": "Cache",
          "label": "Runtime Error",
-         "source": "app/search-params-used-generate-viewport/page.tsx (9:17) @ generateViewport
+         "source": "app/search-params-used-generate-viewport/page.tsx (9:38) @ generateViewport
        >  9 |   const color = (await searchParams).color
-            |                 ^",
+            |                                      ^",
          "stack": [
-           "generateViewport app/search-params-used-generate-viewport/page.tsx (9:17)",
+           "generateViewport app/search-params-used-generate-viewport/page.tsx (9:38)",
          ],
        }
       `)
@@ -179,8 +226,16 @@ describe('use-cache-search-params', () => {
         getExpectedErrorMessage('/search-params-caught')
       )
 
+      expect(cliOutput).toInclude(
+        getExpectedErrorMessage('/search-params-enumerated')
+      )
+
       expect(cliOutput).not.toInclude(
         getExpectedErrorMessage('/search-params-unused')
+      )
+
+      expect(cliOutput).not.toInclude(
+        getExpectedErrorMessage('/search-params-forwarded')
       )
 
       expect(cliOutput).toInclude(
@@ -191,8 +246,16 @@ describe('use-cache-search-params', () => {
         'Error occurred prerendering page "/search-params-caught"'
       )
 
+      expect(cliOutput).toInclude(
+        'Error occurred prerendering page "/search-params-enumerated"'
+      )
+
       expect(cliOutput).not.toInclude(
         'Error occurred prerendering page "/search-params-unused"'
+      )
+
+      expect(cliOutput).not.toInclude(
+        'Error occurred prerendering page "/search-params-forwarded"'
       )
     })
 


### PR DESCRIPTION
### What?

A cached page that forwards its props to a child Server Component reports `` `searchParams` can't be read inside `"use cache"` `` even though it never reads a search param. This shows a redbox in `next dev` and fails `next build --debug-prerender`.

```tsx
export default async function Page(props: PageProps<'/[slug]'>) {
  'use cache'

  return <PageInner {...props} />
}

async function PageInner(props: PageProps<'/[slug]'>) {
  const { slug } = await props.params

  return <h1>Page {slug}</h1>
}
```

Fixes #98173

### Why?

`searchParams` can't be read inside a public `"use cache"` scope, so we pass in a promise that errors. That promise threw when its `then` property was *read*, which means merely touching the promise was enough to trigger the error.

React's dev-only debug info serializer walks the props of every Server Component it renders and probes each prop for thenability by reading `.then`:

```
at throwForSearchParamsAccessInUseCache
at Object.get                     <- the erroring searchParams proxy
at renderDebugModel
at stringify
at emitOutlinedDebugModelChunk
at outlineDebugModel
at outlineComponentInfo
at renderFunctionComponent
```

React catches the error, but by then we have already recorded it on `workStore.invalidDynamicUsageError` — which we need so that a `searchParams` access swallowed by a `try`/`catch` is still reported (#77838) — and `collectResult` fails the cache render with it.

This regressed in #82578, which replaced the hanging `searchParams` promise for public caches with the erroring one. It only affects `next dev` and `next build --debug-prerender`, because debug info is not serialized in a production build.

### How?

The guard moves from the promise to the object that the promise resolves to. Awaiting the promise is now side-effect free, and consuming the search params is what errors. React's probe only reads well-known properties (`then`, `$$typeof`, `toJSON`, `@@iterator`), so it no longer trips the guard.

React does enumerate the resolved object when it serializes it as a component prop, so the `ownKeys` trap throws without recording the error. That keeps `{ ...(await searchParams) }` erroring in user code — the thrown error propagates through the render — while the serializer's own enumeration stays silent. Without this split, guarding `ownKeys` reintroduces the exact same false positive.

Everything that errored before still errors, with unchanged messages:

| | before | after |
| --- | --- | --- |
| `(await searchParams).foo` | errors | errors |
| `searchParams.foo` (no `await`) | errors | errors |
| `{ ...(await searchParams) }`, `Object.keys(await searchParams)` | errors | errors |
| `'foo' in (await searchParams)` | errors | errors |
| forwarding the promise into a nested cached function | errors | errors |
| passing the promise to a Client Component | errors | errors |
| **forwarding page props to a child Server Component** | **errors** | **no error** |

The only user-visible difference for the cases that still error is that the reported source location is now the read itself rather than the `await`, which the updated snapshots reflect:

```diff
- "source": "app/search-params-used/page.tsx (8:17) @ Page
+ "source": "app/search-params-used/page.tsx (8:38) @ Page
  >  8 |   const param = (await searchParams).foo
-      |                 ^",
+      |                                      ^",
```

### Verified

- `test/e2e/app-dir/use-cache-search-params` passes in `test-dev-turbo`, `test-dev-webpack` and `test-start-turbo`, with and without `cacheComponents`. Two tests are added: one for the forwarded-props case, one pinning that enumeration still errors.
- `test/e2e/app-dir/cache-components-errors` and `test/e2e/app-dir/use-cache` (228 tests) pass with `cacheComponents`, as do `use-cache-hanging`, `use-cache-hanging-inputs` and `dynamic-data`.
- On the reproduction from #98173, `next dev`, `next build` and `next build --debug-prerender` are clean for `/a`, and `/b` now reports the `params` error the issue author expected instead of the misleading `searchParams` one.
