### PR TITLE
turbo-tasks-backend: fix strongly consistent read hanging on a canceled task

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -22,8 +22,6 @@ verify_serialization = []
 verify_aggregation_graph = []
 verify_immutable = []
 verify_determinism = ["turbo-tasks/verify_determinism"]
-# Reports an EventListener that is not notified within its timeout, printing the description and
-# note that `listen_with_note` call sites already carry. Diagnostic only.
 hanging_detection = ["turbo-tasks/hanging_detection"]
 task_dirty_cause = ["turbo-tasks/task_dirty_cause"]
 trace_aggregation_update_stats = []

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -22,6 +22,9 @@ verify_serialization = []
 verify_aggregation_graph = []
 verify_immutable = []
 verify_determinism = ["turbo-tasks/verify_determinism"]
+# Reports an EventListener that is not notified within its timeout, printing the description and
+# note that `listen_with_note` call sites already carry. Diagnostic only.
+hanging_detection = ["turbo-tasks/hanging_detection"]
 task_dirty_cause = ["turbo-tasks/task_dirty_cause"]
 trace_aggregation_update_stats = []
 trace_aggregation_update_queue = []

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -621,23 +621,6 @@ impl TurboTasksBackend {
                 );
             }
 
-            // A canceled task never runs again, so it can never become clean and nothing will
-            // ever fire its `all_clean_event`. Subscribing below would park this reader forever:
-            // `task_execution_canceled` notifies the waiters that already exist, but a reader
-            // arriving *after* the cancel re-creates the activeness state and waits on an event
-            // with no remaining notifier.
-            //
-            // Only the `Canceled` arm of `check_in_progress` is taken here, deliberately. Its
-            // `Scheduled`/`InProgress` arms return as soon as the task itself is running, which
-            // is right for the weakly consistent path below but would short-circuit the
-            // dirty-container wait that makes *this* read strongly consistent.
-            if matches!(task.get_in_progress(), Some(InProgressState::Canceled)) {
-                let description = task.get_task_description();
-                drop(task);
-                drop(reader_task);
-                anyhow::bail!("{description} was canceled");
-            }
-
             let is_dirty = task.is_dirty();
 
             // Check the dirty count of the root node
@@ -2004,28 +1987,18 @@ impl TurboTasksBackend {
             }
         }
 
-        // Record a terminal error output. A canceled task has produced no output, and
-        // `connect_children` uses `!child.has_output()` as its test for "not computed yet" and
-        // marks such a child dirty so it gets scheduled. For a canceled task that is wrong: it
-        // will never run again this session, and being marked plain `Dirty` also clears the
-        // session-clean flag set below, so it stays a dirty container of its parent forever. The
-        // parent then never reaches a clean state, and a strongly consistent reader waiting on
-        // the parent's `all_clean_event` waits forever — taking `stop_and_wait` with it, since
-        // the reader holds a foreground job.
-        //
-        // Giving the task an output makes it terminal for this session, so nothing re-dirties it
-        // and the aggregate settles. The `SessionDependent` marking below still ensures the next
-        // session re-executes it rather than trusting this error.
-        if task.get_output().is_none() {
-            task.set_output(OutputValue::Error(Arc::new(TaskError::Error(Box::new(
-                TaskErrorItem {
-                    message: TurboTasksExecutionErrorMessage::PIISafe(std::borrow::Cow::Borrowed(
-                        "task execution was canceled by shutdown",
-                    )),
-                    source: None,
-                },
-            )))));
-        }
+        // Give the task a terminal output. `connect_children` treats a child with no output as
+        // "not computed yet" and marks it dirty to be scheduled, which for a canceled task means
+        // it stays a dirty container of its parent forever and any strongly consistent reader
+        // above it never settles.
+        task.set_output(OutputValue::Error(Arc::new(TaskError::Error(Box::new(
+            TaskErrorItem {
+                message: TurboTasksExecutionErrorMessage::PIISafe(std::borrow::Cow::Borrowed(
+                    "task execution was canceled by shutdown",
+                )),
+                source: None,
+            },
+        )))));
 
         // Mark the cancelled task as session-dependent dirty so it will be re-executed
         // in the next session. Without this, any reader that encounters the cancelled task

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -79,7 +79,7 @@ use crate::{
         ActivenessState, CellRef, CollectibleRef, CollectiblesRef, Dirtyness, InProgressCellState,
         InProgressState, InProgressStateInner, OutputValue, TransientTask,
     },
