### PR TITLE
fix(typegen): merge cacheLife types into next/cache instead of shadowing it

### DIFF
--- a/packages/next/cache.d.ts
+++ b/packages/next/cache.d.ts
@@ -20,6 +20,8 @@ import { cacheTag } from 'next/dist/server/use-cache/cache-tag'
 
 export { cacheTag }
 
+export interface CacheLifeProfiles {}
+
 /**
  * Cache this `"use cache"` for a timespan defined by the `"default"` profile.
  * ```
@@ -128,7 +130,9 @@ export function cacheLife(profile: 'max'): void
  *
  * You can define custom profiles in `next.config.ts`.
  */
-export function cacheLife(profile: string): void
+export function cacheLife(
+  profile: keyof CacheLifeProfiles extends never ? string : never
+): void
 
 /**
  * Cache this `"use cache"` using a custom timespan.

--- a/packages/next/src/server/lib/router-utils/cache-life-type-utils.test.ts
+++ b/packages/next/src/server/lib/router-utils/cache-life-type-utils.test.ts
@@ -20,19 +20,13 @@ describe('cache-life-type-utils', () => {
     expect(output).toMatchInlineSnapshot(`
      "// Type definitions for Next.js cacheLife configs
 
-     declare module 'next/cache' {
-       export { unstable_cache } from 'next/dist/server/web/spec-extension/unstable-cache'
-       export {
-         updateTag,
-         revalidateTag,
-         revalidatePath,
-         refresh,
-       } from 'next/dist/server/web/spec-extension/revalidate'
-       export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
-       export { io } from 'next/dist/server/request/io'
-       export { unstable_navigation } from 'next/dist/server/request/cache-stages'
-       export { unstable_prefetch } from 'next/dist/server/request/cache-stages'
+     export {}
 
+     declare module 'next/cache' {
+       export interface CacheLifeProfiles {
+         "default": true
+         "hours": true
+       }
        
          /**
           * Cache this \`"use cache"\` for a timespan defined by the \`"default"\` profile.
@@ -62,39 +56,6 @@ describe('cache-life-type-utils', () => {
           */
          export function cacheLife(profile: "hours"): void
          
-         /**
-          * Cache this \`"use cache"\` using a custom timespan.
-          * \`\`\`
-          *   stale: ... // seconds
-          *   revalidate: ... // seconds
-          *   expire: ... // seconds
-          * \`\`\`
-          *
-          * This is similar to Cache-Control: max-age=\`stale\`,s-max-age=\`revalidate\`,stale-while-revalidate=\`expire-revalidate\`
-          *
-          * If a value is left out, the lowest of other cacheLife() calls or the default, is used instead.
-          */
-         export function cacheLife(profile: {
-           /**
-            * This cache may be stale on clients for ... seconds before checking with the server.
-            */
-           stale?: number,
-           /**
-            * If the server receives a new request after ... seconds, start revalidating new values in the background.
-            */
-           revalidate?: number,
-           /**
-            * If this entry has no traffic for ... seconds it will expire. The next request will recompute it.
-            */
-           expire?: number
-         }): void
-       
-
-       import { cacheTag } from 'next/dist/server/use-cache/cache-tag'
-       export { cacheTag }
-
-       export const unstable_cacheTag: typeof cacheTag
-       export const unstable_cacheLife: typeof cacheLife
      }
      "
     `)
@@ -159,10 +120,7 @@ describe('cache-life-type-utils', () => {
           *   expire:     1814400 seconds (3 weeks)
           *   stale:      2592000 seconds (1 month)
           *   revalidate: 5184000 seconds (2 months)
-          *   expire:     10368000 seconds (4 months)
-          *   stale: ... // seconds
-          *   revalidate: ... // seconds
-          *   expire: ... // seconds"
+          *   expire:     10368000 seconds (4 months)"
     `)
   })
 
