### PR TITLE
docs: Remove version label from Turbopack in Pages Router

### DIFF
--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/turbopack.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/turbopack.mdx
@@ -1,7 +1,6 @@
 ---
 title: turbopack
 description: Configure Next.js with Turbopack-specific options
-version: experimental
 source: app/api-reference/config/next-config-js/turbopack
 ---
 


### PR DESCRIPTION
Remove the experimental flag from https://nextjs.org/docs/pages/api-reference/config/next-config-js/turbopack