### PR TITLE
test(turbopack): remove dead top-level task unmarks

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/benches/gc.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/gc.rs
@@ -12,9 +12,7 @@ use std::{sync::Arc, time::Duration};
 use anyhow::Result;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput};
 use tokio::runtime::Runtime;
-use turbo_tasks::{
-    ResolvedVc, State, TurboTasks, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
-};
+use turbo_tasks::{ResolvedVc, State, TurboTasks, Vc};
 use turbo_tasks_backend::{
     BackendOptions, BackingStorageOptions, EvictionMode, GitVersionInfo, StorageMode,
     TurboTasksBackend,
@@ -105,7 +103,6 @@ fn setup_wide_garbage(
         // backend must be constructed inside the runtime context.
         let (tt, dir) = create_tt();
         turbo_tasks::run_once(tt.clone(), async move {
-            unmark_top_level_task_may_leak_eventually_consistent_state();
             let generation_op = create_generation();
             let generation_vc = generation_op.resolve().strongly_consistent().await?;
             let generation = generation_op.read_strongly_consistent().await?;

--- a/turbopack/crates/turbo-tasks-backend/tests/detached.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/detached.rs
@@ -9,7 +9,7 @@ use tokio::{
 use turbo_tasks::{
     State, TransientInstance, Vc, prevent_gc,
     trace::{TraceRawVcs, TraceRawVcsContext},
-    turbo_tasks, unmark_top_level_task_may_leak_eventually_consistent_state,
+    turbo_tasks,
 };
 use turbo_tasks_testing::{Registration, register, run_once};
 
@@ -87,7 +87,6 @@ async fn spawns_detached(
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_spawns_detached_changing() -> anyhow::Result<()> {
     run_once(&REGISTRATION, async || {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
         // HACK: The watch channel we use has an incorrect implementation of `TraceRawVcs`
         prevent_gc();
         // timeout: prevent the test from hanging, and fail instead if this is broken

--- a/turbopack/crates/turbo-tasks-backend/tests/eviction.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/eviction.rs
@@ -10,9 +10,7 @@ use std::sync::{
 };
 
 use anyhow::Result;
-use turbo_tasks::{
-    ResolvedVc, State, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
-};
+use turbo_tasks::{ResolvedVc, State, Vc};
 
 use crate::util::{create_tt, create_tt_with_workers};
 
@@ -24,8 +22,6 @@ async fn eviction_recompute() {
     let tt2 = tt.clone();
 
     let result = turbo_tasks::run_once(tt.clone(), async move {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-
         // Create state via operation (persistent task)
         let state_op = create_state(1);
         let state_vc = state_op.resolve().strongly_consistent().await?;
@@ -66,8 +62,6 @@ async fn eviction_deep_chain() {
     let tt2 = tt.clone();
 
     let result = turbo_tasks::run_once(tt.clone(), async move {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-
         let state_op = create_state(10);
         let state_vc = state_op.resolve().strongly_consistent().await?;
         let state = state_op.read_strongly_consistent().await?;
@@ -123,8 +117,6 @@ async fn eviction_dependency_chain() {
     let tt2 = tt.clone();
 
     let result = turbo_tasks::run_once(tt.clone(), async move {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-
         let state_op = create_state(10);
         let state_vc = state_op.resolve().strongly_consistent().await?;
         let state = state_op.read_strongly_consistent().await?;
@@ -301,8 +293,6 @@ async fn eviction_session_stateful_survives() {
     let tt2 = tt.clone();
 
     let result = turbo_tasks::run_once(tt.clone(), async move {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-
         // read_session_counter internally creates+resolves create_session_counter(42).
         // The transient run_once only reads read_session_counter, so
         // create_session_counter has no transient dependents and is eligible for
@@ -354,8 +344,6 @@ async fn eviction_transient_reader_invalidated() {
     let tt2 = tt.clone();
 
     let result = turbo_tasks::run_once(tt.clone(), async move {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-
         // Create persistent state + compute tasks
         let state_op = create_state(50);
         let state_vc = state_op.resolve().strongly_consistent().await?;
@@ -466,8 +454,6 @@ async fn eviction_stress_concurrent() {
     });
 
     let result = turbo_tasks::run_once(tt.clone(), async move {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-
         let state_op = create_state(1);
         let state_vc = state_op.resolve().strongly_consistent().await?;
         let state = state_op.read_strongly_consistent().await?;
@@ -608,8 +594,6 @@ async fn eviction_persistable_never_preserves_live_cell() {
     let tt2 = tt.clone();
 
     let result = turbo_tasks::run_once(tt.clone(), async move {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-
         let state_op = create_state(0);
         let state_vc = state_op.resolve().strongly_consistent().await?;
         let state = state_op.read_strongly_consistent().await?;


### PR DESCRIPTION
## Summary

Remove stale `unmark_top_level_task_may_leak_eventually_consistent_state()` calls from tests and a benchmark that already use strongly consistent operation-root reads.

## Verification

- `cargo test -p turbo-tasks-backend --test detached --test eviction`
- `cargo check -p turbo-tasks-backend --benches`
- `cargo fmt --all -- --check`

<!-- NEXT_JS_LLM -->

<!-- fleet 475180cd-06a7-4669-89b5-a2029a3a18c9 -->