### PR TITLE
Dev server: More aggresively scold users for deleting .next when we detect it while dev is running

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -600,6 +600,8 @@ export async function startServer(
       if (dirWatchPaths.includes(removedPath)) {
         Log.error(
           `The directory at "${removedPath}" was deleted.\n\n` +
+            'Deleting this directory removes caches and will cause slower ' +
+            'performance.\n\n' +
             'Deleting this directory while Next.js is running can lead to ' +
             'undefined behavior. Restarting the server to recover...'
         )


### PR DESCRIPTION
Feedback: https://vercel.slack.com/archives/C03KAR5DCKC/p1788491653257349?thread_ts=1788490509.032699&cid=C03KAR5DCKC

Message was added in https://github.com/vercel/next.js/pull/92135

We can't detect this in most other cases where users (or agents tbh) delete `.next`, but in this case we can.