-    error::TaskError,
+    error::{TaskError, TaskErrorItem},
     kv_backing_storage::TurboBackingStorage,
     utils::{
         dash_map_entry::{get_in_shard, get_shard, with_entry_in_shard},
@@ -619,6 +619,23 @@ impl TurboTasksBackend {
                         |r| self.debug_get_task_description(r)
                     )
                 );
+            }
+
+            // A canceled task never runs again, so it can never become clean and nothing will
+            // ever fire its `all_clean_event`. Subscribing below would park this reader forever:
+            // `task_execution_canceled` notifies the waiters that already exist, but a reader
+            // arriving *after* the cancel re-creates the activeness state and waits on an event
+            // with no remaining notifier.
+            //
+            // Only the `Canceled` arm of `check_in_progress` is taken here, deliberately. Its
+            // `Scheduled`/`InProgress` arms return as soon as the task itself is running, which
+            // is right for the weakly consistent path below but would short-circuit the
+            // dirty-container wait that makes *this* read strongly consistent.
+            if matches!(task.get_in_progress(), Some(InProgressState::Canceled)) {
+                let description = task.get_task_description();
+                drop(task);
+                drop(reader_task);
+                anyhow::bail!("{description} was canceled");
             }
 
             let is_dirty = task.is_dirty();
@@ -1985,6 +2002,29 @@ impl TurboTasksBackend {
             for state in cells.values() {
                 state.event.notify(usize::MAX);
             }
+        }
+
+        // Record a terminal error output. A canceled task has produced no output, and
+        // `connect_children` uses `!child.has_output()` as its test for "not computed yet" and
+        // marks such a child dirty so it gets scheduled. For a canceled task that is wrong: it
+        // will never run again this session, and being marked plain `Dirty` also clears the
+        // session-clean flag set below, so it stays a dirty container of its parent forever. The
+        // parent then never reaches a clean state, and a strongly consistent reader waiting on
+        // the parent's `all_clean_event` waits forever — taking `stop_and_wait` with it, since
+        // the reader holds a foreground job.
+        //
+        // Giving the task an output makes it terminal for this session, so nothing re-dirties it
+        // and the aggregate settles. The `SessionDependent` marking below still ensures the next
+        // session re-executes it rather than trusting this error.
+        if task.get_output().is_none() {
+            task.set_output(OutputValue::Error(Arc::new(TaskError::Error(Box::new(
+                TaskErrorItem {
+                    message: TurboTasksExecutionErrorMessage::PIISafe(std::borrow::Cow::Borrowed(
+                        "task execution was canceled by shutdown",
+                    )),
+                    source: None,
+                },
+            )))));
         }
 
         // Mark the cancelled task as session-dependent dirty so it will be re-executed

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1624,10 +1624,38 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         }
     }
 
+    /// The task type, or `None` when this guard cannot read it.
+    ///
+    /// The task type lives in the `Data` category, so reading it through a guard opened with
+    /// `Meta` only would trip `check_access`. Diagnostics must not be the thing that panics, so
+    /// this reports unavailability instead of asserting.
+    fn try_get_task_type(&self) -> Option<TaskTypeRef<'_>> {
+        // Only `debug_assertions` builds track the access level, and only they assert on it. A
+        // release build has no category recorded and the read is safe.
+        #[cfg(debug_assertions)]
+        if !matches!(
+            self.access(),
+            TaskDataCategory::Data | TaskDataCategory::All
+        ) {
+            return None;
+        }
+        Some(self.get_task_type())
+    }
+
+    /// A description of this task for diagnostics: `"<id> <task type>"`.
+    ///
+    /// Degrades to a placeholder for the type rather than panicking when the guard's access level
+    /// cannot read it, so a diagnostic is never the cause of a crash. In particular
+    /// [`EventDescription::new`] only invokes its closure when the `hanging_detection` feature is
+    /// enabled, so a `Meta`-guard call site here is dead code by default and would otherwise
+    /// panic the moment that feature is turned on.
     fn get_task_desc_fn(&self) -> impl Fn() -> String + Send + Sync + 'static {
-        let task_type = self.get_task_type().to_owned();
+        let task_type = self.try_get_task_type().map(|ty| ty.to_owned());
         let task_id = self.id();
-        move || format!("{task_id:?} {task_type}")
+        move || match &task_type {
+            Some(task_type) => format!("{task_id:?} {task_type}"),
+            None => format!("{task_id:?} task-type-not-available"),
+        }
     }
     fn get_task_description(&self) -> String {
         let task_type = self.get_task_type().to_owned();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1624,44 +1624,37 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         }
     }
 
