### PR TITLE
fix(turbopack): patch lightningcss to handle unparseable @container conditions

### DIFF
--- a/.changeset/fix-lightningcss-container.md
+++ b/.changeset/fix-lightningcss-container.md
@@ -1,0 +1,12 @@
+---
+"next": patch
+---
+
+fix(turbopack): patch lightningcss to handle unparseable @container conditions
+
+When error_recovery is enabled (used by Turbopack), the lightningcss CSS parser
+would fail on valid CSS containing `@container <name> { ... }` named container
+queries, reporting "Unexpected end of input". This patch fixes the parser to use
+ContainerCondition::Unknown for unparseable conditions when error_recovery is enabled.
+
+Fixes #98261

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -376,3 +376,7 @@ virtue = { git = "https://github.com/bgw/virtue.git", branch = "bgw/fix-generic-
 mdxjs = { git = "https://github.com/vercel-labs/mdxjs-rs-turbopack.git", branch = "turbopack" }
 # Doesn't compile on recent nightly versions because of https://github.com/Michael-F-Bryan/include_dir/pull/117
 include_dir = { git = "https://github.com/vercel-labs/include_dir", branch = "turbopack" }
+# Patch lightningcss to fix @container named query parsing with error_recovery
+# This allows @container scroll-content { ... } to be parsed without erroring
+# when error_recovery is enabled (Turbopack uses error_recovery: true).
+lightningcss = { git = "https://github.com/Larslllllll/lightningcss.git", branch = "fix/container-error-recovery", tag = "v1.0.0-alpha.72.fix" }


### PR DESCRIPTION
## Summary

Turbopack's CSS parser (lightningcss) fails to build projects that use CSS containing `@container <name> { ... }` named container queries, reporting:

```
Parsing CSS source code failed / Unexpected end of input on the named container query
```

This affects real-world CSS from libraries like `nhsuk-frontend`.

## Root Cause

In `lightningcss/src/parser.rs`, the `@container` rule parsing has this error handling:

```rust
Err(e) => {
  if name.is_some() && input.is_exhausted() {
    AtRulePrelude::Container(name, None)
  } else {
    return Err(e);  // Fails for named queries with no condition
  }
}
```

When parsing `@container scroll-content { ... }`, `input.is_exhausted()` is `false` (because `{` is waiting), so the error is propagated instead of being handled gracefully.

## Fix

Check `self.options.error_recovery` before returning the error. When error recovery is enabled (which Turbopack uses), use `ContainerCondition::Unknown` for unparseable conditions:

```rust
Err(e) => {
  if name.is_some() && input.is_exhausted() {
    AtRulePrelude::Container(name, None)
  } else if self.options.error_recovery {
    self.options.warn(e);
    AtRulePrelude::Container(name, Some(
      ContainerCondition::Unknown(TokenList::parse(input, &self.options, 0)?)
    ))
  } else {
    return Err(e);
  }
}
```

The fix is in a patched fork of lightningcss: https://github.com/Larslllllll/lightningcss/tree/fix/container-error-recovery
A PR has been submitted to upstream: https://github.com/parcel-bundler/lightningcss/pull/1330

Fixes #98261
