### PR TITLE
fix(edge): don't stub optional Node.js APIs with a throwing function

### DIFF
--- a/packages/next/src/server/web/sandbox/context.ts
+++ b/packages/next/src/server/web/sandbox/context.ts
@@ -134,12 +134,26 @@ Learn more: https://nextjs.org/docs/api-reference/edge-runtime`)
   throw error
 }
 
+/**
+ * Node.js APIs that are documented as optional, meaning callers are expected
+ * to detect them before use and fall back when they are missing:
+ *
+ *     if (globalThis.process?.getBuiltinModule) { ... }
+ *
+ * Defining these as a function that throws would satisfy the detection and
+ * then fail at the call, so they are left off the polyfill entirely.
+ *
+ * https://nodejs.org/api/process.html#processgetbuiltinmoduleid
+ */
+const OPTIONAL_PROCESS_APIS = new Set(['getBuiltinModule'])
+
 function createProcessPolyfill(env: Record<string, string>) {
   const processPolyfill = { env: buildEnvironmentVariablesFrom(env) }
   const overriddenValue: Record<string, any> = {}
 
   for (const key of Object.keys(process)) {
     if (key === 'env') continue
+    if (OPTIONAL_PROCESS_APIS.has(key)) continue
     Object.defineProperty(processPolyfill, key, {
       get() {
         if (overriddenValue[key] !== undefined) {

--- a/test/e2e/edge-runtime-optional-node-apis/edge-runtime-optional-node-apis.test.ts
+++ b/test/e2e/edge-runtime-optional-node-apis/edge-runtime-optional-node-apis.test.ts
@@ -1,0 +1,26 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('edge runtime optional Node.js APIs', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('leaves process.getBuiltinModule undefined so feature detection can fall back', async () => {
+    const res = await next.fetch('/api/optional-node-apis')
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.detected).toBe(false)
+    expect(body.present).toBe(false)
+    expect(body.usedFallback).toBe(true)
+  })
+
+  it('still throws for Node.js APIs that are not optional', async () => {
+    const res = await next.fetch('/api/optional-node-apis')
+    const body = await res.json()
+
+    expect(body.unsupportedApiError).toContain(
+      'A Node.js API is used (process.cwd) which is not supported in the Edge Runtime'
+    )
+  })
+})

--- a/test/e2e/edge-runtime-optional-node-apis/pages/api/optional-node-apis.js
+++ b/test/e2e/edge-runtime-optional-node-apis/pages/api/optional-node-apis.js
@@ -1,0 +1,29 @@
+export const config = {
+  runtime: 'edge',
+}
+
+export default function handler() {
+  const detected = typeof globalThis.process?.getBuiltinModule === 'function'
+  const present = 'getBuiltinModule' in process
+
+  let usedFallback = false
+  if (globalThis.process?.getBuiltinModule) {
+    globalThis.process.getBuiltinModule('fs')
+  } else {
+    usedFallback = true
+  }
+
+  let unsupportedApiError = null
+  try {
+    process.cwd()
+  } catch (err) {
+    unsupportedApiError = err.message
+  }
+
+  return Response.json({
+    detected,
+    present,
+    usedFallback,
+    unsupportedApiError,
+  })
+}

--- a/test/e2e/edge-runtime-optional-node-apis/pages/index.tsx
+++ b/test/e2e/edge-runtime-optional-node-apis/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}


### PR DESCRIPTION
### What?

Importing a package that feature-detects `process.getBuiltinModule` crashes any route running on the Edge Runtime. The reporter hit this importing `bson` into a page with `runtime = "edge"`; the request 500s with "A Node.js API is used (process.getBuiltinModule) which is not supported in the Edge Runtime".

### Why?

`createProcessPolyfill` walks every own key of Node's real `process` and, for each one whose value is a function, defines a stub that throws. `getBuiltinModule` is an own enumerable function key, so it gets a stub like any other.

But Node documents `getBuiltinModule` as optional, and the documented way to use it is to check for it first:

```js
if (globalThis.process?.getBuiltinModule) {
  const fs = globalThis.process.getBuiltinModule('fs')
}
```
A stub satisfies that check, because it is a function. The guard passes, the call runs, and the call throws. Code written exactly the way Node prescribes is worse off than code that does nothing, and there is no way for a library to detect the difference.

How?

Optional APIs are now skipped when the polyfill is built, so they are absent rather than present-and-throwing. Both typeof process.getBuiltinModule and 'getBuiltinModule' in process then report absence, so either style of detection falls back correctly. They are listed in a named set so the criterion is explicit and the list can grow. APIs that are not optional, such as process.cwd, still throw exactly as before.

Verified against a dev server on the same edge route: the current build returns 500 with the error above, and the patched build returns 200 with the guard falling through and process.cwd still throwing.

Tests: new test/e2e/edge-runtime-optional-node-apis suite. An edge API route runs the documented detection, reports whether it fell back, and separately confirms a non-optional API still throws.

Fixes #98226