### PR TITLE
Re-enable @vercel/devlow-bench publishing

### DIFF
--- a/packages/devlow-bench/package.json
+++ b/packages/devlow-bench/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@vercel/devlow-bench",
-  "private": true,
   "version": "16.4.0-canary.23",
   "description": "Benchmarking tool for the developer workflow",
   "repository": {


### PR DESCRIPTION
## Summary

Revert 699ee92b2b168839af67404f1dddfcc999510651 to publish `@vercel/devlow-bench` again. Trusted publishing has now been set up, so the package should publish correctly.

## Verification

- Confirmed the package manifest parses without a `private` field and retains public access.

<!-- NEXT_JS_LLM -->