### PR TITLE
fix(router): cascade Pages Router route announcer to the h1 and pathname

### DIFF
--- a/packages/next/src/client/route-announcer.tsx
+++ b/packages/next/src/client/route-announcer.tsx
@@ -23,27 +23,43 @@ export const RouteAnnouncer = () => {
 
   // Only announce the path change, but not for the first load because screen
   // reader will do that automatically.
-  const previouslyLoadedPath = React.useRef(asPath)
+  const previousRoute = React.useRef<{
+    title: string
+    heading: string
+    asPath: string
+  } | null>(null)
 
   // Every time the path changes, announce the new page’s title following this
-  // priority: first the document title (from head), otherwise the first h1, or
-  // if none of these exist, then the pathname from the URL. This methodology is
-  // inspired by Marcy Sutton’s accessible client routing user testing. More
-  // information can be found here:
+  // priority: first the document title, otherwise the first h1, or if neither
+  // of those changed, the pathname from the URL. This methodology is inspired
+  // by Marcy Sutton’s accessible client routing user testing. More information
+  // can be found here:
   // https://www.gatsbyjs.com/blog/2019-07-11-user-testing-accessible-client-routing/
   React.useEffect(
     () => {
-      // If the path hasn't change, we do nothing.
-      if (previouslyLoadedPath.current === asPath) return
-      previouslyLoadedPath.current = asPath
+      const title = document.title
+      const pageHeader = document.querySelector('h1')
+      const heading = pageHeader
+        ? pageHeader.innerText || pageHeader.textContent || ''
+        : ''
 
-      if (document.title) {
-        setRouteAnnouncement(document.title)
-      } else {
-        const pageHeader = document.querySelector('h1')
-        const content = pageHeader?.innerText ?? pageHeader?.textContent
+      const previous = previousRoute.current
+      previousRoute.current = { title, heading, asPath }
 
-        setRouteAnnouncement(content || asPath)
+      if (previous === null) {
+        return
+      }
+
+      // Announce the first of these that actually changed. Falling through
+      // matters when two routes share a document title (e.g. `/docs` and
+      // `/docs/intro`): re-announcing the identical title is a no-op for React,
+      // so nothing would reach the live region at all.
+      if (title && title !== previous.title) {
+        setRouteAnnouncement(title)
+      } else if (heading && heading !== previous.heading) {
+        setRouteAnnouncement(heading)
+      } else if (asPath !== previous.asPath) {
+        setRouteAnnouncement(asPath)
       }
     },
     // TODO: switch to pathname + query object of dynamic route requirements

--- a/test/development/client-navigation-a11y/client-navigation-a11y.test.ts
+++ b/test/development/client-navigation-a11y/client-navigation-a11y.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 describe('Client Navigation accessibility', () => {
   const { next } = nextTestSetup({
@@ -84,6 +85,28 @@ describe('Client Navigation accessibility', () => {
         const pathname = '/page-without-h1-or-title'
 
         expect(routeAnnouncerValue).toBe(pathname)
+      })
+    })
+
+    describe('The title is unchanged but the h1 is', () => {
+      it('has the innerText equal to the value of the new h1', async () => {
+        const browser = await next.browser('/shared-title/page-a')
+        await navigateTo(browser, 'shared-title-page-b')
+
+        await retry(async () => {
+          expect(await getAnnouncedTitle(browser)).toBe('Heading B')
+        })
+      })
+    })
+
+    describe('Neither the title nor the h1 changed', () => {
+      it('has the innerText equal to the value of the pathname', async () => {
+        const browser = await next.browser('/shared-title/no-h1-1')
+        await navigateTo(browser, 'shared-title-no-h1-2')
+
+        await retry(async () => {
+          expect(await getAnnouncedTitle(browser)).toBe('/shared-title/no-h1-2')
+        })
       })
     })
   })

--- a/test/development/client-navigation-a11y/pages/shared-title/no-h1-1.js
+++ b/test/development/client-navigation-a11y/pages/shared-title/no-h1-1.js
@@ -1,0 +1,13 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+export default () => (
+  <div id="shared-title-no-h1-1">
+    <Head>
+      <title>Shared Title</title>
+    </Head>
+    <Link href="/shared-title/no-h1-2" id="shared-title-no-h1-2-link">
+      Go to a page with the same title and no h1
+    </Link>
+  </div>
+)

--- a/test/development/client-navigation-a11y/pages/shared-title/no-h1-2.js
+++ b/test/development/client-navigation-a11y/pages/shared-title/no-h1-2.js
@@ -1,0 +1,10 @@
+import Head from 'next/head'
+
+export default () => (
+  <div id="shared-title-no-h1-2">
+    <Head>
+      <title>Shared Title</title>
+    </Head>
+    <div>Extraneous stuff</div>
+  </div>
+)

--- a/test/development/client-navigation-a11y/pages/shared-title/page-a.js
+++ b/test/development/client-navigation-a11y/pages/shared-title/page-a.js
@@ -1,0 +1,14 @@
+import Head from 'next/head'
+import Link from 'next/link'
+
+export default () => (
+  <div id="shared-title-page-a">
+    <Head>
+      <title>Shared Title</title>
+    </Head>
+    <h1>Heading A</h1>
+    <Link href="/shared-title/page-b" id="shared-title-page-b-link">
+      Go to a page with the same title but a different h1
+    </Link>
+  </div>
+)

--- a/test/development/client-navigation-a11y/pages/shared-title/page-b.js
+++ b/test/development/client-navigation-a11y/pages/shared-title/page-b.js
@@ -1,0 +1,10 @@
+import Head from 'next/head'
+
+export default () => (
+  <div id="shared-title-page-b">
+    <Head>
+      <title>Shared Title</title>
+    </Head>
+    <h1>Heading B</h1>
+  </div>
+)


### PR DESCRIPTION
### What?

Applies the same route-announcer cascade to the **Pages Router** `RouteAnnouncer`: fall back to the page's `<h1>`, then to the URL pathname, when `document.title` did not change between routes.

Fixes #86660

This is the Pages Router half of the defect. The App Router half is #98285 — the two files are independent, so this is a separate PR to keep each diff reviewable on its own. Please close either one if you'd rather they were combined or scoped differently.

### Why?

`RouteAnnouncer` set the live region from `document.title` on every navigation, and only reached for the `<h1>` when the title was falsy:

```js
if (document.title) {
  setRouteAnnouncement(document.title)
} else {
  const pageHeader = document.querySelector('h1')
  const content = pageHeader?.innerText ?? pageHeader?.textContent
  setRouteAnnouncement(content || asPath)
}
```

So for two routes that share a title — `/docs` and `/docs/intro`, or any app that sets one title for a whole section — the announcer is handed the exact string it already holds. React bails out of the state update, no text node changes inside `#__next-route-announcer__`, and `aria-live="assertive"` has nothing to announce. The navigation is silent for screen reader users.

The `<h1>` branch has the same problem as it did in the App Router: it only runs when the document has no title at all, which is rare in practice, so it was effectively dead and the `asPath` fallback nested inside it was unreachable for any titled app.

The comment directly above this effect already describes the intended behaviour — "first the document title (from head), otherwise the first h1, or if none of these exist, then the pathname" (from [Marcy Sutton's accessible client routing research](https://www.gatsbyjs.com/blog/2019-07-11-user-testing-accessible-client-routing/)). The implementation only ever honoured the first step.

### How?

Track `title`, `heading` and `asPath` separately and announce the first source that actually changed:

1. `document.title`, if non-empty and different from the previous route's;
2. otherwise the first `<h1>`, if non-empty and different;
3. otherwise `asPath`, if different.

The first effect run records the baseline and returns without announcing, matching the previous `useRef(asPath)` guard, so initial page loads stay silent.

Behaviour for routes that do change their title is unchanged, and the comment is updated to match what the code now does.

### Tests

Extended `test/development/client-navigation-a11y` with four pages under `/shared-title` that all render the same `<title>`, and two cases:

- `The title is unchanged but the h1 is` → announces the new `<h1>`
- `Neither the title nor the h1 changed` → announces the pathname

Both fail on `canary` — the announcer holds `"Shared Title"` instead of `"Heading B"` / `"/shared-title/no-h1-2"` — and pass with this change. The six existing announcer tests still pass.

Verified locally on Windows:

- `NEXT_TEST_MODE=dev IS_WEBPACK_TEST=1 jest test/development/client-navigation-a11y/` — 8/8 pass
- `NEXT_TEST_MODE=start IS_WEBPACK_TEST=1 jest test/development/client-navigation-a11y/` — 8/8 pass
- `NEXT_TEST_MODE=dev IS_TURBOPACK_TEST=1 jest test/development/client-navigation-a11y/` — 8/8 pass
- `test/e2e/app-dir/app-a11y/` — 4/4 pass (unaffected)
- `pnpm prettier --check` and `pnpm lint-eslint` on the changed files — clean

<!-- NEXT_JS_LLM -->
