### PR TITLE
Turbopack: don't crash when resolving `next/package.json` errors

### DIFF
--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -6,7 +6,7 @@ use either::Either;
 use next_taskless::{EDGE_NODE_EXTERNALS, NODE_EXTERNALS};
 use rustc_hash::FxHashMap;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, ResolvedVc, Vc, fxindexmap};
+use turbo_tasks::{FxIndexMap, PrettyPrintError, ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::{
     FileContent, FileSystem, FileSystemPath,
     glob::{Glob, GlobOptions},
@@ -1311,6 +1311,9 @@ pub async fn get_next_package(context_directory: FileSystemPath) -> Result<FileS
 struct MissingNextFolderIssue {
     path: FileSystemPath,
     root: FileSystemPath,
+    /// Set when resolving `next/package.json` failed with an error, rather than the package not
+    /// being found.
+    error_message: Option<RcStr>,
 }
 
 #[async_trait]
@@ -1347,7 +1350,7 @@ impl Issue for MissingNextFolderIssue {
             _ => rcstr!("{unknown}"),
         };
 
-        Ok(Some(StyledString::Stack(vec![
+        let mut description = vec![
             StyledString::Line(vec![
                 StyledString::Text(rcstr!("Resolved from: ")),
                 StyledString::Strong(context_path),
@@ -1356,6 +1359,14 @@ impl Issue for MissingNextFolderIssue {
                 StyledString::Text(rcstr!("Filesystem root used for resolution: ")),
                 StyledString::Strong(root_path),
             ]),
+        ];
+        if let Some(error_message) = &self.error_message {
+            description.push(StyledString::Line(vec![
+                StyledString::Text(rcstr!("Resolution error: ")),
+                StyledString::Text(error_message.clone()),
+            ]));
+        }
+        description.extend([
             StyledString::Line(vec![StyledString::Text(rcstr!(""))]),
             StyledString::Line(vec![StyledString::Text(rcstr!("Possible causes:"))]),
             StyledString::Line(vec![StyledString::Text(rcstr!(
@@ -1387,7 +1398,8 @@ impl Issue for MissingNextFolderIssue {
                 "Note: To ensure a hermetic build and a portable cache, files outside of the \
                  workspace root are not compiled."
             ))]),
-        ])))
+        ]);
+        Ok(Some(StyledString::Stack(description)))
     }
 
     fn documentation_link(&self) -> RcStr {
@@ -1408,12 +1420,20 @@ pub async fn try_get_next_package(
         Request::parse(Pattern::Constant(rcstr!("next/package.json"))),
         node_cjs_resolve_options(root.clone()),
     );
-    if let Some(source) = result.await?.first_source() {
+    // A resolution error (e.g. `node_modules` is a symlink whose target is outside of the
+    // filesystem root) is reported like a missing package. Propagating it would surface as a
+    // fatal internal error instead of a recoverable issue.
+    let (source, error_message) = match result.await {
+        Ok(result) => (result.first_source(), None),
+        Err(error) => (None, Some(PrettyPrintError(&error).to_string().into())),
+    };
+    if let Some(source) = source {
         Ok(Vc::cell(Some(source.ident().await?.path.parent())))
     } else {
         MissingNextFolderIssue {
             path: context_directory,
             root,
+            error_message,
         }
         .resolved_cell()
         .emit();

--- a/test/development/app-dir/node-modules-symlink-outside-root/app/layout.tsx
+++ b/test/development/app-dir/node-modules-symlink-outside-root/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/node-modules-symlink-outside-root/app/page.tsx
+++ b/test/development/app-dir/node-modules-symlink-outside-root/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/node-modules-symlink-outside-root/node-modules-symlink-outside-root.test.ts
+++ b/test/development/app-dir/node-modules-symlink-outside-root/node-modules-symlink-outside-root.test.ts
@@ -1,0 +1,69 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import fs from 'fs/promises'
+import path from 'path'
+
+/**
+ * `node_modules` is a symlink whose target is outside of the project root, e.g. a git worktree
+ * that shares the `node_modules` of the primary checkout.
+ *
+ * Turbopack does not follow symlinks that leave the filesystem root, so `next/package.json` cannot
+ * be resolved. The dev server must:
+ *   - surface a recoverable issue that names the cause
+ *   - NOT crash with a `TurbopackInternalError` / "FATAL" log
+ */
+const describeMaybe =
+  process.env.NEXT_SKIP_ISOLATE ||
+  !process.env.IS_TURBOPACK_TEST ||
+  // Creating symlinks requires elevated privileges on Windows.
+  process.platform === 'win32'
+    ? describe.skip
+    : describe
+
+describeMaybe('node-modules-symlink-outside-root', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  let outsideDir: string
+
+  beforeAll(async () => {
+    // Move the installed `node_modules` next to the project and link to it from the project.
+    const nodeModules = path.join(next.testDir, 'node_modules')
+    outsideDir = `${next.testDir}-outside`
+    await fs.mkdir(outsideDir)
+    await fs.rename(nodeModules, path.join(outsideDir, 'node_modules'))
+    await fs.symlink(path.join(outsideDir, 'node_modules'), nodeModules)
+
+    await next.start()
+  })
+
+  afterAll(async () => {
+    await fs.rm(outsideDir, { recursive: true, force: true })
+  })
+
+  it('surfaces a friendly issue instead of crashing', async () => {
+    await retry(
+      async () => {
+        expect(next.cliOutput).toContain(
+          'Could not find the Next.js package (next/package.json)'
+        )
+      },
+      10000,
+      500
+    )
+    expect(next.cliOutput).toContain(
+      'Symlink node_modules could not be resolved: the symlink target leaves the filesystem root'
+    )
+
+    expect(next.cliOutput).not.toContain(
+      'FATAL: An unexpected Turbopack error occurred'
+    )
+    expect(next.cliOutput).not.toContain('TurbopackInternalError')
+
+    // The dev server is still running.
+    const res = await next.fetch('/')
+    expect(res.status).toBe(500)
+  })
+})


### PR DESCRIPTION
### What?

When `next/package.json` can't be resolved because resolution *errors* (as opposed to the package simply not being found), Turbopack crashed with a fatal `TurbopackInternalError` asking the user to report a bug:

```
FATAL: An unexpected Turbopack error occurred. A panic log has been written to …
Error [TurbopackInternalError]: Symlink node_modules could not be resolved: the symlink target leaves the filesystem root or its parent directory could not be resolved
```

This happens e.g. when `node_modules` is a symlink whose target is outside of the workspace root — a git worktree that shares the `node_modules` of the primary checkout ([#98111](https://github.com/vercel/next.js/issues/98111)) — since Turbopack intentionally doesn't follow symlinks that leave the root.

This PR reports that error through the existing recoverable `MissingNextFolderIssue` instead, including the underlying error, so `next dev` stays up and `next build` fails with the actionable message from #93877:

```
Error: Could not find the Next.js package (next/package.json)
Resolved from: /…/worktree/app
Filesystem root used for resolution: /…/worktree
Resolution error: Symlink node_modules could not be resolved: the symlink target leaves the filesystem root or its parent directory could not be resolved
…
Possible causes:
  - …
  - node_modules/next was removed, renamed, or has a broken symlink.
  - The workspace root is incorrect — see turbopack.root in the Next.js config docs for how to configure it.
  …
https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#root-directory
```

This does **not** make symlinks outside of the root work; that's tracked in #93556 and being implemented in #98003. It only turns the internal-error crash into the existing user-facing error.

### Why?

`try_get_next_package` only handled the "not found" case (`Ok` with no source). A resolution `Err` was propagated with `?` and no issue was emitted, so `strongly_consistent_catch_collectables` at the napi boundary had nothing to downgrade the failure to and it surfaced as an internal error — the exact failure mode #93877 fixed for the not-found case. Every other resolution in Turbopack already reports errors this way (`handle_resolve_error` → `ResolvingIssue` with the error message).

### How?

- `try_get_next_package`: match on `result.await`; on `Err`, emit `MissingNextFolderIssue` and return `None`, exactly like the not-found path. The success and not-found paths are unchanged.
- `MissingNextFolderIssue`: new `error_message: Option<RcStr>` (formatted with `PrettyPrintError`, like `ResolvingIssue`), rendered as a `Resolution error:` line. `None` for the not-found case, so that output is unchanged.
- New test `test/development/app-dir/node-modules-symlink-outside-root` (moves the installed `node_modules` out of the project and symlinks it back). Fails on `canary` with the FATAL above, passes with this change. `test/development/app-dir/concurrent-install` still passes.

Related: #98111, #93556, #98003
