### PR TITLE
docs: clarify Cache Components build output

### DIFF
--- a/docs/01-app/02-guides/ai-agents.mdx
+++ b/docs/01-app/02-guides/ai-agents.mdx
@@ -148,7 +148,7 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
     ...
 ```
 
-In `next dev` the stack frame resolves to your source, in both the dev overlay and the terminal. A production build minifies server code, so when the build error alone isn't enough, [`next build --debug-prerender`](/docs/app/guides/building#debug-prerender-errors) turns on server source maps and continues past the first failure.
+`next dev` shows all validation errors with source-mapped stacks in the overlay and terminal. Production builds minify server code and stop after a route fails. Use [`next build --debug-prerender`](/docs/app/guides/building#debug-prerender-errors) to enable server source maps and continue checking other routes.
 
 The `Learn more` link resolves to a per-error page under [`/docs/messages`](https://nextjs.org/docs/messages/blocking-prerender-dynamic) written for agents to read. Each page follows the same shape, with the canonical patterns for every fix, the trade-offs against the other fixes, and the gotchas an agent is likely to miss on a first attempt. The [Instant navigation guide](/docs/app/guides/instant-navigation#ai-workflow) walks through the full loop an agent runs on these errors, from reading the insight to writing an `instant()` test that fails before the fix and passes once it's in place.
 

--- a/docs/01-app/02-guides/ai-agents.mdx
+++ b/docs/01-app/02-guides/ai-agents.mdx
@@ -148,7 +148,7 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
     ...
 ```
 
