### PR TITLE
fix(types): apply AppType generic parameters to App props instead of only pageProps (#42846)

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -28,10 +28,10 @@ export type DocumentType = NextComponentType<
   DocumentProps
 >
 
-export type AppType<P = {}> = NextComponentType<
+export type AppType<P = {}, CP = any> = NextComponentType<
   AppContextType,
   P,
-  AppPropsType<any, P>
+  AppPropsType<any, CP> & P
 >
 
 export type AppTreeType = ComponentType<

--- a/test/e2e/typescript/pages/_app.tsx
+++ b/test/e2e/typescript/pages/_app.tsx
@@ -1,7 +1,7 @@
 import type { AppType } from 'next/app'
 
-const MyApp: AppType<{ foo: string }> = ({ Component, pageProps }) => {
-  return <Component {...pageProps} />
+const MyApp: AppType<{ foo: string }> = ({ Component, pageProps, foo }) => {
+  return <Component {...pageProps} data-foo={foo} />
 }
 
 MyApp.getInitialProps = () => ({ foo: 'bar' })


### PR DESCRIPTION
Closes #42846

### What?

Fixes `AppType` generic typing in `packages/next/src/shared/lib/utils.ts` so custom initial prop types defined by the generic parameter `P` are applied to the `App` component's own props rather than solely `pageProps`.

### Why?

When creating custom Pages router `_app` components with custom initial props returned by `getInitialProps` (e.g. `App.getInitialProps = () => ({ foo: 'bar' })`), Next.js passes those props directly into the root `App` component (`props.foo`).

Previously, `AppType` was defined as:
```typescript
export type AppType<P = {}> = NextComponentType<
  AppContextType,
  P,
  AppPropsType<any, P>
>
```
Because `P` was passed as the second argument to `AppPropsType<Router, PageProps>`, TypeScript placed `P` on `props.pageProps` instead of `props`. Consequently:
1. Accessing `props.foo` threw: `Property 'foo' does not exist on type 'AppPropsType<any, MyInitialProps>'`.
2. TypeScript incorrectly believed `props.pageProps.foo` existed, when at runtime `foo` is on `props`, not `props.pageProps`.

### How?

Updated `AppType` to:
```typescript
export type AppType<P = {}, CP = any> = NextComponentType<
  AppContextType,
  P,
  AppPropsType<any, CP> & P
>
```
1. `P` is now intersected with `AppPropsType<any, CP>`, so custom App props returned by `getInitialProps` are correctly typed on `props`.
2. Added optional generic parameter `CP = any` for typing `pageProps` when needed, aligning with the `App<P, CP>` class component definition in `pages/_app.tsx` (`P & AppProps<CP>`).
3. Fully backward-compatible when invoked with default arguments (`AppType`).
4. Updated `test/e2e/typescript/pages/_app.tsx` to verify custom App initial props are accessible on App component props.
