### PR TITLE
Add Turbopack HMR subscription initialization regression tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4928,6 +4928,7 @@ dependencies = [
  "turbo-tasks-env",
  "turbo-tasks-fs",
  "turbo-tasks-hash",
+ "turbo-tasks-testing",
  "turbo-unix-path",
  "turbopack",
  "turbopack-analyze",

--- a/crates/next-api/Cargo.toml
+++ b/crates/next-api/Cargo.toml
@@ -56,6 +56,7 @@ urlencoding = { workspace = true }
 tokio = { workspace = true }
 tempfile = { workspace = true }
 turbo-tasks-backend = { workspace = true }
+turbo-tasks-testing = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -111,6 +111,17 @@ use crate::{
     versioned_content_map::VersionedContentMap,
 };
 
+async fn read_hmr_version_baseline(
+    version_op: OperationVc<Box<dyn Version>>,
+) -> Result<TraitRef<Box<dyn Version>>> {
+    // INVALIDATION: This is intentionally eventual and untracked. The baseline
+    // must remain the first version observed when the subscription starts. A
+    // strongly consistent read can restart after an invalidation and instead
+    // adopt the post-edit version. The following update then appears empty even
+    // though an already-loaded browser still has the pre-edit output.
+    version_op.connect().into_trait_ref().untracked().await
+}
+
 #[turbo_tasks::task_input]
 #[derive(
     Debug,
@@ -2558,12 +2569,7 @@ impl Project {
         }
         let version_op = hmr_version_operation(self, chunk_name.clone(), target);
 
-        // INVALIDATION: This is intentionally eventual and untracked. The baseline
-        // must remain the first version observed when the subscription starts. A
-        // strongly consistent read can restart after an invalidation and instead
-        // adopt the post-edit version. The following update then appears empty even
-        // though an already-loaded browser still has the pre-edit output.
-        let initial_version = version_op.connect().into_trait_ref().untracked().await?;
+        let initial_version = read_hmr_version_baseline(version_op).await?;
         if tracing::enabled!(target: "turbopack_hmr_diagnostics", tracing::Level::INFO) {
             let version_id = TraitRef::cell(initial_version.clone())
                 .id()
@@ -3049,4 +3055,111 @@ fn all_assets_from_entries_operation(
 ) -> Result<Vc<ExpandedOutputAssets>> {
     let assets = operation.connect();
     Ok(all_assets_from_entries(assets))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use anyhow::Result;
+    use turbo_rcstr::{RcStr, rcstr};
+    use turbo_tasks::{
+        OperationVc, ReadRef, ResolvedVc, State, TraitRef, Vc, mark_top_level_task,
+        unmark_top_level_task_may_leak_eventually_consistent_state,
+    };
+    use turbo_tasks_testing::{Registration, register, run_once};
+    use turbopack_core::version::Version;
+
+    use super::read_hmr_version_baseline;
+
+    static REGISTRATION: Registration = register!();
+
+    #[turbo_tasks::value]
+    struct ChangingVersion {
+        value: State<RcStr>,
+    }
+
+    #[turbo_tasks::value]
+    struct TestVersion {
+        value: RcStr,
+    }
+
+    #[turbo_tasks::value_impl]
+    impl Version for TestVersion {
+        #[turbo_tasks::function]
+        fn id(&self) -> Vc<RcStr> {
+            Vc::cell(self.value.clone())
+        }
+    }
+
+    #[turbo_tasks::function(operation, root)]
+    async fn slow_internal_operation(input: ResolvedVc<ChangingVersion>) -> Result<Vc<()>> {
+        let _ = input.await?.value.get();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        Ok(Vc::cell(()))
+    }
+
+    #[turbo_tasks::function(operation, root)]
+    async fn version_operation(input: ResolvedVc<ChangingVersion>) -> Result<Vc<Box<dyn Version>>> {
+        let value = input.await?.value.get().clone();
+        let _ = slow_internal_operation(input).connect();
+        Ok(Vc::upcast(TestVersion { value }.cell()))
+    }
+
+    async fn read_strongly_consistent_version_baseline(
+        version_op: OperationVc<Box<dyn Version>>,
+    ) -> Result<TraitRef<Box<dyn Version>>> {
+        version_op
+            .read_trait_strongly_consistent()
+            .untracked()
+            .await
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn hmr_version_baseline_keeps_the_first_observed_version() {
+        run_once(&REGISTRATION, || async {
+            let input = ReadRef::new_owned(ChangingVersion {
+                value: State::new(rcstr!("before")),
+            });
+            let input_vc = ReadRef::resolved_cell(input.clone());
+            unmark_top_level_task_may_leak_eventually_consistent_state();
+            let (baseline, ()) = tokio::join!(
+                read_hmr_version_baseline(version_operation(input_vc)),
+                async {
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    input.value.set(rcstr!("after"));
+                }
+            );
+            let baseline = baseline?;
+            let baseline_id = TraitRef::cell(baseline).id().untracked().owned().await?;
+
+            // The previous implementation used this strongly-consistent read.
+            // Under the same invalidation schedule it restarts and adopts the
+            // post-edit version, demonstrating the lost-update failure mode.
+            let strong_input = ReadRef::new_owned(ChangingVersion {
+                value: State::new(rcstr!("before")),
+            });
+            let strong_input_vc = ReadRef::resolved_cell(strong_input.clone());
+            let (strong_baseline, ()) = tokio::join!(
+                read_strongly_consistent_version_baseline(version_operation(strong_input_vc)),
+                async {
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    strong_input.value.set(rcstr!("after"));
+                }
+            );
+            let strong_baseline = strong_baseline?;
+            let strong_baseline_id = TraitRef::cell(strong_baseline)
+                .id()
+                .untracked()
+                .owned()
+                .await?;
+
+            mark_top_level_task();
+            assert_eq!(baseline_id.as_str(), "before");
+            assert_eq!(strong_baseline_id.as_str(), "after");
+            Ok(())
+        })
+        .await
+        .unwrap()
+    }
 }

--- a/crates/next-api/tests/test_config.trs
+++ b/crates/next-api/tests/test_config.trs
@@ -1,0 +1,29 @@
+|name, initial| {
+  use std::hash::BuildHasher;
+  let path = std::env::temp_dir().join(
+    format!("next-api-test-{}", rustc_hash::FxBuildHasher.hash_one(name)));
+  if initial {
+    let _ = std::fs::remove_dir_all(&path);
+  }
+  std::fs::create_dir_all(&path).unwrap();
+  turbo_tasks::TurboTasks::new(
+    turbo_tasks_backend::TurboTasksBackend::new(
+      turbo_tasks_backend::BackendOptions {
+        num_workers: Some(2),
+        small_preallocation: true,
+        storage_mode: Some(turbo_tasks_backend::StorageMode::ReadWriteOnShutdown),
+        ..Default::default()
+      },
+      turbo_tasks_backend::turbo_backing_storage(
+        path.as_path(),
+        &turbo_tasks_backend::GitVersionInfo {
+          describe: "test-unversioned",
+          dirty: false,
+        },
+        false,
+        true,
+        false,
+      ).unwrap().0
+    )
+  )
+}

--- a/test/development/app-dir/hmr-dynamic-component/hmr-dynamic-component.test.ts
+++ b/test/development/app-dir/hmr-dynamic-component/hmr-dynamic-component.test.ts
@@ -8,9 +8,6 @@ describe('hmr-dynamic-component', () => {
   const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: __dirname,
     patchFileDelay: 500,
-    env: {
-      NEXT_TURBOPACK_HMR_DIAGNOSTICS: '1',
-    },
   })
 
   it('should update text in a dynamically-imported client component without a full reload', async () => {
@@ -191,7 +188,6 @@ export default function Dynamic() {
       try {
         await next.patchFile(componentPath, createComponent('before'))
 
-        const cliOutputStart = next.cliOutput.length
         const subscriptionPaths = new Set<string>()
         let editTriggered = false
         let pageLoads = 0
@@ -239,12 +235,6 @@ export default function Dynamic() {
           const div = await browser.elementByCss('#dynamic-component')
           expect(await div.text()).toContain(
             `HMR subscription after ${moduleCount}`
-          )
-        }, 10000)
-
-        await retry(() => {
-          expect(next.cliOutput.slice(cliOutputStart)).toContain(
-            'client-subscription-initial-update'
           )
         }, 10000)
 

--- a/test/development/app-dir/hmr-dynamic-component/hmr-dynamic-component.test.ts
+++ b/test/development/app-dir/hmr-dynamic-component/hmr-dynamic-component.test.ts
@@ -1,11 +1,16 @@
+import { mkdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+import type * as Playwright from 'playwright'
 
 describe('hmr-dynamic-component', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: __dirname,
     patchFileDelay: 500,
+    env: {
+      NEXT_TURBOPACK_HMR_DIAGNOSTICS: '1',
+    },
   })
 
   it('should update text in a dynamically-imported client component without a full reload', async () => {
@@ -138,4 +143,118 @@ describe('hmr-dynamic-component', () => {
       await next.patchFile(cssPath, originalCss)
     }
   })
+  if (isTurbopack && isNextDev) {
+    it('should not lose an edit while establishing the client HMR subscription', async () => {
+      const componentPath = join('app', 'components', 'dynamic.tsx')
+      const absoluteComponentPath = join(next.testDir, componentPath)
+      const originalContent = await next.readFile(componentPath)
+      const graphDirectory = join(
+        next.testDir,
+        'app',
+        'components',
+        'hmr-subscription-race'
+      )
+      const moduleCount = 800
+
+      mkdirSync(graphDirectory, { recursive: true })
+      for (let index = 0; index < moduleCount; index++) {
+        writeFileSync(
+          join(graphDirectory, `module-${index}.ts`),
+          `export default ${index}\n`
+        )
+      }
+
+      const createComponent = (label: string) => `
+'use client'
+
+import styles from './dynamic.module.css'
+${Array.from(
+  { length: moduleCount },
+  (_, index) =>
+    `import value${index} from './hmr-subscription-race/module-${index}'`
+).join('\n')}
+
+const values = [${Array.from(
+        { length: moduleCount },
+        (_, index) => `value${index}`
+      ).join(', ')}]
+
+export default function Dynamic() {
+  return (
+    <div id="dynamic-component" className={styles.dynamic}>
+      HMR subscription ${label} {values.length}
+    </div>
+  )
+}
+`
+
+      try {
+        await next.patchFile(componentPath, createComponent('before'))
+
+        const cliOutputStart = next.cliOutput.length
+        const subscriptionPaths = new Set<string>()
+        let editTriggered = false
+        let pageLoads = 0
+
+        const browser = await next.browser('/', {
+          beforePageLoad(page: Playwright.Page) {
+            page.on('load', () => {
+              pageLoads++
+            })
+            page.on('websocket', (ws) => {
+              if (!ws.url().includes('/_next/hmr')) {
+                return
+              }
+              ws.on('framesent', (frame) => {
+                const payload =
+                  typeof frame.payload === 'string'
+                    ? frame.payload
+                    : frame.payload.toString('utf8')
+                try {
+                  const message = JSON.parse(payload)
+                  if (
+                    message?.type === 'turbopack-subscribe' &&
+                    typeof message?.path === 'string' &&
+                    message.path.endsWith('.js')
+                  ) {
+                    subscriptionPaths.add(message.path)
+                    if (subscriptionPaths.size === 2 && !editTriggered) {
+                      editTriggered = true
+                      writeFileSync(
+                        absoluteComponentPath,
+                        createComponent('after')
+                      )
+                    }
+                  }
+                } catch {
+                  // Non-JSON frames are unrelated to Turbopack subscriptions.
+                }
+              })
+            })
+          },
+        })
+
+        await retry(async () => {
+          expect(editTriggered).toBe(true)
+          const div = await browser.elementByCss('#dynamic-component')
+          expect(await div.text()).toContain(
+            `HMR subscription after ${moduleCount}`
+          )
+        }, 10000)
+
+        await retry(() => {
+          expect(next.cliOutput.slice(cliOutputStart)).toContain(
+            'client-subscription-initial-update'
+          )
+        }, 10000)
+
+        // The edit must arrive through HMR, not a recovery reload.
+        expect(pageLoads).toBe(1)
+      } finally {
+        await next.patchFile(componentPath, originalContent)
+      }
+    })
+  } else {
+    it.skip('subscription race is Turbopack development-mode only', () => {})
+  }
 })


### PR DESCRIPTION
## Summary

Adds deterministic Rust coverage proving that the HMR subscription baseline retains the first observed version when invalidation overlaps initialization. The `project.rs` production diff only extracts the existing baseline read into a helper so the colocated `#[cfg(test)]` module exercises the exact production path.

Adds a Turbopack development-mode e2e test that edits a client component as its page-specific HMR subscription is established, then verifies that the initial update reaches the browser without a full-page reload.

This PR is stacked on #98215 and contains the regression coverage for that fix.

## Verification

- `cargo test -p next-api --lib`
- `cargo fmt --all -- --check`
- `NEXT_TEST_PREFER_OFFLINE=1 pnpm test-dev-turbo test/development/app-dir/hmr-dynamic-component/hmr-dynamic-component.test.ts -t "should not lose an edit while establishing the client HMR subscription"`
- `pnpm lint-eslint test/development/app-dir/hmr-dynamic-component/hmr-dynamic-component.test.ts`

<!-- NEXT_JS_LLM -->