### PR TITLE
Fix root layout CSS duplicated in RSC payload through global-error styles

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -267,6 +267,7 @@ import {
 
 import { HTML_CONTENT_TYPE_HEADER, INFINITE_CACHE } from '../../lib/constants'
 import { createComponentStylesAndScripts } from './create-component-styles-and-scripts'
+import { getLinkAndScriptTags } from './get-css-inlined-link-tags'
 import { parseLoaderTree } from '../../shared/lib/router/utils/parse-loader-tree'
 import {
   createPrerenderResumeDataCache,
@@ -10444,7 +10445,8 @@ const getGlobalErrorStyles = async (
   GlobalError: GlobalErrorComponent
   styles: ReactNode | undefined
 }> => {
-  const globalErrorModule = parseLoaderTree(tree).modules['global-error']
+  const { layout: rootLayoutModule, 'global-error': globalErrorModule } =
+    parseLoaderTree(tree).modules
 
   if (!globalErrorModule) {
     throw new Error(
@@ -10456,12 +10458,22 @@ const getGlobalErrorStyles = async (
     componentMod: { createElement },
   } = ctx
 
+  // The root layout's CSS is already rendered as part of the tree, so it must
+  // not be sent again with the global-error styles. This matters for Turbopack,
+  // which also lists the root layout's CSS under the global-error entry of the
+  // client reference manifest; without excluding it, the stylesheet would be
+  // duplicated in the RSC payload (the entire content when using `inlineCss`).
+  const injectedCSS = new Set<string>()
+  if (rootLayoutModule) {
+    getLinkAndScriptTags(rootLayoutModule[1], injectedCSS, new Set(), true)
+  }
+
   // Get the GlobalError component and styles from the loader tree
   const [GlobalErrorComponent, styles] = await createComponentStylesAndScripts({
     ctx,
     filePath: globalErrorModule[1],
     getComponent: globalErrorModule[0],
-    injectedCSS: new Set(),
+    injectedCSS,
     injectedJS: new Set(),
   })
 

--- a/test/e2e/app-dir/app-inline-css/index.test.ts
+++ b/test/e2e/app-dir/app-inline-css/index.test.ts
@@ -16,6 +16,15 @@ describe('app dir - css - experimental inline css', () => {
       expect(await p.getComputedCss('color')).toBe('rgb(255, 255, 0)') // yellow
     })
 
+    it('should include the inlined root layout styles only once in the RSC payload', async () => {
+      const html = await next.render('/')
+
+      // Once in the <style> tag for SSR and once in the RSC payload. The
+      // global-error styles must not re-emit the root layout's stylesheet.
+      // https://github.com/vercel/next.js/issues/98079
+      expect(html.match(/var\(--font-1\)/g)).toHaveLength(2)
+    })
+
     it('should not return rsc payload with inlined style as a dynamic client nav', async () => {
       const rscPayload = await (
         await next.fetch(`/a?${NEXT_RSC_UNION_QUERY}`, {


### PR DESCRIPTION
### What?

With Turbopack, the root layout's stylesheet was emitted twice in the RSC payload: once by the root layout segment, and once more as part of the global-error styles (`G[1]`). With `experimental.inlineCss` that duplicates the entire CSS text, so every prerendered/ISR HTML document carried the stylesheet 3× (one SSR `<style>` + two flight copies) instead of the documented 2×, and `.rsc` / `_full.segment.rsc` carried it 2× instead of 1×.

### Why?

Turbopack's client reference manifest builds `entryCSSFiles` from per-layout accumulated chunk groups, so the built-in `global-error` (a client component processed right after the root layout) lists the root layout's CSS too. From the issue's repro:

```
"[project]/app/layout"                                                    => [1yt1zkn6fyezr.css]
"[project]/node_modules/next/dist/client/components/builtin/global-error" => [1yt1zkn6fyezr.css]
```

`getGlobalErrorStyles` looked this up with an empty `injectedCSS` set, so nothing deduplicated it. This affects every app since #88437 made the built-in global-error always part of the loader tree (before that, only a custom `global-error.tsx` under Turbopack was affected). Webpack lists no CSS under the global-error entry and was never affected.

### How?

Seed `injectedCSS` with the root layout's CSS before collecting the global-error styles — the same dedup every other module in the tree gets through `injectedCSSWithCurrentLayout`. The root layout's CSS is always part of the rendered tree (and hoisted stylesheets are never removed), so the global-error styles only need to carry CSS that `global-error` itself imports. That matches webpack, and the documented contract that `global-error` "does not include your global styles".

Verified on the issue's repro (`next build --turbopack`, occurrences of the CSS text):

| artifact | before | after |
| --- | --- | --- |
| `nl.html` | 3 | 2 |
| `nl.rsc` | 2 | 1 |
| `nl.segments/_full.segment.rsc` | 2 | 1 |
| `nl.segments/_index.segment.rsc` | 1 | 1 |

A custom `global-error.tsx` importing its own CSS still receives that CSS in `G[1]` (checked manually, and covered by `test/e2e/app-dir/global-error/with-style-import`). The new test in `app-inline-css` fails on canary (3 copies) and passes with this change, in both Turbopack and webpack.

> **Behavior note for reviewers:** with Turbopack, a custom `global-error.tsx` that relied on CSS imported only by the root layout used to receive that CSS through `G[1]` by accident. After this change it doesn't (same as webpack today, and per the docs `global-error` "must define its own … global styles" / "does not include your global styles"). Its own imported CSS is unaffected.

Fixes #98079