-In `next dev` the stack frame resolves to your source, in both the dev overlay and the terminal. A production build minifies server code, so when the build error alone isn't enough, [`next build --debug-prerender`](/docs/app/guides/building#debugging-build-errors) turns on server source maps and continues past the first failure.
+In `next dev` the stack frame resolves to your source, in both the dev overlay and the terminal. A production build minifies server code, so when the build error alone isn't enough, [`next build --debug-prerender`](/docs/app/guides/building#debug-prerender-errors) turns on server source maps and continues past the first failure.
 
 The `Learn more` link resolves to a per-error page under [`/docs/messages`](https://nextjs.org/docs/messages/blocking-prerender-dynamic) written for agents to read. Each page follows the same shape, with the canonical patterns for every fix, the trade-offs against the other fixes, and the gotchas an agent is likely to miss on a first attempt. The [Instant navigation guide](/docs/app/guides/instant-navigation#ai-workflow) walks through the full loop an agent runs on these errors, from reading the insight to writing an `instant()` test that fails before the fix and passes once it's in place.
 

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -55,16 +55,18 @@ bun run build
 
 After a successful build, Next.js prints a route table with a symbol next to each route, showing how it is served:
 
-| Symbol | Name              | Behavior                                                                     |
-| ------ | ----------------- | ---------------------------------------------------------------------------- |
-| `○`    | Static            | Fully prerendered at build time. Served without server rendering.            |
-| `◐`    | Partial Prerender | Static shell served immediately. Dynamic content streams in at request time. |
-| `●`    | SSG               | Prerendered static HTML (from `generateStaticParams` or `getStaticProps`).   |
-| `ƒ`    | Dynamic           | Server-rendered on demand for each request.                                  |
+| Symbol | Name              | Behavior                                                                   |
+| ------ | ----------------- | -------------------------------------------------------------------------- |
+| `○`    | Static            | Fully prerendered at build time. Served without server rendering.          |
+| `◐`    | Partial Prerender | Prerenders what it can at build time. Remaining content renders on demand. |
+| `●`    | SSG               | Prerendered static HTML (from `generateStaticParams` or `getStaticProps`). |
+| `ƒ`    | Dynamic           | Cannot use PPR. Server-rendered on demand for each request.                |
 
 `○` Static, `●` SSG, and `ƒ` Dynamic are the modes Next.js applications have always rendered in, including on the Pages Router: each route is either prerendered to static HTML or server-rendered on demand for each request.
 
-[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) adds `◐` Partial Prerender and makes [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) the default rendering model. Each route is split into a static shell, prerendered at build time, and dynamic parts that stream in at request time. Routes sit on a spectrum from fully static (`○`) to partially prerendered (`◐`) and are no longer fully server-rendered: a route shows `ƒ` only when it has nothing to prerender, such as [Route Handlers](/docs/app/api-reference/file-conventions/route) that depend on the request, Proxy (Middleware), and dynamic [metadata](/docs/app/api-reference/functions/generate-metadata) like `icon` or `opengraph-image`.
+[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) uses [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) as the rendering model for every App Router page. At build time, a page can produce a complete, partial, or empty prerender. Even when the HTML file is empty, individual route segments can still contain static data in their [RSC payloads](/docs/app/getting-started/server-and-client-components#on-the-server), so the page is not equivalent to a Dynamic route.
+
+The `◐` symbol means the page uses PPR and still has request-time work. It does not guarantee that the page produced visible HTML at build time. The `ƒ` symbol is reserved for outputs that cannot use PPR, such as [Route Handlers](/docs/app/api-reference/file-conventions/route) that depend on the request, Proxy (Middleware), and dynamic [metadata](/docs/app/api-reference/functions/generate-metadata) like `icon` or `opengraph-image`.
 
 The symbol reflects what the route does at prerender time, not which validation configs (such as [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant)) it exports. Without Cache Components, or on the Pages Router, prerendered pages can also show `●` (SSG).
 
@@ -334,7 +336,7 @@ The routes [revalidate](/docs/app/getting-started/revalidating) after 15 minutes
 
 ### A blocking route
 
-The error's last suggestion, `[block]`, is the alternative to the fixes above. Say we had removed them, and only set `instant = false` on the original page. This doesn't change how the route renders. It only opts out of validation to purposely allow a blocking route:
+The error's last suggestion, `[block]`, is the alternative to the fixes above. Say we had removed them, and only set `instant = false` on the original page. This opts the segment out of instant-navigation validation. Because it is the highest `instant` config in this route's tree, it also opts the route out of static-shell validation. It doesn't change the rendering model; it explicitly allows the route to block:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export const instant = false

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -14,22 +14,22 @@ related:
     - app/guides/ci-build-caching
 ---
 
-Running `next build` compiles your application for production. It bundles and optimizes your code, [prerenders](/docs/app/glossary#prerendering) every route it can, and prints a route table that shows how each URL is served.
+Running `next build` compiles your application for production, [prerenders](/docs/app/glossary#prerendering) eligible routes, and prints a route table. Use the output to see how Next.js serves each route and to debug prerender errors.
 
-This guide will show you how to read the build output, including the route table and prerender-blocking errors.
-
-> The output and errors on this page show [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) enabled, set with `cacheComponents: true` in your `next.config.ts` file. Much of the guide applies without it, but the route table symbols and the prerender-blocking errors differ. See [Enabling Cache Components](/docs/app/getting-started/caching#enabling-cache-components) for setup.
+> The examples use [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), enabled with `cacheComponents: true` in `next.config.ts`. The route symbols and prerender errors differ when Cache Components is disabled. See [Enabling Cache Components](/docs/app/getting-started/caching#enabling-cache-components) for setup.
 
 ## What `next build` does
 
-When you run `next build`, the build moves through these phases:
+The build runs these phases:
 
-1. **Setup.** Loads [environment variables](/docs/app/guides/environment-variables) (`.env` files), validates your [`next.config`](/docs/app/api-reference/config/next-config-js), and generates a [build ID](/docs/app/api-reference/config/next-config-js/generateBuildId).
-2. **Route discovery.** Scans the `app/` and `pages/` directories for routes, and detects root-level convention files like [`proxy`](/docs/app/api-reference/file-conventions/proxy) and [`instrumentation`](/docs/app/api-reference/file-conventions/instrumentation). Generates TypeScript route definitions.
-3. **Compilation.** Bundles client, server, and edge code with [Turbopack](/docs/app/api-reference/turbopack) (or webpack). Transpiles TypeScript and JSX, tree-shakes unused code, and optimizes CSS and fonts. Type checking runs in parallel.
-4. **Static analysis.** Classifies each route for prerendering versus on-demand rendering. Collects [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) output. Checks for [prerender-blocking errors](/docs/messages/blocking-prerender-dynamic).
-5. **Prerendering.** Prerenders static pages and PPR shells to HTML. Generates [RSC payloads](/docs/app/getting-started/server-and-client-components#on-the-server) for client-side navigation.
-6. **Output.** Writes the build to `.next/`. For [`output: 'standalone'`](/docs/app/guides/self-hosting), bundles only the files needed at runtime. For [`output: 'export'`](/docs/app/guides/static-exports), generates a full static site. Prints the route table.
+1. **Setup.** Next.js loads [environment variables](/docs/app/guides/environment-variables) from `.env` files, validates [`next.config`](/docs/app/api-reference/config/next-config-js), and generates a [build ID](/docs/app/api-reference/config/next-config-js/generateBuildId).
+2. **Route discovery.** Next.js scans the `app/` and `pages/` directories for routes and finds root-level files such as [`proxy`](/docs/app/api-reference/file-conventions/proxy) and [`instrumentation`](/docs/app/api-reference/file-conventions/instrumentation).
+3. **Compilation.** [Turbopack](/docs/app/api-reference/turbopack), or webpack when selected, bundles the client and server code for production.
+4. **Page data collection.** Next.js runs [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) and classifies routes for prerendering or request-time rendering.
+5. **Static generation.** Next.js prerenders eligible routes. App Router routes can produce HTML and [React Server Component (RSC) payloads](/docs/app/getting-started/server-and-client-components#on-the-server).
+6. **Output.** Next.js writes the build to `.next/` and prints the route table. With [`output: 'standalone'`](/docs/app/guides/self-hosting), it creates `.next/standalone` with the files needed to run the production server. With [`output: 'export'`](/docs/app/guides/static-exports), it writes the static export to `out/`.
+
+The build checks TypeScript unless [`typescript.ignoreBuildErrors`](/docs/app/api-reference/config/next-config-js/typescript) is enabled.
 
 `next dev` stores the running development server's state and incremental compilation caches in `.next/dev`. Deleting or moving `.next` discards that state, so the development server has to recreate it. To run an isolated production build, configure a separate [`distDir`](/docs/app/api-reference/config/next-config-js/distDir).
 
@@ -55,62 +55,62 @@ bun run build
 
 After a successful build, Next.js prints a route table with a symbol next to each route, showing how it is served:
 
-| Symbol | Name              | Behavior                                                                   |
-| ------ | ----------------- | -------------------------------------------------------------------------- |
-| `○`    | Static            | Fully prerendered at build time. Served without server rendering.          |
-| `◐`    | Partial Prerender | Prerenders what it can at build time. Remaining content renders on demand. |
-| `●`    | SSG               | Prerendered static HTML (from `generateStaticParams` or `getStaticProps`). |
-| `ƒ`    | Dynamic           | Cannot use PPR. Server-rendered on demand for each request.                |
+| Symbol | Name              | Behavior                                                                    |
+| ------ | ----------------- | --------------------------------------------------------------------------- |
+| `○`    | Static            | Fully prerendered at build time. Served without server rendering.           |
+| `◐`    | Partial Prerender | Has a PPR result and content that still renders at request time.            |
+| `●`    | SSG               | Prerendered static HTML from `generateStaticParams` or `getStaticProps`.    |
+| `ƒ`    | Dynamic           | Rendered on demand. With Cache Components, this can use an empty PPR shell. |
 
-`○` Static, `●` SSG, and `ƒ` Dynamic are the modes Next.js applications have always rendered in, including on the Pages Router: each route is either prerendered to static HTML or server-rendered on demand for each request.
+Next.js uses `○` Static, `●` SSG, and `ƒ` Dynamic for Pages Router routes and App Router routes without Cache Components. In those models, a route is either prerendered to static HTML or rendered on demand for each request.
 
-[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) uses [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) as the rendering model for every App Router page. At build time, a page can produce a complete, partial, or empty prerender. Even when the HTML file is empty, individual route segments can still contain static data in their [RSC payloads](/docs/app/getting-started/server-and-client-components#on-the-server), so the page is not equivalent to a Dynamic route.
+[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) uses [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) for every App Router page, even when the build produces no HTML shell. The build can produce complete HTML, partial HTML, or an empty HTML file. The current route symbols do not distinguish all three results.
 
-The `◐` symbol means the page uses PPR and still has request-time work. It does not guarantee that the page produced visible HTML at build time. The `ƒ` symbol is reserved for outputs that cannot use PPR, such as [Route Handlers](/docs/app/api-reference/file-conventions/route) that depend on the request, Proxy (Middleware), and dynamic [metadata](/docs/app/api-reference/functions/generate-metadata) like `icon` or `opengraph-image`.
+For example, a blocking page with an empty HTML file can show `ƒ`. A fallback row for a dynamic route can show `◐` even when its HTML file is empty. In both cases, per-segment [RSC payloads](/docs/app/getting-started/server-and-client-components#on-the-server) may contain static information. An empty HTML file does not mean the build produced no static data.
 
-The symbol reflects what the route does at prerender time, not which validation configs (such as [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant)) it exports. Without Cache Components, or on the Pages Router, prerendered pages can also show `●` (SSG).
+The symbol is not a direct report of route config such as [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant). Without Cache Components, or on the Pages Router, prerendered pages can also show `●` (SSG).
 
 ## Example
 
-Prerender validation is one of the most common reasons production builds fail. This is a safeguard: Cache Components catches uncached and runtime data at build time, before it can slow down your app in production. The rest of this guide walks through one such error, from the failed build to the fix.
-
-This example uses a store app with a dynamic product page that loads data by id:
+Cache Components validates whether a route can produce a static shell. The following store app has a dynamic product page that reads the product slug and fetches uncached data:
 
 ```txt
 app/
 ├── layout.tsx
 ├── page.tsx
 └── products/
-    └── [id]/
+    └── [slug]/
         └── page.tsx
 ```
 
-We'll work in `app/products/[id]/page.tsx`:
+The page fetches a product from the [Recipe API](https://next-recipe-api.vercel.dev/):
 
-```tsx filename="app/products/[id]/page.tsx" switcher
-export default async function Page(props: PageProps<'/products/[id]'>) {
-  const { id } = await props.params
-  const res = await fetch(`https://api.example.com/products/${id}`)
+```tsx filename="app/products/[slug]/page.tsx" switcher
+export default async function Page(props: PageProps<'/products/[slug]'>) {
+  const { slug } = await props.params
+  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
   const product = await res.json()
   return <div>{product.name}</div>
 }
 ```
 
-```jsx filename="app/products/[id]/page.js" switcher
+```jsx filename="app/products/[slug]/page.js" switcher
 export default async function Page({ params }) {
-  const { id } = await params
-  const res = await fetch(`https://api.example.com/products/${id}`)
+  const { slug } = await params
+  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
   const product = await res.json()
   return <div>{product.name}</div>
 }
 ```
 
-During the build, Next.js prerenders as much of each route as it can at [build time](/docs/app/glossary#build-time). [Runtime data](/docs/app/glossary#request-time-apis) ([`params`](/docs/app/api-reference/file-conventions/page#params-optional), [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional), [`cookies()`](/docs/app/api-reference/functions/cookies), [`headers()`](/docs/app/api-reference/functions/headers)) and uncached data (`fetch()`, database calls) are not available during that pass. Wrap runtime reads in [`<Suspense>`](https://react.dev/reference/react/Suspense), and cache data accesses with [`use cache`](/docs/app/api-reference/directives/use-cache) or wrap them in `<Suspense>` too. Otherwise, the build fails with a [`blocking-prerender-runtime`](/docs/messages/blocking-prerender-runtime) or [`blocking-prerender-dynamic`](/docs/messages/blocking-prerender-dynamic) error. [Random values and timestamps](/docs/app/getting-started/caching#random-values-and-timestamps) such as `Math.random()` or `new Date()` can also fail the build.
+During the build, Next.js prerenders as much of the route as it can. It cannot resolve URL data such as [`params`](/docs/app/api-reference/file-conventions/page#params-optional) and [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) while generating a shared shell. [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) provides known params for specific prerenders. Other [runtime data](/docs/app/glossary#request-time-apis), including [`cookies()`](/docs/app/api-reference/functions/cookies) and [`headers()`](/docs/app/api-reference/functions/headers), and uncached `fetch()` calls or database queries require request-time work.
 
-Run `next build`. It fails with a prerender-blocking error because the `params` read and the uncached `fetch` run outside a `<Suspense>` boundary:
+Wrap request-time work in [`<Suspense>`](https://react.dev/reference/react/Suspense) to define where the static shell ends. Cache reusable data with [`use cache`](/docs/app/api-reference/directives/use-cache). When request-time work remains outside a Suspense boundary, the build fails with a [`blocking-prerender-runtime`](/docs/messages/blocking-prerender-runtime) or [`blocking-prerender-dynamic`](/docs/messages/blocking-prerender-dynamic) error. [Random values and timestamps](/docs/app/getting-started/caching#random-values-and-timestamps), such as `Math.random()` and `new Date()`, can also block prerendering.
 
-```bash filename="Terminal"
-Error: Route "/products/[id]": Next.js encountered uncached or runtime data during prerendering.
+Run `next build`. The `params` read and uncached `fetch()` call run outside a `<Suspense>` boundary, so the build fails with this error:
+
+```text filename="Terminal"
+Error: Route "/products/[slug]": Next.js encountered uncached or runtime data during prerendering.
 
 `fetch(...)`, `cookies()`, `headers()`, `params`, `searchParams`, or `connection()` accessed outside of `<Suspense>` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
 
@@ -123,261 +123,278 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
     at body (<anonymous>)
     at html (<anonymous>)
 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-  - Start the app in development mode by running `next dev`, then open "/products/[id]" in your browser to investigate the error.
+  - Start the app in development mode by running `next dev`, then open "/products/[slug]" in your browser to investigate the error.
   - Rerun the production build with `next build --debug-prerender` to generate better stack traces.
-Error occurred prerendering page "/products/[id]".
+Error occurred prerendering page "/products/[slug]".
 ```
 
 ### Debugging build errors
 
-Sometimes the error cannot provide enough information, because production builds minify server code and don't generate source maps for it. Rerun the build with [`--debug-prerender`](/docs/app/api-reference/cli/next#debugging-prerender-errors):
+Production builds minify server code and omit server source maps by default, so a stack trace may not identify the source line. Rerun the build with [`--debug-prerender`](/docs/app/api-reference/cli/next#debugging-prerender-errors):
 
 ```bash filename="Terminal"
 next build --debug-prerender
 ```
 
-That disables minification, turns on source maps for server bundles, and continues past the first failure, so remaining issues surface in one run. This helps with any error thrown during prerendering, not only blocking ones. The stack now points at the first blocked access in the page, the `params` read:
+The flag disables server minification, enables server source maps, and continues after the first prerender error. This produces more readable stack traces and code frames for errors that occur while prerendering.
 
-```bash filename="Terminal"
-Error: Route "/products/[id]": Next.js encountered uncached or runtime data during prerendering.
-  ...
-    at Page (app/products/[id]/page.tsx:2:30)
-  1 | export default async function Page(props: PageProps<'/products/[id]'>) {
-> 2 |   const { id } = await props.params
-    |                              ^
-  3 |   const res = await fetch(`https://api.example.com/products/${id}`)
-  4 |   const product = await res.json()
-```
+> **Warning**: Do not deploy builds produced with `--debug-prerender`. The debugging options can affect performance.
 
-> **Warning**: Do not deploy builds produced with `--debug-prerender`. They skip optimizations you need in production.
-
-Running the route in `next dev` shows the full error immediately, with the component and line already resolved. See [Ensuring instant navigations](/docs/app/guides/instant-navigation) for working with these errors in depth.
-
-With the cause located, let's apply each fix and see how the build output changes.
+The development server shows the resolved component and source line in the error overlay. See [Ensuring instant navigations](/docs/app/guides/instant-navigation) for the development workflow.
 
 ### A streaming route
 
-The error's first suggestion, `[stream]`, is to provide a placeholder around the data access. Add a [`loading.js`](/docs/app/api-reference/file-conventions/loading) file to wrap the whole segment in a `<Suspense>` boundary. Next.js prerenders the fallback as the route's static shell, while the params and data work runs at request time. For other boundary placements, see [Streaming](/docs/app/guides/streaming):
+To stream the product lookup, add a [`loading.js`](/docs/app/api-reference/file-conventions/loading) file. Next.js wraps the segment in a `<Suspense>` boundary and prerenders the fallback as part of the static shell. The `params` read and product request continue at request time:
 
-```tsx filename="app/products/[id]/loading.tsx" switcher
+```tsx filename="app/products/[slug]/loading.tsx" switcher
 export default function Loading() {
   return <div>Loading...</div>
 }
 ```
 
-```jsx filename="app/products/[id]/loading.js" switcher
+```jsx filename="app/products/[slug]/loading.js" switcher
 export default function Loading() {
   return <div>Loading...</div>
 }
 ```
 
-Run the build. It passes, and the route is [partially prerendered](/docs/app/glossary#partial-prerendering-ppr):
+Run the build again. The route is now [partially prerendered](/docs/app/glossary#partial-prerendering-ppr):
 
-```bash filename="Terminal"
+```text filename="Terminal"
 Route (app)
-┌ ○ /                   # Prerendered at build time
+┌ ○ /
 ├ ○ /_not-found
-└   /products/[id]
-  └ ◐ /products/[id]    # Shell prerendered, content streams on request
+└   /products/[slug]
+  └ ◐ /products/[slug]
 
 ○  (Static)             prerendered as static content
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-Product URLs now serve the prerendered shell instantly, then stream the page content.
+Product URLs now serve the fallback from `loading.js` before the product content finishes. See [Streaming](/docs/app/guides/streaming) for other ways to place the `<Suspense>` boundary.
 
 ### Building specific routes
 
-If we were iterating on this route alone in a larger app, we could also scope each build to it instead of rebuilding everything. Pass [`--debug-build-paths`](/docs/app/api-reference/cli/next#building-specific-routes) with the route files to include:
+Use [`--debug-build-paths`](/docs/app/api-reference/cli/next#building-specific-routes) to compile and prerender selected routes while debugging a large application:
 
 ```bash filename="Terminal"
-next build --debug-build-paths="app/products/[id]/page.tsx"
+next build --debug-build-paths="app/products/[slug]/page.tsx"
 ```
 
-Next.js compiles and prerenders only the matching routes, and skips the rest of the app. The option accepts comma-separated paths and glob patterns, with a `!` prefix to exclude, and combines with `--debug-prerender` while debugging. Our store only has a few routes, so we'll keep building the whole app.
+The option accepts comma-separated paths and glob patterns. Prefix a pattern with `!` to exclude it. You can combine the option with `--debug-prerender`. TypeScript still checks the complete project selected by your `tsconfig` file.
 
 ### Prerendered params
 
 The [dynamic segment](/docs/app/glossary#dynamic-route-segments) shows a single fallback row because Next.js doesn't know which param values exist. Export `generateStaticParams` to list them:
 
-```tsx filename="app/products/[id]/page.tsx" switcher
+```tsx filename="app/products/[slug]/page.tsx" switcher
 export async function generateStaticParams() {
-  const res = await fetch('https://api.example.com/products')
+  const res = await fetch('https://next-recipe-api.vercel.dev/products?limit=3')
   const products = await res.json()
-  return products.map((product) => ({ id: product.id }))
+  return products.map((product) => ({ slug: product.slug }))
 }
 
-export default async function Page(props: PageProps<'/products/[id]'>) {
-  const { id } = await props.params
-  const res = await fetch(`https://api.example.com/products/${id}`)
+export default async function Page(props: PageProps<'/products/[slug]'>) {
+  const { slug } = await props.params
+  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
   const product = await res.json()
   return <div>{product.name}</div>
 }
 ```
 
-```jsx filename="app/products/[id]/page.js" switcher
+```jsx filename="app/products/[slug]/page.js" switcher
 export async function generateStaticParams() {
-  const res = await fetch('https://api.example.com/products')
+  const res = await fetch('https://next-recipe-api.vercel.dev/products?limit=3')
   const products = await res.json()
-  return products.map((product) => ({ id: product.id }))
+  return products.map((product) => ({ slug: product.slug }))
 }
 
 export default async function Page({ params }) {
-  const { id } = await params
-  const res = await fetch(`https://api.example.com/products/${id}`)
+  const { slug } = await params
+  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
   const product = await res.json()
   return <div>{product.name}</div>
 }
 ```
 
-Running the build again adds a row for each listed param, indented under the `/products/[id]` route:
+Running the build again adds a row for each listed param, indented under the `/products/[slug]` route:
 
-```bash filename="Terminal"
+```text filename="Terminal"
 Route (app)
 ┌ ○ /
 ├ ○ /_not-found
-└   /products/[id]
-  ├ ◐ /products/[id]
-  ├ ◐ /products/1       # Params known, data still uncached
-  ├ ◐ /products/2       # Params known, data still uncached
-  └ ◐ /products/3       # Params known, data still uncached
+└   /products/[slug]
+  ├ ◐ /products/[slug]
+  ├ ◐ /products/tee
+  ├ ◐ /products/joggers
+  └ ◐ /products/tennis-shoes
 
 ○  (Static)             prerendered as static content
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-> **Good to know**: `generateStaticParams` must return at least one param. An empty array causes a [build error](/docs/messages/empty-generate-static-params).
+> **Good to know**: With Cache Components, `generateStaticParams` must return at least one param. An empty array causes a [build error](/docs/messages/empty-generate-static-params).
 
 The new rows show `◐`, not `○`. Listing the params tells Next.js which pages exist, but their content still comes from the uncached lookup, which only runs at request time. Each page serves the static shell and streams its content.
 
-> **Good to know**: Here the `fetch` runs during prerendering, so point it at a working endpoint or a fake async source that returns data. The `◐` rows appear only when the lookup is real uncached I/O; a synchronous in-memory value is treated as static and prerenders each param to `○` instead.
-
 ### Cached data
 
-The error's `[cache]` fix moves the lookup to build time. Add `use cache` so it can run during prerendering:
+The error's `[cache]` fix makes the product lookup reusable. Add `use cache` so Next.js can include the result when it prerenders a known product:
 
-```tsx filename="app/products/[id]/page.tsx" switcher
+```tsx filename="app/products/[slug]/page.tsx" switcher
 export async function generateStaticParams() {
-  const res = await fetch('https://api.example.com/products')
+  const res = await fetch('https://next-recipe-api.vercel.dev/products?limit=3')
   const products = await res.json()
-  return products.map((product) => ({ id: product.id }))
+  return products.map((product) => ({ slug: product.slug }))
 }
 
-async function getProduct(id: string) {
+async function getProduct(slug: string) {
   'use cache'
-  const res = await fetch(`https://api.example.com/products/${id}`)
+  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
   return res.json()
 }
 
-export default async function Page(props: PageProps<'/products/[id]'>) {
-  const { id } = await props.params
-  const product = await getProduct(id)
+export default async function Page(props: PageProps<'/products/[slug]'>) {
+  const { slug } = await props.params
+  const product = await getProduct(slug)
   return <div>{product.name}</div>
 }
 ```
 
-```jsx filename="app/products/[id]/page.js" switcher
+```jsx filename="app/products/[slug]/page.js" switcher
 export async function generateStaticParams() {
-  const res = await fetch('https://api.example.com/products')
+  const res = await fetch('https://next-recipe-api.vercel.dev/products?limit=3')
   const products = await res.json()
-  return products.map((product) => ({ id: product.id }))
+  return products.map((product) => ({ slug: product.slug }))
 }
 
-async function getProduct(id) {
+async function getProduct(slug) {
   'use cache'
-  const res = await fetch(`https://api.example.com/products/${id}`)
+  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
   return res.json()
 }
 
 export default async function Page({ params }) {
-  const { id } = await params
-  const product = await getProduct(id)
+  const { slug } = await params
+  const product = await getProduct(slug)
   return <div>{product.name}</div>
 }
 ```
 
 Running the build again shows the listed params as `○`. Their params are known and their data is cached, so Next.js prerenders each page in full. The `◐` row remains for unlisted params, which serve the static shell while their content streams:
 
-```bash filename="Terminal"
+```text filename="Terminal"
 Route (app)
 ┌ ○ /
 ├ ○ /_not-found
-└   /products/[id]
-  ├ ◐ /products/[id]    # Unlisted params stream on demand
-  ├ ○ /products/1       # Prerendered in full at build time
-  ├ ○ /products/2       # Prerendered in full at build time
-  └ ○ /products/3       # Prerendered in full at build time
+└   /products/[slug]
+  ├ ◐ /products/[slug]
+  ├ ○ /products/tee
+  ├ ○ /products/joggers
+  └ ○ /products/tennis-shoes
 
 ○  (Static)             prerendered as static content
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-Pages that read `cookies()`, `headers()`, or `searchParams` stay `◐`, streaming those parts into the shell on each visit.
+Content that reads `cookies()`, `headers()`, or `searchParams` remains request-time work. Place that content inside `<Suspense>` to keep the rest of the page in the static shell.
 
-When a user visits an unlisted param, Next.js serves the static shell immediately while the content streams in, then upgrades the page in the background. See [Incremental Static Regeneration with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components).
+With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching) enabled, the first prefetch or visit to an unlisted param serves the static shell and generates the page in the background. Later requests can reuse the completed prerender. See [Incremental Static Regeneration with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components).
 
 When there are more prerendered paths than fit in the table, Next.js prints a short list ending with `[+N more paths]`.
 
-Routes that contain cached functions or components also show `Revalidate` and `Expire` columns. A route reports the shortest `revalidate` and `expire` across all the caches it contains. This applies even without an explicit [`cacheLife`](/docs/app/api-reference/functions/cacheLife) call, since caches use the [`default` profile](/docs/app/api-reference/functions/cacheLife#preset-cache-profiles). Let's add a `/products` listing page that renders the same cached product data:
+When a prerender uses cached functions or components, the output can include `Revalidate` and `Expire` columns. A route reports the shortest `revalidate` and `expire` values across its caches. Without an explicit [`cacheLife`](/docs/app/api-reference/functions/cacheLife) call, caches use the [`default` profile](/docs/app/api-reference/functions/cacheLife#preset-cache-profiles).
 
-```bash filename="Terminal"
-Route (app)           Revalidate  Expire
-┌ ○ /
-├ ○ /_not-found
-├ ○ /products                15m      1y
-└   /products/[id]
-  ├ ◐ /products/[id]
-  ├ ○ /products/1            15m      1y
-  ├ ○ /products/2            15m      1y
-  └ ○ /products/3            15m      1y
+Add a cached `/products` listing page:
+
+```tsx filename="app/products/page.tsx" switcher
+async function getProducts() {
+  'use cache'
+  const res = await fetch('https://next-recipe-api.vercel.dev/products?limit=3')
+  return res.json()
+}
+
+export default async function ProductsPage() {
+  const products = await getProducts()
+  return products.map((product) => <div key={product.slug}>{product.name}</div>)
+}
 ```
 
-The routes [revalidate](/docs/app/getting-started/revalidating) after 15 minutes, the value of the `default` profile. The profile never expires, and the `Expire` column caps at one year, shown as `1y`. The table doesn't show which cache produced the values, so with multiple caches in a route, check their `cacheLife` calls.
+```jsx filename="app/products/page.js" switcher
+async function getProducts() {
+  'use cache'
+  const res = await fetch('https://next-recipe-api.vercel.dev/products?limit=3')
+  return res.json()
+}
+
+export default async function ProductsPage() {
+  const products = await getProducts()
+  return products.map((product) => <div key={product.slug}>{product.name}</div>)
+}
+```
+
+The next build includes the cache timing for the listing page and the prerendered product pages:
+
+```text filename="Terminal"
+Route (app)                   Revalidate  Expire
+┌ ○ /
+├ ○ /_not-found
+├ ○ /products                        15m      1y
+└   /products/[slug]
+  ├ ◐ /products/[slug]
+  ├ ○ /products/tee                  15m      1y
+  ├ ○ /products/joggers              15m      1y
+  └ ○ /products/tennis-shoes         15m      1y
+```
+
+The built-in `default` profile revalidates after 15 minutes and never expires. The build output represents an unbounded expiration as one year, shown as `1y`. You can override the default profile in `next.config.ts`. The table does not identify which cache produced each value, so check the route's `cacheLife` calls when it contains multiple caches.
 
 ### A blocking route
 
-The error's last suggestion, `[block]`, is the alternative to the fixes above. Say we had removed them, and only set `instant = false` on the original page. This opts the segment out of instant-navigation validation. Because it is the highest `instant` config in this route's tree, it also opts the route out of static-shell validation. It doesn't change the rendering model; it explicitly allows the route to block:
+Set `instant = false` when the route is allowed to block. The export opts the segment out of instant-navigation validation. When the page is the highest segment with an `instant` config, it also opts the route out of static-shell validation. The rendering model remains PPR, but the build can finish with empty HTML:
 
-```tsx filename="app/products/[id]/page.tsx" switcher
+```tsx filename="app/products/[slug]/page.tsx" switcher
 export const instant = false
 
-export default async function Page(props: PageProps<'/products/[id]'>) {
-  const { id } = await props.params
-  const res = await fetch(`https://api.example.com/products/${id}`)
+export default async function Page(props: PageProps<'/products/[slug]'>) {
+  const { slug } = await props.params
+  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
   const product = await res.json()
   return <div>{product.name}</div>
 }
 ```
 
-```jsx filename="app/products/[id]/page.js" switcher
+```jsx filename="app/products/[slug]/page.js" switcher
 export const instant = false
 
 export default async function Page({ params }) {
-  const { id } = await params
-  const res = await fetch(`https://api.example.com/products/${id}`)
+  const { slug } = await params
+  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
   const product = await res.json()
   return <div>{product.name}</div>
 }
 ```
 
-The build passes, and the output looks the same as the streaming route. Dynamic segments show a `◐` fallback row even when nothing meaningful is prerendered:
+The opt-out applies to asynchronous work such as the `params` read and product request. Synchronous runtime values such as `Math.random()`, `new Date()`, and `crypto.randomUUID()` can still cause a prerender error.
 
-```bash filename="Terminal"
+The build passes. A fixed route whose prerender contains empty HTML shows `ƒ`. This example has a dynamic segment, so its fallback row shows `◐` even though the fallback HTML is empty:
+
+```text filename="Terminal"
 Route (app)
 ┌ ○ /
 ├ ○ /_not-found
-└   /products/[id]
-  └ ◐ /products/[id]    # Renders on demand, blocking on the lookup
+└   /products/[slug]
+  └ ◐ /products/[slug]
 
 ○  (Static)             prerendered as static content
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-Unlike the streaming route, there is no fallback UI: users see nothing until the lookup completes. See [Opting out](/docs/app/guides/instant-navigation#opting-out) for when this is appropriate.
+Next.js can still prerender RSC payloads for static route segments. That static work means an empty HTML file is not equivalent to a route outside the PPR model. On an initial request, the server waits for the product lookup before returning the completed page. During a client navigation, the destination has no fallback to show while that work runs. See [Opting out](/docs/app/guides/instant-navigation#opting-out) for when this is appropriate.
 
 ## Next steps
 
-We've learned how to run a production build, read the route table, and understand prerender-blocking errors. Next, learn how to:
+Use these resources to deploy the build, control its caches, and configure CI:
 
 - [Deploy your application](/docs/app/getting-started/deploying)
 - [Cache data and UI](/docs/app/getting-started/caching)

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -20,14 +20,14 @@ Running `next build` compiles your application for production, [prerenders](/doc
 
 ## What `next build` does
 
-The build runs these phases:
+When you run `next build`, the build moves through these phases:
 
-1. **Setup.** Next.js loads [environment variables](/docs/app/guides/environment-variables) from `.env` files, validates [`next.config`](/docs/app/api-reference/config/next-config-js), and generates a [build ID](/docs/app/api-reference/config/next-config-js/generateBuildId).
-2. **Route discovery.** Next.js scans the `app/` and `pages/` directories for routes and finds root-level files such as [`proxy`](/docs/app/api-reference/file-conventions/proxy) and [`instrumentation`](/docs/app/api-reference/file-conventions/instrumentation).
-3. **Compilation.** [Turbopack](/docs/app/api-reference/turbopack), or webpack when selected, bundles the client and server code for production.
-4. **Page data collection.** Next.js runs [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) and classifies routes for prerendering or request-time rendering.
-5. **Static generation.** Next.js prerenders eligible routes. App Router routes can produce HTML and [React Server Component (RSC) payloads](/docs/app/getting-started/server-and-client-components#on-the-server).
-6. **Output.** Next.js writes the build to `.next/` and prints the route table. With [`output: 'standalone'`](/docs/app/guides/self-hosting), it creates `.next/standalone` with the files needed to run the production server. With [`output: 'export'`](/docs/app/guides/static-exports), it writes the static export to `out/`.
+1. **Setup.** Loads [environment variables](/docs/app/guides/environment-variables) (`.env` files), validates your [`next.config`](/docs/app/api-reference/config/next-config-js), and generates a [build ID](/docs/app/api-reference/config/next-config-js/generateBuildId).
+2. **Route discovery.** Scans the `app/` and `pages/` directories for routes, and detects root-level convention files like [`proxy`](/docs/app/api-reference/file-conventions/proxy) and [`instrumentation`](/docs/app/api-reference/file-conventions/instrumentation). Generates TypeScript route definitions.
+3. **Compilation.** Bundles client, server, and edge code with [Turbopack](/docs/app/api-reference/turbopack) (or webpack). Transpiles TypeScript and JSX, tree-shakes unused code, and optimizes CSS and fonts.
+4. **Static analysis.** Classifies each route for prerendering versus on-demand rendering. Collects [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) output. Checks for [prerender-blocking errors](/docs/messages/blocking-prerender-dynamic).
+5. **Prerendering.** Prerenders static pages and PPR shells to HTML. Generates [RSC payloads](/docs/app/getting-started/server-and-client-components#on-the-server) for client-side navigation.
+6. **Output.** Writes the build to `.next/`. For [`output: 'standalone'`](/docs/app/guides/self-hosting), bundles only the files needed at runtime. For [`output: 'export'`](/docs/app/guides/static-exports), generates a full static site. Prints the route table.
 
 The build checks TypeScript unless [`typescript.ignoreBuildErrors`](/docs/app/api-reference/config/next-config-js/typescript) is enabled.
 
@@ -58,59 +58,61 @@ After a successful build, Next.js prints a route table with a symbol next to eac
 | Symbol | Name              | Behavior                                                                    |
 | ------ | ----------------- | --------------------------------------------------------------------------- |
 | `○`    | Static            | Fully prerendered at build time. Served without server rendering.           |
-| `◐`    | Partial Prerender | Has a PPR result and content that still renders at request time.            |
-| `●`    | SSG               | Prerendered static HTML from `generateStaticParams` or `getStaticProps`.    |
-| `ƒ`    | Dynamic           | Rendered on demand. With Cache Components, this can use an empty PPR shell. |
+| `◐`    | Partial Prerender | Prerenders what it can at build time. Remaining content renders on demand.  |
+| `●`    | SSG               | Prerendered static HTML (from `generateStaticParams` or `getStaticProps`).  |
+| `ƒ`    | Dynamic           | Rendered on demand. With Cache Components, the HTML prerender can be empty. |
 
-Next.js uses `○` Static, `●` SSG, and `ƒ` Dynamic for Pages Router routes and App Router routes without Cache Components. In those models, a route is either prerendered to static HTML or rendered on demand for each request.
+Next.js also uses `○` Static, `●` SSG, and `ƒ` Dynamic for Pages Router routes and App Router routes without Cache Components. In those models, a route is either prerendered to static HTML or rendered on demand for each request.
 
-[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) uses [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) for every App Router page, even when the build produces no HTML shell. The build can produce complete HTML, partial HTML, or an empty HTML file. The current route symbols do not distinguish all three results.
+[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) uses [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) for every App Router page, even when the build produces no HTML shell. The build can produce complete HTML, partial HTML, or an empty HTML file. Per-segment [RSC payloads](/docs/app/getting-started/server-and-client-components#on-the-server) may still contain static information when the HTML file is empty.
 
-For example, a blocking page with an empty HTML file can show `ƒ`. A fallback row for a dynamic route can show `◐` even when its HTML file is empty. In both cases, per-segment [RSC payloads](/docs/app/getting-started/server-and-client-components#on-the-server) may contain static information. An empty HTML file does not mean the build produced no static data.
+The current symbols do not distinguish complete, partial, and empty prerenders. A blocking page with an empty HTML file can show `ƒ`. A fallback row for a dynamic route can show `◐` even when its HTML file is empty.
 
 The symbol is not a direct report of route config such as [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant). Without Cache Components, or on the Pages Router, prerendered pages can also show `●` (SSG).
 
 ## Example
 
-Cache Components validates whether a route can produce a static shell. The following store app has a dynamic product page that reads the product slug and fetches uncached data:
+Cache Components validates whether a route can produce a static shell. A product page that reads runtime params and uncached data outside a Suspense boundary fails this validation.
+
+The store has a dynamic product page that loads data by id:
 
 ```txt
 app/
 ├── layout.tsx
 ├── page.tsx
 └── products/
-    └── [slug]/
+    └── [id]/
         └── page.tsx
 ```
 
-The page fetches a product from the [Recipe API](https://next-recipe-api.vercel.dev/):
+The page fetches a product by id:
 
-```tsx filename="app/products/[slug]/page.tsx" switcher
-export default async function Page(props: PageProps<'/products/[slug]'>) {
-  const { slug } = await props.params
-  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
+```tsx filename="app/products/[id]/page.tsx" switcher
+export default async function Page(props: PageProps<'/products/[id]'>) {
+  const { id } = await props.params
+  const res = await fetch(`https://api.example.com/products/${id}`)
   const product = await res.json()
   return <div>{product.name}</div>
 }
 ```
 
-```jsx filename="app/products/[slug]/page.js" switcher
+```jsx filename="app/products/[id]/page.js" switcher
 export default async function Page({ params }) {
-  const { slug } = await params
-  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
+  const { id } = await params
+  const res = await fetch(`https://api.example.com/products/${id}`)
   const product = await res.json()
   return <div>{product.name}</div>
 }
 ```
 
-During the build, Next.js prerenders as much of the route as it can. It cannot resolve URL data such as [`params`](/docs/app/api-reference/file-conventions/page#params-optional) and [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) while generating a shared shell. [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) provides known params for specific prerenders. Other [runtime data](/docs/app/glossary#request-time-apis), including [`cookies()`](/docs/app/api-reference/functions/cookies) and [`headers()`](/docs/app/api-reference/functions/headers), and uncached `fetch()` calls or database queries require request-time work.
+During the build, Next.js prerenders as much of each route as it can. It cannot resolve URL data such as [`params`](/docs/app/api-reference/file-conventions/page#params-optional) and [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) while generating a shared shell. [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) provides known params for specific prerenders. Other [runtime data](/docs/app/glossary#request-time-apis), including [`cookies()`](/docs/app/api-reference/functions/cookies) and [`headers()`](/docs/app/api-reference/functions/headers), and uncached `fetch()` calls or database queries require request-time work.
 
 Wrap request-time work in [`<Suspense>`](https://react.dev/reference/react/Suspense) to define where the static shell ends. Cache reusable data with [`use cache`](/docs/app/api-reference/directives/use-cache). When request-time work remains outside a Suspense boundary, the build fails with a [`blocking-prerender-runtime`](/docs/messages/blocking-prerender-runtime) or [`blocking-prerender-dynamic`](/docs/messages/blocking-prerender-dynamic) error. [Random values and timestamps](/docs/app/getting-started/caching#random-values-and-timestamps), such as `Math.random()` and `new Date()`, can also block prerendering.
 
-Run `next build`. The `params` read and uncached `fetch()` call run outside a `<Suspense>` boundary, so the build fails with this error:
+Run `next build`. It fails with a prerender-blocking error because the `params` read and the uncached `fetch` run outside a `<Suspense>` boundary:
 
-```text filename="Terminal"
-Error: Route "/products/[slug]": Next.js encountered uncached or runtime data during prerendering.
+```bash filename="Terminal"
+Error: Route "/products/[id]": Next.js encountered uncached or runtime data during prerendering.
 
 `fetch(...)`, `cookies()`, `headers()`, `params`, `searchParams`, or `connection()` accessed outside of `<Suspense>` prevents the route from being prerendered, blocking the page load and leading to a slower user experience.
 
@@ -123,9 +125,9 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic
     at body (<anonymous>)
     at html (<anonymous>)
 To get a more detailed stack trace and pinpoint the issue, try one of the following:
-  - Start the app in development mode by running `next dev`, then open "/products/[slug]" in your browser to investigate the error.
+  - Start the app in development mode by running `next dev`, then open "/products/[id]" in your browser to investigate the error.
   - Rerun the production build with `next build --debug-prerender` to generate better stack traces.
-Error occurred prerendering page "/products/[slug]".
+Error occurred prerendering page "/products/[id]".
 ```
 
 ### Debugging build errors
@@ -136,7 +138,18 @@ Production builds minify server code and omit server source maps by default, so 
 next build --debug-prerender
 ```
 
-The flag disables server minification, enables server source maps, and continues after the first prerender error. This produces more readable stack traces and code frames for errors that occur while prerendering.
+The flag disables server minification, enables server source maps, and continues after the first prerender error. It helps with all errors thrown during prerendering, including blocking errors. The stack now points to the first blocked access in the page, the `params` read:
+
+```bash filename="Terminal"
+Error: Route "/products/[id]": Next.js encountered uncached or runtime data during prerendering.
+  ...
+    at Page (app/products/[id]/page.tsx:2:30)
+  1 | export default async function Page(props: PageProps<'/products/[id]'>) {
+> 2 |   const { id } = await props.params
+    |                              ^
+  3 |   const res = await fetch(`https://api.example.com/products/${id}`)
+  4 |   const product = await res.json()
+```
 
 > **Warning**: Do not deploy builds produced with `--debug-prerender`. The debugging options can affect performance.
 
@@ -144,90 +157,90 @@ The development server shows the resolved component and source line in the error
 
 ### A streaming route
 
-To stream the product lookup, add a [`loading.js`](/docs/app/api-reference/file-conventions/loading) file. Next.js wraps the segment in a `<Suspense>` boundary and prerenders the fallback as part of the static shell. The `params` read and product request continue at request time:
+The error's first suggestion, `[stream]`, is to provide a placeholder around the data access. Add a [`loading.js`](/docs/app/api-reference/file-conventions/loading) file to wrap the whole segment in a `<Suspense>` boundary. Next.js prerenders the fallback as the route's static shell, while the params and data work runs at request time. For other boundary placements, see [Streaming](/docs/app/guides/streaming):
 
-```tsx filename="app/products/[slug]/loading.tsx" switcher
+```tsx filename="app/products/[id]/loading.tsx" switcher
 export default function Loading() {
   return <div>Loading...</div>
 }
 ```
 
-```jsx filename="app/products/[slug]/loading.js" switcher
+```jsx filename="app/products/[id]/loading.js" switcher
 export default function Loading() {
   return <div>Loading...</div>
 }
 ```
 
-Run the build again. The route is now [partially prerendered](/docs/app/glossary#partial-prerendering-ppr):
+Run the build. It passes, and the route is [partially prerendered](/docs/app/glossary#partial-prerendering-ppr):
 
-```text filename="Terminal"
+```bash filename="Terminal"
 Route (app)
-┌ ○ /
+┌ ○ /                   # Prerendered at build time
 ├ ○ /_not-found
-└   /products/[slug]
-  └ ◐ /products/[slug]
+└   /products/[id]
+  └ ◐ /products/[id]    # Shell prerendered, content streams on request
 
 ○  (Static)             prerendered as static content
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-Product URLs now serve the fallback from `loading.js` before the product content finishes. See [Streaming](/docs/app/guides/streaming) for other ways to place the `<Suspense>` boundary.
+Product URLs now serve the prerendered shell instantly, then stream the page content.
 
 ### Building specific routes
 
 Use [`--debug-build-paths`](/docs/app/api-reference/cli/next#building-specific-routes) to compile and prerender selected routes while debugging a large application:
 
 ```bash filename="Terminal"
-next build --debug-build-paths="app/products/[slug]/page.tsx"
+next build --debug-build-paths="app/products/[id]/page.tsx"
 ```
 
-The option accepts comma-separated paths and glob patterns. Prefix a pattern with `!` to exclude it. You can combine the option with `--debug-prerender`. TypeScript still checks the complete project selected by your `tsconfig` file.
+Next.js compiles and prerenders the matching routes and skips the rest. The option accepts comma-separated paths and glob patterns. Prefix a pattern with `!` to exclude it. You can combine the option with `--debug-prerender`. TypeScript still checks the complete project selected by your `tsconfig` file.
 
 ### Prerendered params
 
 The [dynamic segment](/docs/app/glossary#dynamic-route-segments) shows a single fallback row because Next.js doesn't know which param values exist. Export `generateStaticParams` to list them:
 
-```tsx filename="app/products/[slug]/page.tsx" switcher
+```tsx filename="app/products/[id]/page.tsx" switcher
 export async function generateStaticParams() {
-  const res = await fetch('https://next-recipe-api.vercel.dev/products?limit=3')
+  const res = await fetch('https://api.example.com/products')
   const products = await res.json()
-  return products.map((product) => ({ slug: product.slug }))
+  return products.map((product) => ({ id: product.id }))
 }
 
-export default async function Page(props: PageProps<'/products/[slug]'>) {
-  const { slug } = await props.params
-  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
+export default async function Page(props: PageProps<'/products/[id]'>) {
+  const { id } = await props.params
+  const res = await fetch(`https://api.example.com/products/${id}`)
   const product = await res.json()
   return <div>{product.name}</div>
 }
 ```
 
-```jsx filename="app/products/[slug]/page.js" switcher
+```jsx filename="app/products/[id]/page.js" switcher
 export async function generateStaticParams() {
-  const res = await fetch('https://next-recipe-api.vercel.dev/products?limit=3')
+  const res = await fetch('https://api.example.com/products')
   const products = await res.json()
-  return products.map((product) => ({ slug: product.slug }))
+  return products.map((product) => ({ id: product.id }))
 }
 
 export default async function Page({ params }) {
-  const { slug } = await params
-  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
+  const { id } = await params
+  const res = await fetch(`https://api.example.com/products/${id}`)
   const product = await res.json()
   return <div>{product.name}</div>
 }
 ```
 
-Running the build again adds a row for each listed param, indented under the `/products/[slug]` route:
+Running the build again adds a row for each listed param, indented under the `/products/[id]` route:
 
-```text filename="Terminal"
+```bash filename="Terminal"
 Route (app)
 ┌ ○ /
 ├ ○ /_not-found
-└   /products/[slug]
-  ├ ◐ /products/[slug]
-  ├ ◐ /products/tee
-  ├ ◐ /products/joggers
-  └ ◐ /products/tennis-shoes
+└   /products/[id]
+  ├ ◐ /products/[id]
+  ├ ◐ /products/1       # Params known, data still uncached
+  ├ ◐ /products/2       # Params known, data still uncached
+  └ ◐ /products/3       # Params known, data still uncached
 
 ○  (Static)             prerendered as static content
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
@@ -237,61 +250,63 @@ Route (app)
 
 The new rows show `◐`, not `○`. Listing the params tells Next.js which pages exist, but their content still comes from the uncached lookup, which only runs at request time. Each page serves the static shell and streams its content.
 
+> **Good to know**: Here the `fetch` runs during prerendering, so point it at a working endpoint or an asynchronous test source. The `◐` rows appear only when the lookup performs uncached asynchronous I/O. A synchronous in-memory value is static and prerenders each param to `○` instead.
+
 ### Cached data
 
 The error's `[cache]` fix makes the product lookup reusable. Add `use cache` so Next.js can include the result when it prerenders a known product:
 
-```tsx filename="app/products/[slug]/page.tsx" switcher
+```tsx filename="app/products/[id]/page.tsx" switcher
 export async function generateStaticParams() {
-  const res = await fetch('https://next-recipe-api.vercel.dev/products?limit=3')
+  const res = await fetch('https://api.example.com/products')
   const products = await res.json()
-  return products.map((product) => ({ slug: product.slug }))
+  return products.map((product) => ({ id: product.id }))
 }
 
-async function getProduct(slug: string) {
+async function getProduct(id: string) {
   'use cache'
-  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
+  const res = await fetch(`https://api.example.com/products/${id}`)
   return res.json()
 }
 
-export default async function Page(props: PageProps<'/products/[slug]'>) {
-  const { slug } = await props.params
-  const product = await getProduct(slug)
+export default async function Page(props: PageProps<'/products/[id]'>) {
+  const { id } = await props.params
+  const product = await getProduct(id)
   return <div>{product.name}</div>
 }
 ```
 
-```jsx filename="app/products/[slug]/page.js" switcher
+```jsx filename="app/products/[id]/page.js" switcher
 export async function generateStaticParams() {
-  const res = await fetch('https://next-recipe-api.vercel.dev/products?limit=3')
+  const res = await fetch('https://api.example.com/products')
   const products = await res.json()
-  return products.map((product) => ({ slug: product.slug }))
+  return products.map((product) => ({ id: product.id }))
 }
 
-async function getProduct(slug) {
+async function getProduct(id) {
   'use cache'
-  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
+  const res = await fetch(`https://api.example.com/products/${id}`)
   return res.json()
 }
 
 export default async function Page({ params }) {
-  const { slug } = await params
-  const product = await getProduct(slug)
+  const { id } = await params
+  const product = await getProduct(id)
   return <div>{product.name}</div>
 }
 ```
 
 Running the build again shows the listed params as `○`. Their params are known and their data is cached, so Next.js prerenders each page in full. The `◐` row remains for unlisted params, which serve the static shell while their content streams:
 
-```text filename="Terminal"
+```bash filename="Terminal"
 Route (app)
 ┌ ○ /
 ├ ○ /_not-found
-└   /products/[slug]
-  ├ ◐ /products/[slug]
-  ├ ○ /products/tee
-  ├ ○ /products/joggers
-  └ ○ /products/tennis-shoes
+└   /products/[id]
+  ├ ◐ /products/[id]    # Unlisted params stream on demand
+  ├ ○ /products/1       # Prerendered in full at build time
+  ├ ○ /products/2       # Prerendered in full at build time
+  └ ○ /products/3       # Prerendered in full at build time
 
 ○  (Static)             prerendered as static content
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
@@ -303,48 +318,18 @@ With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partial
 
 When there are more prerendered paths than fit in the table, Next.js prints a short list ending with `[+N more paths]`.
 
-When a prerender uses cached functions or components, the output can include `Revalidate` and `Expire` columns. A route reports the shortest `revalidate` and `expire` values across its caches. Without an explicit [`cacheLife`](/docs/app/api-reference/functions/cacheLife) call, caches use the [`default` profile](/docs/app/api-reference/functions/cacheLife#preset-cache-profiles).
+Routes that contain cached functions or components can also show `Revalidate` and `Expire` columns. A route reports the shortest `revalidate` and `expire` across all the caches it contains. Caches use the [`default` profile](/docs/app/api-reference/functions/cacheLife#preset-cache-profiles) when there is no explicit [`cacheLife`](/docs/app/api-reference/functions/cacheLife) call. A `/products` listing page that renders the same cached data produces this output:
 
-Add a cached `/products` listing page:
-
-```tsx filename="app/products/page.tsx" switcher
-async function getProducts() {
-  'use cache'
-  const res = await fetch('https://next-recipe-api.vercel.dev/products?limit=3')
-  return res.json()
-}
-
-export default async function ProductsPage() {
-  const products = await getProducts()
-  return products.map((product) => <div key={product.slug}>{product.name}</div>)
-}
-```
-
-```jsx filename="app/products/page.js" switcher
-async function getProducts() {
-  'use cache'
-  const res = await fetch('https://next-recipe-api.vercel.dev/products?limit=3')
-  return res.json()
-}
-
-export default async function ProductsPage() {
-  const products = await getProducts()
-  return products.map((product) => <div key={product.slug}>{product.name}</div>)
-}
-```
-
-The next build includes the cache timing for the listing page and the prerendered product pages:
-
-```text filename="Terminal"
-Route (app)                   Revalidate  Expire
+```bash filename="Terminal"
+Route (app)           Revalidate  Expire
 ┌ ○ /
 ├ ○ /_not-found
-├ ○ /products                        15m      1y
-└   /products/[slug]
-  ├ ◐ /products/[slug]
-  ├ ○ /products/tee                  15m      1y
-  ├ ○ /products/joggers              15m      1y
-  └ ○ /products/tennis-shoes         15m      1y
+├ ○ /products                15m      1y
+└   /products/[id]
+  ├ ◐ /products/[id]
+  ├ ○ /products/1            15m      1y
+  ├ ○ /products/2            15m      1y
+  └ ○ /products/3            15m      1y
 ```
 
 The built-in `default` profile revalidates after 15 minutes and never expires. The build output represents an unbounded expiration as one year, shown as `1y`. You can override the default profile in `next.config.ts`. The table does not identify which cache produced each value, so check the route's `cacheLife` calls when it contains multiple caches.
@@ -353,23 +338,23 @@ The built-in `default` profile revalidates after 15 minutes and never expires. T
 
 Set `instant = false` when the route is allowed to block. The export opts the segment out of instant-navigation validation. When the page is the highest segment with an `instant` config, it also opts the route out of static-shell validation. The rendering model remains PPR, but the build can finish with empty HTML:
 
-```tsx filename="app/products/[slug]/page.tsx" switcher
+```tsx filename="app/products/[id]/page.tsx" switcher
 export const instant = false
 
-export default async function Page(props: PageProps<'/products/[slug]'>) {
-  const { slug } = await props.params
-  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
+export default async function Page(props: PageProps<'/products/[id]'>) {
+  const { id } = await props.params
+  const res = await fetch(`https://api.example.com/products/${id}`)
   const product = await res.json()
   return <div>{product.name}</div>
 }
 ```
 
-```jsx filename="app/products/[slug]/page.js" switcher
+```jsx filename="app/products/[id]/page.js" switcher
 export const instant = false
 
 export default async function Page({ params }) {
-  const { slug } = await params
-  const res = await fetch(`https://next-recipe-api.vercel.dev/products/${slug}`)
+  const { id } = await params
+  const res = await fetch(`https://api.example.com/products/${id}`)
   const product = await res.json()
   return <div>{product.name}</div>
 }
@@ -379,18 +364,18 @@ The opt-out applies to asynchronous work such as the `params` read and product r
 
 The build passes. A fixed route whose prerender contains empty HTML shows `ƒ`. This example has a dynamic segment, so its fallback row shows `◐` even though the fallback HTML is empty:
 
-```text filename="Terminal"
+```bash filename="Terminal"
 Route (app)
 ┌ ○ /
 ├ ○ /_not-found
-└   /products/[slug]
-  └ ◐ /products/[slug]
+└   /products/[id]
+  └ ◐ /products/[id]    # Renders on demand, blocking on the lookup
 
 ○  (Static)             prerendered as static content
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-Next.js can still prerender RSC payloads for static route segments. That static work means an empty HTML file is not equivalent to a route outside the PPR model. On an initial request, the server waits for the product lookup before returning the completed page. During a client navigation, the destination has no fallback to show while that work runs. See [Opting out](/docs/app/guides/instant-navigation#opting-out) for when this is appropriate.
+Per-segment RSC payloads may still contain static information. On an initial request, the server waits for the product lookup before returning the completed page. During a client navigation, the destination has no fallback to show while that work runs. See [Opting out](/docs/app/guides/instant-navigation#opting-out) for when this is appropriate.
 
 ## Next steps
 

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -69,17 +69,39 @@ Without Cache Components, App Router pages and Pages Router routes use these ren
 
 With [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) is the only rendering model for App Router pages. For these pages, the symbols describe how much HTML the build produced:
 
-| Symbol | Build label       | HTML produced during the build                                               |
-| ------ | ----------------- | ---------------------------------------------------------------------------- |
-| `○`    | Static            | A complete HTML prerender.                                                   |
-| `◐`    | Partial Prerender | A static shell followed by content that renders on demand.                   |
-| `ƒ`    | Dynamic           | An empty HTML prerender for a specific pathname. The page renders on demand. |
+| Symbol | Build label       | HTML produced during the build                             |
+| ------ | ----------------- | ---------------------------------------------------------- |
+| `○`    | Static            | A complete HTML prerender.                                 |
+| `◐`    | Partial Prerender | A static shell followed by content that renders on demand. |
+| `ƒ`    | Dynamic           | No HTML for that row. The page renders on demand.          |
 
-For a Cache Components page, `ƒ` means the build produced empty HTML for that specific pathname. Next.js produces the page HTML on request.
+For a Cache Components page, `ƒ` means the build accepted an empty HTML prerender for that row. Next.js produces the page HTML on request. A dynamic route can also have a fallback row for pathnames not listed by `generateStaticParams`. The example below shows how this row is displayed.
 
 ### Other route entries
 
 Request-dependent [Route Handlers](/docs/app/api-reference/file-conventions/route) (API endpoints), Proxy (Middleware), and dynamic metadata routes such as `icon`, `opengraph-image`, and `twitter-image` use `ƒ`. These entries render on demand and do not use PPR.
+
+### Prerender validation
+
+With Cache Components, `next build` validates that each App Router page can produce a static shell. Request-time values such as `params`, `cookies()`, and `headers()` outside of `<Suspense>` produce a [runtime data error](/docs/messages/blocking-prerender-runtime). Uncached data produces an [uncached data error](/docs/messages/blocking-prerender-dynamic). Each error links to the fixes that apply to that data source.
+
+### Debug prerender errors
+
+Production builds minify server code and omit server source maps by default. Use [`--debug-prerender`](/docs/app/api-reference/cli/next#debugging-prerender-errors) for more detailed stack traces and code frames:
+
+```bash filename="Terminal"
+next build --debug-prerender
+```
+
+The option disables server minification, enables server source maps, and continues after the first prerender error.
+
+> **Warning**: Do not deploy builds produced with `--debug-prerender`. These builds include debugging options and are not optimized for production.
+
+### Build specific routes
+
+Use [`--debug-build-paths`](/docs/app/api-reference/cli/next#building-specific-routes) to compile and prerender selected routes while debugging a large application. The option accepts comma-separated paths and glob patterns. Prefix a pattern with `!` to exclude it. You can also combine it with `--debug-prerender`.
+
+Only matching routes appear in the route table. When you select an App Router route, Next.js also includes the built-in `/_not-found` route.
 
 ## Example
 
@@ -139,17 +161,13 @@ Error occurred prerendering page "/products/[id]".
 
 With Cache Components, Next.js validates whether the route can produce a static shell.
 
-The error shows that request-time work is blocking prerendering, but the stack only points to `body` and `html`. It does not identify the source line.
-
-### Debugging build errors
-
-Production builds minify server code and omit server source maps by default. Rerun the build with [`--debug-prerender`](/docs/app/api-reference/cli/next#debugging-prerender-errors):
+The error shows that request-time work is blocking prerendering, but the stack only points to `body` and `html`. It does not identify the source line. Rerun only the product route with both debugging options:
 
 ```bash filename="Terminal"
-next build --debug-prerender
+next build --debug-prerender --debug-build-paths="app/products/[id]/page.tsx"
 ```
 
-The flag disables server minification, enables server source maps, and continues after the first prerender error. It helps with all errors thrown during prerendering, including blocking errors. The stack now points to the first blocked access in the page, the `params` read:
+The stack now points to the first blocked access in the page, the `params` read:
 
 ```bash filename="Terminal"
 Error: Route "/products/[id]": Next.js encountered uncached or runtime data during prerendering.
@@ -164,13 +182,11 @@ Error: Route "/products/[id]": Next.js encountered uncached or runtime data duri
 
 The detailed stack identifies the [`params`](/docs/app/api-reference/file-conventions/page#params-optional) read as the first blocked access. The uncached product request below it also requires request-time work.
 
-> **Warning**: Do not deploy builds produced with `--debug-prerender`. These builds include debugging options and are not optimized for production.
-
 The development server shows the resolved component and source line in the error overlay. See [Ensuring instant navigations](/docs/app/guides/instant-navigation) for the development workflow.
 
 The error provides three options: stream the request-time work, cache the product request, or allow the route to block. The following sections show how each option changes the build output.
 
-### A streaming route
+### Stream request-time content
 
 Follow the error's `[stream]` suggestion by adding a [`loading.js`](/docs/app/api-reference/file-conventions/loading) file. The file wraps the segment in a `<Suspense>` boundary. Next.js prerenders the fallback as the route's static shell, while the params and data work runs at request time. For other boundary placements, see [Streaming](/docs/app/guides/streaming):
 
@@ -186,12 +202,17 @@ export default function Loading() {
 }
 ```
 
-Run the build. It passes, and the route is [partially prerendered](/docs/app/glossary#partial-prerendering-ppr):
+Rebuild only the product route:
+
+```bash filename="Terminal"
+next build --debug-build-paths="app/products/[id]/page.tsx"
+```
+
+The build passes, and the route is [partially prerendered](/docs/app/glossary#partial-prerendering-ppr). Because the command selects only the product route, the table omits `/`:
 
 ```bash filename="Terminal"
 Route (app)
-┌ ○ /                   # Prerendered at build time
-├ ○ /_not-found
+┌ ○ /_not-found
 └   /products/[id]
   └ ◐ /products/[id]    # Shell prerendered, content streams on request
 
@@ -199,19 +220,9 @@ Route (app)
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-Product URLs now serve the prerendered shell instantly, then stream the page content.
+Product URLs now serve the prerendered shell instantly, then stream the page content. At this point, every product URL uses the same shell and waits for its product data. If some product IDs are known during the build, Next.js can attempt to prerender more of those pages.
 
-### Building specific routes
-
-Use [`--debug-build-paths`](/docs/app/api-reference/cli/next#building-specific-routes) to compile and prerender selected routes while debugging a large application:
-
-```bash filename="Terminal"
-next build --debug-build-paths="app/products/[id]/page.tsx"
-```
-
-Next.js compiles and prerenders the matching routes and skips the rest. The option accepts comma-separated paths and glob patterns. Prefix a pattern with `!` to exclude it. You can combine the option with `--debug-prerender`. TypeScript still checks the complete project selected by your `tsconfig` file.
-
-### Prerendered params
+### Prerender known paths
 
 The [dynamic segment](/docs/app/glossary#dynamic-route-segments) shows a single fallback row because Next.js doesn't know which param values exist. Export `generateStaticParams` to list them:
 
@@ -245,12 +256,11 @@ export default async function Page({ params }) {
 }
 ```
 
-Running the build again adds a row for each listed param, indented under the `/products/[id]` route:
+Rebuilding the product route adds a row for each listed param, indented under the `/products/[id]` route:
 
 ```bash filename="Terminal"
 Route (app)
-┌ ○ /
-├ ○ /_not-found
+┌ ○ /_not-found
 └   /products/[id]
   ├ ◐ /products/[id]
   ├ ◐ /products/1       # Params known, data still uncached
@@ -265,7 +275,9 @@ Route (app)
 
 The listed params appear as `◐`. The params tell Next.js which pathnames to prerender, while the uncached lookup supplies their content at request time. Each page serves the static shell and streams its content.
 
-### Cached data
+The known paths still wait for the product lookup because it remains uncached. If the product data can be reused, cache the lookup so the build can finish prerendering those pages.
+
+### Cache reusable data
 
 The error's `[cache]` fix makes the product lookup reusable. Add `use cache` so Next.js can include the result when it prerenders a known product:
 
@@ -309,12 +321,11 @@ export default async function Page({ params }) {
 }
 ```
 
-Running the build again shows the listed params as `○`. Their params are known and their data is cached, so Next.js prerenders each page in full. The `◐` row remains for unlisted params, which serve the static shell while their content streams:
+Rebuilding the product route shows the listed params as `○`. Their params are known and their data is cached, so Next.js prerenders each page in full. The `◐` row remains for unlisted params, which serve the static shell while their content streams:
 
 ```bash filename="Terminal"
 Route (app)
-┌ ○ /
-├ ○ /_not-found
+┌ ○ /_not-found
 └   /products/[id]
   ├ ◐ /products/[id]    # Unlisted params stream on demand
   ├ ○ /products/1       # Prerendered in full at build time
@@ -345,14 +356,20 @@ Route (app)           Revalidate  Expire
   └ ○ /products/3            15m      1y
 ```
 
-The built-in `default` profile revalidates after 15 minutes and never expires. The build output represents an unbounded expiration as one year, shown as `1y`. You can override the default profile in `next.config.ts`. The table does not identify which cache produced each value, so check the route's `cacheLife` calls when it contains multiple caches.
+The built-in `default` profile revalidates after 15 minutes. Its cache lifetime is unbounded, so the route uses the global `expireTime` fallback. `expireTime` defaults to one year, shown as `1y`. You can override the cache profile or `expireTime` in `next.config.ts`. The table does not identify which cache produced each value, so check the route's `cacheLife` calls when it contains multiple caches.
 
-### A blocking route
+### Allow the route to block
 
-Set `instant = false` when the route is allowed to block. The export does not change the rendering model. It opts the segment out of instant-navigation validation. When it is the highest `instant` config in the route tree, it also disables static-shell validation, allowing the build to accept an empty HTML prerender. The route continues to use PPR:
+The `[block]` option is an alternative to caching the product lookup. Suppose the product IDs should still be collected during the build, but each page must read fresh product data before responding. Keep `generateStaticParams`, remove the `loading` file and `use cache`, and set `instant = false`:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export const instant = false
+
+export async function generateStaticParams() {
+  const res = await fetch('https://api.example.com/products')
+  const products = await res.json()
+  return products.map((product) => ({ id: product.id }))
+}
 
 export default async function Page(props: PageProps<'/products/[id]'>) {
   const { id } = await props.params
@@ -365,6 +382,12 @@ export default async function Page(props: PageProps<'/products/[id]'>) {
 ```jsx filename="app/products/[id]/page.js" switcher
 export const instant = false
 
+export async function generateStaticParams() {
+  const res = await fetch('https://api.example.com/products')
+  const products = await res.json()
+  return products.map((product) => ({ id: product.id }))
+}
+
 export default async function Page({ params }) {
   const { id } = await params
   const res = await fetch(`https://api.example.com/products/${id}`)
@@ -373,20 +396,26 @@ export default async function Page({ params }) {
 }
 ```
 
-Next.js attempts to prerender the route. If request-time work blocks the whole page, the build produces empty HTML. Synchronous values such as `Math.random()`, `new Date()`, and `crypto.randomUUID()` still produce prerender errors.
+The `instant = false` export does not change the rendering model. It opts the segment out of instant-navigation validation. When it is the highest `instant` config in the route tree, it also disables static-shell validation, allowing the build to accept an empty HTML prerender. The route continues to use PPR.
 
-The build passes with PPR and an empty HTML prerender. This example has a dynamic segment, so the route table shows `◐` on its fallback row. The same empty output for a specific pathname shows `ƒ`:
+Next.js attempts to prerender each path from `generateStaticParams`. The uncached product request blocks the whole page, so the build produces empty HTML for each row:
 
 ```bash filename="Terminal"
 Route (app)
-┌ ○ /
-├ ○ /_not-found
+┌ ○ /_not-found
 └   /products/[id]
-  └ ◐ /products/[id]    # Empty PPR HTML. Content renders on demand
+  ├ ƒ /products/[id]    # Empty fallback HTML
+  ├ ƒ /products/1       # Empty HTML. Renders on request
+  ├ ƒ /products/2       # Empty HTML. Renders on request
+  └ ƒ /products/3       # Empty HTML. Renders on request
 
-○  (Static)             prerendered as static content
-◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
+○  (Static)   prerendered as static content
+ƒ  (Dynamic)  server-rendered on demand
 ```
+
+Without `generateStaticParams`, the table has only the `/products/[id]` fallback row. That row uses `◐` because it represents the PPR fallback for the dynamic route pattern, even when its HTML is empty. When `generateStaticParams` adds child rows, each row reflects its prerender result, so an empty result uses `ƒ`.
+
+Synchronous values such as `Math.random()`, `new Date()`, and `crypto.randomUUID()` still produce prerender errors.
 
 On an initial request, the server waits for the product lookup before returning the completed page. During a client navigation, the destination has no fallback to show while that work runs. See [Opting out](/docs/app/guides/instant-navigation#opting-out) for when this is appropriate.
 

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -265,8 +265,6 @@ Route (app)
 
 The listed params appear as `◐`. The params tell Next.js which pathnames to prerender, while the uncached lookup supplies their content at request time. Each page serves the static shell and streams its content.
 
-> **Good to know**: Before enabling Cache Components, generated paths use `●` (SSG). After enabling Cache Components, the same paths show `◐` because Next.js postpones the uncached product lookup. Caching the lookup moves them to `○`.
-
 ### Cached data
 
 The error's `[cache]` fix makes the product lookup reusable. Add `use cache` so Next.js can include the result when it prerenders a known product:

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -55,18 +55,18 @@ bun run build
 
 After a successful build, Next.js prints a route table with a symbol next to each route, showing how it is served:
 
-| Symbol | Name              | Behavior                                                                    |
-| ------ | ----------------- | --------------------------------------------------------------------------- |
-| `○`    | Static            | Fully prerendered at build time. Served without server rendering.           |
-| `◐`    | Partial Prerender | Prerenders what it can at build time. Remaining content renders on demand.  |
-| `●`    | SSG               | Prerendered static HTML (from `generateStaticParams` or `getStaticProps`).  |
-| `ƒ`    | Dynamic           | Rendered on demand. With Cache Components, the HTML prerender can be empty. |
+| Symbol | Name              | Behavior                                                                   |
+| ------ | ----------------- | -------------------------------------------------------------------------- |
+| `○`    | Static            | Fully prerendered at build time. Served without server rendering.          |
+| `◐`    | Partial Prerender | Prerenders what it can at build time. Remaining content renders on demand. |
+| `●`    | SSG               | Prerendered static HTML (from `generateStaticParams` or `getStaticProps`). |
+| `ƒ`    | Dynamic           | Rendered on demand. Can also label an empty PPR HTML output.               |
 
-Next.js also uses `○` Static, `●` SSG, and `ƒ` Dynamic for Pages Router routes and App Router routes without Cache Components. In those models, a route is either prerendered to static HTML or rendered on demand for each request.
+Next.js uses `○` Static, `●` SSG, and `ƒ` Dynamic for Pages Router routes, App Router routes without Cache Components, and non-page routes such as request-dependent Route Handlers. In those models, a route is either prerendered to static HTML or rendered on demand for each request.
 
-[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) uses [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) for every App Router page, even when the build produces no HTML shell. The build can produce complete HTML, partial HTML, or an empty HTML file. Per-segment [RSC payloads](/docs/app/getting-started/server-and-client-components#on-the-server) may still contain static information when the HTML file is empty.
+[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) uses [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) for every App Router page. This is still the rendering model when the build produces an empty HTML file. Per-segment [RSC payloads](/docs/app/getting-started/server-and-client-components#on-the-server) may contain static information even when the route has no prerendered HTML.
 
-The current symbols do not distinguish complete, partial, and empty prerenders. A blocking page with an empty HTML file can show `ƒ`. A fallback row for a dynamic route can show `◐` even when its HTML file is empty.
+The symbols do not map directly to the PPR model's complete, partial, and empty HTML outputs. `○` represents a complete prerender. An empty prerender can appear as `ƒ` for a page at a fixed pathname or `◐` on the fallback row for a dynamic pathname. For a Cache Components page, `ƒ` describes its empty HTML output. It does not mean the page stopped using PPR.
 
 The symbol is not a direct report of route config such as [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant). Without Cache Components, or on the Pages Router, prerendered pages can also show `●` (SSG).
 
@@ -362,14 +362,14 @@ export default async function Page({ params }) {
 
 The opt-out applies to asynchronous work such as the `params` read and product request. Synchronous runtime values such as `Math.random()`, `new Date()`, and `crypto.randomUUID()` can still cause a prerender error.
 
-The build passes. A fixed route whose prerender contains empty HTML shows `ƒ`. This example has a dynamic segment, so its fallback row shows `◐` even though the fallback HTML is empty:
+The build passes. The page still uses PPR even though its HTML prerender is empty. This example has a dynamic segment, so the route table shows `◐` on its fallback row. A page at a fixed pathname with the same empty PPR HTML output can show `ƒ` instead:
 
 ```bash filename="Terminal"
 Route (app)
 ┌ ○ /
 ├ ○ /_not-found
 └   /products/[id]
-  └ ◐ /products/[id]    # Renders on demand, blocking on the lookup
+  └ ◐ /products/[id]    # Empty PPR HTML; content renders on demand
 
 ○  (Static)             prerendered as static content
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -180,15 +180,52 @@ Error: Route "/products/[id]": Next.js encountered uncached or runtime data duri
   4 |   const product = await res.json()
 ```
 
-The detailed stack identifies the [`params`](/docs/app/api-reference/file-conventions/page#params-optional) read as the first blocked access. The `[cache]` suggestion in the error applies to uncached data, not to `params`.
+The detailed stack identifies the [`params`](/docs/app/api-reference/file-conventions/page#params-optional) read as the first blocked access.
 
 During development, `next dev` shows the resolved component and source line, then reruns validation as you edit. This example uses `--debug-prerender` to trace each error from production build output. See [Ensuring instant navigations](/docs/app/guides/instant-navigation) for the development workflow.
 
+### Stream request-time work
+
+Choose the `[stream]` option by adding a [`loading.js`](/docs/app/api-reference/file-conventions/loading) file:
+
+```tsx filename="app/products/[id]/loading.tsx" switcher
+export default function Loading() {
+  return <div>Loading...</div>
+}
+```
+
+```jsx filename="app/products/[id]/loading.js" switcher
+export default function Loading() {
+  return <div>Loading...</div>
+}
+```
+
+`loading.js` wraps the page in a `<Suspense>` boundary and uses the loading component as its fallback. Next.js prerenders this fallback as the product route's static shell. The page reads the params and fetches the product at request time, then replaces the fallback with the completed content.
+
+For more granular streaming, add an explicit `<Suspense>` boundary around only the component that needs request-time data. More of the page can then remain in the static shell. See [Streaming](/docs/app/guides/streaming).
+
+Rebuild only the product route:
+
+```bash filename="Terminal"
+next build --debug-build-paths="app/products/[id]/page.tsx"
+```
+
+The build passes. Because the command selects only the product route, the table omits `/`:
+
+```bash filename="Terminal"
+Route (app)
+┌ ○ /_not-found
+└ ◐ /products/[id]
+
+○  (Static)             prerendered as static content
+◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
+```
+
+The `◐` symbol shows that the route serves a static shell and streams the remaining content.
+
 ### Prerender selected paths
 
-[`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) is optional. Use it to prerender a set of dynamic pathnames known at build time. It resolves `params` only for the paths it returns. Unlisted paths still need a `loading.js` file or a `<Suspense>` boundary for instant navigation.
-
-This example uses `generateStaticParams` to prerender known product IDs. The build can then continue past `params` and identify the next blocked access:
+[`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) is optional. Use it to prerender a set of dynamic pathnames known at build time. Keep `loading.js` and export the product IDs from the page:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export async function generateStaticParams() {
@@ -220,61 +257,13 @@ export default async function Page({ params }) {
 }
 ```
 
-Rebuild the product route with both debugging options:
-
-```bash filename="Terminal"
-next build --debug-prerender --debug-build-paths="app/products/[id]/page.tsx"
-```
-
-For each generated path, `params` now resolves during prerendering. The build continues to the uncached product lookup and fails on that line:
-
-```bash filename="Terminal"
-Error: Route "/products/[id]": Next.js encountered uncached or runtime data during prerendering.
-  ...
-Ways to fix this:
-  - [stream] Provide a placeholder with `<Suspense fallback={...}>` around the data access
-  - [cache] For uncached data (`fetch`, database calls): cache the access with `"use cache"`
-  - [block] Set `export const instant = false` to allow a blocking route
-  ...
-    at Page (app/products/[id]/page.tsx:9:21)
-   8 |   const { id } = await props.params
->  9 |   const res = await fetch(`https://api.example.com/products/${id}`)
-     |                     ^
-  10 |   const product = await res.json()
-Error occurred prerendering page "/products/1".
-```
-
-Adding `generateStaticParams` does not make the build pass. It reveals the uncached product lookup as the next blocked access. First choose `[stream]` to see how generated paths appear while this data remains uncached.
-
-> **Good to know**: With Cache Components, `generateStaticParams` must return at least one param. An empty array causes a [build error](/docs/messages/empty-generate-static-params). Apps with a large, frequently changing, or unbounded set of pathnames can omit `generateStaticParams` and use a static shell for request-time params.
-
-### Stream uncached data
-
-Add a [`loading.js`](/docs/app/api-reference/file-conventions/loading) file:
-
-```tsx filename="app/products/[id]/loading.tsx" switcher
-export default function Loading() {
-  return <div>Loading...</div>
-}
-```
-
-```jsx filename="app/products/[id]/loading.js" switcher
-export default function Loading() {
-  return <div>Loading...</div>
-}
-```
-
-`loading.js` automatically wraps the page content in a `<Suspense>` boundary and uses the loading component as its fallback. In this example, Next.js prerenders the loading state as the product route's static shell. The page reads the params and fetches the product at request time, then replaces the loading state with the completed content.
-
-For more granular streaming, add an explicit `<Suspense>` boundary around only the component that needs request-time data. More of the page can then remain in the static shell. See [Streaming](/docs/app/guides/streaming).
-
-Rebuild only the product route:
+Rebuild the product route:
 
 ```bash filename="Terminal"
 next build --debug-build-paths="app/products/[id]/page.tsx"
 ```
 
-The build passes and adds a row for each generated path. Because the command selects only the product route, the table omits `/`:
+The route table now includes each generated path:
 
 ```bash filename="Terminal"
 Route (app)
@@ -289,11 +278,13 @@ Route (app)
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-The generated paths appear as `◐` because their params are known, but the product lookup remains request-time work. Each page serves the static shell and streams its product content. If the product data can be reused, cache the lookup so the build can finish prerendering those pages.
+The generated paths remain `◐` because the product lookup is uncached. `generateStaticParams` selects pathnames to prerender, but it does not cache their data. Apps with a large, frequently changing, or unbounded set of pathnames can omit it and use the static shell for request-time params.
+
+> **Good to know**: With Cache Components, `generateStaticParams` must return at least one param. An empty array causes a [build error](/docs/messages/empty-generate-static-params).
 
 ### Cache reusable data
 
-Add `use cache` to make the product lookup reusable. Next.js can then include the result when it prerenders a known product:
+The first build error also suggested `[cache]` for uncached data. Add `use cache` to make the product lookup reusable. Next.js can then include the result when it prerenders a known product:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export async function generateStaticParams() {

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -182,7 +182,7 @@ Error: Route "/products/[id]": Next.js encountered uncached or runtime data duri
 
 The detailed stack identifies the [`params`](/docs/app/api-reference/file-conventions/page#params-optional) read as the first blocked access.
 
-This guide uses production builds to show how each change affects the route table. Within a route, the build reports blocking accesses in execution order. Rerun it after each fix to find the next error.
+This guide uses production builds to show how each change affects the route table.
 
 During development, `next dev` shows all validation errors in the dev overlay and terminal with stack frames that resolve to your source. It reruns validation as you edit. See [Ensuring instant navigations](/docs/app/guides/instant-navigation) for the development workflow.
 

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -85,9 +85,7 @@ Request-dependent [Route Handlers](/docs/app/api-reference/file-conventions/rout
 
 > **Good to know**: The following example uses [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), enabled with `cacheComponents: true` in `next.config.ts`. The route symbols and prerender errors differ when Cache Components is disabled. See [Enabling Cache Components](/docs/app/getting-started/caching#enabling-cache-components) for setup.
 
-Cache Components validates whether a route can produce a static shell. A product page that reads runtime params and uncached data outside a Suspense boundary fails validation.
-
-The store has a product page with a dynamic segment that loads data by ID:
+In this example, a store application has a product page with a dynamic `[id]` segment:
 
 ```txt
 app/
@@ -98,7 +96,7 @@ app/
         └── page.tsx
 ```
 
-The page fetches a product by ID:
+The page uses the ID to fetch the product:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export default async function Page(props: PageProps<'/products/[id]'>) {
@@ -118,11 +116,7 @@ export default async function Page({ params }) {
 }
 ```
 
-During the build, Next.js prerenders as much of each route as it can. It cannot resolve URL data such as [`params`](/docs/app/api-reference/file-conventions/page#params-optional) and [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) while generating a shared shell. [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) provides known params for specific prerenders. Other [runtime data](/docs/app/glossary#request-time-apis), including [`cookies()`](/docs/app/api-reference/functions/cookies) and [`headers()`](/docs/app/api-reference/functions/headers), and uncached `fetch()` calls or database queries require request-time work.
-
-Wrap request-time work in [`<Suspense>`](https://react.dev/reference/react/Suspense) to define where the static shell ends. Cache reusable data with [`use cache`](/docs/app/api-reference/directives/use-cache). When request-time work remains outside a Suspense boundary, the build fails with a [`blocking-prerender-runtime`](/docs/messages/blocking-prerender-runtime) or [`blocking-prerender-dynamic`](/docs/messages/blocking-prerender-dynamic) error. [Random values and timestamps](/docs/app/getting-started/caching#random-values-and-timestamps), such as `Math.random()` and `new Date()`, can also block prerendering.
-
-Run `next build`. It fails with a prerender-blocking error because the `params` read and the uncached `fetch` run outside a `<Suspense>` boundary:
+Run `next build`. Next.js prerenders as much of each route as it can before printing the build output. In this case, the build fails:
 
 ```bash filename="Terminal"
 Error: Route "/products/[id]": Next.js encountered uncached or runtime data during prerendering.
@@ -143,9 +137,13 @@ To get a more detailed stack trace and pinpoint the issue, try one of the follow
 Error occurred prerendering page "/products/[id]".
 ```
 
+With Cache Components, Next.js validates whether the route can produce a static shell.
+
+The error shows that request-time work is blocking prerendering, but the stack only points to `body` and `html`. It does not identify the source line.
+
 ### Debugging build errors
 
-Production builds minify server code and omit server source maps by default, so a stack trace may not identify the source line. Rerun the build with [`--debug-prerender`](/docs/app/api-reference/cli/next#debugging-prerender-errors):
+Production builds minify server code and omit server source maps by default. Rerun the build with [`--debug-prerender`](/docs/app/api-reference/cli/next#debugging-prerender-errors):
 
 ```bash filename="Terminal"
 next build --debug-prerender
@@ -164,9 +162,13 @@ Error: Route "/products/[id]": Next.js encountered uncached or runtime data duri
   4 |   const product = await res.json()
 ```
 
+The detailed stack identifies the [`params`](/docs/app/api-reference/file-conventions/page#params-optional) read as the first blocked access. The uncached product request below it also requires request-time work.
+
 > **Warning**: Do not deploy builds produced with `--debug-prerender`. These builds include debugging options and are not optimized for production.
 
 The development server shows the resolved component and source line in the error overlay. See [Ensuring instant navigations](/docs/app/guides/instant-navigation) for the development workflow.
+
+The error provides three options: stream the request-time work, cache the product request, or allow the route to block. The following sections show how each option changes the build output.
 
 ### A streaming route
 

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -55,20 +55,26 @@ bun run build
 
 After a successful build, Next.js prints a route table with a symbol next to each route, showing how it is served:
 
-| Symbol | Name              | Behavior                                                                   |
-| ------ | ----------------- | -------------------------------------------------------------------------- |
-| `○`    | Static            | Fully prerendered at build time. Served without server rendering.          |
-| `◐`    | Partial Prerender | Prerenders what it can at build time. Remaining content renders on demand. |
-| `●`    | SSG               | Prerendered static HTML (from `generateStaticParams` or `getStaticProps`). |
-| `ƒ`    | Dynamic           | Rendered on demand. Can also label an empty PPR HTML output.               |
+| Symbol | Name              | Behavior                                                                        |
+| ------ | ----------------- | ------------------------------------------------------------------------------- |
+| `○`    | Static            | Fully prerendered at build time. Served without server rendering.               |
+| `◐`    | Partial Prerender | Prerenders what it can at build time. Remaining content renders on demand.      |
+| `●`    | SSG               | Prerendered static HTML. Not used by Cache Components pages.                    |
+| `ƒ`    | Dynamic           | Rendered on demand. Also used for an allowed blocking page with empty PPR HTML. |
 
 Next.js uses `○` Static, `●` SSG, and `ƒ` Dynamic for Pages Router routes, App Router routes without Cache Components, and non-page routes such as request-dependent Route Handlers. In those models, a route is either prerendered to static HTML or rendered on demand for each request.
 
-[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) uses [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) for every App Router page. This is still the rendering model when the build produces an empty HTML file. Per-segment [RSC payloads](/docs/app/getting-started/server-and-client-components#on-the-server) may contain static information even when the route has no prerendered HTML.
+[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) uses [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) as the only rendering model for App Router pages. At build time, Next.js prerenders static work into HTML and per-segment [RSC payloads](/docs/app/getting-started/server-and-client-components#on-the-server). The HTML output can be complete, partial, or empty. Request-time work renders on demand. Static output can stay in the RSC payloads when the HTML output is empty.
 
-The symbols do not map directly to the PPR model's complete, partial, and empty HTML outputs. `○` represents a complete prerender. An empty prerender can appear as `ƒ` for a page at a fixed pathname or `◐` on the fallback row for a dynamic pathname. For a Cache Components page, `ƒ` describes its empty HTML output. It does not mean the page stopped using PPR.
+For Cache Components pages, the route table uses:
 
-The symbol is not a direct report of route config such as [`instant`](/docs/app/api-reference/file-conventions/route-segment-config/instant). Without Cache Components, or on the Pages Router, prerendered pages can also show `●` (SSG).
+- `○` when the HTML output is complete
+- `◐` when the HTML output is partial, and for an empty fallback row on a dynamic pathname
+- `ƒ` when an allowed blocking page at a fixed pathname has empty HTML output
+
+Request-time work outside `<Suspense>` normally fails the build. Covering the route with [`instant = false`](/docs/app/api-reference/file-conventions/route-segment-config/instant) allows it to block and can produce the `ƒ` page case above.
+
+Cache Components pages do not use `●`. With `generateStaticParams`, the dynamic route is a group without a symbol. Each generated pathname shows `○` or `◐` based on its HTML output.
 
 ## Example
 

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -16,8 +16,6 @@ related:
 
 Running `next build` compiles your application for production, [prerenders](/docs/app/glossary#prerendering) eligible routes, and prints a route table showing how each route is served.
 
-> The examples use [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), enabled with `cacheComponents: true` in `next.config.ts`. The route symbols and prerender errors differ when Cache Components is disabled. See [Enabling Cache Components](/docs/app/getting-started/caching#enabling-cache-components) for setup.
-
 ## What `next build` does
 
 When you run `next build`, the build moves through these phases:
@@ -25,7 +23,7 @@ When you run `next build`, the build moves through these phases:
 1. **Setup.** Loads [environment variables](/docs/app/guides/environment-variables) (`.env` files), validates your [`next.config`](/docs/app/api-reference/config/next-config-js), and generates a [build ID](/docs/app/api-reference/config/next-config-js/generateBuildId).
 2. **Route discovery.** Scans the `app/` and `pages/` directories for routes, and detects root-level convention files like [`proxy`](/docs/app/api-reference/file-conventions/proxy) and [`instrumentation`](/docs/app/api-reference/file-conventions/instrumentation). Generates TypeScript route definitions.
 3. **Compilation.** Bundles client, server, and edge code with [Turbopack](/docs/app/api-reference/turbopack) (or webpack). Transpiles TypeScript and JSX, tree-shakes unused code, and optimizes CSS and fonts.
-4. **Static analysis.** Classifies each route for prerendering versus on-demand rendering. Collects [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) output. Checks for [prerender-blocking errors](/docs/messages/blocking-prerender-dynamic).
+4. **Static analysis.** Classifies each route for prerendering versus on-demand rendering. Collects [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) output. With Cache Components, checks for [prerender-blocking errors](/docs/messages/blocking-prerender-dynamic).
 5. **Prerendering.** Prerenders static pages and PPR shells to HTML. Generates [RSC payloads](/docs/app/getting-started/server-and-client-components#on-the-server) for client-side navigation.
 6. **Output.** Writes the build to `.next/`. For [`output: 'standalone'`](/docs/app/guides/self-hosting), bundles only the files needed at runtime. For [`output: 'export'`](/docs/app/guides/static-exports), generates a full static site. Prints the route table.
 
@@ -55,7 +53,21 @@ bun run build
 
 After a successful build, Next.js prints a route table with a symbol next to each route.
 
-With [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) is the only rendering model for App Router pages. The route table currently uses:
+The symbols differ depending on whether Cache Components is enabled.
+
+### Without Cache Components
+
+Without Cache Components, App Router pages and Pages Router routes use these rendering classifications:
+
+| Symbol | Name    | Behavior                                                                 |
+| ------ | ------- | ------------------------------------------------------------------------ |
+| `○`    | Static  | Fully prerendered at build time. Served without server rendering.        |
+| `●`    | SSG     | Prerendered static HTML from `generateStaticParams` or `getStaticProps`. |
+| `ƒ`    | Dynamic | Rendered on demand.                                                      |
+
+### With Cache Components
+
+With [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) is the only rendering model for App Router pages. For these pages, the symbols describe how much HTML the build produced:
 
 | Symbol | Build label       | HTML produced during the build                                               |
 | ------ | ----------------- | ---------------------------------------------------------------------------- |
@@ -65,25 +77,17 @@ With [Cache Components](/docs/app/api-reference/config/next-config-js/cacheCompo
 
 For a Cache Components page, `ƒ` means the build produced empty HTML for that specific pathname. Next.js produces the page HTML on request.
 
-The [`instant = false`](/docs/app/api-reference/file-conventions/route-segment-config/instant) export allows a blocking route and an empty shell by opting out of instant-navigation and static-shell validation. Next.js still prerenders the route: complete HTML shows `○`, a static shell shows `◐`, and empty HTML for a specific pathname shows `ƒ`. A dynamic pathname uses `◐` for its fallback row, including when the fallback HTML is empty. A `<Suspense>` boundary above `<body>` with an empty fallback can also allow an empty shell.
+### Other route entries
 
-For non-page entries, `ƒ` keeps its Dynamic meaning. It marks request-dependent [Route Handlers](/docs/app/api-reference/file-conventions/route) (API endpoints), Proxy (Middleware), and dynamic metadata routes such as `icon`, `opengraph-image`, and `twitter-image`.
-
-### Without Cache Components
-
-Without Cache Components, App Router pages and Pages Router routes use static and dynamic rendering classifications:
-
-| Symbol | Name    | Behavior                                                                 |
-| ------ | ------- | ------------------------------------------------------------------------ |
-| `○`    | Static  | Fully prerendered at build time. Served without server rendering.        |
-| `●`    | SSG     | Prerendered static HTML from `generateStaticParams` or `getStaticProps`. |
-| `ƒ`    | Dynamic | Rendered on demand.                                                      |
+Request-dependent [Route Handlers](/docs/app/api-reference/file-conventions/route) (API endpoints), Proxy (Middleware), and dynamic metadata routes such as `icon`, `opengraph-image`, and `twitter-image` use `ƒ`. These entries render on demand and do not use PPR.
 
 ## Example
 
-Cache Components validates whether a route can produce a static shell. A product page that reads runtime params and uncached data outside a Suspense boundary fails this validation.
+> **Good to know**: The following example uses [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), enabled with `cacheComponents: true` in `next.config.ts`. The route symbols and prerender errors differ when Cache Components is disabled. See [Enabling Cache Components](/docs/app/getting-started/caching#enabling-cache-components) for setup.
 
-The store has a dynamic product page that loads data by id:
+Cache Components validates whether a route can produce a static shell. A product page that reads runtime params and uncached data outside a Suspense boundary fails validation.
+
+The store has a product page with a dynamic segment that loads data by ID:
 
 ```txt
 app/
@@ -94,7 +98,7 @@ app/
         └── page.tsx
 ```
 
-The page fetches a product by id:
+The page fetches a product by ID:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export default async function Page(props: PageProps<'/products/[id]'>) {
@@ -160,13 +164,13 @@ Error: Route "/products/[id]": Next.js encountered uncached or runtime data duri
   4 |   const product = await res.json()
 ```
 
-> **Warning**: Do not deploy builds produced with `--debug-prerender`. The debugging options can affect performance.
+> **Warning**: Do not deploy builds produced with `--debug-prerender`. These builds include debugging options and are not optimized for production.
 
 The development server shows the resolved component and source line in the error overlay. See [Ensuring instant navigations](/docs/app/guides/instant-navigation) for the development workflow.
 
 ### A streaming route
 
-The error's first suggestion, `[stream]`, is to provide a placeholder around the data access. Add a [`loading.js`](/docs/app/api-reference/file-conventions/loading) file to wrap the whole segment in a `<Suspense>` boundary. Next.js prerenders the fallback as the route's static shell, while the params and data work runs at request time. For other boundary placements, see [Streaming](/docs/app/guides/streaming):
+Follow the error's `[stream]` suggestion by adding a [`loading.js`](/docs/app/api-reference/file-conventions/loading) file. The file wraps the segment in a `<Suspense>` boundary. Next.js prerenders the fallback as the route's static shell, while the params and data work runs at request time. For other boundary placements, see [Streaming](/docs/app/guides/streaming):
 
 ```tsx filename="app/products/[id]/loading.tsx" switcher
 export default function Loading() {
@@ -257,7 +261,7 @@ Route (app)
 
 > **Good to know**: With Cache Components, `generateStaticParams` must return at least one param. An empty array causes a [build error](/docs/messages/empty-generate-static-params).
 
-The listed params appear as `◐`. The params tell Next.js which pages exist, while the uncached lookup supplies their content at request time. Each page serves the static shell and streams its content.
+The listed params appear as `◐`. The params tell Next.js which pathnames to prerender, while the uncached lookup supplies their content at request time. Each page serves the static shell and streams its content.
 
 > **Good to know**: Before enabling Cache Components, generated paths use `●` (SSG). After enabling Cache Components, the same paths show `◐` because Next.js postpones the uncached product lookup. Caching the lookup moves them to `○`.
 
@@ -345,7 +349,7 @@ The built-in `default` profile revalidates after 15 minutes and never expires. T
 
 ### A blocking route
 
-Set `instant = false` when the route is allowed to block. The export opts the segment out of instant-navigation validation. When it is the highest `instant` config in the route tree, it also permits an empty static shell. Cache Components continues to use PPR:
+Set `instant = false` when the route is allowed to block. The export opts the segment out of instant-navigation validation. When it is the highest `instant` config in the route tree, it also disables static-shell validation and allows the build to produce empty HTML. The route uses PPR:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export const instant = false
@@ -369,7 +373,7 @@ export default async function Page({ params }) {
 }
 ```
 
-Next.js attempts to prerender the route. The opt-out produces empty HTML when request-time work blocks the whole page. Synchronous runtime values such as `Math.random()`, `new Date()`, and `crypto.randomUUID()` produce prerender errors.
+Next.js attempts to prerender the route. If request-time work blocks the whole page, the build produces empty HTML. Synchronous values such as `Math.random()`, `new Date()`, and `crypto.randomUUID()` still produce prerender errors.
 
 The build passes with PPR and an empty HTML prerender. This example has a dynamic segment, so the route table shows `◐` on its fallback row. The same empty output for a specific pathname shows `ƒ`:
 
@@ -378,13 +382,13 @@ Route (app)
 ┌ ○ /
 ├ ○ /_not-found
 └   /products/[id]
-  └ ◐ /products/[id]    # Empty PPR HTML; content renders on demand
+  └ ◐ /products/[id]    # Empty PPR HTML. Content renders on demand
 
 ○  (Static)             prerendered as static content
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-Per-segment RSC payloads may still contain static information. On an initial request, the server waits for the product lookup before returning the completed page. During a client navigation, the destination has no fallback to show while that work runs. See [Opting out](/docs/app/guides/instant-navigation#opting-out) for when this is appropriate.
+On an initial request, the server waits for the product lookup before returning the completed page. During a client navigation, the destination has no fallback to show while that work runs. See [Opting out](/docs/app/guides/instant-navigation#opting-out) for when this is appropriate.
 
 ## Next steps
 

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -53,28 +53,31 @@ yarn build
 bun run build
 ```
 
-After a successful build, Next.js prints a route table with a symbol next to each route, showing how it is served:
+After a successful build, Next.js prints a route table with a symbol next to each route.
 
-| Symbol | Name              | Behavior                                                                        |
-| ------ | ----------------- | ------------------------------------------------------------------------------- |
-| `○`    | Static            | Fully prerendered at build time. Served without server rendering.               |
-| `◐`    | Partial Prerender | Prerenders what it can at build time. Remaining content renders on demand.      |
-| `●`    | SSG               | Prerendered static HTML. Not used by Cache Components pages.                    |
-| `ƒ`    | Dynamic           | Rendered on demand. Also used for an allowed blocking page with empty PPR HTML. |
+With [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) is the only rendering model for App Router pages. The route table currently uses:
 
-Next.js uses `○` Static, `●` SSG, and `ƒ` Dynamic for Pages Router routes, App Router routes without Cache Components, and non-page routes such as request-dependent Route Handlers. In those models, a route is either prerendered to static HTML or rendered on demand for each request.
+| Symbol | Build label       | HTML produced during the build                                               |
+| ------ | ----------------- | ---------------------------------------------------------------------------- |
+| `○`    | Static            | A complete HTML prerender.                                                   |
+| `◐`    | Partial Prerender | A static shell followed by content that renders on demand.                   |
+| `ƒ`    | Dynamic           | An empty HTML prerender for a specific pathname. The page renders on demand. |
 
-[Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents) uses [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) as the only rendering model for App Router pages. At build time, Next.js prerenders static work into HTML and per-segment [RSC payloads](/docs/app/getting-started/server-and-client-components#on-the-server). The HTML output can be complete, partial, or empty. Request-time work renders on demand. Static output can stay in the RSC payloads when the HTML output is empty.
+For a Cache Components page, `ƒ` means the build produced empty HTML for that specific pathname. Next.js produces the page HTML on request.
 
-For Cache Components pages, the route table uses:
+The [`instant = false`](/docs/app/api-reference/file-conventions/route-segment-config/instant) export allows a blocking route and an empty shell by opting out of instant-navigation and static-shell validation. Next.js still prerenders the route: complete HTML shows `○`, a static shell shows `◐`, and empty HTML for a specific pathname shows `ƒ`. A dynamic pathname uses `◐` for its fallback row, including when the fallback HTML is empty. A `<Suspense>` boundary above `<body>` with an empty fallback can also allow an empty shell.
 
-- `○` when the HTML output is complete
-- `◐` when the HTML output is partial, and for an empty fallback row on a dynamic pathname
-- `ƒ` when an allowed blocking page at a fixed pathname has empty HTML output
+For non-page entries, `ƒ` keeps its Dynamic meaning. It marks request-dependent [Route Handlers](/docs/app/api-reference/file-conventions/route) (API endpoints), Proxy (Middleware), and dynamic metadata routes such as `icon`, `opengraph-image`, and `twitter-image`.
 
-Request-time work outside `<Suspense>` normally fails the build. Covering the route with [`instant = false`](/docs/app/api-reference/file-conventions/route-segment-config/instant) allows it to block and can produce the `ƒ` page case above.
+### Without Cache Components
 
-Cache Components pages do not use `●`. With `generateStaticParams`, the dynamic route is a group without a symbol. Each generated pathname shows `○` or `◐` based on its HTML output.
+Without Cache Components, App Router pages and Pages Router routes use static and dynamic rendering classifications:
+
+| Symbol | Name    | Behavior                                                                 |
+| ------ | ------- | ------------------------------------------------------------------------ |
+| `○`    | Static  | Fully prerendered at build time. Served without server rendering.        |
+| `●`    | SSG     | Prerendered static HTML from `generateStaticParams` or `getStaticProps`. |
+| `ƒ`    | Dynamic | Rendered on demand.                                                      |
 
 ## Example
 
@@ -254,9 +257,9 @@ Route (app)
 
 > **Good to know**: With Cache Components, `generateStaticParams` must return at least one param. An empty array causes a [build error](/docs/messages/empty-generate-static-params).
 
-The new rows show `◐`, not `○`. Listing the params tells Next.js which pages exist, but their content still comes from the uncached lookup, which only runs at request time. Each page serves the static shell and streams its content.
+The listed params appear as `◐`. The params tell Next.js which pages exist, while the uncached lookup supplies their content at request time. Each page serves the static shell and streams its content.
 
-> **Good to know**: Here the `fetch` runs during prerendering, so point it at a working endpoint or an asynchronous test source. The `◐` rows appear only when the lookup performs uncached asynchronous I/O. A synchronous in-memory value is static and prerenders each param to `○` instead.
+> **Good to know**: Before enabling Cache Components, generated paths use `●` (SSG). After enabling Cache Components, the same paths show `◐` because Next.js postpones the uncached product lookup. Caching the lookup moves them to `○`.
 
 ### Cached data
 
@@ -342,7 +345,7 @@ The built-in `default` profile revalidates after 15 minutes and never expires. T
 
 ### A blocking route
 
-Set `instant = false` when the route is allowed to block. The export opts the segment out of instant-navigation validation. When the page is the highest segment with an `instant` config, it also opts the route out of static-shell validation. The rendering model remains PPR, but the build can finish with empty HTML:
+Set `instant = false` when the route is allowed to block. The export opts the segment out of instant-navigation validation. When it is the highest `instant` config in the route tree, it also permits an empty static shell. Cache Components continues to use PPR:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export const instant = false
@@ -366,9 +369,9 @@ export default async function Page({ params }) {
 }
 ```
 
-The opt-out applies to asynchronous work such as the `params` read and product request. Synchronous runtime values such as `Math.random()`, `new Date()`, and `crypto.randomUUID()` can still cause a prerender error.
+Next.js attempts to prerender the route. The opt-out produces empty HTML when request-time work blocks the whole page. Synchronous runtime values such as `Math.random()`, `new Date()`, and `crypto.randomUUID()` produce prerender errors.
 
-The build passes. The page still uses PPR even though its HTML prerender is empty. This example has a dynamic segment, so the route table shows `◐` on its fallback row. A page at a fixed pathname with the same empty PPR HTML output can show `ƒ` instead:
+The build passes with PPR and an empty HTML prerender. This example has a dynamic segment, so the route table shows `◐` on its fallback row. The same empty output for a specific pathname shows `ƒ`:
 
 ```bash filename="Terminal"
 Route (app)

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -14,7 +14,7 @@ related:
     - app/guides/ci-build-caching
 ---
 
-Running `next build` compiles your application for production, [prerenders](/docs/app/glossary#prerendering) eligible routes, and prints a route table. Use the output to see how Next.js serves each route and to debug prerender errors.
+Running `next build` compiles your application for production, [prerenders](/docs/app/glossary#prerendering) eligible routes, and prints a route table showing how each route is served.
 
 > The examples use [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), enabled with `cacheComponents: true` in `next.config.ts`. The route symbols and prerender errors differ when Cache Components is disabled. See [Enabling Cache Components](/docs/app/getting-started/caching#enabling-cache-components) for setup.
 

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -93,7 +93,7 @@ Production builds minify server code and omit server source maps by default. Use
 next build --debug-prerender
 ```
 
-The option disables server minification, enables server source maps, and continues after the first prerender error.
+The option disables server minification, enables server source maps, and prevents one failed route from stopping the rest of the build.
 
 > **Warning**: Do not deploy builds produced with `--debug-prerender`. These builds include debugging options and are not optimized for production.
 
@@ -182,7 +182,9 @@ Error: Route "/products/[id]": Next.js encountered uncached or runtime data duri
 
 The detailed stack identifies the [`params`](/docs/app/api-reference/file-conventions/page#params-optional) read as the first blocked access.
 
-During development, `next dev` shows the resolved component and source line, then reruns validation as you edit. This example uses `--debug-prerender` to trace each error from production build output. See [Ensuring instant navigations](/docs/app/guides/instant-navigation) for the development workflow.
+This guide uses production builds to show how each change affects the route table. Within a route, the build reports blocking accesses in execution order. Rerun it after each fix to find the next error.
+
+During development, `next dev` shows all validation errors in the dev overlay and terminal with stack frames that resolve to your source. It reruns validation as you edit. See [Ensuring instant navigations](/docs/app/guides/instant-navigation) for the development workflow.
 
 ### Stream request-time work
 

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -69,7 +69,7 @@ Without Cache Components, App Router pages and Pages Router routes use these ren
 
 With [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), [Partial Prerendering](/docs/app/getting-started/caching#static-cached-and-streaming) is the only rendering model for App Router pages. For these pages, the symbols describe how much HTML the build produced:
 
-| Symbol | Build label       | HTML produced during the build                             |
+| Symbol | Name              | Behavior                                                   |
 | ------ | ----------------- | ---------------------------------------------------------- |
 | `○`    | Static            | A complete HTML prerender.                                 |
 | `◐`    | Partial Prerender | A static shell followed by content that renders on demand. |
@@ -106,6 +106,8 @@ Only matching routes appear in the route table. When you select an App Router ro
 ## Example
 
 > **Good to know**: The following example uses [Cache Components](/docs/app/api-reference/config/next-config-js/cacheComponents), enabled with `cacheComponents: true` in `next.config.ts`. The route symbols and prerender errors differ when Cache Components is disabled. See [Enabling Cache Components](/docs/app/getting-started/caching#enabling-cache-components) for setup.
+
+### Find blocking work
 
 In this example, a store application has a product page with a dynamic `[id]` segment:
 
@@ -178,51 +180,15 @@ Error: Route "/products/[id]": Next.js encountered uncached or runtime data duri
   4 |   const product = await res.json()
 ```
 
-The detailed stack identifies the [`params`](/docs/app/api-reference/file-conventions/page#params-optional) read as the first blocked access. The uncached product request below it also requires request-time work.
+The detailed stack identifies the [`params`](/docs/app/api-reference/file-conventions/page#params-optional) read as the first blocked access. The `[cache]` suggestion in the error applies to uncached data, not to `params`.
 
-The development server shows the resolved component and source line in the error overlay. See [Ensuring instant navigations](/docs/app/guides/instant-navigation) for the development workflow.
+During development, `next dev` shows the resolved component and source line, then reruns validation as you edit. This example uses `--debug-prerender` to trace each error from production build output. See [Ensuring instant navigations](/docs/app/guides/instant-navigation) for the development workflow.
 
-The error provides three options: stream the request-time work, cache the product request, or allow the route to block. The following sections show how each option changes the build output.
+### Prerender selected paths
 
-### Stream request-time content
+[`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) is optional. Use it to prerender a set of dynamic pathnames known at build time. It resolves `params` only for the paths it returns. Unlisted paths still need a `loading.js` file or a `<Suspense>` boundary for instant navigation.
 
-Follow the error's `[stream]` suggestion by adding a [`loading.js`](/docs/app/api-reference/file-conventions/loading) file. The file wraps the segment in a `<Suspense>` boundary. Next.js prerenders the fallback as the route's static shell, while the params and data work runs at request time. For other boundary placements, see [Streaming](/docs/app/guides/streaming):
-
-```tsx filename="app/products/[id]/loading.tsx" switcher
-export default function Loading() {
-  return <div>Loading...</div>
-}
-```
-
-```jsx filename="app/products/[id]/loading.js" switcher
-export default function Loading() {
-  return <div>Loading...</div>
-}
-```
-
-Rebuild only the product route:
-
-```bash filename="Terminal"
-next build --debug-build-paths="app/products/[id]/page.tsx"
-```
-
-The build passes, and the route is [partially prerendered](/docs/app/glossary#partial-prerendering-ppr). Because the command selects only the product route, the table omits `/`:
-
-```bash filename="Terminal"
-Route (app)
-┌ ○ /_not-found
-└   /products/[id]
-  └ ◐ /products/[id]    # Shell prerendered, content streams on request
-
-○  (Static)             prerendered as static content
-◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
-```
-
-Product URLs now serve the prerendered shell instantly, then stream the page content. At this point, every product URL uses the same shell and waits for its product data. If some product IDs are known during the build, Next.js can attempt to prerender more of those pages.
-
-### Prerender known paths
-
-The [dynamic segment](/docs/app/glossary#dynamic-route-segments) shows a single fallback row because Next.js doesn't know which param values exist. Export `generateStaticParams` to list them:
+This example uses `generateStaticParams` to prerender known product IDs. The build can then continue past `params` and identify the next blocked access:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export async function generateStaticParams() {
@@ -254,7 +220,61 @@ export default async function Page({ params }) {
 }
 ```
 
-Rebuilding the product route adds a row for each listed param, indented under the `/products/[id]` route:
+Rebuild the product route with both debugging options:
+
+```bash filename="Terminal"
+next build --debug-prerender --debug-build-paths="app/products/[id]/page.tsx"
+```
+
+For each generated path, `params` now resolves during prerendering. The build continues to the uncached product lookup and fails on that line:
+
+```bash filename="Terminal"
+Error: Route "/products/[id]": Next.js encountered uncached or runtime data during prerendering.
+  ...
+Ways to fix this:
+  - [stream] Provide a placeholder with `<Suspense fallback={...}>` around the data access
+  - [cache] For uncached data (`fetch`, database calls): cache the access with `"use cache"`
+  - [block] Set `export const instant = false` to allow a blocking route
+  ...
+    at Page (app/products/[id]/page.tsx:9:21)
+   8 |   const { id } = await props.params
+>  9 |   const res = await fetch(`https://api.example.com/products/${id}`)
+     |                     ^
+  10 |   const product = await res.json()
+Error occurred prerendering page "/products/1".
+```
+
+Adding `generateStaticParams` does not make the build pass. It reveals the uncached product lookup as the next blocked access. First choose `[stream]` to see how generated paths appear while this data remains uncached.
+
+> **Good to know**: With Cache Components, `generateStaticParams` must return at least one param. An empty array causes a [build error](/docs/messages/empty-generate-static-params). Apps with a large, frequently changing, or unbounded set of pathnames can omit `generateStaticParams` and use a static shell for request-time params.
+
+### Stream uncached data
+
+Add a [`loading.js`](/docs/app/api-reference/file-conventions/loading) file:
+
+```tsx filename="app/products/[id]/loading.tsx" switcher
+export default function Loading() {
+  return <div>Loading...</div>
+}
+```
+
+```jsx filename="app/products/[id]/loading.js" switcher
+export default function Loading() {
+  return <div>Loading...</div>
+}
+```
+
+`loading.js` automatically wraps the page content in a `<Suspense>` boundary and uses the loading component as its fallback. In this example, Next.js prerenders the loading state as the product route's static shell. The page reads the params and fetches the product at request time, then replaces the loading state with the completed content.
+
+For more granular streaming, add an explicit `<Suspense>` boundary around only the component that needs request-time data. More of the page can then remain in the static shell. See [Streaming](/docs/app/guides/streaming).
+
+Rebuild only the product route:
+
+```bash filename="Terminal"
+next build --debug-build-paths="app/products/[id]/page.tsx"
+```
+
+The build passes and adds a row for each generated path. Because the command selects only the product route, the table omits `/`:
 
 ```bash filename="Terminal"
 Route (app)
@@ -262,22 +282,18 @@ Route (app)
 └   /products/[id]
   ├ ◐ /products/[id]
   ├ ◐ /products/1       # Params known, data still uncached
-  ├ ◐ /products/2       # Params known, data still uncached
-  └ ◐ /products/3       # Params known, data still uncached
+  ├ ◐ /products/2
+  └ ◐ /products/3
 
 ○  (Static)             prerendered as static content
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-> **Good to know**: With Cache Components, `generateStaticParams` must return at least one param. An empty array causes a [build error](/docs/messages/empty-generate-static-params).
-
-The listed params appear as `◐`. The params tell Next.js which pathnames to prerender, while the uncached lookup supplies their content at request time. Each page serves the static shell and streams its content.
-
-The known paths still wait for the product lookup because it remains uncached. If the product data can be reused, cache the lookup so the build can finish prerendering those pages.
+The generated paths appear as `◐` because their params are known, but the product lookup remains request-time work. Each page serves the static shell and streams its product content. If the product data can be reused, cache the lookup so the build can finish prerendering those pages.
 
 ### Cache reusable data
 
-The error's `[cache]` fix makes the product lookup reusable. Add `use cache` so Next.js can include the result when it prerenders a known product:
+Add `use cache` to make the product lookup reusable. Next.js can then include the result when it prerenders a known product:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export async function generateStaticParams() {
@@ -334,8 +350,6 @@ Route (app)
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-Content that reads `cookies()`, `headers()`, or `searchParams` remains request-time work. Place that content inside `<Suspense>` to keep the rest of the page in the static shell.
-
 With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching) enabled, the first prefetch or visit to an unlisted param serves the static shell and generates the page in the background. Later requests can reuse the completed prerender. See [Incremental Static Regeneration with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components).
 
 When there are more prerendered paths than fit in the table, Next.js prints a short list ending with `[+N more paths]`.
@@ -354,11 +368,13 @@ Route (app)           Revalidate  Expire
   └ ○ /products/3            15m      1y
 ```
 
-The built-in `default` profile revalidates after 15 minutes. Its cache lifetime is unbounded, so the route uses the global `expireTime` fallback. `expireTime` defaults to one year, shown as `1y`. You can override the cache profile or `expireTime` in `next.config.ts`. The table does not identify which cache produced each value, so check the route's `cacheLife` calls when it contains multiple caches.
+The default [`use cache` profile](/docs/app/api-reference/functions/cacheLife#preset-cache-profiles) revalidates after 15 minutes. The route's default [`expireTime`](/docs/app/api-reference/config/next-config-js/expireTime) is one year, so the table shows `15m` and `1y`. You can configure both values in `next.config.ts`.
 
 ### Allow the route to block
 
-The `[block]` option is an alternative to caching the product lookup. Suppose the product IDs should still be collected during the build, but each page must read fresh product data before responding. Keep `generateStaticParams`, remove the `loading` file and `use cache`, and set `instant = false`:
+Static-shell validation helps protect instant navigation performance. Choose `[block]` when a route is intentionally allowed to wait for request-time work, such as before it redirects, or when you want to defer its refactor while [adopting Cache Components incrementally](/docs/app/guides/migrating-to-cache-components#adopting-incrementally).
+
+For this example, suppose the product route will be refactored in a later migration pass. Keep `generateStaticParams`, remove the `loading` file and `use cache`, and set `instant = false`:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export const instant = false
@@ -413,7 +429,7 @@ Route (app)
 
 Without `generateStaticParams`, the table has only the `/products/[id]` fallback row. That row uses `◐` because it represents the PPR fallback for the dynamic route pattern, even when its HTML is empty. When `generateStaticParams` adds child rows, each row reflects its prerender result, so an empty result uses `ƒ`.
 
-Synchronous values such as `Math.random()`, `new Date()`, and `crypto.randomUUID()` still produce prerender errors.
+Synchronous values such as `Math.random()`, [`new Date()`](/docs/messages/blocking-prerender-current-time), and `crypto.randomUUID()` still produce prerender errors.
 
 On an initial request, the server waits for the product lookup before returning the completed page. During a client navigation, the destination has no fallback to show while that work runs. See [Opting out](/docs/app/guides/instant-navigation#opting-out) for when this is appropriate.
 

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -349,7 +349,7 @@ The built-in `default` profile revalidates after 15 minutes and never expires. T
 
 ### A blocking route
 
-Set `instant = false` when the route is allowed to block. The export opts the segment out of instant-navigation validation. When it is the highest `instant` config in the route tree, it also disables static-shell validation and allows the build to produce empty HTML. The route uses PPR:
+Set `instant = false` when the route is allowed to block. The export does not change the rendering model. It opts the segment out of instant-navigation validation. When it is the highest `instant` config in the route tree, it also disables static-shell validation, allowing the build to accept an empty HTML prerender. The route continues to use PPR:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export const instant = false

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -223,9 +223,9 @@ Route (app)
 
 The `◐` symbol shows that the route serves a static shell and streams the remaining content.
 
-### Prerender selected paths
+### Prerender product pages
 
-[`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) is optional. Use it to prerender a set of dynamic pathnames known at build time. Keep `loading.js` and export the product IDs from the page:
+The route now has a shared static shell. To prerender pages for known products, keep `loading.js` and use [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) to provide their IDs:
 
 ```tsx filename="app/products/[id]/page.tsx" switcher
 export async function generateStaticParams() {
@@ -263,13 +263,13 @@ Rebuild the product route:
 next build --debug-build-paths="app/products/[id]/page.tsx"
 ```
 
-The route table now includes each generated path:
+Next.js now attempts to prerender a page for each product ID:
 
 ```bash filename="Terminal"
 Route (app)
 ┌ ○ /_not-found
-└   /products/[id]
-  ├ ◐ /products/[id]
+└   /products/[id]      # Route pattern group
+  ├ ◐ /products/[id]    # Fallback row
   ├ ◐ /products/1       # Params known, data still uncached
   ├ ◐ /products/2
   └ ◐ /products/3
@@ -278,9 +278,9 @@ Route (app)
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
 
-The generated paths remain `◐` because the product lookup is uncached. `generateStaticParams` selects pathnames to prerender, but it does not cache their data. Apps with a large, frequently changing, or unbounded set of pathnames can omit it and use the static shell for request-time params.
+The unmarked `/products/[id]` row groups the fallback and generated product paths. Each indented row shows its own build result. The generated product paths remain `◐` because their IDs are known during the build, but the product lookup is still uncached. Each page serves the static shell and streams the product data.
 
-> **Good to know**: With Cache Components, `generateStaticParams` must return at least one param. An empty array causes a [build error](/docs/messages/empty-generate-static-params).
+> **Good to know**: `generateStaticParams` is optional. Use it when a set of pathnames is known at build time and worth prerendering. With Cache Components, it must return at least one param. An empty array causes a [build error](/docs/messages/empty-generate-static-params).
 
 ### Cache reusable data
 
@@ -326,22 +326,20 @@ export default async function Page({ params }) {
 }
 ```
 
-Rebuilding the product route shows the listed params as `○`. Their params are known and their data is cached, so Next.js prerenders each page in full. The `◐` row remains for unlisted params, which serve the static shell while their content streams:
+Rebuilding the product route shows the listed params as `○`. Their params are known and their data is cached, so Next.js prerenders each page in full. The fallback row remains `◐`:
 
 ```bash filename="Terminal"
 Route (app)
 ┌ ○ /_not-found
-└   /products/[id]
-  ├ ◐ /products/[id]    # Unlisted params stream on demand
+└   /products/[id]      # Route pattern group
+  ├ ◐ /products/[id]    # Fallback row
   ├ ○ /products/1       # Prerendered in full at build time
-  ├ ○ /products/2       # Prerendered in full at build time
-  └ ○ /products/3       # Prerendered in full at build time
+  ├ ○ /products/2
+  └ ○ /products/3
 
 ○  (Static)             prerendered as static content
 ◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
 ```
-
-With [Partial Prefetching](/docs/app/api-reference/config/next-config-js/partialPrefetching) enabled, the first prefetch or visit to an unlisted param serves the static shell and generates the page in the background. Later requests can reuse the completed prerender. See [Incremental Static Regeneration with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components).
 
 When there are more prerendered paths than fit in the table, Next.js prints a short list ending with `[+N more paths]`.
 
@@ -408,19 +406,32 @@ Next.js attempts to prerender each path from `generateStaticParams`. The uncache
 ```bash filename="Terminal"
 Route (app)
 ┌ ○ /_not-found
-└   /products/[id]
-  ├ ƒ /products/[id]    # Empty fallback HTML
+└   /products/[id]      # Route pattern group
+  ├ ƒ /products/[id]    # Empty fallback for unlisted IDs
   ├ ƒ /products/1       # Empty HTML. Renders on request
-  ├ ƒ /products/2       # Empty HTML. Renders on request
-  └ ƒ /products/3       # Empty HTML. Renders on request
+  ├ ƒ /products/2
+  └ ƒ /products/3
 
 ○  (Static)   prerendered as static content
 ƒ  (Dynamic)  server-rendered on demand
 ```
 
-Without `generateStaticParams`, the table has only the `/products/[id]` fallback row. That row uses `◐` because it represents the PPR fallback for the dynamic route pattern, even when its HTML is empty. When `generateStaticParams` adds child rows, each row reflects its prerender result, so an empty result uses `ƒ`.
+Here, the indented `/products/[id]` row is the fallback for IDs not returned by `generateStaticParams`. Its prerender is empty, so it uses `ƒ`.
 
-Synchronous values such as `Math.random()`, [`new Date()`](/docs/messages/blocking-prerender-current-time), and `crypto.randomUUID()` still produce prerender errors.
+Without `generateStaticParams`, the build prints only the fallback row:
+
+```bash filename="Terminal"
+Route (app)
+┌ ○ /_not-found
+└ ◐ /products/[id]
+
+○  (Static)             prerendered as static content
+◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
+```
+
+The fallback uses `◐` because it represents the PPR shell for the dynamic route pattern, even when its HTML is empty.
+
+Synchronous values such as [`Math.random()`](/docs/messages/blocking-prerender-random), [`new Date()`](/docs/messages/blocking-prerender-current-time), and [`crypto.randomUUID()`](/docs/messages/blocking-prerender-crypto) still produce prerender errors.
 
 On an initial request, the server waits for the product lookup before returning the completed page. During a client navigation, the destination has no fallback to show while that work runs. See [Opting out](/docs/app/guides/instant-navigation#opting-out) for when this is appropriate.
 

--- a/docs/01-app/02-guides/building.mdx
+++ b/docs/01-app/02-guides/building.mdx
@@ -159,8 +159,6 @@ To get a more detailed stack trace and pinpoint the issue, try one of the follow
 Error occurred prerendering page "/products/[id]".
 ```
 
-With Cache Components, Next.js validates whether the route can produce a static shell.
-
 The error shows that request-time work is blocking prerendering, but the stack only points to `body` and `html`. It does not identify the source line. Rerun only the product route with both debugging options:
 
 ```bash filename="Terminal"

--- a/docs/01-app/03-api-reference/03-file-conventions/forbidden.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/forbidden.mdx
@@ -7,7 +7,9 @@ related:
 version: experimental
 ---
 
-The **forbidden** file is used to render UI when the [`forbidden`](/docs/app/api-reference/functions/forbidden) function is invoked during authentication. Along with allowing you to customize the UI, Next.js will return a `403` status code.
+The **forbidden** file renders UI when the [`forbidden`](/docs/app/api-reference/functions/forbidden) function is invoked.
+
+Before streaming starts, Next.js returns a `403` status code. After streaming starts, the status code remains `200` and the forbidden UI renders in the response. Next.js injects a `<meta name="robots" content="noindex" />` tag in both cases. See [Status codes](/docs/app/api-reference/file-conventions/loading#status-codes) for details.
 
 ```tsx filename="app/forbidden.tsx" switcher
 import Link from 'next/link'

--- a/docs/01-app/03-api-reference/03-file-conventions/loading.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/loading.mdx
@@ -98,26 +98,26 @@ In the [component hierarchy](/docs/app/getting-started/project-structure#compone
 - Otherwise, [streaming metadata](/docs/app/api-reference/functions/generate-metadata#streaming-metadata) may be used. Next.js automatically detects user agents to choose between blocking and streaming behavior.
 - Since streaming is server-rendered, it does not impact SEO. You can use the [Rich Results Test](https://search.google.com/test/rich-results) tool from Google to see how your page appears to Google's web crawlers and view the serialized HTML ([source](https://web.dev/rendering-on-the-web/#seo-considerations)).
 
-### Status Codes
+### Status codes
 
-When streaming, a `200` status code will be returned to signal that the request was successful.
+Streaming page responses begin with a `200` status code.
 
-The server can still communicate errors or issues to the client within the streamed content itself, for example, when using [`redirect`](/docs/app/api-reference/functions/redirect) or [`notFound`](/docs/app/api-reference/functions/not-found). Because the response headers have already been sent to the client, the status code of the response cannot be updated.
+The initial response headers set the status for the rest of the response. Next.js can then stream redirects and HTTP access fallbacks with [`redirect`](/docs/app/api-reference/functions/redirect), [`notFound`](/docs/app/api-reference/functions/not-found), [`forbidden`](/docs/app/api-reference/functions/forbidden), or [`unauthorized`](/docs/app/api-reference/functions/unauthorized).
 
 For example, when a 404 page is streamed to the client, Next.js includes a `<meta name="robots" content="noindex">` tag in the streamed HTML. This prevents search engines from indexing that URL even if the HTTP status is 200. See Google’s guidance on the [`robots` meta tag](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag).
 
-Some crawlers may label these responses as “soft 404s”. In the streaming case, this does not lead to indexation because the page is explicitly marked `noindex` in the HTML.
+Some crawlers may label these responses as “soft 404s”. The `noindex` tag keeps them out of search results.
 
-If you need a 404 status, for compliance or analytics, ensure the resource exists before the response body is streamed, so that the server can set the HTTP status code.
+Run the corresponding check before the response body streams to return a `404`, `403`, or `401` status for compliance or analytics.
 
-You can run this check in [`proxy`](/docs/app/api-reference/file-conventions/proxy) to rewrite missing slugs to a not-found route, or [produce a 404 response](/docs/app/api-reference/file-conventions/proxy#producing-a-response). Keep proxy checks fast, and avoid fetching full content there.
+For a `404`, you can check the slug in [Proxy](/docs/app/api-reference/file-conventions/proxy), then rewrite it to a not-found route or [return a `404` response](/docs/app/api-reference/file-conventions/proxy#producing-a-response). Keep Proxy checks fast, and avoid fetching full content there.
 
 <details>
 <summary>When is the response body streamed?</summary>
 
-The response body starts streaming when a Suspense fallback renders (for example, a `loading.tsx`) or when a Server Component suspends under a `Suspense` boundary. Place `notFound()` before those boundaries and before any `await` that may suspend.
+The response body starts streaming when a Suspense fallback renders (for example, a `loading.tsx`) or when a Server Component suspends under a `<Suspense>` boundary. Calling `notFound()`, `forbidden()`, or `unauthorized()` before this point preserves its `404`, `403`, or `401` status.
 
-To start streaming, the response headers must be set. This is why it is not possible to change the status code after streaming started.
+Starting the stream sends the response headers and fixes the status code.
 
 </details>
 

--- a/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/not-found.mdx
@@ -10,7 +10,9 @@ Next.js provides two conventions to handle not found cases:
 
 ## `not-found.js`
 
-The **not-found** file is used to render UI when the [`notFound`](/docs/app/api-reference/functions/not-found) function is thrown within a route segment. Along with serving a custom UI, Next.js will return a `200` HTTP status code for streamed responses, and `404` for non-streamed responses (see [Status Codes](/docs/app/api-reference/file-conventions/loading#status-codes) for details about SEO).
+The **not-found** file renders UI when the [`notFound`](/docs/app/api-reference/functions/not-found) function is thrown within a route segment.
+
+Before streaming starts, Next.js returns a `404` status code. After streaming starts, the status code remains `200` and the not-found UI renders in the response. Next.js injects a `<meta name="robots" content="noindex" />` tag in both cases. See [Status codes](/docs/app/api-reference/file-conventions/loading#status-codes) for details.
 
 ```tsx filename="app/not-found.tsx" switcher
 import Link from 'next/link'

--- a/docs/01-app/03-api-reference/03-file-conventions/unauthorized.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/unauthorized.mdx
@@ -7,7 +7,9 @@ related:
 version: experimental
 ---
 
-The **unauthorized** file is used to render UI when the [`unauthorized`](/docs/app/api-reference/functions/unauthorized) function is invoked during authentication. Along with allowing you to customize the UI, Next.js will return a `401` status code.
+The **unauthorized** file renders UI when the [`unauthorized`](/docs/app/api-reference/functions/unauthorized) function is invoked.
+
+Before streaming starts, Next.js returns a `401` status code. After streaming starts, the status code remains `200` and the unauthorized UI renders in the response. Next.js injects a `<meta name="robots" content="noindex" />` tag in both cases. See [Status codes](/docs/app/api-reference/file-conventions/loading#status-codes) for details.
 
 ```tsx filename="app/unauthorized.tsx" switcher
 import Login from '@/app/components/Login'

--- a/docs/01-app/03-api-reference/04-functions/forbidden.mdx
+++ b/docs/01-app/03-api-reference/04-functions/forbidden.mdx
@@ -182,7 +182,9 @@ export default function Forbidden() {
 }
 ```
 
-The trade-off is the HTTP status code. Because the check runs inside the `<Suspense>` boundary, the response has already begun streaming as a `200`, and the status can't change once streaming has started. This is usually fine for a page, where the user sees the `forbidden` UI regardless. To return a real `403` status, the check has to run before the response streams. With [Cache Components](/docs/app/getting-started/caching), every dynamic route streams a static shell first, so run that check in [`proxy`](/docs/app/api-reference/file-conventions/proxy) instead. See [Status codes](/docs/app/api-reference/file-conventions/loading#status-codes).
+The response starts streaming from the `<Suspense>` boundary before `forbidden()` runs, so it keeps its `200` status. Next.js adds a `noindex` tag.
+
+Calling `forbidden()` before streaming starts returns a `403`. A page that reaches `forbidden()` during prerendering can remain `○` Static and serve a `403`. A request-time check can run in [Proxy](/docs/app/api-reference/file-conventions/proxy) before the page renders. See [Status codes](/docs/app/api-reference/file-conventions/loading#status-codes).
 
 ### Role-based route protection
 

--- a/docs/01-app/03-api-reference/04-functions/not-found.mdx
+++ b/docs/01-app/03-api-reference/04-functions/not-found.mdx
@@ -190,7 +190,9 @@ export default function NotFound() {
 }
 ```
 
-The trade-off is the HTTP status code. Because the check runs inside the `<Suspense>` boundary, the response has already begun streaming as a `200`, and the status can't change once streaming has started. The `noindex` tag keeps a soft 404 out of search results. To return a real `404` status, the resource has to be checked before the response streams. With [Cache Components](/docs/app/getting-started/caching), every dynamic route streams a static shell first, so run that check in [`proxy`](/docs/app/api-reference/file-conventions/proxy) instead. See [Status codes](/docs/app/api-reference/file-conventions/loading#status-codes).
+The response starts streaming from the `<Suspense>` boundary before `notFound()` runs, so it keeps its `200` status. Next.js adds a `noindex` tag.
+
+Calling `notFound()` before streaming starts returns a `404`. A page that reaches `notFound()` during prerendering can remain `○` Static and serve a `404`. A request-time check can run in [Proxy](/docs/app/api-reference/file-conventions/proxy) before the page renders. See [Status codes](/docs/app/api-reference/file-conventions/loading#status-codes).
 
 ### Serving a 404 from a Route Handler
 

--- a/docs/01-app/03-api-reference/04-functions/unauthorized.mdx
+++ b/docs/01-app/03-api-reference/04-functions/unauthorized.mdx
@@ -186,7 +186,9 @@ export default function Unauthorized() {
 }
 ```
 
-The trade-off is the HTTP status code. Because the check runs inside the `<Suspense>` boundary, the response has already begun streaming as a `200`, and the status can't change once streaming has started. This is usually fine for a page, where the user sees the `unauthorized` UI regardless. To return a real `401` status, the check has to run before the response streams. With [Cache Components](/docs/app/getting-started/caching), every dynamic route streams a static shell first, so run that check in [`proxy`](/docs/app/api-reference/file-conventions/proxy) instead. See [Status codes](/docs/app/api-reference/file-conventions/loading#status-codes).
+The response starts streaming from the `<Suspense>` boundary before `unauthorized()` runs, so it keeps its `200` status. Next.js adds a `noindex` tag.
+
+Calling `unauthorized()` before streaming starts returns a `401`. A page that reaches `unauthorized()` during prerendering can remain `○` Static and serve a `401`. A request-time check can run in [Proxy](/docs/app/api-reference/file-conventions/proxy) before the page renders. See [Status codes](/docs/app/api-reference/file-conventions/loading#status-codes).
 
 ### Displaying login UI to unauthenticated users
 


### PR DESCRIPTION
## Summary

- Clarify that Cache Components uses PPR for every App Router page, including pages whose build-time HTML is empty.
- Explain that the current tree-view symbols describe output rather than a different rendering model: an empty PPR HTML output can show `ƒ` at a fixed pathname or `◐` on a dynamic-path fallback row.
- Clarify that Cache Components pages do not use `●`; generated paths from `generateStaticParams` show `○` or `◐` based on their HTML output.
- Clarify that `instant = false` opts out of instant-navigation validation and, when it is the highest config, static-shell validation without changing the PPR rendering model.
- Keep the guide's existing structure and examples while correcting factual wording about TypeScript checking, `generateStaticParams`, Partial Prefetching, cache lifetime output, and build debugging.
- Remove signposting, filler, and unverified claims in the sections being corrected.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --check docs/01-app/02-guides/building.mdx`
- `npx eslint --config eslint.config.mjs docs/01-app/02-guides/building.mdx`
- `git diff --check`
- Verified with `cacheComponents: true` that a fixed page covered by `instant = false` prints `ƒ`, writes 0-byte HTML, and remains `PARTIALLY_STATIC` in the prerender manifest. Removing the opt-out produces the expected prerender-blocking error.
- Verified that a Cache Components route using `generateStaticParams` prints an unmarked route group, a `◐` fallback, and a `○` generated pathname without any `●` row.
- Verified `instant = false` with synchronous runtime values and `--debug-prerender` source frames against a minimal Cache Components app using the local Next.js package and webpack.
- Not run: `pnpm lint` (docs-only change; focused formatting, ESLint, and runtime checks passed).

<!-- NEXT_JS_LLM -->
