### PR TITLE
fix(app-router): cascade route announcer to the h1 and pathname

### DIFF
--- a/packages/next/src/client/components/app-router-announcer.tsx
+++ b/packages/next/src/client/components/app-router-announcer.tsx
@@ -42,28 +42,49 @@ export function AppRouterAnnouncer({ tree }: { tree: FlightRouterState }) {
   }, [])
 
   const [routeAnnouncement, setRouteAnnouncement] = useState('')
-  const previousTitle = useRef<string | undefined>(undefined)
+  const previousRoute = useRef<{
+    title: string
+    heading: string
+    pathname: string
+  } | null>(null)
 
+  // Every time the route changes, announce the new page following this
+  // priority: first the document title, otherwise the first h1, or if neither
+  // of those changed, the pathname from the URL. This methodology is inspired
+  // by Marcy Sutton's accessible client routing user testing. More information
+  // can be found here:
+  // https://www.gatsbyjs.com/blog/2019-07-11-user-testing-accessible-client-routing/
   useEffect(() => {
-    let currentTitle = ''
-    if (document.title) {
-      currentTitle = document.title
-    } else {
-      const pageHeader = document.querySelector('h1')
-      if (pageHeader) {
-        currentTitle = pageHeader.innerText || pageHeader.textContent || ''
-      }
+    const title = document.title
+    const pageHeader = document.querySelector('h1')
+    const heading = pageHeader
+      ? pageHeader.innerText || pageHeader.textContent || ''
+      : ''
+    // `HistoryUpdater` writes the new URL in an insertion effect, which runs
+    // before this passive effect, so `location` already reflects the route that
+    // was just committed.
+    const pathname = window.location.pathname
+
+    const previous = previousRoute.current
+    previousRoute.current = { title, heading, pathname }
+
+    // Don't announce the first load, because screen readers do that
+    // automatically.
+    if (previous === null) {
+      return
     }
 
-    // Only announce the title change, but not for the first load because screen
-    // readers do that automatically.
-    if (
-      previousTitle.current !== undefined &&
-      previousTitle.current !== currentTitle
-    ) {
-      setRouteAnnouncement(currentTitle)
+    // Announce the first of these that actually changed. Falling through
+    // matters when two routes share a document title (e.g. `/docs` and
+    // `/docs/intro` rendered by the same layout): before, the title was the
+    // only source that was ever considered, so nothing was announced at all.
+    if (title && title !== previous.title) {
+      setRouteAnnouncement(title)
+    } else if (heading && heading !== previous.heading) {
+      setRouteAnnouncement(heading)
+    } else if (pathname !== previous.pathname) {
+      setRouteAnnouncement(pathname)
     }
-    previousTitle.current = currentTitle
   }, [tree])
 
   return portalNode ? createPortal(routeAnnouncement, portalNode) : null

--- a/test/e2e/app-dir/app-a11y/app/layout.js
+++ b/test/e2e/app-dir/app-a11y/app/layout.js
@@ -22,6 +22,22 @@ export default function Layout({ children }) {
           /noop-layout/page-2
         </Link>
         <br />
+        <Link href="/shared-title/page-a" id="shared-title-page-a">
+          /shared-title/page-a
+        </Link>
+        <br />
+        <Link href="/shared-title/page-b" id="shared-title-page-b">
+          /shared-title/page-b
+        </Link>
+        <br />
+        <Link href="/shared-title/no-h1-1" id="shared-title-no-h1-1">
+          /shared-title/no-h1-1
+        </Link>
+        <br />
+        <Link href="/shared-title/no-h1-2" id="shared-title-no-h1-2">
+          /shared-title/no-h1-2
+        </Link>
+        <br />
       </body>
     </html>
   )

--- a/test/e2e/app-dir/app-a11y/app/shared-title/layout.js
+++ b/test/e2e/app-dir/app-a11y/app/shared-title/layout.js
@@ -1,0 +1,7 @@
+export const metadata = {
+  title: 'shared-title',
+}
+
+export default function Layout({ children }) {
+  return <div>{children}</div>
+}

--- a/test/e2e/app-dir/app-a11y/app/shared-title/no-h1-1/page.js
+++ b/test/e2e/app-dir/app-a11y/app/shared-title/no-h1-1/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>shared-title/no-h1-1</div>
+}

--- a/test/e2e/app-dir/app-a11y/app/shared-title/no-h1-2/page.js
+++ b/test/e2e/app-dir/app-a11y/app/shared-title/no-h1-2/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>shared-title/no-h1-2</div>
+}