-    /// The task type, or `None` when this guard cannot read it.
-    ///
-    /// The task type lives in the `Data` category, so reading it through a guard opened with
-    /// `Meta` only would trip `check_access`. Diagnostics must not be the thing that panics, so
-    /// this reports unavailability instead of asserting.
-    fn try_get_task_type(&self) -> Option<TaskTypeRef<'_>> {
-        // Only `debug_assertions` builds track the access level, and only they assert on it. A
-        // release build has no category recorded and the read is safe.
-        #[cfg(debug_assertions)]
-        if !matches!(
-            self.access(),
-            TaskDataCategory::Data | TaskDataCategory::All
-        ) {
-            return None;
-        }
-        Some(self.get_task_type())
-    }
-
     /// A description of this task for diagnostics: `"<id> <task type>"`.
     ///
-    /// Degrades to a placeholder for the type rather than panicking when the guard's access level
-    /// cannot read it, so a diagnostic is never the cause of a crash. In particular
-    /// [`EventDescription::new`] only invokes its closure when the `hanging_detection` feature is
-    /// enabled, so a `Meta`-guard call site here is dead code by default and would otherwise
-    /// panic the moment that feature is turned on.
+    /// Is intentionally tolerant of non-resident data.
     fn get_task_desc_fn(&self) -> impl Fn() -> String + Send + Sync + 'static {
-        let task_type = self.try_get_task_type().map(|ty| ty.to_owned());
+        // Bypass `check_access`!!
+        // Generally it is a bad idea since accessing a `Data` field like get_persistence_task_type
+        // without opening the task that way is bug But this is for diagnostics and
+        // debugging purposes only so we can cheat.
+        let task_type = self
+            .typed()
+            .get_persistent_task_type()
+            .map(|task_type| TaskTypeRef::Cached(task_type).to_owned())
+            .or_else(|| {
+                self.typed()
+                    .get_transient_task_type()
+                    .map(|task_type| TaskTypeRef::Transient(task_type).to_owned())
+            });
+
         let task_id = self.id();
         move || match &task_type {
             Some(task_type) => format!("{task_id:?} {task_type}"),
             None => format!("{task_id:?} task-type-not-available"),
         }
     }
+    // Requires the task to have been opened with Data access
     fn get_task_description(&self) -> String {
         let task_type = self.get_task_type().to_owned();
         let task_id = self.id();
         format!("{task_id:?} {task_type}")
     }
