### PR TITLE
fix(next/image): follow redirects for internal image requests

### DIFF
--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -989,7 +989,9 @@ export async function fetchInternalImage(
     newReq: IncomingMessage,
     newRes: ServerResponse,
     newParsedUrl?: NextUrlWithParsedQuery
-  ) => Promise<void>
+  ) => Promise<void>,
+  dangerouslyAllowLocalIP = false,
+  count = 3
 ): Promise<ImageUpstream> {
   try {
     // Coerce HEAD to GET to avoid issues with the image optimizer
@@ -1004,6 +1006,51 @@ export async function fetchInternalImage(
 
     await handleRequest(mocked.req, mocked.res, parseReqUrl(href))
     await mocked.res.hasStreamed
+
+    const locationHeader = mocked.res.getHeader('Location')
+    if (
+      isRedirect(mocked.res.statusCode) &&
+      typeof locationHeader === 'string'
+    ) {
+      if (count === 0) {
+        Log.error('internal image response had too many redirects', href)
+        throw new ImageError(
+          508,
+          '"url" parameter is valid but internal response is invalid'
+        )
+      }
+
+      const redirect = URL.canParse(locationHeader)
+        ? new URL(locationHeader)
+        : URL.canParse(locationHeader, 'http://n')
+          ? new URL(locationHeader, 'http://n')
+          : null
+
+      if (
+        redirect &&
+        redirect.origin !== 'http://n' &&
+        (redirect.protocol === 'http:' || redirect.protocol === 'https:')
+      ) {
+        return fetchExternalImage(
+          redirect.href,
+          dangerouslyAllowLocalIP,
+          maximumResponseBody,
+          count - 1
+        )
+      }
+
+      if (redirect?.origin === 'http://n') {
+        return fetchInternalImage(
+          `${redirect.pathname}${redirect.search}`,
+          _req,
+          _res,
+          maximumResponseBody,
+          handleRequest,
+          dangerouslyAllowLocalIP,
+          count - 1
+        )
+      }
+    }
 
     if (!mocked.res.statusCode) {
       Log.error('image response failed for', href, mocked.res.statusCode)

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -753,7 +753,9 @@ export default class NextNodeServer extends BaseServer<
             req.originalRequest,
             res.originalResponse,
             this.nextConfig.images.maximumResponseBody,
-            handleInternalReq
+            handleInternalReq,
+            this.nextConfig.images.dangerouslyAllowLocalIP,
+            this.nextConfig.images.maximumRedirects
           )
 
       return imageOptimizer(imageUpstream, paramsResult, this.nextConfig, {

--- a/test/unit/image-optimizer/fetch-internal-image.test.ts
+++ b/test/unit/image-optimizer/fetch-internal-image.test.ts
@@ -6,6 +6,80 @@ import {
 import type { IncomingMessage, ServerResponse } from 'http'
 
 describe('fetchInternalImage', () => {
+  describe('redirects', () => {
+    it('should follow absolute redirects to external images', async () => {
+      const mockReq = {} as IncomingMessage
+      const mockRes = {} as ServerResponse
+      const maximumResponseBody = 300_000_000
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array([1, 2, 3]))
+            controller.close()
+          },
+        }),
+        headers: {
+          get: jest.fn((header: string) => {
+            if (header === 'Content-Type') return 'image/png'
+            return null
+          }),
+        },
+      })
+
+      const handleRequest = jest.fn(async (_req: IncomingMessage, res: any) => {
+        res.statusCode = 302
+        res.setHeader('Location', 'https://example.com/test.png')
+        res.end()
+      })
+
+      const result = await fetchInternalImage(
+        '/redirected-image',
+        mockReq,
+        mockRes,
+        maximumResponseBody,
+        handleRequest,
+        false
+      )
+
+      expect(result.buffer).toEqual(Buffer.from([1, 2, 3]))
+      expect(result.contentType).toBe('image/png')
+      expect(global.fetch).toHaveBeenCalledWith('https://example.com/test.png', {
+        signal: expect.any(AbortSignal),
+        redirect: 'manual',
+      })
+    })
+
+    it('should throw error when response has too many internal redirects', async () => {
+      const mockReq = {} as IncomingMessage
+      const mockRes = {} as ServerResponse
+      const maximumResponseBody = 300_000_000
+
+      const handleRequest = jest.fn(async (_req: IncomingMessage, res: any) => {
+        res.statusCode = 302
+        res.setHeader('Location', '/redirected-image')
+        res.end()
+      })
+
+      const error = await fetchInternalImage(
+        '/redirected-image',
+        mockReq,
+        mockRes,
+        maximumResponseBody,
+        handleRequest,
+        false
+      ).catch((e) => e)
+
+      expect(error).toBeInstanceOf(ImageError)
+      expect((error as ImageError).statusCode).toBe(508)
+      expect((error as ImageError).message).toBe(
+        '"url" parameter is valid but internal response is invalid'
+      )
+    })
+  })
+
   describe('response size limit', () => {
     it('should throw error when response has no buffers', async () => {
       const mockReq = {} as IncomingMessage


### PR DESCRIPTION
Closes #98237

Fixes `next/image` optimization for relative image URLs that redirect to an external image. Internal image responses now handle redirect status codes before treating the response body as invalid, and external redirects continue through the existing upstream image fetch path.

### Changelog

**Fixed**

- Followed redirect responses from internal image optimization requests.
- Preserved `images.maximumRedirects`, `images.maximumResponseBody`, and `images.dangerouslyAllowLocalIP` when an internal image request redirects externally.
- Added unit coverage for internal-to-external redirects and internal redirect loop limits.

**Changed**

- Passed image redirect and local-IP settings into the internal image fetch path.

**Removed**

- None.

#### Testing / Reviewing

1. Run the focused unit test:

       pnpm test-unit test/unit/image-optimizer/fetch-internal-image.test.ts

2. Run a focused Next.js build:

       pnpm --filter=next build

3. Verify a relative image route returning a 302 `Location` to an external image renders through `next/image`.

<!-- NEXT_JS_LLM_PR -->