@@ -180,19 +138,12 @@ describe('cache-life-type-utils', () => {
     expect(output).toMatchInlineSnapshot(`
      "// Type definitions for Next.js cacheLife configs
 
-     declare module 'next/cache' {
-       export { unstable_cache } from 'next/dist/server/web/spec-extension/unstable-cache'
-       export {
-         updateTag,
-         revalidateTag,
-         revalidatePath,
-         refresh,
-       } from 'next/dist/server/web/spec-extension/revalidate'
-       export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
-       export { io } from 'next/dist/server/request/io'
-       export { unstable_navigation } from 'next/dist/server/request/cache-stages'
-       export { unstable_prefetch } from 'next/dist/server/request/cache-stages'
+     export {}
 
+     declare module 'next/cache' {
+       export interface CacheLifeProfiles {
+         "partial": true
+       }
        
          /**
           * Cache this \`"use cache"\` for a timespan defined by the \`"partial"\` profile.
@@ -208,39 +159,6 @@ describe('cache-life-type-utils', () => {
           */
          export function cacheLife(profile: "partial"): void
          
-         /**
-          * Cache this \`"use cache"\` using a custom timespan.
-          * \`\`\`
-          *   stale: ... // seconds
-          *   revalidate: ... // seconds
-          *   expire: ... // seconds
-          * \`\`\`
-          *
-          * This is similar to Cache-Control: max-age=\`stale\`,s-max-age=\`revalidate\`,stale-while-revalidate=\`expire-revalidate\`
-          *
-          * If a value is left out, the lowest of other cacheLife() calls or the default, is used instead.
-          */
-         export function cacheLife(profile: {
-           /**
-            * This cache may be stale on clients for ... seconds before checking with the server.
-            */
-           stale?: number,
-           /**
-            * If the server receives a new request after ... seconds, start revalidating new values in the background.
-            */
-           revalidate?: number,
-           /**
-            * If this entry has no traffic for ... seconds it will expire. The next request will recompute it.
-            */
-           expire?: number
-         }): void
-       
-
-       import { cacheTag } from 'next/dist/server/use-cache/cache-tag'
-       export { cacheTag }
-
-       export const unstable_cacheTag: typeof cacheTag
-       export const unstable_cacheLife: typeof cacheLife
      }
      "
     `)
@@ -260,19 +178,12 @@ describe('cache-life-type-utils', () => {
     expect(output).toMatchInlineSnapshot(`
      "// Type definitions for Next.js cacheLife configs
 
-     declare module 'next/cache' {
-       export { unstable_cache } from 'next/dist/server/web/spec-extension/unstable-cache'
-       export {
-         updateTag,
-         revalidateTag,
-         revalidatePath,
-         refresh,
-       } from 'next/dist/server/web/spec-extension/revalidate'
-       export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
-       export { io } from 'next/dist/server/request/io'
-       export { unstable_navigation } from 'next/dist/server/request/cache-stages'
-       export { unstable_prefetch } from 'next/dist/server/request/cache-stages'
+     export {}
 
+     declare module 'next/cache' {
+       export interface CacheLifeProfiles {
+         "infinite": true
+       }
        
          /**
           * Cache this \`"use cache"\` for a timespan defined by the \`"infinite"\` profile.
@@ -287,45 +198,12 @@ describe('cache-life-type-utils', () => {
           */
          export function cacheLife(profile: "infinite"): void
          
-         /**
-          * Cache this \`"use cache"\` using a custom timespan.
-          * \`\`\`
-          *   stale: ... // seconds
-          *   revalidate: ... // seconds
-          *   expire: ... // seconds
-          * \`\`\`
-          *
-          * This is similar to Cache-Control: max-age=\`stale\`,s-max-age=\`revalidate\`,stale-while-revalidate=\`expire-revalidate\`
-          *
-          * If a value is left out, the lowest of other cacheLife() calls or the default, is used instead.
-          */
-         export function cacheLife(profile: {
-           /**
-            * This cache may be stale on clients for ... seconds before checking with the server.
-            */
-           stale?: number,
-           /**
-            * If the server receives a new request after ... seconds, start revalidating new values in the background.
-            */
-           revalidate?: number,
-           /**
-            * If this entry has no traffic for ... seconds it will expire. The next request will recompute it.
-            */
-           expire?: number
-         }): void
-       
-
-       import { cacheTag } from 'next/dist/server/use-cache/cache-tag'
-       export { cacheTag }
-
-       export const unstable_cacheTag: typeof cacheTag
-       export const unstable_cacheLife: typeof cacheLife
      }
      "
     `)
   })
 
-  it('should include base cacheLife function signature', () => {
+  it('should only declare the generated profile overloads', () => {
     const cacheLifeConfig = {
       custom: {
         stale: 100,
@@ -339,19 +217,12 @@ describe('cache-life-type-utils', () => {
     expect(output).toMatchInlineSnapshot(`
      "// Type definitions for Next.js cacheLife configs
 
-     declare module 'next/cache' {
-       export { unstable_cache } from 'next/dist/server/web/spec-extension/unstable-cache'
-       export {
-         updateTag,
-         revalidateTag,
-         revalidatePath,
-         refresh,
-       } from 'next/dist/server/web/spec-extension/revalidate'
-       export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
-       export { io } from 'next/dist/server/request/io'
-       export { unstable_navigation } from 'next/dist/server/request/cache-stages'
-       export { unstable_prefetch } from 'next/dist/server/request/cache-stages'
+     export {}
 
+     declare module 'next/cache' {
+       export interface CacheLifeProfiles {
+         "custom": true
+       }
        
          /**
           * Cache this \`"use cache"\` for a timespan defined by the \`"custom"\` profile.
@@ -367,45 +238,12 @@ describe('cache-life-type-utils', () => {
           */
          export function cacheLife(profile: "custom"): void
          
-         /**
-          * Cache this \`"use cache"\` using a custom timespan.
-          * \`\`\`
-          *   stale: ... // seconds
-          *   revalidate: ... // seconds
-          *   expire: ... // seconds
-          * \`\`\`
-          *
-          * This is similar to Cache-Control: max-age=\`stale\`,s-max-age=\`revalidate\`,stale-while-revalidate=\`expire-revalidate\`
-          *
-          * If a value is left out, the lowest of other cacheLife() calls or the default, is used instead.
-          */
-         export function cacheLife(profile: {
-           /**
-            * This cache may be stale on clients for ... seconds before checking with the server.
-            */
-           stale?: number,
-           /**
-            * If the server receives a new request after ... seconds, start revalidating new values in the background.
-            */
-           revalidate?: number,
-           /**
-            * If this entry has no traffic for ... seconds it will expire. The next request will recompute it.
-            */
-           expire?: number
-         }): void
-       
-
-       import { cacheTag } from 'next/dist/server/use-cache/cache-tag'
-       export { cacheTag }
-
-       export const unstable_cacheTag: typeof cacheTag
-       export const unstable_cacheLife: typeof cacheLife
      }
      "
     `)
   })
 
-  it('should include module exports', () => {
+  it('should augment next/cache instead of redeclaring its exports', () => {
     const cacheLifeConfig = {
       test: {
         stale: 100,
@@ -419,19 +257,12 @@ describe('cache-life-type-utils', () => {
     expect(output).toMatchInlineSnapshot(`
      "// Type definitions for Next.js cacheLife configs
 
-     declare module 'next/cache' {
-       export { unstable_cache } from 'next/dist/server/web/spec-extension/unstable-cache'
-       export {
-         updateTag,
-         revalidateTag,
-         revalidatePath,
-         refresh,
-       } from 'next/dist/server/web/spec-extension/revalidate'
-       export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
-       export { io } from 'next/dist/server/request/io'
-       export { unstable_navigation } from 'next/dist/server/request/cache-stages'
-       export { unstable_prefetch } from 'next/dist/server/request/cache-stages'
+     export {}
 
+     declare module 'next/cache' {
+       export interface CacheLifeProfiles {
+         "test": true
+       }
        
          /**
           * Cache this \`"use cache"\` for a timespan defined by the \`"test"\` profile.
@@ -447,39 +278,6 @@ describe('cache-life-type-utils', () => {
           */
          export function cacheLife(profile: "test"): void
          
-         /**
-          * Cache this \`"use cache"\` using a custom timespan.
-          * \`\`\`
-          *   stale: ... // seconds
-          *   revalidate: ... // seconds
-          *   expire: ... // seconds
-          * \`\`\`
-          *
-          * This is similar to Cache-Control: max-age=\`stale\`,s-max-age=\`revalidate\`,stale-while-revalidate=\`expire-revalidate\`
-          *
-          * If a value is left out, the lowest of other cacheLife() calls or the default, is used instead.
-          */
-         export function cacheLife(profile: {
-           /**
-            * This cache may be stale on clients for ... seconds before checking with the server.
-            */
-           stale?: number,
-           /**
-            * If the server receives a new request after ... seconds, start revalidating new values in the background.
-            */
-           revalidate?: number,
-           /**
-            * If this entry has no traffic for ... seconds it will expire. The next request will recompute it.
-            */
-           expire?: number
-         }): void
-       
-
-       import { cacheTag } from 'next/dist/server/use-cache/cache-tag'
-       export { cacheTag }
-
-       export const unstable_cacheTag: typeof cacheTag
-       export const unstable_cacheLife: typeof cacheLife
      }
      "
     `)
@@ -503,19 +301,12 @@ describe('cache-life-type-utils', () => {
     expect(output).toMatchInlineSnapshot(`
      "// Type definitions for Next.js cacheLife configs
 
-     declare module 'next/cache' {
-       export { unstable_cache } from 'next/dist/server/web/spec-extension/unstable-cache'
-       export {
-         updateTag,
-         revalidateTag,
-         revalidatePath,
-         refresh,
-       } from 'next/dist/server/web/spec-extension/revalidate'
-       export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
-       export { io } from 'next/dist/server/request/io'
-       export { unstable_navigation } from 'next/dist/server/request/cache-stages'
-       export { unstable_prefetch } from 'next/dist/server/request/cache-stages'
+     export {}
 
+     declare module 'next/cache' {
+       export interface CacheLifeProfiles {
+         "valid": true
+       }
        
          /**
           * Cache this \`"use cache"\` for a timespan defined by the \`"valid"\` profile.
@@ -531,39 +322,6 @@ describe('cache-life-type-utils', () => {
           */
          export function cacheLife(profile: "valid"): void
          
-         /**
-          * Cache this \`"use cache"\` using a custom timespan.
-          * \`\`\`
-          *   stale: ... // seconds
-          *   revalidate: ... // seconds
-          *   expire: ... // seconds
-          * \`\`\`
-          *
-          * This is similar to Cache-Control: max-age=\`stale\`,s-max-age=\`revalidate\`,stale-while-revalidate=\`expire-revalidate\`
-          *
-          * If a value is left out, the lowest of other cacheLife() calls or the default, is used instead.
-          */
-         export function cacheLife(profile: {
-           /**
-            * This cache may be stale on clients for ... seconds before checking with the server.
-            */
-           stale?: number,
-           /**
-            * If the server receives a new request after ... seconds, start revalidating new values in the background.
-            */
-           revalidate?: number,
-           /**
-            * If this entry has no traffic for ... seconds it will expire. The next request will recompute it.
-            */
-           expire?: number
-         }): void
-       
-
-       import { cacheTag } from 'next/dist/server/use-cache/cache-tag'
-       export { cacheTag }
-
-       export const unstable_cacheTag: typeof cacheTag
-       export const unstable_cacheLife: typeof cacheLife
      }
      "
     `)

--- a/packages/next/src/server/lib/router-utils/cache-life-type-utils.ts
+++ b/packages/next/src/server/lib/router-utils/cache-life-type-utils.ts
@@ -71,6 +71,7 @@ function formatTimespanWithSeconds(seconds: undefined | number): string {
 export function generateCacheLifeTypes(cacheLife: {
   [profile: string]: CacheLife
 }): string {
+  let profileKeys = ''
   let overloads = ''
 
   const profileNames = Object.keys(cacheLife)
@@ -80,6 +81,9 @@ export function generateCacheLifeTypes(cacheLife: {
     if (typeof profile !== 'object' || profile === null) {
       continue
     }
+
+    profileKeys += `
+    ${JSON.stringify(profileName)}: true`
 
     let description = ''
 
@@ -136,58 +140,21 @@ export function generateCacheLifeTypes(cacheLife: {
     `
   }
 
-  overloads += `
-    /**
-     * Cache this \`"use cache"\` using a custom timespan.
-     * \`\`\`
-     *   stale: ... // seconds
-     *   revalidate: ... // seconds
-     *   expire: ... // seconds
-     * \`\`\`
-     *
-     * This is similar to Cache-Control: max-age=\`stale\`,s-max-age=\`revalidate\`,stale-while-revalidate=\`expire-revalidate\`
-     *
-     * If a value is left out, the lowest of other cacheLife() calls or the default, is used instead.
-     */
-    export function cacheLife(profile: {
-      /**
-       * This cache may be stale on clients for ... seconds before checking with the server.
-       */
-      stale?: number,
-      /**
-       * If the server receives a new request after ... seconds, start revalidating new values in the background.
-       */
-      revalidate?: number,
-      /**
-       * If this entry has no traffic for ... seconds it will expire. The next request will recompute it.
-       */
-      expire?: number
-    }): void
-  `
-
-  // Redefine the cacheLife() accepted arguments.
+  // The top-level `export {}` makes this file a module, which in turn makes
+  // the block below a module augmentation that merges into the `next/cache`
+  // types. Without it the file is a script, the block is a standalone ambient
+  // module declaration, and it shadows `next/cache` instead of merging: every
+  // other export then has to be redeclared here, and TypeScript offers two
+  // identical auto-import completions for each of them, one from this file and
+  // one from the package's own types.
   return `// Type definitions for Next.js cacheLife configs
 
+export {}
+
 declare module 'next/cache' {
-  export { unstable_cache } from 'next/dist/server/web/spec-extension/unstable-cache'
-  export {
-    updateTag,
-    revalidateTag,
-    revalidatePath,
-    refresh,
-  } from 'next/dist/server/web/spec-extension/revalidate'
-  export { unstable_noStore } from 'next/dist/server/web/spec-extension/unstable-no-store'
-  export { io } from 'next/dist/server/request/io'
-  export { unstable_navigation } from 'next/dist/server/request/cache-stages'
-  export { unstable_prefetch } from 'next/dist/server/request/cache-stages'
-
+  export interface CacheLifeProfiles {${profileKeys}
+  }
   ${overloads}
-
-  import { cacheTag } from 'next/dist/server/use-cache/cache-tag'
-  export { cacheTag }
-
-  export const unstable_cacheTag: typeof cacheTag
-  export const unstable_cacheLife: typeof cacheLife
 }
 `
 }

--- a/test/e2e/cache-life-typecheck/app/layout.tsx
+++ b/test/e2e/cache-life-typecheck/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/cache-life-typecheck/app/page.tsx
+++ b/test/e2e/cache-life-typecheck/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/cache-life-typecheck/cache-life-typecheck.test.ts
+++ b/test/e2e/cache-life-typecheck/cache-life-typecheck.test.ts
@@ -1,0 +1,35 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import execa from 'execa'
+
+describe('cache-life-typecheck', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('accepts configured cacheLife profiles and rejects unknown ones', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+
+    await retry(async () => {
+      await next.readFile(`${next.distDir}/types/cache-life.d.ts`)
+    }, 10_000)
+
+    await next.stop()
+    try {
+      const { stdout, stderr } = await execa('pnpm', ['tsc', '--noEmit'], {
+        cwd: next.testDir,
+        reject: false,
+      })
+
+      expect({ stdout, stderr }).toEqual({ stdout: '', stderr: '' })
+    } finally {
+      await next.start()
+    }
+  })
+})

--- a/test/e2e/cache-life-typecheck/next.config.js
+++ b/test/e2e/cache-life-typecheck/next.config.js
@@ -1,0 +1,14 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheLife: {
+    blog: {
+      stale: 300,
+      revalidate: 900,
+      expire: 3600,
+    },
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/cache-life-typecheck/tsconfig.json
+++ b/test/e2e/cache-life-typecheck/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.mts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/test/e2e/cache-life-typecheck/typecheck-validation.ts
+++ b/test/e2e/cache-life-typecheck/typecheck-validation.ts
@@ -1,0 +1,13 @@
+import { cacheLife, unstable_cacheLife } from 'next/cache'
+
+export function validate() {
+  cacheLife('blog')
+  cacheLife('minutes')
+  cacheLife({ stale: 30, revalidate: 60, expire: 120 })
+  unstable_cacheLife('blog')
+
+  // @ts-expect-error unknown profile
+  cacheLife('bogus')
+  // @ts-expect-error unknown profile
+  unstable_cacheLife('bogus')
+}


### PR DESCRIPTION
### What?

After `next build`, `next dev`, or `next typegen`, every `next/cache` export is offered twice in editor autocomplete. Both entries are labelled identically as `Add import from "next/cache"`, so there is no way to tell them apart. It affects any file in the project, since these are auto-import suggestions.
### Why?
`.next/types/cache-life.d.ts` has no top-level import or export. That makes it a script rather than a module, which in
turn makes its `declare module 'next/cache'` a standalone ambient module declaration instead of a moduleaugmentation. So it shadows the package's own types rather than merging with them, and that is why the generated file
has to redeclare every unrelated `next/cache` export just to keep them resolvable.
Ambient declarations win module resolution, so after a build imports resolve to the generated file. But TypeScript'sauto-import index still indexes `node_modules/next/cache.d.ts` as a module exporting those same names. Both are then
offered under the `next/cache` specifier, producing two identical completions per export.
### How?
Emit a top-level `export {}` in the generated file. That makes it a module, so the `declare module 'next/cache'` blockbelow becomes an augmentation and merges into the package's types. The redeclarations of `revalidatePath`,
`revalidateTag`, `unstable_cache`, `cacheTag` and the rest were only needed while the file was shadowing, so they areremoved.

Merging also brings back the package's catch-all `cacheLife(profile: string)` overload from `next/cache.d.ts`, which the shadowing file used to hide. On its own that would make `cacheLife('bogus')` compile, where today it is a type error (thanks to @m-elagamy for measuring this).

To keep that check, `next/cache` now declares an empty `CacheLifeProfiles` interface, and the generated file augments it with one key per configured profile alongside the per-profile overloads. The catch-all's parameter is `keyof CacheLifeProfiles extends never ? string : never`, so it accepts any string until the types have been generated and nothing once they have. Configured names, the built-in profiles and the object form still resolve to their own overloads, with their documentation. This is the same shape as the draft in vercel-labs/next.js#199.

Tests: `test/e2e/cache-life-typecheck` builds an app with a custom `blog` profile, waits for `cache-life.d.ts` to be written, and runs `tsc --noEmit` against it. The validation file calls `cacheLife` with the custom profile, a built-in profile, the object form and the `unstable_` alias, and has `@ts-expect-error` on two unknown names, so it fails if either the generated overloads or the unknown-name check stop working. A shadowing file would also fail it, since the catch-all and the object form would no longer be visible. The existing inline snapshots in `cache-life-type-utils.test.ts` cover the generated file's shape. The LanguageService unit test from the first revision is removed per review.

Fixes #98251