--- a/test/e2e/app-dir/app-a11y/app/shared-title/page-a/page.js
+++ b/test/e2e/app-dir/app-a11y/app/shared-title/page-a/page.js
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>shared-title/page-a</h1>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-a11y/app/shared-title/page-b/page.js
+++ b/test/e2e/app-dir/app-a11y/app/shared-title/page-b/page.js
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <div>
+      <h1>shared-title/page-b</h1>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-a11y/index.test.ts
+++ b/test/e2e/app-dir/app-a11y/index.test.ts
@@ -41,5 +41,17 @@ describe('app a11y features', () => {
       await browser.elementById('noop-layout-page-2').click()
       await check(() => getAnnouncerContent(browser), 'noop-layout/page-2')
     })
+
+    it('should announce h1 changes when the document title is unchanged', async () => {
+      const browser = await next.browser('/shared-title/page-a')
+      await browser.elementById('shared-title-page-b').click()
+      await check(() => getAnnouncerContent(browser), 'shared-title/page-b')
+    })
+
+    it('should announce the pathname when neither the title nor the h1 changed', async () => {
+      const browser = await next.browser('/shared-title/no-h1-1')
+      await browser.elementById('shared-title-no-h1-2').click()
+      await check(() => getAnnouncerContent(browser), '/shared-title/no-h1-2')
+    })
   })
 })


### PR DESCRIPTION
### What?

Makes the App Router route announcer fall back to the page's `<h1>` and then to the URL pathname when `document.title` did not change between routes.

Fixes #86660

### Why?

`AppRouterAnnouncer` computed a single `currentTitle` value:

```js
let currentTitle = ''
if (document.title) {
  currentTitle = document.title
} else {
  const pageHeader = document.querySelector('h1')
  if (pageHeader) currentTitle = pageHeader.innerText || pageHeader.textContent || ''
}
if (previousTitle.current !== undefined && previousTitle.current !== currentTitle) {
  setRouteAnnouncement(currentTitle)
}
```

Two consequences:

1. The `<h1>` was only consulted when the document had **no** title at all. Almost every real app sets one, so that branch was effectively dead code.
2. The pathname was never used, even though the Pages Router announcer documents a title → h1 → pathname priority (from [Marcy Sutton's accessible client routing research](https://www.gatsbyjs.com/blog/2019-07-11-user-testing-accessible-client-routing/)).

So navigating between two routes that share a title — e.g. `/docs` and `/docs/intro` rendered by the same layout, which is the common case when `metadata.title` is set once on a layout — announced **nothing** to screen reader users. The reproduction in #86660 shows exactly this: `/` → `/test` is announced, `/test` → `/test/subpath` is silent.

Note that the existing e2e fixture only passed because it sets no title at the root, which is what kept the `<h1>` path alive in tests.

### How?

Track `title`, `heading` and `pathname` separately and announce the first source that actually changed:

1. `document.title`, if it is non-empty and differs from the previous route's;
2. otherwise the first `<h1>`, if it is non-empty and differs;
3. otherwise `location.pathname`, if it differs.

The first commit still records the baseline without announcing, so initial page loads stay silent (screen readers announce those themselves).

`location.pathname` is safe to read in this passive effect: `HistoryUpdater` writes the new URL in a `useInsertionEffect`, which runs earlier in the same commit.

Behaviour for routes that *do* change their title is unchanged.

### Tests

Extended `test/e2e/app-dir/app-a11y` with a `shared-title` layout (one `metadata.title` shared by four routes) and two cases:

- `should announce h1 changes when the document title is unchanged`
- `should announce the pathname when neither the title nor the h1 changed`

Both fail on `canary` (the announcer stays empty until the 30s `check` timeout) and pass with this change. The four existing announcer tests still pass.

Verified locally on Windows:

- `NEXT_TEST_MODE=dev IS_WEBPACK_TEST=1 jest test/e2e/app-dir/app-a11y/` — 6/6 pass
- `NEXT_TEST_MODE=start IS_WEBPACK_TEST=1 jest test/e2e/app-dir/app-a11y/` — 6/6 pass
- `NEXT_TEST_MODE=dev IS_TURBOPACK_TEST=1 jest test/e2e/app-dir/app-a11y/` — 6/6 pass
- `pnpm prettier --check` and `pnpm lint-eslint` on the changed files — clean

### Out of scope

The Pages Router `RouteAnnouncer` (`packages/next/src/client/route-announcer.tsx`) has the same gap — it re-announces the unchanged title instead of cascading, and React bails out on the identical string, so nothing is read. That was raised in the issue thread as well. I left it out to keep this diff focused on the reported App Router behaviour, and I'm happy to send a follow-up PR if you'd like it fixed the same way.

<!-- NEXT_JS_LLM -->
