### PR TITLE
docs(contributing): recommend running pnpm build before pnpm dev on fresh clone

### DIFF
--- a/contributing/core/developing.md
+++ b/contributing/core/developing.md
@@ -76,6 +76,12 @@ _You can skip these steps if you don't intend to modify any Rust code._
    pnpm install
    ```
 
+1. On a fresh clone, build the packages once before starting the development server:
+
+   ```
+   pnpm build
+   ```
+
 1. Start developing and watch for JavaScript code changes using
    [Turborepo](https://turborepo.dev/):
 


### PR DESCRIPTION
### What?

Update `contributing/core/developing.md` under the "Local Development" section to recommend running `pnpm build` before running `pnpm dev` on a fresh clone.

### Why?

When setting up the Next.js monorepo on a fresh clone, running `pnpm dev` immediately after `pnpm install` fails because internal packages and precompiled dependencies (such as `@next/polyfill-nomodule`, `@next/polyfill-module`, `@next/font`, and `eslint-config-next`) have not yet produced their build output. Running `pnpm build` once first populates the necessary packages and dist files so that `pnpm dev` can start watch mode without missing module errors.

Fixes #97506

### How?

Added an explicit build step to the local development workflow in `contributing/core/developing.md`:
```markdown
1. On a fresh clone, build the packages once before starting the development server:

   ```
   pnpm build
   ```
```
