### PR TITLE
Fix turbopacks webpack loader setup to support options being optional

### DIFF
--- a/test/e2e/app-dir/webpack-loader-resolve/app/no-options/file.no-options.ts
+++ b/test/e2e/app-dir/webpack-loader-resolve/app/no-options/file.no-options.ts
@@ -1,0 +1,1 @@
+export default 'wrong'

--- a/test/e2e/app-dir/webpack-loader-resolve/app/no-options/page.js
+++ b/test/e2e/app-dir/webpack-loader-resolve/app/no-options/page.js
@@ -1,0 +1,5 @@
+import resolved from './file.no-options'
+
+export default function Page() {
+  return <p id="no-options">{resolved}</p>
+}

--- a/test/e2e/app-dir/webpack-loader-resolve/get-resolve-no-options-loader.js
+++ b/test/e2e/app-dir/webpack-loader-resolve/get-resolve-no-options-loader.js
@@ -1,0 +1,9 @@
+const fs = require('fs')
+
+module.exports = async function () {
+  const resolve = this.getResolve()
+  const result = await resolve(__dirname, './data2')
+  this.addDependency(result)
+
+  return fs.readFileSync(result, 'utf8')
+}

--- a/test/e2e/app-dir/webpack-loader-resolve/next.config.js
+++ b/test/e2e/app-dir/webpack-loader-resolve/next.config.js
@@ -5,12 +5,19 @@ const nextConfig = {
   turbopack: {
     rules: {
       '*.test-file.ts': [require.resolve('./test-file-loader.js')],
+      '*.no-options.ts': [
+        require.resolve('./get-resolve-no-options-loader.js'),
+      ],
     },
   },
   webpack(config) {
     config.module.rules.push({
       test: /\.test-file\.ts/,
       use: require.resolve('./test-file-loader.js'),
+    })
+    config.module.rules.push({
+      test: /\.no-options\.ts/,
+      use: require.resolve('./get-resolve-no-options-loader.js'),
     })
     return config
   },

--- a/test/e2e/app-dir/webpack-loader-resolve/webpack-loader-resolve.test.ts
+++ b/test/e2e/app-dir/webpack-loader-resolve/webpack-loader-resolve.test.ts
@@ -16,4 +16,9 @@ describe('webpack-loader-resolve', () => {
     expect($('#absolute').text()).toBe('abc')
     expect($('#relative').text()).toBe('xyz')
   })
+
+  it('should support loader getResolve without options', async () => {
+    const $ = await next.render$('/no-options')
+    expect($('#no-options').text()).toBe('xyz')
+  })
 })

--- a/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -138,7 +138,7 @@ type ResolveOptions = {
   conditionNames?: string[]
   descriptionFiles?: string[]
   enforceExtension?: boolean
-  extensionAlias: Record<string, string[]>
+  extensionAlias?: Record<string, string[]>
   extensions?: string[]
   fallback?: Record<string, string[]>
   mainFields?: string[]
@@ -215,7 +215,7 @@ const transform = (
                 )
             },
           },
-          getResolve: (options: ResolveOptions) => {
+          getResolve: (options: ResolveOptions = {}) => {
             const rustOptions = {
               aliasFields: undefined as undefined | string[],
               conditionNames: undefined as undefined | string[],


### PR DESCRIPTION
If you look at the types for webpacks loaders, you can see that options is optional. https://github.com/webpack/webpack/blob/c17742f631eaeaf1ad880a70b105eedd96dd21b9/declarations/LoaderContext.d.ts#L83

The implementation between the two is slightly different so webpacks impementation doens't jsut set it to {}. But with the way turbopack works, this is the equivalent.

I saw a bunch of failures all related to this in real loaders, so figure it was an easy quick fix.

(also extensionOptions is optional in webpack and needed to be here for the the types to all checkout https://github.com/webpack/webpack/blob/c17742f631eaeaf1ad880a70b105eedd96dd21b9/declarations/WebpackOptions.d.ts#L2175) 