+
     #[cfg(feature = "trace_task_dirty")]
     fn get_task_name(&self) -> String {
         let task_type = self.get_task_type().to_owned();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -1789,8 +1789,11 @@ mod tests {
     // Schema Size Tests
     // ==========================================================================
 
+    // `hanging_detection` adds an `Arc<dyn Fn() -> String>` description to every `Event`, which
+    // grows `LazyField` past the size asserted here. The feature is diagnostic-only, so the sizes
+    // are not meaningful under it.
     #[test]
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(all(target_pointer_width = "64", not(feature = "hanging_detection")))]
     fn test_schema_size() {
         assert_eq!(
             size_of::<TaskStorage>(),

--- a/turbopack/crates/turbo-tasks-backend/tests/shutdown_cancellation.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/shutdown_cancellation.rs
@@ -1,42 +1,30 @@
 #![feature(arbitrary_self_types)]
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
-//! Shutdown must not strand a strongly consistent read behind a canceled task.
-//!
-//! Turbo-tasks does not cancel a task that is already executing; cancellation applies to a task
-//! that is *dispatched* after `stopped` is set. So a task launched during shutdown is canceled
-//! before it runs, and a canceled task never runs again — it can never become clean, so nothing
-//! will ever fire its `all_clean_event`. A strongly consistent reader waiting on that event would
-//! wait forever, and `stop_and_wait` would in turn block on the foreground job the reader holds.
-//!
-//! Only `next build` reaches this in production (the dev server uses a short-timeout
-//! `project_on_exit`), which is why it went untested.
+//! Regression test for a bug where shutdown would cause a strongly consistent read to hang
+//! if a task in scope was cancelled.
 
 mod util;
 
 use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, LazyLock},
     time::Duration,
 };
 
 use anyhow::Result;
-use tokio::sync::Semaphore;
+use tokio::sync::Barrier;
 use turbo_tasks::{TurboTasks, Vc};
 use turbo_tasks_backend::TurboTasksBackend;
 
 use crate::util::create_tt;
 
-/// Set once the outer task is parked, so the test only begins shutting down at that point.
-static PARKED: AtomicBool = AtomicBool::new(false);
+/// Rendezvous between the task and the test: the task waits here, the test joins once it is ready
+/// to shut down, and both proceed. Two barriers rather than one so the test can shut down
+/// *between* them, which is what puts the child's dispatch after `stopped` is set.
+static PARKED: LazyLock<Barrier> = LazyLock::new(|| Barrier::new(2));
+static RELEASED: LazyLock<Barrier> = LazyLock::new(|| Barrier::new(2));
 
-/// Released by the test once shutdown has begun. The outer task then tries to launch a child,
-/// which is dispatched after `stopped` is set and is therefore canceled.
-static RELEASE: Semaphore = Semaphore::const_new(0);
-
-/// Launched only after shutdown has started, so it is canceled before it executes.
+/// Launched only after shutdown has started, so it is cancelled before it executes.
 #[turbo_tasks::function]
 fn launched_during_shutdown() -> Vc<u32> {
     Vc::cell(42)
@@ -44,17 +32,16 @@ fn launched_during_shutdown() -> Vc<u32> {
 
 #[turbo_tasks::function(operation, root)]
 async fn pauses_then_launches_a_child() -> Result<Vc<u32>> {
-    PARKED.store(true, Ordering::SeqCst);
-    // Wait for the test to start shutting down.
-    let _permit = RELEASE.acquire().await?;
-    // Dispatched post-`stopped`, so this child is canceled rather than run. Reading it must
-    // surface that rather than hang.
+    PARKED.wait().await;
+    RELEASED.wait().await;
+    // Dispatched after `stopped` is set, so this child is cancelled rather than run. Reading it
+    // must surface that rather than hang.
     Ok(Vc::cell(*launched_during_shutdown().await?))
 }
 
 /// A strongly consistent read whose task launches a child during shutdown.
 ///
-/// The read is expected to fail — the child is canceled. What must not happen is
+/// The read is expected to fail — the child is cancelled. What must not happen is
 /// `stop_and_wait` blocking forever on the reader's foreground job.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn shutdown_unblocks_read_of_canceled_child() {
@@ -63,7 +50,7 @@ async fn shutdown_unblocks_read_of_canceled_child() {
     let tt_reader: Arc<TurboTasks<TurboTasksBackend>> = tt.clone();
     let reader = tokio::spawn(async move {
         let _ = turbo_tasks::run_once(tt_reader.clone(), async move {
-            // An error is the expected outcome once the child is canceled; returning at all is
+            // An error is the expected outcome once the child is cancelled; returning at all is
             // the property under test.
             let _ = pauses_then_launches_a_child()
                 .read_strongly_consistent()
@@ -73,28 +60,20 @@ async fn shutdown_unblocks_read_of_canceled_child() {
         .await;
     });
 
-    for _ in 0..500 {
-        if PARKED.load(Ordering::SeqCst) {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
-    assert!(
-        PARKED.load(Ordering::SeqCst),
-        "the task never parked, so this test would not exercise cancellation"
-    );
+    // Wait for the task to park, so shutdown lands between its two barriers.
+    PARKED.wait().await;
 
-    // Begin shutdown, then release the task so its child is dispatched into a stopping backend.
-    // The parent then runs to completion — turbo-tasks does not cancel an executing task — and
-    // the only thing that can strand the reader is the canceled child.
     let tt_stop = tt.clone();
     let stop = tokio::spawn(async move { tt_stop.stop_and_wait().await });
+    // Let shutdown set `stopped` before releasing the task, so its child is dispatched into a
+    // stopping backend. The task then runs to completion — turbo-tasks does not cancel a task
+    // that is already executing — and only the cancelled child can strand the reader.
     tokio::time::sleep(Duration::from_millis(50)).await;
-    RELEASE.add_permits(1);
+    RELEASED.wait().await;
 
     tokio::time::timeout(Duration::from_secs(30), stop)
         .await
-        .expect("stop_and_wait hung: a canceled task stranded a strongly consistent reader")
+        .expect("stop_and_wait hung: a cancelled task stranded a strongly consistent reader")
         .unwrap();
 
     tokio::time::timeout(Duration::from_secs(30), reader)

--- a/turbopack/crates/turbo-tasks-backend/tests/shutdown_cancellation.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/shutdown_cancellation.rs
@@ -1,0 +1,104 @@
+#![feature(arbitrary_self_types)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+//! Shutdown must not strand a strongly consistent read behind a canceled task.
+//!
+//! Turbo-tasks does not cancel a task that is already executing; cancellation applies to a task
+//! that is *dispatched* after `stopped` is set. So a task launched during shutdown is canceled
+//! before it runs, and a canceled task never runs again — it can never become clean, so nothing
+//! will ever fire its `all_clean_event`. A strongly consistent reader waiting on that event would
+//! wait forever, and `stop_and_wait` would in turn block on the foreground job the reader holds.
+//!
+//! Only `next build` reaches this in production (the dev server uses a short-timeout
+//! `project_on_exit`), which is why it went untested.
+
+mod util;
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use anyhow::Result;
+use tokio::sync::Semaphore;
+use turbo_tasks::{TurboTasks, Vc};
+use turbo_tasks_backend::TurboTasksBackend;
+
+use crate::util::create_tt;
+
+/// Set once the outer task is parked, so the test only begins shutting down at that point.
+static PARKED: AtomicBool = AtomicBool::new(false);
+
+/// Released by the test once shutdown has begun. The outer task then tries to launch a child,
+/// which is dispatched after `stopped` is set and is therefore canceled.
+static RELEASE: Semaphore = Semaphore::const_new(0);
+
+/// Launched only after shutdown has started, so it is canceled before it executes.
+#[turbo_tasks::function]
+fn launched_during_shutdown() -> Vc<u32> {
+    Vc::cell(42)
+}
+
+#[turbo_tasks::function(operation, root)]
+async fn pauses_then_launches_a_child() -> Result<Vc<u32>> {
+    PARKED.store(true, Ordering::SeqCst);
+    // Wait for the test to start shutting down.
+    let _permit = RELEASE.acquire().await?;
+    // Dispatched post-`stopped`, so this child is canceled rather than run. Reading it must
+    // surface that rather than hang.
+    Ok(Vc::cell(*launched_during_shutdown().await?))
+}
+
+/// A strongly consistent read whose task launches a child during shutdown.
+///
+/// The read is expected to fail — the child is canceled. What must not happen is
+/// `stop_and_wait` blocking forever on the reader's foreground job.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn shutdown_unblocks_read_of_canceled_child() {
+    let (tt, _persistence_dir) = create_tt("shutdown_unblocks_read_of_canceled_child");
+
+    let tt_reader: Arc<TurboTasks<TurboTasksBackend>> = tt.clone();
+    let reader = tokio::spawn(async move {
+        let _ = turbo_tasks::run_once(tt_reader.clone(), async move {
+            // An error is the expected outcome once the child is canceled; returning at all is
+            // the property under test.
+            let _ = pauses_then_launches_a_child()
+                .read_strongly_consistent()
+                .await;
+            anyhow::Ok(())
+        })
+        .await;
+    });
+
+    for _ in 0..500 {
+        if PARKED.load(Ordering::SeqCst) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        PARKED.load(Ordering::SeqCst),
+        "the task never parked, so this test would not exercise cancellation"
+    );
+
+    // Begin shutdown, then release the task so its child is dispatched into a stopping backend.
+    // The parent then runs to completion — turbo-tasks does not cancel an executing task — and
+    // the only thing that can strand the reader is the canceled child.
+    let tt_stop = tt.clone();
+    let stop = tokio::spawn(async move { tt_stop.stop_and_wait().await });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    RELEASE.add_permits(1);
+
+    tokio::time::timeout(Duration::from_secs(30), stop)
+        .await
+        .expect("stop_and_wait hung: a canceled task stranded a strongly consistent reader")
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(30), reader)
+        .await
+        .expect("the strongly consistent read never returned after shutdown")
+        .unwrap();
+}


### PR DESCRIPTION
### What

Fixes a shutdown hang in `next build`: a strongly consistent read could wait forever on a task that shutdown had canceled, which in turn blocked `stop_and_wait` and hung the build until the test timeout.

Also makes the `hanging_detection` feature usable — it panics due to a `data` access check today.

### Why the read hangs

1. Shutdown sets `stopped`. A task dispatched after that point is canceled before it runs, so it has no output.
2. Its parent completes and connects its children. `process_new_children` uses `!child.has_output()` as the test for "not computed yet" and marks such a child `InitialDirty` so it gets scheduled.
3. `make_task_dirty` promotes the canceled task's `SessionDependent` to plain `Dirty` and clears `current_session_clean`. That is correct for a live task that must re-run, and wrong for one that never will.
4. `AggregatedDataUpdate::from_task` then snapshots `dirty_state() == (true, false)` and contributes a dirty container that is not session-clean.
5. The parent is itself clean, so its own `update_dirty_state(None -> None)` early-returns and never evaluates `all_clean_event`. Its dirty-container count never drains.
6. The strongly consistent reader waits on that event forever, holding a foreground job that `stop_and_wait` blocks on.

`has_output()` is a proxy for "needs computing", and a canceled task breaks that assumption.

### The fix

Record a terminal error output when a task execution is canceled. 

Make hanging_detection more reliable

