### PR TITLE
Fix spurious webpack rebuild on cold start when Tailwind content directories don't exist

### DIFF
--- a/packages/next/src/build/webpack/loaders/postcss-loader/src/index.ts
+++ b/packages/next/src/build/webpack/loaders/postcss-loader/src/index.ts
@@ -1,6 +1,27 @@
+import { existsSync } from 'fs'
 import Warning from './Warning'
 import SyntaxError from './Error'
 import { normalizeSourceMap, normalizeSourceMapAfterPostcss } from './utils'
+
+/**
+ * Registers a directory reported by a PostCSS plugin as a dependency of the
+ * module.
+ *
+ * A directory that doesn't exist (e.g. a Tailwind CSS `content` glob like
+ * `./pages/**` in a project without a `pages` directory) is registered as a
+ * missing dependency instead of a context dependency. Webpack still
+ * invalidates the module once the directory is created, but the watcher no
+ * longer reports the non-existent directory as removed right after the first
+ * compilation, which triggered a spurious rebuild that rewrote the emitted
+ * chunks while the browser could still be downloading them.
+ */
+function addContextDependency(loaderContext: any, directory: string): void {
+  if (existsSync(directory)) {
+    loaderContext.addContextDependency(directory)
+  } else {
+    loaderContext.addMissingDependency(directory)
+  }
+}
 
 /**
  * **PostCSS Loader**
@@ -94,10 +115,10 @@ export default async function loader(
             this.addMissingDependency(message.file)
             break
           case 'context-dependency':
-            this.addContextDependency(message.file)
+            addContextDependency(this, message.file)
             break
           case 'dir-dependency':
-            this.addContextDependency(message.dir)
+            addContextDependency(this, message.dir)
             break
           case 'asset':
             if (message.content && message.file) {

--- a/test/unit/postcss-loader.test.ts
+++ b/test/unit/postcss-loader.test.ts
@@ -1,0 +1,74 @@
+/* eslint-env jest */
+import os from 'os'
+import path from 'path'
+import postcss from 'postcss'
+import { Span } from 'next/dist/trace'
+import loader from 'next/dist/build/webpack/loaders/postcss-loader/src'
+
+const existingDir = path.resolve(os.tmpdir())
+const missingDir = path.join(
+  existingDir,
+  `next-postcss-loader-missing-${process.pid}-${Date.now()}`
+)
+
+function runLoader(messages: Array<Record<string, unknown>>) {
+  const loaderContext = {
+    resourcePath: path.join(existingDir, 'styles.css'),
+    context: existingDir,
+    sourceMap: false,
+    emitWarning: jest.fn(),
+    emitFile: jest.fn(),
+    addDependency: jest.fn(),
+    addBuildDependency: jest.fn(),
+    addMissingDependency: jest.fn(),
+    addContextDependency: jest.fn(),
+    currentTraceSpan: new Span({ name: 'test' }),
+    getOptions: () => ({
+      postcss: async () => ({
+        postcssWithPlugins: postcss([
+          {
+            postcssPlugin: 'test-messages',
+            Once(_root, { result }) {
+              result.messages.push(...(messages as any[]))
+            },
+          },
+        ]),
+      }),
+    }),
+    async: undefined as unknown as () => (err: Error | null) => void,
+  }
+
+  return new Promise<typeof loaderContext>((resolve, reject) => {
+    loaderContext.async = () => (err) =>
+      err ? reject(err) : resolve(loaderContext)
+    loader.call(loaderContext, 'a { color: red }', null, null)
+  })
+}
+
+describe('postcss-loader', () => {
+  it.each([
+    ['dir-dependency', 'dir'],
+    ['context-dependency', 'file'],
+  ])(
+    'registers an existing directory from a %s message as a context dependency',
+    async (type, key) => {
+      const ctx = await runLoader([{ type, [key]: existingDir }])
+
+      expect(ctx.addContextDependency).toHaveBeenCalledWith(existingDir)
+      expect(ctx.addMissingDependency).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each([
+    ['dir-dependency', 'dir'],
+    ['context-dependency', 'file'],
+  ])(
+    'registers a non-existent directory from a %s message as a missing dependency',
+    async (type, key) => {
+      const ctx = await runLoader([{ type, [key]: missingDir }])
+
+      expect(ctx.addMissingDependency).toHaveBeenCalledWith(missingDir)
+      expect(ctx.addContextDependency).not.toHaveBeenCalled()
+    }
+  )
+})


### PR DESCRIPTION
### What?

When a PostCSS plugin reports a directory that doesn't exist as a `dir-dependency` / `context-dependency`, the postcss-loader now registers it with `addMissingDependency` instead of `addContextDependency`. Existing directories are still registered as context dependencies.

Tailwind CSS v3 reports a `dir-dependency` for the base directory of every `content` glob, including ones that don't exist. The `create-next-app` Tailwind template shipped `./pages/**/*`, `./components/**/*` and `./app/**/*` (or the `./src/...` variants), so most App Router projects created with it register one or two non-existent directories on every cold start.

### Why?

webpack's watcher (watchpack) reports a *context* dependency that doesn't exist as **removed** as soon as it attaches to it, i.e. right after the first compilation that registered it. That forces a second, spurious client compilation ~20ms after `ensurePage` has already resolved, so the HTML is sent while webpack is rebuilding. ~300ms later the rebuild re-emits `static/chunks/app/layout.js` (the chunk that contains the global CSS) while the browser is downloading it. Dev chunks are served straight from disk, so the browser gets a truncated file: either `ERR_CONTENT_LENGTH_MISMATCH`, or, when `stat` observes the file mid-write, a complete-looking response with truncated JS that throws `SyntaxError: Invalid or unexpected token` and ends 120s later in `ChunkLoadError: Loading chunk app/layout failed. (timeout: …/app/layout.js)`. A reload works because the watcher state is settled by then.

Both reproductions attached to #66526 and #64760 have `content: ['./src/pages/**/*…', …]` without a `src/pages` directory, plus a large client component tree in the root layout (Clerk / antd), which makes the download slow enough to overlap with the rewrite. Timeline traced on the #64760 reproduction (`next@14.2.2`, cold `next dev`, `fs.writeFile` and webpack hooks instrumented):

```
[+12502ms] WEBPACK[client] done                                      ← ensurePage('/') resolves, render starts
[+12524ms] WEBPACK[client] invalid
[+12525ms] WEBPACK[client] watchRun modified=[] removed=["…/src/pages"]  ← phantom removal
[+13005ms] HTTP  fin GET /  200                                      ← HTML sent
[+13046ms] HTTP  req GET /_next/static/chunks/app/layout.js          ← browser starts downloading (9 MB)
[+13291ms] writeFile START static/chunks/app/layout.js               ← rebuild rewrites it → truncated response
```

watchpack already special-cases *files* listed as missing (`if (!missing.has(file)) onRemove(...)`) but not directories, so registering the directory as a missing dependency is the intended way to express "watch this path for creation".

The same sequence reproduces on 13.5.1, 13.5.2, 14.2.x and 16.3.4 (`--webpack`), so this is not a regression from #55562. Turbopack is unaffected.

### How?

Only the non-existent branch changes. A missing dependency still invalidates the compilation when the directory is created: creating `src/pages/Extra.tsx` with a new Tailwind class triggers a rebuild and the class shows up in the CSS, and later edits inside the new directory are picked up too (verified identical to the behaviour before this change).

With the change, the cold start of the reproduction runs a single client compilation (no `removed=[…]` `watchRun`) and `app/layout.js` is written once, before the HTML is sent: 0/3 truncated responses vs 2/2 before. `test/development/basic/tailwind-jit`, `test/e2e/app-dir/tailwind-css`, `test/e2e/app-dir/no-double-tailwind-execution` and `test/e2e/postcss-config-cjs` pass in webpack dev mode. The added unit test fails without the loader change.

Scope: this removes the trigger the tracked reproductions hit (and a wasted full client recompile on every cold start for these projects). It does not make chunk serving robust against any rebuild that lands while a chunk is being downloaded, e.g. an HMR edit during a slow download; that would need atomic emits or gating static chunk requests on the compiler being idle.

Fixes #66526
Closes NEXT-3982
