### PR TITLE
fix(app-router): handle browser-translated route announcements

### DIFF
--- a/packages/next/src/client/components/app-router-announcer.tsx
+++ b/packages/next/src/client/components/app-router-announcer.tsx
@@ -66,5 +66,10 @@ export function AppRouterAnnouncer({ tree }: { tree: FlightRouterState }) {
     previousTitle.current = currentTitle
   }, [tree])
 
-  return portalNode ? createPortal(routeAnnouncement, portalNode) : null
+  return portalNode
+    ? createPortal(
+        <span key={routeAnnouncement}>{routeAnnouncement}</span>,
+        portalNode
+      )
+    : null
 }

--- a/test/unit/app-router-announcer-translation.test.tsx
+++ b/test/unit/app-router-announcer-translation.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react'
+import { AppRouterAnnouncer } from '../../packages/next/src/client/components/app-router-announcer'
+import type { FlightRouterState } from '../../packages/next/src/shared/lib/app-router-types'
+
+const tree = (): FlightRouterState => ['', {}]
+
+function translate(announcer: Element, mode: 'replace' | 'reparent') {
+  const text = document
+    .createTreeWalker(announcer, NodeFilter.SHOW_TEXT)
+    .nextNode()!
+  const outer = document.createElement('font')
+  const inner = document.createElement('font')
+  outer.appendChild(inner)
+  text.parentNode!.replaceChild(outer, text)
+  if (mode === 'reparent') inner.appendChild(text)
+  else inner.textContent = 'Translated announcement'
+}
+
+describe('AppRouterAnnouncer after browser translation', () => {
+  const originalTitle = document.title
+
+  afterEach(() => {
+    document.title = originalTitle
+  })
+
+  it.each(['replace', 'reparent'] as const)(
+    'updates and clears announcements after translation uses %s',
+    (mode) => {
+      document.title = 'Home'
+      const { rerender, unmount } = render(<AppRouterAnnouncer tree={tree()} />)
+      const announcer = document
+        .querySelector('next-route-announcer')!
+        .shadowRoot!.querySelector<HTMLElement>('#__next-route-announcer__')!
+
+      expect(announcer.textContent).toBe('')
+      expect(announcer.ariaLive).toBe('assertive')
+      expect(announcer.role).toBe('alert')
+
+      document.title = 'Tickets'
+      rerender(<AppRouterAnnouncer tree={tree()} />)
+      expect(announcer.textContent).toBe('Tickets')
+
+      translate(announcer, mode)
+      document.title = 'Payment'
+      rerender(<AppRouterAnnouncer tree={tree()} />)
+      expect(announcer.textContent).toBe('Payment')
+
+      translate(announcer, mode)
+      document.title = ''
+      rerender(<AppRouterAnnouncer tree={tree()} />)
+      expect(announcer.textContent).toBe('')
+
+      document.title = 'Confirmation'
+      rerender(<AppRouterAnnouncer tree={tree()} />)
+      expect(announcer.textContent).toBe('Confirmation')
+      translate(announcer, mode)
+      expect(() => unmount()).not.toThrow()
+      expect(document.querySelector('next-route-announcer')).toBeNull()
+    }
+  )
+})


### PR DESCRIPTION
Use a span keyed by the announcement text for app router's route change announcements. This fixes a bug where browser translation could cause NextJS to crash with `Failed to execute 'removeChild' on 'Node'`. 

Note that there have been reports of similar issues in the past, mainly related to app-side nodes, but this one is specific to a node that NextJS itself generates. We are currently getting around this with a custom patch to NextJS. 

Here's the sequence of events: 
1. App Router renders a hidden text node inside `__next-route-announcer__`. 
2. NextJS renders it as bare text using `createPortal`
3. Browser (Chrome) translation then replaces the node with nested `<font>` elements. React still references the original detached node. 
4. When announcement changes, React can update the detached node which leaves the region stale. 
5. If/when announcement becomes empty, React attempts to remove the text node. Since the node is no longer a child of the announcer, the browser raises an exception. 

Important to note that the crash we reproduced happens when the announcement becomes empty. This can happen when a route update has neither a document title, nor an `<h1>`.

The fix is simple: Update the `createPortal` call to render a `span` with a key instead of bare text. Translations replace the text inside the span and across announcements, the span itself gets safely replaced because the key changes.
