### PR TITLE
Skip styles for the built-in global-error

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -287,7 +287,10 @@ import {
 } from './module-loading/track-module-loading.external'
 import { isReactLargeShellError } from './react-large-shell-error'
 import type { GlobalErrorComponent } from '../../client/components/builtin/global-error'
-import { normalizeConventionFilePath } from './segment-explorer-path'
+import {
+  isNextjsBuiltinFilePath,
+  normalizeConventionFilePath,
+} from './segment-explorer-path'
 import { getRequestMeta } from '../request-meta'
 import {
   getDynamicParam,
@@ -10465,7 +10468,13 @@ const getGlobalErrorStyles = async (
     injectedJS: new Set(),
   })
 
-  let globalErrorStyles: ReactNode = styles
+  // The built-in global-error doesn't import any stylesheets, so it doesn't
+  // need any styles. With Turbopack, its CSS entry still contains the root
+  // layout's stylesheets, which would otherwise be duplicated in the RSC
+  // payload.
+  const isBuiltinGlobalError = isNextjsBuiltinFilePath(globalErrorModule[1])
+
+  let globalErrorStyles: ReactNode = isBuiltinGlobalError ? undefined : styles
 
   if (process.env.__NEXT_DEV_SERVER) {
     const dir =

--- a/test/e2e/app-dir/app-inline-css/app/global.css
+++ b/test/e2e/app-dir/app-inline-css/app/global.css
@@ -1,3 +1,7 @@
+:root {
+  --root-layout-css-marker: 1;
+}
+
 p {
   color: yellow;
 }

--- a/test/e2e/app-dir/app-inline-css/index.test.ts
+++ b/test/e2e/app-dir/app-inline-css/index.test.ts
@@ -93,5 +93,13 @@ describe('app dir - css - experimental inline css', () => {
       expect(res.status).toBe(200)
       expect(res.headers.get('content-type')).toContain('font')
     })
+
+    it('should not include the root layout stylesheets in the global error styles', async () => {
+      const html = await next.render('/')
+
+      // The root layout's stylesheets are expected to be inlined twice: once
+      // in a <style> tag for SSR, and once in the RSC payload.
+      expect(html.match(/--root-layout-css-marker/g)).toHaveLength(2)
+    })
   })
 })


### PR DESCRIPTION
### What?

With Turbopack, the RSC payload of every page includes the root layout's stylesheets a second time as the styles of the built-in `global-error` (the `"G"` entry). With `experimental.inlineCss` that is a full extra copy of the global CSS in every prerendered HTML document.

This PR skips the styles for the built-in `global-error`, which doesn't have any stylesheets.

### Why?

`getGlobalErrorStyles` renders the CSS entry of the `global-error` module from the client reference manifest. Turbopack's manifest lists CSS cumulatively along the layout chain: the entry of a module below a layout also contains that layout's stylesheets. So the entry of the built-in `global-error` is exactly the root layout's CSS, although it doesn't import any CSS itself (it only uses inline styles).

#88437 started adding the built-in `global-error` to the loader tree (before, only a user-defined one was part of it), which is when apps without a custom `global-error` started to get this extra copy. Webpack's manifest is per module, so there's no entry for the built-in `global-error` and no duplication there.

For the repro from the issue, `.next/server/app/index.html` contains the global stylesheet 3 times before and 2 times after this change (once inlined in a `<style>` tag for SSR and once in the RSC payload, which is the documented limitation of `inlineCss`).

User-defined `global-error` files are intentionally unchanged: their styles have to be self-sufficient. When the root layout errors on the server, the client hydrates the `__next_error__` shell — which has no stylesheets — from the original RSC payload, and the layout's stylesheets never commit because the render throws. A `global-error` that imports the same stylesheet as the root layout would render unstyled if the shared stylesheet were deduplicated from `G`, because with Turbopack that stylesheet only appears in the `global-error` entry through the root layout's chunk group. I verified this with a headless browser: with the root layout throwing, `global-error` importing `globals.css` keeps its styles on canary and with this PR, but loses them when `G` is deduplicated against the root layout's (#98241) or all rendered (#98136) stylesheets.

### How?

- `getGlobalErrorStyles`: don't return styles when the `global-error` module is the built-in one (`isNextjsBuiltinFilePath`, the same check `create-component-tree` uses for it). This restores the behavior from before #88437 and matches webpack.
- Test: assert that the root layout's stylesheet is only inlined twice in the `app-inline-css` fixture (fails with Turbopack before this change).

Fixes #98110
