### PR TITLE
test: add failing nested scroll restoration case

### DIFF
--- a/test/e2e/app-dir/back-forward-cache/app/nested-scroll-restoration/detail/page.tsx
+++ b/test/e2e/app-dir/back-forward-cache/app/nested-scroll-restoration/detail/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h2 id="nested-scroll-detail">Detail</h2>
+}

--- a/test/e2e/app-dir/back-forward-cache/app/nested-scroll-restoration/page.tsx
+++ b/test/e2e/app-dir/back-forward-cache/app/nested-scroll-restoration/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div
+      id="nested-scroll-container"
+      style={{ height: 300, overflowY: 'auto' }}
+    >
+      <Link
+        id="nested-scroll-detail-link"
+        href="/nested-scroll-restoration/detail"
+        style={{ position: 'sticky', top: 0 }}
+      >
+        Open detail
+      </Link>
+      <div style={{ height: 2000 }} />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
+++ b/test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts
@@ -267,4 +267,40 @@ describe('back/forward cache', () => {
       await browser.elementById('counter-display-1')
     expect(await counterDisplay1AfterNav.text()).toBe('Count: 2')
   })
+
+  // TODO: Remove `.failing` once nested scroll restoration is fixed.
+  it.failing(
+    'preserves a nested scroll position across repeated back/forward navigations',
+    async () => {
+      const browser = await next.browser('/nested-scroll-restoration')
+
+      const scrollPosition = await browser.eval(() => {
+        const scroller = document.getElementById('nested-scroll-container')
+        scroller!.scrollTop = 1000
+        return scroller!.scrollTop
+      })
+
+      await browser.elementById('nested-scroll-detail-link').click()
+      await browser.waitForElementByCss('#nested-scroll-detail')
+
+      await browser.back()
+      await browser.waitForElementByCss('#nested-scroll-container')
+      expect(
+        await browser.eval(
+          `document.getElementById('nested-scroll-container').scrollTop`
+        )
+      ).toBe(scrollPosition)
+
+      await browser.forward()
+      await browser.waitForElementByCss('#nested-scroll-detail')
+      await browser.back()
+      await browser.waitForElementByCss('#nested-scroll-container')
+
+      expect(
+        await browser.eval(
+          `document.getElementById('nested-scroll-container').scrollTop`
+        )
+      ).toBe(scrollPosition)
+    }
+  )
 })


### PR DESCRIPTION
## Summary

Adds an `it.failing` regression test for a Cache Components scroll-restoration bug. A route-owned nested scroller restores on the first Back navigation, but after Forward and Back to the same retained route its `scrollTop` resets to `0`.

The fixture lives in the existing back/forward cache suite. Once the framework behavior is fixed, the witness test can be changed from `it.failing` to `it`.

Reproduction: https://cache-components-nested-scroll-rest.vercel.app

## Verification

- `HEADLESS=true pnpm test-dev-turbo test/e2e/app-dir/back-forward-cache/back-forward-cache.test.ts`
- Confirmed the test fails with expected `1000` and received `0` when temporarily run without `it.failing`

<!-- NEXT_JS_LLM -->