### PR TITLE
Wait for Server Action HMR before asserting state

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1043,15 +1043,27 @@ describe('app-dir action handling', () => {
             expect(await browser.elementById('count').text()).toBe('1')
           })
 
+          await browser.eval(() => {
+            ;(window as any).__HMR_STATE = 'pending'
+            window.__NEXT_HMR_CB = (message) => {
+              ;(window as any).__HMR_STATE = message ?? 'success'
+            }
+          })
+
           await next.patchFile(
             filePath,
             origContent.replace('return value + 1', 'return value + 1000')
           )
 
           await retry(async () => {
-            await browser.elementByCss('#inc').click()
-            const val = Number(await browser.elementById('count').text())
-            expect(val).toBeGreaterThan(1000)
+            expect(await browser.eval(() => (window as any).__HMR_STATE)).toBe(
+              'success'
+            )
+          }, 30_000)
+
+          await browser.elementByCss('#inc').click()
+          await retry(async () => {
+            expect(await browser.elementById('count').text()).toBe('1001')
           })
         } finally {
           await next.patchFile(filePath, origContent)


### PR DESCRIPTION
### Why?

The Server Action HMR test can invoke the action before Webpack finishes applying the update. Because the retry also repeats the click, several action requests can overlap with Fast Refresh. A full reload then resets client state and produces 1000 instead of preserving state.

### How?

Register the existing HMR completion callback before patching the action and wait for it to finish. Invoke the updated action once, then retry only the exact 1001 state assertion. This keeps the state-preservation coverage and changes no runtime code.

<!-- NEXT_JS_LLM -->