### PR TITLE
[16.3.x] Backport docs fixes 

### DIFF
--- a/docs/01-app/01-getting-started/06-fetching-data.mdx
+++ b/docs/01-app/01-getting-started/06-fetching-data.mdx
@@ -545,23 +545,27 @@ export default async function Page({ params }) {
 
 ### Reusing data with `React.cache`
 
-Wrap a data-fetching function in [`React.cache`](https://react.dev/reference/react/cache) so multiple components in the same request share one result instead of refetching:
+For data access that does not use `fetch`, such as an ORM or database query, wrap the function in [`React.cache`](https://react.dev/reference/react/cache). Multiple components can then call the function within the same request while sharing one result:
 
 ```ts filename="app/lib/user.ts" switcher
 import { cache } from 'react'
+import { db, eq, users } from '@/lib/db'
 
-export const getUser = cache(async () => {
-  const res = await fetch('https://api.example.com/user')
-  return res.json()
+export const getUser = cache(async (id: string) => {
+  return db.query.users.findFirst({
+    where: eq(users.id, id),
+  })
 })
 ```
 
 ```js filename="app/lib/user.js" switcher
 import { cache } from 'react'
+import { db, eq, users } from '@/lib/db'
 
-export const getUser = cache(async () => {
-  const res = await fetch('https://api.example.com/user')
-  return res.json()
+export const getUser = cache(async (id) => {
+  return db.query.users.findFirst({
+    where: eq(users.id, id),
+  })
 })
 ```
 
@@ -571,7 +575,12 @@ Server Components can call `getUser()` directly:
 import { getUser } from '../lib/user'
 
 export default async function DashboardPage() {
-  const user = await getUser() // Cached - same request, no duplicate fetch
+  const user = await getUser('1')
+
+  if (!user) {
+    return null
+  }
+
   return <h1>Dashboard for {user.name}</h1>
 }
 ```
@@ -580,11 +589,100 @@ export default async function DashboardPage() {
 import { getUser } from '../lib/user'
 
 export default async function DashboardPage() {
-  const user = await getUser() // Cached - same request, no duplicate fetch
+  const user = await getUser('1')
+
+  if (!user) {
+    return null
+  }
+
   return <h1>Dashboard for {user.name}</h1>
 }
 ```
 
-Since `getUser` is wrapped with `React.cache`, multiple calls within the same request return the same memoized result, whether called directly in Server Components or resolved via context in Client Components.
+Since `getUser` is wrapped with `React.cache`, calls with the same `id` within one request return the same memoized result.
 
-> **Good to know**: `React.cache` is scoped to the current request only. Each request gets its own memoization scope with no sharing between requests.
+> **Good to know:** [`React.cache`](https://react.dev/reference/react/cache#caveats) is scoped to the current request only. Each request gets its own memoization scope with no sharing between requests.
+
+### Preloading data
+
+When a component renders after other blocking work, its data request starts late even if the request inputs are already available. Preloading starts the request earlier so it can run in parallel with that work and avoid a request waterfall.
+
+To preload data, call the data-fetching function without `await` before blocking work, then call the same function in the component that consumes the result.
+
+The data-fetching function must deduplicate matching calls so the component can reuse the request started during preloading. Use one of the following approaches:
+
+- For `fetch`, [identical requests are memoized automatically](/docs/app/api-reference/functions/fetch#memoization).
+- For an ORM or database, wrap the data-fetching function in [`React.cache`](#reusing-data-with-reactcache).
+- With Cache Components, add [`'use cache'`](/docs/app/api-reference/directives/use-cache) to the data-fetching function. If the function reads request APIs such as `cookies()` or `headers()`, use [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private).
+
+In production, matching calls to a private Cache Function can reuse the same result within one request. This lets a component reuse a request started during preloading without storing the result in a server cache across requests.
+
+Keep the preload function next to the component that consumes the data. This makes the dependency easier to find if you move or remove the component:
+
+```tsx filename="app/item/[id]/item.tsx" switcher
+async function getItem(id: string) {
+  const res = await fetch(`https://api.example.com/items/${id}`)
+  return res.json()
+}
+
+export const preload = (id: string) => {
+  void getItem(id)
+}
+
+export default async function Item({ id }: { id: string }) {
+  const item = await getItem(id)
+  return <div>{item.name}</div>
+}
+```
+
+```jsx filename="app/item/[id]/item.js" switcher
+async function getItem(id) {
+  const res = await fetch(`https://api.example.com/items/${id}`)
+  return res.json()
+}
+
+export const preload = (id) => {
+  void getItem(id)
+}
+
+export default async function Item({ id }) {
+  const item = await getItem(id)
+  return <div>{item.name}</div>
+}
+```
+
+Call `preload()` before another blocking request to start loading the item earlier:
+
+```tsx filename="app/item/[id]/page.tsx" switcher
+import Item, { preload } from './item'
+import { checkIsAvailable } from '@/app/lib/data'
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+
+  preload(id)
+  const isAvailable = await checkIsAvailable(id)
+
+  return isAvailable ? <Item id={id} /> : null
+}
+```
+
+```jsx filename="app/item/[id]/page.js" switcher
+import Item, { preload } from './item'
+import { checkIsAvailable } from '@/app/lib/data'
+
+export default async function Page({ params }) {
+  const { id } = await params
+
+  preload(id)
+  const isAvailable = await checkIsAvailable(id)
+
+  return isAvailable ? <Item id={id} /> : null
+}
+```
+
+The item request continues while `checkIsAvailable()` runs. If the page renders `<Item>`, the identical `fetch` call reuses the request that `preload()` started.

--- a/docs/01-app/01-getting-started/15-route-handlers.mdx
+++ b/docs/01-app/01-getting-started/15-route-handlers.mdx
@@ -1,7 +1,7 @@
 ---
 title: Route Handlers
 nav_title: Route Handlers
-description: Learn how to use Route Handlers
+description: Create custom request handlers with Next.js Route Handlers using the Web Request and Response APIs.
 related:
   title: API Reference
   description: Learn more about Route Handlers

--- a/docs/01-app/01-getting-started/16-proxy.mdx
+++ b/docs/01-app/01-getting-started/16-proxy.mdx
@@ -1,7 +1,7 @@
 ---
 title: Proxy
 nav_title: Proxy
-description: Learn how to use Proxy
+description: Use Next.js Proxy to rewrite, redirect, modify headers, or respond directly before a request completes.
 related:
   title: API Reference
   description: Learn more about Proxy

--- a/docs/01-app/02-guides/adopting-partial-prefetching.mdx
+++ b/docs/01-app/02-guides/adopting-partial-prefetching.mdx
@@ -14,7 +14,7 @@ related:
 
 [Partial Prefetching](/docs/app/glossary#partial-prefetching) changes what a `<Link>` downloads for a Cache Components route. With Partial Prefetching enabled, a `<Link>` prefetches the route's [App Shell](/docs/app/glossary#app-shell): its static content and the cached content that doesn't depend on the URL. Next.js builds one App Shell per route and reuses it for every link to that route, rather than prefetching each link separately as it did before.
 
-To prefetch more than the App Shell, a link can opt into [per-link prefetching](/docs/app/guides/optimizing-prefetching) with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch). The prefetch then also resolves URL-specific content that depends on `params`, `searchParams`, or the full URL.
+To prefetch more than the App Shell, a link can opt into [per-link prefetching](/docs/app/guides/optimizing-prefetching) with [`<Link prefetch={true}>`](/docs/app/api-reference/components/link#prefetch). The prefetch can then resolve cached URL-specific content that depends on `params`, `searchParams`, or the full URL.
 
 Along the way, Next.js surfaces [instant navigation](/docs/app/guides/instant-navigation) insights in development, naming the link or route to change.
 
@@ -22,7 +22,7 @@ Along the way, Next.js surfaces [instant navigation](/docs/app/guides/instant-na
 
 ## Use the adoption skill (recommended)
 
-The [`next-partial-prefetching-adoption`](https://github.com/vercel/next.js/tree/canary/skills/next-partial-prefetching-adoption) skill drives this adoption with a coding agent. It audits your `<Link prefetch={true}>` calls with you, enables the flag, and sweeps every route for the insights this guide covers.
+The [`next-partial-prefetching-adoption`](https://github.com/vercel/next.js/tree/canary/skills/next-partial-prefetching-adoption) skill drives this adoption with a coding agent. It reviews your `<Link prefetch={true}>` calls, captures the prefetched UI to preserve with [`instant()` tests](#verify-prefetched-ui-with-tests) when a production test rig is available, then enables the flag and checks each route for the insights this guide covers.
 
 Install the skill:
 
@@ -38,15 +38,18 @@ Adopt Partial Prefetching in this project using the next-partial-prefetching-ado
 
 ## Or adopt by hand
 
-Adopting an existing app by hand follows the two [instant navigation](/docs/app/guides/instant-navigation) insights Next.js surfaces in `next dev`:
+To adopt an existing app by hand:
 
-1. [Enable `partialPrefetching`](#enable-partial-prefetching), then [audit every `<Link prefetch={true}>`](#auditing-link-prefetchtrue-calls) and decide per destination how to preserve what its prefetch delivered. When the adoption is large enough that reviewers need smaller diffs, or adopted routes should reach users before the rest, [adopt incrementally](#adopting-incrementally) with the flag off, guided by the [dynamic data during prefetching](/docs/messages/instant-link-prefetch-partial) insight.
-2. [Audit routes for URL data](#auditing-routes-for-url-data), resolving the [URL data outside of Suspense](/docs/messages/instant-shell-url-data) insight.
-3. Optionally, [prefetch URL data](#prefetching-url-data) on the routes where streaming in after navigation isn't enough.
+1. [Review existing full prefetches](#migrate-existing-full-prefetches) and choose which part of each destination should continue to be prefetched. You can use [`instant()` tests](#verify-prefetched-ui-with-tests) to add regression coverage.
+2. [Enable `partialPrefetching`](#enable-partial-prefetching). For larger migrations, you can [adopt incrementally](#adopting-incrementally) with the global flag off. The [dynamic data during prefetching](/docs/messages/instant-link-prefetch-partial) insight identifies each destination that still uses the legacy full prefetch.
+3. [Move URL data behind Suspense](#move-url-data-behind-suspense), resolving the [URL data outside of Suspense](/docs/messages/instant-shell-url-data) insight.
+4. Optionally, [prefetch URL data](#prefetching-url-data) on the routes where streaming in after navigation isn't enough.
 
 Both insights are development-only and never block the build. They appear in the dev overlay with fix cards that link the docs page for each fix. If a route isn't ready to adopt, export [`instant = false`](/docs/app/api-reference/file-conventions/route-segment-config/instant) from its page or layout to opt the route out of instant-navigation validation, and return to it later.
 
 ## Enable Partial Prefetching
+
+> **Good to know**: In an existing app, review the UI delivered by [`<Link prefetch={true}>`](#migrate-existing-full-prefetches) before enabling Partial Prefetching. These links use the legacy full prefetch, and enabling Partial Prefetching changes their behavior.
 
 Enable [`partialPrefetching`](/docs/app/api-reference/config/next-config-js/partialPrefetching) in `next.config.ts`:
 
@@ -61,31 +64,29 @@ const nextConfig: NextConfig = {
 export default nextConfig
 ```
 
-After enabling the flag, every `<Link>` prefetches its destination's App Shell, and `<Link prefetch={true}>` no longer includes the route's dynamic content. Audit those links next to preserve what they delivered. A new project has no legacy links to audit and is done here.
+After enabling the flag, links using the default behavior, `prefetch="auto"`, or `prefetch={true}` prefetch the destination's App Shell. A link with `prefetch={true}` can also resolve cached URL-specific content, but it no longer includes uncached dynamic content from the legacy full prefetch. New projects can enable the flag without this audit because they have no legacy full prefetches to migrate.
 
 ## What changes for `<Link>`
 
-| `<Link>` prop                       | Before (Cache Components default)                              | After Partial Prefetching                                                                                                                  |
-| ----------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `<Link href="/x">`                  | Prefetched the cached page render.                             | Loads the shared App Shell for `/x`.                                                                                                       |
-| `<Link href="/x" prefetch>`         | Prefetched the cached page render **and** any dynamic content. | Loads the App Shell, plus URL-specific content through [per-link prefetching](/docs/app/guides/optimizing-prefetching) when `/x` reads it. |
-| `<Link href="/x" prefetch={false}>` | Disabled prefetching for this link.                            | Unchanged. Still disabled.                                                                                                                 |
+| `<Link>` prop                       | Before (Cache Components default)                              | After Partial Prefetching                                                                                                                              |
+| ----------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `<Link href="/x">`                  | Prefetched the cached page render.                             | Prefetches the shared App Shell for `/x`.                                                                                                              |
+| `<Link href="/x" prefetch>`         | Prefetched the cached page render **and** any dynamic content. | Prefetches the App Shell, plus cached URL-specific content through [per-link prefetching](/docs/app/guides/optimizing-prefetching) when `/x` reads it. |
+| `<Link href="/x" prefetch={false}>` | Disabled prefetching for this link.                            | Unchanged. Still disabled.                                                                                                                             |
 
 The App Shell is shared across every link to a given route, regardless of dynamic params, so rendering many `<Link>`s to the same destination doesn't multiply the work.
 
-## Auditing `<Link prefetch={true}>` calls
+## Migrate existing full prefetches
 
-Each `<Link prefetch={true}>` used to prefetch its destination's dynamic content along with the page. With the flag on it loads the App Shell like every other link, which can be thinner than the old full prefetch. Go through each one and decide what the destination should still prefetch:
+Before Partial Prefetching, a `<Link>` whose effective `prefetch` value is `true` prefetches the complete destination, including uncached dynamic content. This includes `prefetch={true}`, the bare `prefetch` prop, and wrapper or conditional props that resolve to `true`. The default value, `prefetch="auto"`, and `prefetch={false}` don't use the legacy full prefetch.
+
+A legacy full prefetch can include more UI than the navigation needs. In most cases, the primary content at the top of the destination should be available before navigation, while secondary or frequently changing content can stream afterward.
 
 > **Good to know**: `cookies()` and `headers()` don't tie a prefetch to a URL. They vary per session, not per link, so the App Shell still carries session content. Only `params` and `searchParams` are [URL data](/docs/app/glossary#url-data), which varies per link and can't be included in the shared App Shell.
 
-| Destination                                                                       | Recommendation                                                            |
-| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| [Fully static, or content already cached](#static-or-cached-content)              | Remove the now-redundant `prefetch={true}`.                               |
-| [Delivered uncached content you want kept ahead of the click](#uncached-content)  | Cache it with `use cache`, then remove `prefetch={true}`.                 |
-| [Delivered content that depends on `cookies()` or `headers()`](#session-content)  | Cache the lookup behind the session value, then remove `prefetch={true}`. |
-| [Reads URL data, or has cached content that depends on it](#url-data)             | Keep `prefetch={true}` to resolve the content ahead of the click.         |
-| [Delivers real-time content that must stay fresh per request](#real-time-content) | Remove `prefetch={true}` and let the content stream in.                   |
+### Verify prefetched UI with tests
+
+To verify the migration programmatically, an [`instant()`](/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests) test can capture the UI that should stay available from an existing full prefetch. Run this baseline against a production build with `partialPrefetching` disabled because automatic prefetching doesn't run in `next dev`. Then rerun the same assertions after adopting the destination. A failure identifies UI the App Shell no longer carries, so you can cache the data or subtree that restores it. The passing test provides regression coverage.
 
 ### Static or cached content
 
@@ -246,11 +247,19 @@ export default function Page() {
 
 A prefetch of real-time content would be stale by the click, so there is nothing to preserve. Remove `prefetch={true}` and let the content stream in from behind its `<Suspense>` boundary.
 
+| Destination                                                                       | Recommendation                                                            |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| [Fully static, or content already cached](#static-or-cached-content)              | Remove the now-redundant `prefetch={true}`.                               |
+| [Delivered uncached content you want kept ahead of the click](#uncached-content)  | Cache it with `use cache`, then remove `prefetch={true}`.                 |
+| [Delivered content that depends on `cookies()` or `headers()`](#session-content)  | Cache the lookup behind the session value, then remove `prefetch={true}`. |
+| [Reads URL data, or has cached content that depends on it](#url-data)             | Keep `prefetch={true}` to resolve the content ahead of the click.         |
+| [Delivers real-time content that must stay fresh per request](#real-time-content) | Remove `prefetch={true}` and let the content stream in.                   |
+
 ## Adopting incrementally
 
 Adoption doesn't have to happen in one change. [`prefetch = 'partial'`](/docs/app/api-reference/file-conventions/route-segment-config/prefetch) is the global flag scoped to one route, so with the global flag still off, you can adopt and deploy each destination on its own.
 
-While the flag is off, `prefetch={true}` still performs the legacy full prefetch. Navigating through one of these links in development surfaces the [dynamic data during prefetching](/docs/messages/instant-link-prefetch-partial) insight, naming the destination and pointing at its fixes:
+Before a destination opts into Partial Prefetching, `prefetch={true}` performs the legacy full prefetch. Navigating through one of these links in development surfaces the [dynamic data during prefetching](/docs/messages/instant-link-prefetch-partial) insight, naming the destination and pointing at its fixes:
 
 <FixCardGrid>
   <FixCard
@@ -276,7 +285,7 @@ While the flag is off, `prefetch={true}` still performs the legacy full prefetch
 
 Each card is clickable and opens a page with patterns, code samples, and trade-offs.
 
-1. Audit one destination, preserving what its prefetch delivered and updating its links' `prefetch={true}` per the [table above](#auditing-link-prefetchtrue-calls). Then adopt it by adding `export const prefetch = 'partial'` to its page or layout, which clears the insight for every link pointing at the route:
+1. Start with one destination. Preserve the intended prefetched UI and update its `prefetch={true}` links using the [patterns above](#migrate-existing-full-prefetches). Then add `export const prefetch = 'partial'` to its page or layout, which clears the insight for every link pointing at the route:
 
    ```tsx filename="app/dashboard/page.tsx" switcher
    // Before
@@ -323,7 +332,7 @@ npx @next/codemod@canary remove-partial-prefetch ./app
 
 The codemod removes only the `'partial'` value and leaves other values such as `prefetch = 'force-disabled'` in place.
 
-## Auditing routes for URL data
+## Move URL data behind Suspense
 
 With the flag enabled, Next.js validates each App Shell as you navigate in development. The App Shell is shared across every link to a route, so it can't contain data that belongs to a single URL. Reading [`params`](/docs/app/api-reference/file-conventions/page#params-optional) or [`searchParams`](/docs/app/api-reference/file-conventions/page#searchparams-optional) outside a [`<Suspense>`](https://react.dev/reference/react/Suspense) boundary ties the shell to the link's URL and surfaces the [URL data outside of Suspense](/docs/messages/instant-shell-url-data) insight, naming the route and pointing at its fixes:
 

--- a/docs/01-app/02-guides/ai-agents.mdx
+++ b/docs/01-app/02-guides/ai-agents.mdx
@@ -222,11 +222,11 @@ Make the navigation from /settings to /dashboard instant using the next-cache-co
 
 The [`next-partial-prefetching-adoption`](https://www.skills.sh/vercel/next.js/next-partial-prefetching-adoption) Skill moves an app onto [Partial Prefetching](/docs/app/guides/adopting-partial-prefetching), where links share one App Shell:
 
-1. Audits the existing `<Link prefetch={true}>` calls with you.
-2. Turns the flag on and resolves the insights it surfaces.
-3. Marks the routes whose URL data might be worth prefetching later.
+1. Audits existing `<Link prefetch={true}>` navigations and identifies the prefetched UI to preserve.
+2. Captures that UI in passing [`instant()`](/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests) tests before enabling Partial Prefetching, then migrates each destination until the same tests pass unchanged.
+3. Enables the flag, resolves the URL-data insights it surfaces, and marks optional per-link prefetching candidates for later.
 
-It needs [Cache Components](/docs/app/getting-started/caching) already adopted.
+It needs [Cache Components](/docs/app/getting-started/caching) already adopted and a production-like build it can run for prefetch verification.
 
 ```bash filename="Terminal"
 npx skills add vercel/next.js --skill next-partial-prefetching-adoption

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -437,6 +437,14 @@ export async function getUser(id) {
 
 Like the `fetch` Data Cache, `unstable_cache` persists cached values across deployments and serverless instances, while `use cache` does not. See [`fetch` cache options](#fetch-cache-options) above for the storage details.
 
+## `React.cache`
+
+**Usually no change.** `React.cache` continues to deduplicate matching calls within a React render.
+
+However, each Cache Function has an isolated React cache scope. Calls from separate Cache Functions do not share a `React.cache` result, such as when one Cache Function preloads data and another consumes it.
+
+When a helper reads request data and matching calls need to share work across Cache Function scopes, replace the React wrapper with [`'use cache: private'`](/docs/app/api-reference/directives/use-cache-private). If the function only needs request-scoped deduplication, use `cacheLife({ stale: Infinity })` so it does not lower the route's stale time. Private Cache Function results are not stored in a server cache across production requests.
+
 ## On-demand revalidation (`revalidateTag`, `revalidatePath`, `updateTag`)
 
 On-demand invalidation still works by tagging cached data and expiring it after an event. Tag data with [`cacheTag`](/docs/app/api-reference/functions/cacheTag) inside a `use cache` function instead of the `fetch` `next.tags` option, then choose the invalidation API by the behavior you want:

--- a/docs/01-app/02-guides/migrating-to-cache-components.mdx
+++ b/docs/01-app/02-guides/migrating-to-cache-components.mdx
@@ -89,7 +89,7 @@ export const instant = false
 
 You don't have to migrate every route at once. `instant = false` lets you get the whole app building and running first, then convert routes one at a time:
 
-1. **Enable the flag and remove the route segment configs** (`dynamic`, `revalidate`, `fetchCache`). Routes that still render instantly need no further work.
+1. **Enable the flag and migrate each route segment config.** Follow the relevant sections below for [`dynamic = "force-dynamic"`](#dynamic--force-dynamic), [`dynamic = "force-static"`](#dynamic--force-static), [`revalidate`](#revalidate), and [`fetchCache`](#fetchcache). For routes with dynamic params, also follow the [`generateStaticParams`](#generatestaticparams-and-dynamicparams) guidance. Routes that still render instantly need no further work.
 2. **Opt out the routes that aren't ready.** Where an insight or error appears, set `instant = false` on the segment that raised it. To do this in one pass across the whole app, run the [`cache-components-instant-false`](/docs/app/guides/upgrading/codemods#cache-components-instant-false) codemod, which adds the opt-out to every `page`, `layout`, and `default` that doesn't already declare `instant`:
 
    ```bash filename="Terminal"
@@ -568,6 +568,8 @@ Cache Components changes how [dynamic routes](/docs/app/api-reference/file-conve
 ### `generateStaticParams` must return at least one param
 
 **Returning an empty array now errors.** Without Cache Components, returning `[]` defers every path to the first runtime visit. With Cache Components, [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) must return at least one param so Next.js can prerender the route and validate it produces a non-empty [static shell](/docs/app/glossary#static-shell). An empty array raises [`empty-generate-static-params`](/docs/messages/empty-generate-static-params).
+
+Keep `generateStaticParams` and return at least one real param. Removing the export opts the route out of ISR, so Next.js renders it on every request, even when it uses `use cache` for data. Read [ISR with Cache Components](/docs/app/guides/incremental-static-regeneration-cache-components) to learn how `generateStaticParams` prerenders dynamic routes and upgrades unlisted paths after their first visit.
 
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
 // Before - defer all paths to runtime

--- a/docs/01-app/02-guides/videos.mdx
+++ b/docs/01-app/02-guides/videos.mdx
@@ -17,7 +17,13 @@ The HTML [`<video>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/v
 ```jsx filename="app/ui/video.jsx"
 export function Video() {
   return (
-    <video width="320" height="240" controls preload="none">
+    <video
+      width="320"
+      height="240"
+      poster="/path/to/poster.jpg"
+      controls
+      preload="none"
+    >
       <source src="/path/to/video.mp4" type="video/mp4" />
       <track
         src="/path/to/captions.vtt"
@@ -42,6 +48,7 @@ export function Video() {
 | `autoPlay`    | Automatically starts playing the video when the page loads. Note: Autoplay policies vary across browsers. | `<video autoPlay />`                 |
 | `loop`        | Loops the video playback.                                                                                 | `<video loop />`                     |
 | `muted`       | Mutes the audio by default. Often used with `autoPlay`.                                                   | `<video muted />`                    |
+| `poster`      | An image shown in the video's box until the first frame is available.                                     | `<video poster="/poster.jpg" />`     |
 | `preload`     | Specifies how the video is preloaded. Values: `none`, `metadata`, `auto`.                                 | `<video preload="none" />`           |
 | `playsInline` | Enables inline playback on iOS devices, often necessary for autoplay to work on iOS Safari.               | `<video playsInline />`              |
 
@@ -51,6 +58,8 @@ For a comprehensive list of video attributes, refer to the [MDN documentation](h
 
 ### Video best practices
 
+- **Dimensions:** Set `width` and `height`, or a CSS `aspect-ratio`, so the browser reserves the box before the file loads. A video without dimensions collapses and then pushes the rest of the page down, which counts against [Cumulative Layout Shift](https://web.dev/articles/cls).
+- **Poster Image:** Use `poster` to fill that reserved box while the video loads, especially with `preload="none"`, where no frame is fetched until playback starts.
 - **Fallback Content:** When using the `<video>` tag, include fallback content inside the tag for browsers that do not support video playback.
 - **Subtitles or Captions:** Include subtitles or captions for users who are deaf or hard of hearing. Utilize the [`<track>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track) tag with your `<video>` elements to specify caption file sources.
 - **Accessible Controls:** Standard HTML5 video controls are recommended for keyboard navigation and screen reader compatibility. For advanced needs, consider third-party players like [react-player](https://github.com/cookpete/react-player) or [video.js](https://videojs.com/), which offer accessible controls and consistent browser experience.
@@ -77,7 +86,10 @@ export default function Page() {
 | `allowFullScreen` | Allows the iframe content to be displayed in full-screen mode.         | `<iframe allowFullScreen />`           |
 | `sandbox`         | Enables an extra set of restrictions on the content within the iframe. | `<iframe sandbox />`                   |
 | `loading`         | Optimize loading behavior (e.g., lazy loading).                        | `<iframe loading="lazy" />`            |
+| `style`           | Apply CSS, such as an `aspect-ratio` to keep the box a fixed shape.    | `<iframe style={{ border: 0 }} />`     |
 | `title`           | Provides a title for the iframe to support accessibility.              | `<iframe title="Description" />`       |
+
+An iframe without dimensions collapses until its content loads, the same as a video. Give it `width` and `height` or an `aspect-ratio`, particularly with `loading="lazy"`, where the embed can resolve long after the surrounding page has painted.
 
 For a comprehensive list of iframe attributes, refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attributes).
 

--- a/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
+++ b/docs/01-app/03-api-reference/01-directives/use-cache-private.mdx
@@ -11,14 +11,16 @@ related:
     - app/api-reference/functions/cacheTag
 ---
 
-The `'use cache: private'` directive allows functions to access runtime request APIs like `cookies()`, `headers()`, and `searchParams` within a cached scope. However, results are **never stored on the server**, they're cached only in the browser's memory and do not persist across page reloads.
+The `'use cache: private'` directive allows functions to access runtime request APIs like `cookies()`, `headers()`, and `searchParams` within a cached scope. In production, matching calls within one request can reuse the same result, but Next.js does not store it in a server cache across requests.
+
+The client router can keep the rendered output in browser memory for the [`stale` time](/docs/app/api-reference/functions/cacheLife#client-cache-behavior) configured with `cacheLife`. This client-side cache does not persist across page reloads.
 
 Reach for `'use cache: private'` when:
 
 - You want to cache a function that already accesses runtime data, and refactoring to [move the runtime access outside and pass values as arguments](/docs/app/getting-started/caching#working-with-runtime-apis) is not practical.
-- Compliance requirements prevent storing certain data on the server, even temporarily
+- You need request-specific data to be excluded from server caches that persist across production requests.
 
-Because this directive accesses runtime data, the function executes on every server render and is excluded from running during [static shell](/docs/app/getting-started/caching#prerendering) generation.
+Private Cache Functions run at request time and are excluded from [static shell](/docs/app/getting-started/caching#prerendering) generation. To start a private Cache Function before a component needs its result, see [Preloading data](/docs/app/getting-started/fetching-data#preloading-data).
 
 It is **not** possible to configure custom cache handlers for `'use cache: private'`.
 
@@ -149,7 +151,13 @@ async function getRecommendations(productId) {
 }
 ```
 
-> **Good to know**: The `stale` time must be at least 30 seconds for per-link prefetching to work, and at least 5 minutes for the content to be included in the route's [App Shell](/docs/app/glossary#app-shell). See [`cacheLife` prerendering behavior](/docs/app/api-reference/functions/cacheLife#prerendering-behavior) for details.
+> **Good to know:** The `stale` time must be at least 30 seconds for per-link prefetching to work, and at least 5 minutes for the content to be included in the route's [App Shell](/docs/app/glossary#app-shell). See [`cacheLife` prerendering behavior](/docs/app/api-reference/functions/cacheLife#prerendering-behavior) for details.
+
+### Configuring the client stale time
+
+Private Cache Functions contribute their `stale` time to the route's [Client Cache](/docs/app/glossary#client-cache). If a function only needs request-scoped deduplication, use `cacheLife({ stale: Infinity })` to keep it from lowering the route's stale time.
+
+Next.js uses the shortest stale time from the route's cache entries, so another cache or route setting can still set a finite value. Setting `stale` to `Infinity` does not store the private result on the server across production requests. Use a finite value when the client router should revalidate personalized output after a known interval.
 
 ## Request APIs allowed in private caches
 

--- a/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/proxy.mdx
@@ -256,7 +256,7 @@ Proxy defaults to using the Node.js runtime. The [`runtime`](/docs/app/api-refer
 
 ## Advanced Proxy flags
 
-In `v13.1` of Next.js two additional flags were introduced for proxy, `skipProxyUrlNormalize` (formerly `skipMiddlewareUrlNormalize`) and `skipTrailingSlashRedirect` to handle advanced use cases.
+In `v13.1` of Next.js two additional flags were introduced for proxy, [`skipProxyUrlNormalize`](/docs/app/api-reference/config/next-config-js/skipProxyUrlNormalize) (formerly `skipMiddlewareUrlNormalize`) and [`skipTrailingSlashRedirect`](/docs/app/api-reference/config/next-config-js/skipTrailingSlashRedirect) to handle advanced use cases.
 
 `skipTrailingSlashRedirect` disables Next.js redirects for adding or removing trailing slashes. This allows custom handling inside proxy to maintain the trailing slash for some paths but not others, which can make incremental migrations easier.
 
@@ -477,7 +477,7 @@ When you use `NextResponse.rewrite()`, Next.js automatically propagates the requ
 
 If you implement custom rewrite logic with `fetch()` instead of `NextResponse.rewrite()`, you can run into missing RSC headers unless you forward them manually.
 
-For custom `fetch` rewrite setups, you can also enable `skipProxyUrlNormalize` in `next.config.js` so your rewrite logic can receive the necessary URL shape and RSC headers from the provided request object:
+For custom `fetch` rewrite setups, you can also enable [`skipProxyUrlNormalize`](/docs/app/api-reference/config/next-config-js/skipProxyUrlNormalize) in `next.config.js` so your rewrite logic can receive the necessary URL shape and RSC headers from the provided request object:
 
 ```js filename="next.config.js"
 module.exports = {

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/allowedDevOrigins.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/allowedDevOrigins.mdx
@@ -16,3 +16,25 @@ module.exports = {
   allowedDevOrigins: ['local-origin.dev', '*.local-origin.dev'],
 }
 ```
+
+Only the [`hostname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/hostname) of the request's `Origin` header is matched against your entries. For a request from `http://local-origin.dev:3000/dashboard?tab=1`, that is `local-origin.dev`. The scheme, the port, the path, and the query string are ignored. Write your entries that way too, without `https://` and without a port.
+
+A no-cors cross-site request, such as a script tag loading a dev asset, sends no `Origin` header. Those are matched on the `Referer` hostname instead.
+
+Entries can also expand, through two wildcards: a `*` stands in for exactly one label of the hostname, and `**` for one or more. That is why the example above lists two entries, one for the bare hostname and one for its subdomains.
+
+| Entry                 | Matches                                             | Does not match                                 |
+| --------------------- | --------------------------------------------------- | ---------------------------------------------- |
+| `local-origin.dev`    | `local-origin.dev`                                  | `team.local-origin.dev`                        |
+| `*.local-origin.dev`  | `team.local-origin.dev`                             | `local-origin.dev`, `team.eu.local-origin.dev` |
+| `**.local-origin.dev` | `team.local-origin.dev`, `team.eu.local-origin.dev` | `local-origin.dev`                             |
+
+Partial replacement is not supported. Write `*.local-origin.dev`, rather than `team-*.local-origin.dev`. Using `**` is only supported at the start of the pattern.
+
+The dev server already allows `localhost`, its subdomains, and the hostname it was started with. Any other hostname needs an entry, such as a tunnel used for remote development:
+
+```js filename="next.config.js"
+module.exports = {
+  allowedDevOrigins: ['*.tunnel.example.com'],
+}
+```

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
@@ -10,7 +10,7 @@ Options for configuring Server Actions behavior in your Next.js application. For
 
 ## `allowedOrigins`
 
-A list of extra safe origin domains from which Server Actions can be invoked. Next.js compares the origin of a Server Action request with the host domain, ensuring they match to prevent CSRF attacks. If not provided, only the same origin is allowed.
+A list of extra safe hosts from which Server Actions can be invoked. To prevent CSRF attacks, Next.js compares the host in a request's `Origin` header against the app's own host, taken from `x-forwarded-host` or `host`, and rejects the action when the two differ. If not provided, only the same origin is allowed. A request that carries no `Origin` header at all is allowed through with a warning rather than rejected.
 
 ```js filename="next.config.js"
 /** @type {import('next').NextConfig} */
@@ -19,6 +19,38 @@ module.exports = {
   experimental: {
     serverActions: {
       allowedOrigins: ['my-proxy.com', '*.my-proxy.com'],
+    },
+  },
+}
+```
+
+Only the [`host`](https://developer.mozilla.org/en-US/docs/Web/API/URL/host) of the request's `Origin` header is matched against your entries, which is the hostname plus the port when the URL carries one. For a request from `https://my-proxy.com/checkout`, that is `my-proxy.com`. For one from `https://my-proxy.com:8443/checkout`, `my-proxy.com:8443`. Write your entries the same way.
+
+Entries can also expand, through two wildcards: a `*` stands in for exactly one label of the host, and `**` for one or more. That is why the example above lists two entries, one for the bare host and one for its subdomains.
+
+| Entry               | Matches                                   | Does not match                          |
+| ------------------- | ----------------------------------------- | --------------------------------------- |
+| `my-proxy.com`      | `my-proxy.com`                            | `my-proxy.com:8443`, `app.my-proxy.com` |
+| `*.my-proxy.com`    | `app.my-proxy.com`                        | `my-proxy.com`, `app.my-proxy.com:8443` |
+| `**.my-proxy.com`   | `app.my-proxy.com`, `app.eu.my-proxy.com` | `my-proxy.com`                          |
+| `my-proxy.com:8443` | `my-proxy.com:8443`                       | `my-proxy.com`                          |
+
+Partial replacement is not supported. Write `*.my-proxy.com`, rather than `app-*.my-proxy.com`. Using `**` is only supported at the start of the pattern. A port cannot be wildcarded, so write it out in full: `my-proxy.com:8443`, or `*.my-proxy.com:8443` for its subdomains.
+
+Behind a reverse proxy, no entry is needed as long as the proxy forwards the public host in `x-forwarded-host`. When it forwards its own host instead, the browser sends `my-proxy.com` while the server reports something like `localhost:3000`, and that mismatch is what this list is for: the host visible in the browser's address bar is the one to add, not the internal one the server reports.
+
+The check runs in production as well as in development, so the list applies to your deployed app and not only to local work.
+
+For example, remote development through a tunnel needs the tunnel hostname in two places: in [`allowedDevOrigins`](/docs/app/api-reference/config/next-config-js/allowedDevOrigins), so the dev server serves its own assets and endpoints, and here, so actions from it are accepted:
+
+```js filename="next.config.js"
+/** @type {import('next').NextConfig} */
+
+module.exports = {
+  allowedDevOrigins: ['*.tunnel.example.com'],
+  experimental: {
+    serverActions: {
+      allowedOrigins: ['*.tunnel.example.com'],
     },
   },
 }

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/skipProxyUrlNormalize.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/skipProxyUrlNormalize.mdx
@@ -1,0 +1,136 @@
+---
+title: skipProxyUrlNormalize
+description: Let Proxy see the original request instead of Next.js's normalized version. Formerly skipMiddlewareUrlNormalize.
+---
+
+{/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
+Enabling `skipProxyUrlNormalize` lets [Proxy](/docs/app/api-reference/file-conventions/proxy) see the original request instead of Next.js's normalized version. This includes internal URLs, query parameters, and headers used during client-side navigation.
+
+**Most projects don't need this option.** It is one of the [advanced Proxy flags](/docs/app/api-reference/file-conventions/proxy#advanced-proxy-flags), meant for specific routing cases and debugging.
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  skipProxyUrlNormalize: true,
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  skipProxyUrlNormalize: true,
+}
+
+module.exports = nextConfig
+```
+
+## Reference
+
+During client-side navigation, Next.js uses an internal request rather than requesting the destination URL as a full document load. By default, Next.js normalizes that request before it reaches Proxy, so Proxy sees the same destination URL for both client-side navigation and a full page load.
+
+Next.js also normalizes what Proxy returns, so any URL you rewrite or redirect to is rewritten to match.
+
+With `skipProxyUrlNormalize: true`, neither normalization runs. Proxy receives the request as sent, and the destinations it rewrites or redirects to are sent as written:
+
+| Default                                                                                                                                                                              | With `skipProxyUrlNormalize: true`        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
+| `request.nextUrl` resolves the internal data URL back to the route path and extracts the locale                                                                                      | Holds the requested pathname as sent      |
+| `request.url` is the normalized URL                                                                                                                                                  | Is the original request URL               |
+| The internal `_rsc` query parameter is stripped                                                                                                                                      | Preserved                                 |
+| Next.js internal navigation headers (`rsc`, `next-router-state-tree`, `next-router-prefetch`, `next-router-segment-prefetch`, `next-hmr-refresh`) are removed from `request.headers` | Preserved                                 |
+| `NextResponse.rewrite()` destinations are re-serialized with the build ID                                                                                                            | Sent as written                           |
+| `NextResponse.redirect()` `Location` is rewritten to a relative URL                                                                                                                  | Sent as written, trailing slash preserved |
+| With [`trailingSlash: true`](/docs/app/api-reference/config/next-config-js/trailingSlash), a trailing slash is appended before Proxy runs                                            | Pathname passed through unchanged         |
+
+### Deprecated alias
+
+The former name of this option is `skipMiddlewareUrlNormalize`, from when Proxy was called Middleware. It still works and logs a deprecation warning. Setting both at once throws:
+
+```bash filename="Terminal"
+Config options `skipProxyUrlNormalize` and `skipMiddlewareUrlNormalize` cannot be set at the same time. Please use `skipProxyUrlNormalize` instead.
+```
+
+The [version 16 codemod](/docs/app/guides/upgrading/codemods#160) renames it for you.
+
+## Good to know
+
+- Avoid using the internal navigation headers to return different content for client-side navigation and full page loads.
+- You do not need this option to limit which routes Proxy runs on. The [`matcher`](/docs/app/api-reference/file-conventions/proxy#matcher) config still matches the destination URL either way.
+- Only the request and response Proxy sees change. Filesystem routing, `redirects`, and `rewrites` from `next.config.js` behave the same.
+
+## Examples
+
+### Reading the URL as the client sent it
+
+<AppOnly>
+
+During client-side navigation, Next.js adds an `_rsc` query parameter and its internal navigation headers to the request. With the option enabled, Proxy can read both.
+
+```ts filename="proxy.ts" switcher
+import type { NextRequest } from 'next/server'
+
+export default function proxy(request: NextRequest) {
+  console.log(request.nextUrl.searchParams.get('_rsc'))
+  // Enabled: the value Next.js added to the request
+  // Disabled: null
+
+  console.log(request.headers.get('rsc'))
+  // Enabled: '1' during client-side navigation
+  // Disabled: null
+}
+```
+
+```js filename="proxy.js" switcher
+export default function proxy(request) {
+  console.log(request.nextUrl.searchParams.get('_rsc'))
+  // Enabled: the value Next.js added to the request
+  // Disabled: null
+
+  console.log(request.headers.get('rsc'))
+  // Enabled: '1' during client-side navigation
+  // Disabled: null
+}
+```
+
+</AppOnly>
+
+<PagesOnly>
+
+During client-side navigation, Next.js requests a `/_next/data` URL instead of the destination URL. With the option enabled, Proxy sees that URL as sent.
+
+```ts filename="proxy.ts" switcher
+import type { NextRequest } from 'next/server'
+
+export default function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  // Request: GET /_next/data/build-id/hello.json
+  console.log(pathname)
+  // Enabled: /_next/data/build-id/hello.json
+  // Disabled: /hello
+}
+```
+
+```js filename="proxy.js" switcher
+export default function proxy(request) {
+  const { pathname } = request.nextUrl
+
+  // Request: GET /_next/data/build-id/hello.json
+  console.log(pathname)
+  // Enabled: /_next/data/build-id/hello.json
+  // Disabled: /hello
+}
+```
+
+</PagesOnly>
+
+## Version History
+
+| Version   | Changes                                                               |
+| --------- | --------------------------------------------------------------------- |
+| `v16.0.0` | Renamed from `skipMiddlewareUrlNormalize` to `skipProxyUrlNormalize`. |
+| `v13.1.0` | `skipMiddlewareUrlNormalize` added.                                   |

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/skipTrailingSlashRedirect.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/skipTrailingSlashRedirect.mdx
@@ -1,0 +1,125 @@
+---
+title: skipTrailingSlashRedirect
+description: Disable the automatic trailing slash redirects so you can handle trailing slashes yourself in Proxy.
+---
+
+{/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
+Enabling `skipTrailingSlashRedirect` turns off the automatic redirects that add or remove a trailing slash. You handle any redirecting you still want in [Proxy](/docs/app/api-reference/file-conventions/proxy).
+
+**Most projects don't need this option.** It is one of the [advanced Proxy flags](/docs/app/api-reference/file-conventions/proxy#advanced-proxy-flags), meant for specific routing cases and debugging.
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  skipTrailingSlashRedirect: true,
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  skipTrailingSlashRedirect: true,
+}
+
+module.exports = nextConfig
+```
+
+## Reference
+
+By default, Next.js redirects every request so the trailing slash matches your [`trailingSlash`](/docs/app/api-reference/config/next-config-js/trailingSlash) setting.
+
+| `trailingSlash` | Request   | Default response            |
+| --------------- | --------- | --------------------------- |
+| `false`         | `/about`  | `200`                       |
+| `false`         | `/about/` | `308` redirect to `/about`  |
+| `true`          | `/about`  | `308` redirect to `/about/` |
+| `true`          | `/about/` | `200`                       |
+
+Enabling `skipTrailingSlashRedirect` affects both server responses and client-side navigation:
+
+- Both `/about` and `/about/` return `200`. Neither redirects to the other.
+- Next.js stops changing trailing slashes during client-side navigation. [`<Link>`](/docs/app/api-reference/components/link) and router URLs keep the path exactly as written.
+
+Your own `redirects` and `rewrites` from `next.config.js` still apply.
+
+### Paths that contain a dot
+
+If the last path segment contains a dot, Next.js treats the path as a file and removes the trailing slash, regardless of the `trailingSlash` setting. A dot in an earlier segment has no effect, except under `.well-known/`, which is exempt from the default redirects when `trailingSlash` is `true`.
+
+| Request                   | `trailingSlash: true`              | `trailingSlash: false`                     | `skipTrailingSlashRedirect: true` |
+| ------------------------- | ---------------------------------- | ------------------------------------------ | --------------------------------- |
+| `/about`                  | `308` redirect to `/about/`        | `200`                                      | `200`                             |
+| `/about/`                 | `200`                              | `308` redirect to `/about`                 | `200`                             |
+| `/gcc.git/`               | `308` redirect to `/gcc.git`       | `308` redirect to `/gcc.git`               | `200`                             |
+| `/version/1.2.3/`         | `308` redirect to `/version/1.2.3` | `308` redirect to `/version/1.2.3`         | `200`                             |
+| `/version/1.2.3/my-page/` | `200`                              | `308` redirect to `/version/1.2.3/my-page` | `200`                             |
+| `/.well-known/x/`         | `200`                              | `308` redirect to `/.well-known/x`         | `200`                             |
+
+With `skipTrailingSlashRedirect` enabled, none of these redirects are generated and every path is served at whichever form was requested.
+
+## Good to know
+
+- Keep setting [`trailingSlash`](/docs/app/api-reference/config/next-config-js/trailingSlash) as you did before. It still controls the URLs Next.js generates and the output filenames for [`output: 'export'`](/docs/app/guides/static-exports).
+- With `output: 'export'`, this preserves the `href` instead of resolving `/me` to `/me/`. See [Static Exports](/docs/app/guides/static-exports).
+- Serving one page at both `/about` and `/about/` gives search engines two URLs for it. Set a [canonical URL](/docs/app/api-reference/functions/generate-metadata#alternates) in your metadata, or redirect in [Proxy](/docs/app/api-reference/file-conventions/proxy).
+
+## Examples
+
+### Handling trailing slashes in Proxy
+
+With `skipTrailingSlashRedirect` enabled, Next.js no longer adds trailing slashes, but Proxy can still add them selectively. This example adds a trailing slash to your own routes while leaving a set of legacy prefixes untouched, which makes an incremental migration easier.
+
+```ts filename="proxy.ts" switcher
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+const legacyPrefixes = ['/docs', '/blog']
+
+export default function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  if (legacyPrefixes.some((prefix) => pathname.startsWith(prefix))) {
+    return NextResponse.next()
+  }
+
+  // Apply trailing slash handling, skipping files and `.well-known` paths
+  if (
+    !pathname.endsWith('/') &&
+    !pathname.match(/((?!\.well-known(?:\/.*)?)(?:[^/]+\/)*[^/]+\.\w+)/)
+  ) {
+    return NextResponse.redirect(new URL(`${pathname}/`, request.nextUrl))
+  }
+}
+```
+
+```js filename="proxy.js" switcher
+import { NextResponse } from 'next/server'
+
+const legacyPrefixes = ['/docs', '/blog']
+
+export default function proxy(request) {
+  const { pathname } = request.nextUrl
+
+  if (legacyPrefixes.some((prefix) => pathname.startsWith(prefix))) {
+    return NextResponse.next()
+  }
+
+  // Apply trailing slash handling, skipping files and `.well-known` paths
+  if (
+    !pathname.endsWith('/') &&
+    !pathname.match(/((?!\.well-known(?:\/.*)?)(?:[^/]+\/)*[^/]+\.\w+)/)
+  ) {
+    return NextResponse.redirect(new URL(`${pathname}/`, request.nextUrl))
+  }
+}
+```
+
+## Version History
+
+| Version   | Changes                            |
+| --------- | ---------------------------------- |
+| `v13.1.0` | `skipTrailingSlashRedirect` added. |

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/taint.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/taint.mdx
@@ -11,7 +11,7 @@ The `taint` option enables support for experimental React APIs for tainting obje
 - [`experimental_taintObjectReference`](https://react.dev/reference/react/experimental_taintObjectReference) taint objects references.
 - [`experimental_taintUniqueValue`](https://react.dev/reference/react/experimental_taintUniqueValue) to taint unique values.
 
-> **Good to know**: Activating this flag also enables the React `experimental` channel for `app` directory.
+> **Good to know**: Activating this flag also enables the React `experimental` channel for `app` directory, and taints `process.env` so it cannot be passed whole to a Client Component.
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
@@ -51,6 +51,7 @@ It is recommended to model your data and APIs so that sensitive data is not retu
 ## Caveats
 
 - Tainting can only keep track of objects by reference. Copying an object creates an untainted version, which loses all guarantees given by the API. You'll need to taint the copy.
+- The built-in `process.env` taint applies to the object reference only. Reading individual variables such as `process.env.MY_VAR` and passing the resulting string to a Client Component is unaffected, as is passing a copy like `{ ...process.env }`.
 - Tainting cannot keep track of data derived from a tainted value. You also need to taint the derived value.
 - Values are tainted for as long as their lifetime reference is within scope. See the [`experimental_taintUniqueValue` parameters reference](https://react.dev/reference/react/experimental_taintUniqueValue#parameters), for more information.
 

--- a/docs/02-pages/04-api-reference/03-functions/use-report-web-vitals.mdx
+++ b/docs/02-pages/04-api-reference/03-functions/use-report-web-vitals.mdx
@@ -1,6 +1,6 @@
 ---
 title: useReportWebVitals
-description: useReportWebVitals
+description: Use the Next.js `useReportWebVitals` hook to send Core Web Vitals and custom performance metrics to analytics.
 source: app/api-reference/functions/use-report-web-vitals
 ---
 

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/skipProxyUrlNormalize.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/skipProxyUrlNormalize.mdx
@@ -1,0 +1,7 @@
+---
+title: skipProxyUrlNormalize
+description: Let Proxy see the original request instead of Next.js's normalized version. Formerly skipMiddlewareUrlNormalize.
+source: app/api-reference/config/next-config-js/skipProxyUrlNormalize
+---
+
+{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/skipTrailingSlashRedirect.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/skipTrailingSlashRedirect.mdx
@@ -1,0 +1,7 @@
+---
+title: skipTrailingSlashRedirect
+description: Disable the automatic trailing slash redirects so you can handle trailing slashes yourself in Proxy.
+source: app/api-reference/config/next-config-js/skipTrailingSlashRedirect
+---
+
+{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/turbopack.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/turbopack.mdx
@@ -1,7 +1,6 @@
 ---
 title: turbopack
 description: Configure Next.js with Turbopack-specific options
-version: experimental
 source: app/api-reference/config/next-config-js/turbopack
 ---
 

--- a/skills/next-cache-components-optimizer/rig-template.md
+++ b/skills/next-cache-components-optimizer/rig-template.md
@@ -39,7 +39,10 @@ build/run obstacles, accumulated as you first hit them).
    and never for real production? Spellings: an explicit
    `EXPOSE_TESTING_API=1` for local production builds; `process.env.DEPLOY_ENV
 === 'staging'` for a generic CI/staging env var; `process.env.VERCEL_ENV ===
-'preview'` on Vercel.
+'preview'` on Vercel. Set the condition during `next build`, not only
+   `next start`. Otherwise `instant()` may not acquire the testing cookie
+   before the test times out; rebuild the artifact before debugging the
+   assertion.
 3. **RUN**: how is the Playwright suite invoked, and against which
    `BASE_URL`?
 4. **TEST USER**: which account does the suite run as, and how does login
@@ -64,7 +67,10 @@ build/run obstacles, accumulated as you first hit them).
    chosen mechanism. For a local `build && start` rig the artifact is the one
    freshly built, so no SHA probe is needed. Record the port, stop the previous
    server before starting, fail the loop on `EADDRINUSE`, and verify the newly
-   started process owns the port before running the test.
+   started process owns the port before running the test. `next start` can fork
+   a `next-server` child, so the launcher process ID may not own the port. Start
+   the server in a process group that the rig can stop as a unit, or discover
+   and stop the process listening on the recorded port before the next build.
 
 ## The file: copy, fill, commit as `instant-nav.rig.md`
 

--- a/skills/next-partial-prefetching-adoption/SKILL.md
+++ b/skills/next-partial-prefetching-adoption/SKILL.md
@@ -5,7 +5,8 @@ description: >
   insights it surfaces. Use when the user wants to enable or adopt
   Partial Prefetching, flip the `partialPrefetching` flag, opt routes
   in with `export const prefetch = 'partial'`, audit
-  `<Link prefetch={true}>` calls, or resolve the
+  `Link prefetch={true}` behavior, preserve existing prefetched UI
+  with `instant()` tests, or resolve the
   instant-link-prefetch-partial and instant-shell-url-data insights.
 ---
 
@@ -13,19 +14,23 @@ description: >
 
 Enable Partial Prefetching and walk the app until every link reuses a shared App Shell. This skill sequences the work; per-insight recipes live in the dev overlay fix cards and their docs pages. The [Adopting Partial Prefetching guide](https://nextjs.org/docs/app/guides/adopting-partial-prefetching) is the canonical reference for the concepts this skill applies.
 
-The one thing that shapes everything below: **these insights surface only in `next dev`, in the dev overlay's Insights tab.** Nothing fails the build. There is no build-only fallback loop — confirming an insight is _cleared_ means driving the running app in a browser. But a missing browser gates that verification, not the whole skill: the adoption work is static and runs from the guide, so do the static pass anyway and hand off the live shell check.
+The development insights and the preservation tests are two different paths. Insights surface only in `next dev`, in the dev overlay's Insights tab. Test-backed preservation runs against a production-like build with `instant()` and does not need a development server. After the flag is enabled, the separate URL-data insight sweep still uses `next dev`.
 
-Talk to the user in terms of what they'll see — PRs, features, and how the app behaves after — never the insight slugs or step labels. Before you start, tell them briefly what Partial Prefetching changes: a `<Link>` loads a shared App Shell, and `prefetch={true}` no longer prefetches everything the old full prefetch did.
+## preservation gate
+
+When using test-backed preservation, the first implementation milestone is a passing flag-off `instant()` suite. Set up the production test rig, write the selected assertions, run them with `partialPrefetching` disabled, and record the command and exit status. Test-only configuration required by the rig is allowed, but until that baseline passes, do not enable `partialPrefetching` or edit the destination, cache boundaries, or Link props. Installing missing test dependencies is part of reaching the baseline, not a reason to adopt first. Use the manual path only when `rig-template.md` identifies a concrete blocker the repository cannot resolve, and record the blocker and deferred test coverage.
+
+Talk to the user in terms of what they'll see — PRs, features, and how the app behaves after — never the insight slugs or step labels. Before you start, tell them briefly what Partial Prefetching changes: links to a route prefetch one shared App Shell, and `prefetch={true}` can also resolve cached URL-specific content. The audit determines which UI from the legacy full prefetch to preserve.
 
 ## requires
 
-- **Cache Components on (`cacheComponents: true`).** This is the only hard requirement; `partialPrefetching` depends on it. Full Cache Components adoption is the ideal starting point but not a gate. Nothing in this skill blocks the build, and neither do the prerender insights an unadopted route surfaces, like a leftover `unstable_noStore` or a `cookies()` read outside `<Suspense>`: they are non-blocking dev signals, expected on any fresh branch off `main`, not a reason to stop. They replace the URL-data insight only on their own route in the [step 3](#step-3-sweep-for-url-data-insights-after-enabling) sweep; the flag-off step 1 audit and its static adoption run regardless. The only thing that actually stops this skill is a build-blocking failure, and anything build-blocking would have been resolved before you reached here. Otherwise fix the prerender insights you hit as inline [`next-cache-components-adoption`](https://github.com/vercel/next.js/tree/canary/skills/next-cache-components-adoption) work, or hand them off, and keep going.
+- **Cache Components adopted (`cacheComponents: true`) with a passing build.** Both `partialPrefetching` and the route-level `prefetch` export require Cache Components. If it is off, use [`next-cache-components-adoption`](https://github.com/vercel/next.js/tree/canary/skills/next-cache-components-adoption) first and return after its build-blocking prerender errors are resolved. Those errors can fail `next build`; only the Partial Prefetching insights handled by this skill are non-blocking development signals.
 
 - **Next.js 16.3 or later.** `partialPrefetching`, the `prefetch` route segment config, and the prefetch insights all land there.
 
-- **A browser you can drive.** Install [`next-dev-loop`](https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop) before starting, unless it is already available — it ships alongside this skill (`npx skills add https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop`). Install it without asking — it's a tool, not a product change — and don't assume it's blocked: verify a real blocker (no network, no npm, read-only filesystem) before falling back, and name it in your report. Link prefetches fire when a link renders and enters the viewport, and shell validation fires on navigation — neither is reachable from `curl` or the build. If the app is webpack-pinned, drive a browser directly (`agent-browser`, Playwright) — you lose the framework cross-checks, not the insights; they're still in the overlay and the dev log.
+- **A browser you can drive.** Test-backed preservation uses an existing or minimal production-mode Playwright suite; manual preservation and the final demonstration use the running production app. The development insight path and the post-flag URL-data sweep use [`next-dev-loop`](https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop); install it before either development pass unless it is already available (`npx skills add https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop`). If the app is webpack-pinned, drive a browser directly (`agent-browser`, Playwright) — you lose the framework cross-checks, not the insights; they're still in the overlay and the dev log.
 
-- **A runnable app.** Verification runs against `next dev` for the insight sweep and a production `next build`/`next start` for prefetching (prefetching is prod-only), so the app has to boot in both. If it reads a database or required env at import (e.g. an `env.ts` that throws on a missing `DATABASE_URL`), confirm it starts — with the real environment, or local data you stand up — before step 1. An app that won't run can't be swept or verified.
+- **A runnable app.** Preservation and the final demonstration need a production-like build because automatic prefetching runs only in production. The development server is required only when using the insight path or running the post-flag URL-data sweep; do not start it merely to confirm a test-backed preservation case. If the app reads a database or required environment at import, confirm the environment used by the chosen path can start before step 1.
 
 ### notes
 
@@ -35,75 +40,104 @@ Talk to the user in terms of what they'll see — PRs, features, and how the app
 
 ## background
 
-Adopting Partial Prefetching means every route still delivers what its links prefetched before, now split between the shared App Shell and any extra per-link data a link explicitly asks for. The [guide](https://nextjs.org/docs/app/guides/adopting-partial-prefetching) is the canonical reference for what a prefetch contains and how to decide each case; this skill sequences that work against a running app.
+Adopting Partial Prefetching means every route preserves the prefetched UI that matters, now split between the shared App Shell and any extra per-link data a link explicitly asks for. The [guide](https://nextjs.org/docs/app/guides/adopting-partial-prefetching) is the canonical reference for what a prefetch contains and how to decide each case; this skill sequences that work against a running app.
 
 The catch that decides most of the sweep: a default link warms only the shared App Shell. A route keyed by `params` or `searchParams` can prefetch more only after it has adopted Partial Prefetching and a specific link uses [`<Link prefetch={true}>`](https://nextjs.org/docs/app/api-reference/components/link#prefetch); then Next.js resolves the URL data and any cached content behind it before the click (the guide's [URL data](https://nextjs.org/docs/app/guides/adopting-partial-prefetching#url-data) section).
 
 ## working surfaces
 
-- **The dev server terminal — your primary record.** Each validated route's insights are logged as `Error: Route "...": Next.js encountered ...` lines with the `https://nextjs.org/docs/messages/<slug>` link. Tail the dev log during the sweep; it's the greppable record of what fired where, and it works the same on Turbopack and webpack.
+- **The production-mode `instant()` suite — the primary record for test-backed preservation.** Reuse the app's production build, test context, and Playwright setup. Read an existing `instant-nav.rig.md` first; if the project has no rig, create it from **`rig-template.md`**. The same tests define the legacy target before adoption and become the work queue after each destination opts into Partial Prefetching. Development can help investigate a failure, but only this suite decides whether the prefetched UI was preserved.
+- **The dev server terminal — the primary record for the insight path.** Each validated route's insights are logged as `Error: Route "...": Next.js encountered ...` lines with the `https://nextjs.org/docs/messages/<slug>` link. Tail the dev log during the sweep; it's the greppable record of what fired where, and it works the same on Turbopack and webpack.
 - **The dev overlay Insights tab.** Insights are the amber, non-blocking tab. It appears only once an insight has fired, so a route that surfaces nothing shows no tab at all — that's the clean state, not a missing feature. Don't hunt for the tab on a quiet route; confirm clean from the dev log above, which is the reliable signal. The precondition is no blocking-prerender errors — those replace the insight on their route (see requires). An unrelated Issue (a hydration error, a console error) doesn't block the sweep; don't stall on it. When the tab is present, the overlay pill shows the count and each insight has fix cards linking its docs page. The overlay renders inside a shadow root (`nextjs-portal`), so accessibility-tree snapshots don't see it — evaluate into `shadowRoot` when you need to read or click it programmatically.
 - **`next-dev-loop`** to drive navigations and read the overlay. Prefer it over hand-rolled browser automation for the same reasons as in the Cache Components skill (webpack apps: see requires). When browsing its `/_next/mcp` tools, the prefetch insights surface through `get_errors` and the overlay, not the similarly-named `get_request_insights`. That one is the span and performance recorder (gated behind `experimental.requestInsights`) and reports nothing about prefetching.
 
 Every insight has a docs page — open it. Fetch the linked page for every distinct insight you encounter; the inline message is a summary, the page is the recipe.
 
-## step 1: audit `<Link prefetch={true}>` (before enabling)
+## step 1: audit `<Link prefetch={true}>` navigations (before enabling)
 
-If `partialPrefetching: true` is already set in `next.config.ts`, the app is adopted — skip to [step 3](#step-3-sweep-for-url-data-insights-after-enabling). Otherwise work the audit with the global flag **off**, adopting each destination with `export const prefetch = 'partial'` — enabling the flag first would mark every route adopted and silence the [`instant-link-prefetch-partial`](https://nextjs.org/docs/messages/instant-link-prefetch-partial) insight this audit runs on. Ask the user how to ship it, in the language of PRs:
+Keep the global flag **off** through this audit and the legacy baseline in step 2. Enabling it earlier would remove the legacy behavior the migration needs to measure. If the flag is already on in unshipped work, use the pre-flag commit for the audit and baseline. When the user is available, ask how to ship it in the language of PRs:
 
-- **One branch** — the whole audit in one change, with the flag enabled and the codemod run at the end (step 2).
-- **Route by route** — each adopted destination ships as its own PR. The insight still fires for the destinations you haven't reached, a live worklist, and step 2 comes after the last one.
+- **One branch** — the whole audit in one change, with the flag enabled and the codemod run at the end (step 4).
+- **Route by route** — each adopted destination ships as its own PR. The insight still fires for the destinations you haven't reached, a live worklist, and step 4 comes after the last one.
 
-The work is identical either way — only the commit boundaries differ. Default by app size: one branch for a handful of links, route by route when the audit is big enough that reviewers need smaller diffs. Note the choice in your report.
+The work and its order are identical either way — only the commit boundaries differ. When no user is available, default by app size: one branch for a handful of links, route by route when the audit is big enough that reviewers need smaller diffs. Note the choice in your report.
 
-Enumerate the prefetch sites across the whole source tree, not only `app/` — they often live in `src/components` or shared UI packages: `rg -n '\bprefetch\b|router\.prefetch' -g '*.tsx' -g '*.jsx' .`. Keep the `<Link prefetch={true}>` and bare-prop matches (a bare prop is `true`) as the over-prefetching links this audit adopts destinations for, and drop `prefetch={false}` and other values. Also audit existing imperative [`router.prefetch()`](https://nextjs.org/docs/app/api-reference/functions/use-router#userouter) call sites with the same table, because they can be preserving the same "fetch before navigation" behavior and have no dev insight. For new navigation prefetching, prefer [`<Link>`](https://nextjs.org/docs/app/api-reference/components/link), which the docs call the primary navigation API; use [`router.prefetch()`](https://nextjs.org/docs/app/guides/prefetching#manual-prefetch) only for manual prefetching. If the app already passes an internal `kind` option, treat that as existing implementation detail, not a pattern to spread. Always inspect custom Link wrappers and trace their consumers: a wrapper can call `router.prefetch()` on hover or touch while a consumer omits `prefetch` or passes `prefetch={false}`. Record the declarative and imperative behavior separately, and use keyboard activation when verifying the declarative path so hover prefetching does not mask it. If nothing matches, say so in your report and move on to [step 2](#step-2-enable-the-flag).
+Enumerate explicit prefetch and manual prefetch sites across the whole source tree, not only `app/` — they often live in `src/components` or shared UI packages. Start from `next/link` imports and re-exports, then follow custom wrappers to their consumers. Use `rg -n '\bprefetch\b|router\.prefetch' -g '*.tsx' -g '*.jsx' .` as a candidate list, not as the complete audit; inspect conditional props and forwarded `LinkProps` to determine the effective production value. Include every audited navigation whose effective production Link value is `prefetch={true}`: explicit `true`, a bare `prefetch` prop, and expressions that resolve to `true`. Exclude the default value, `prefetch="auto"`, and `prefetch={false}` from the preservation suite because they do not request the legacy full prefetch. Audit existing [`router.prefetch()`](https://nextjs.org/docs/app/api-reference/functions/use-router#userouter) calls separately because they have no Link insight. For new manual prefetching, follow the [Prefetching guide](https://nextjs.org/docs/app/guides/prefetching#manual-prefetch). If no Link resolves to `prefetch={true}`, say so and move on to [step 4](#step-4-enable-the-flag).
 
-Then, for each one:
+### Choose what to preserve and how to verify it
 
-1. **Click each `<Link>` in `next dev`.** The insight fires at navigation time, not when the link prefetches, so a link sitting in the viewport won't trip it — you have to navigate through it. This click is _verification_: it confirms the insight fires before you adopt and clears after. Imperative `router.prefetch()` sites have no equivalent insight, so audit them from source and verify them in production ([step 4](#step-4-verify)). Without a browser, skip the click and adopt from [`instant-link-prefetch-partial`](https://nextjs.org/docs/messages/instant-link-prefetch-partial) and the audit table below — the destination's structure tells you the row, and type-check gates the edit — then leave the live confirmation for the hand-off.
-2. **Adopt the destination.** Add the temporary route config with a link to the migration guide. That clears the insight for every link pointing at it:
+Before writing tests or editing destinations, follow the guide's [migration guidance](https://nextjs.org/docs/app/guides/adopting-partial-prefetching#migrate-existing-full-prefetches) to propose the UI worth preserving. Present the result in one concise table:
 
-   ```tsx
-   // See: https://nextjs.org/docs/app/guides/adopting-partial-prefetching
-   export const prefetch = 'partial'
-   ```
+| Navigation | Proposed result |
+| ---------- | --------------- |
 
-   If the route reads URL data (`params`, `searchParams`), the default link still warms only its skeleton (the guide's [URL data](https://nextjs.org/docs/app/guides/adopting-partial-prefetching#url-data) section), so it's a per-link-prefetch candidate for step 5, not a finished adoption. Keep `prefetch={true}` on its links and mark the route:
+Group equivalent navigations. Summarize what will be ready immediately and what will stream. When a proposal is ambiguous, show the navigation in the running app and ask the user to confirm it. If they are unavailable, follow the guide and record the assumption.
 
-   ```tsx
-   // TODO(per-link-prefetch): assess with the user whether URL data should resolve before click.
-   // See: https://nextjs.org/docs/app/guides/optimizing-prefetching
-   export const prefetch = 'partial'
-   ```
+After the target UI is settled, inspect the existing test setup. The `instant()` helper comes from the separate [`@next/playwright`](https://nextjs.org/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests) package, not `next/experimental/testmode/playwright`.
 
-   Use that exact prefix so step 5 can grep them back. Don't cache or decide anything for these routes now.
+- **Applicable production-mode suite:** use test-backed preservation by default. Reuse the project's `@next/playwright` tests, production scripts, authentication, and existing `instant-nav.rig.md`. Follow the guide's [prefetched UI test workflow](https://nextjs.org/docs/app/guides/adopting-partial-prefetching#verify-prefetched-ui-with-tests) and make the complete flag-off suite green before adoption. The unchanged assertions drive the migration and stay as regression coverage.
+- **No applicable production-mode suite:** set up the production-mode rig in **`rig-template.md`** using the project's package manager and test conventions. This is part of test-backed adoption and does not require a user to be present.
+- **Rig cannot run reliably:** work through **`rig-template.md`** setup and liveness checks. Fall back to manual preservation only for a concrete blocker the repository cannot resolve, such as unavailable credentials or an inaccessible production environment. Record the blocker and the deferred test coverage; do not claim test-backed verification.
 
-3. **Preserve what that prefetch delivered.** The guide's [audit table](https://nextjs.org/docs/app/guides/adopting-partial-prefetching#auditing-link-prefetchtrue-calls) is the canonical decision — fetch it and apply the matching row. Caching uncached content is the judgment call in that table: trace where the data comes from and what freshness and revalidation it needs, per the [`use cache`](https://nextjs.org/docs/app/api-reference/directives/use-cache) docs, and ask the user when the answer isn't clear-cut. The URL-data routes you marked in the previous item wait for step 5.
+No user input is required to reuse an existing suite or create the rig. Ask only when the repository cannot answer an environment question or when the target UI itself is a product decision. If no user is available, use the guide's safe product default and reserve manual verification for a concrete rig blocker. Treat new prefetched UI as step 7 work; verify any deliberate removal separately after adoption.
 
-   If the repository already has `instant()` e2e coverage for a destination, run it before editing and preserve its assertion as the contract. A successful build or completed navigation does not prove that the same UI was prefetched. If caching the primary data loader still leaves only a fallback inside `instant()`, inspect rendered descendants and providers for dynamic work, then expand the cache only to the smallest coherent rendered subtree that restores the contract.
+This workflow is specific to a clicked `<Link>`. A direct call such as `router.prefetch('/dashboard')` is a manual prefetch, not a Link prefetch; keep it in the source audit and verify it separately in step 6.
+
+## step 2: capture the legacy baseline
+
+Do not enable `partialPrefetching` or edit route behavior, Link props, or cache boundaries during this step. Test-only configuration required to run `instant()` is allowed.
+
+For test-backed preservation, complete the [preservation gate](#preservation-gate): write the complete `instant()` suite and **run it** against the production-like rig with Partial Prefetching disabled. A test file, build, completed navigation, or command printed for the user is not a baseline. Do not continue to step 3 until the suite has actually passed.
+
+For manual preservation, finish the before/target inventory before editing any destination. Fall back to this path only for a concrete rig blocker identified through `rig-template.md`, and record the blocker and deferred tests.
+
+## step 3: adopt destinations and restore the target
+
+Adopt every audited destination with the temporary route config. The route export is enough for the unchanged tests to exercise Partial Prefetching on that destination while the global flag remains off:
+
+```tsx
+// See: https://nextjs.org/docs/app/guides/adopting-partial-prefetching
+export const prefetch = 'partial'
+```
+
+If other URL-specific UI might be worth prefetching but was not part of the legacy contract, keep `prefetch={true}` on its links and mark the route for step 7:
+
+```tsx
+// TODO(per-link-prefetch): assess with the user whether URL data should resolve before click.
+// See: https://nextjs.org/docs/app/guides/optimizing-prefetching
+export const prefetch = 'partial'
+```
+
+Use that exact prefix so step 7 can grep them back. Do not select new target UI now; restore only the target chosen from the legacy behavior.
+
+For test-backed preservation, rerun the affected **unchanged** tests after each destination changes and treat failures as the work queue. Run the complete suite and record its passing exit status before enabling the global flag. For manual preservation, compare the adopted production navigation with the selected target and document anything not yet restored. Apply the guide's matching preservation pattern for caching and Link-prop changes, and ask the user before making an unclear freshness or caching decision. New URL-data candidates marked above wait for step 7.
+
+When restoring the target changes caching or invalidation, follow the project's existing verification approach. Reuse or extend an applicable suite for the affected lifecycle, such as freshness after mutations, cache scope, or generated values. If the project doesn't test this type of behavior, do not introduce new test infrastructure during adoption; verify it manually in production and record the expected and observed results. A green `instant()` test proves readiness, not cache correctness. Ask the user only when the intended behavior is unclear.
 
 > **If you add `use cache`, verify under `next start`, not only the build.** A `cookies()`/`headers()`/session read anywhere in the cached call tree throws at request time while `next build` passes clean. See [`use cache`](https://nextjs.org/docs/app/api-reference/directives/use-cache).
 
-## step 2: enable the flag
+## step 4: enable the flag
 
 Once every audited destination has `prefetch = 'partial'`, finish in two moves.
 
 1. **Enable the flag globally.** Set `partialPrefetching: true` in `next.config.ts` (alongside `cacheComponents: true`). Every route is adopted now, so every link is good.
-2. **Strip the redundant `prefetch = 'partial'` exports.** Run the first-party `remove-partial-prefetch` codemod rather than a text find-and-replace. It removes only `export const prefetch = 'partial'` and its generated Partial Prefetching guide comment. It leaves other values such as `prefetch = 'force-disabled'` in place, along with your `TODO(per-link-prefetch)` markers and their Optimizing prefetching guide links, which wait for step 5.
+2. **Strip the redundant `prefetch = 'partial'` exports.** Run the first-party `remove-partial-prefetch` codemod rather than a text find-and-replace. It removes every `export const prefetch = 'partial'`, including exports below a `TODO(per-link-prefetch)` marker, and removes its generated Partial Prefetching guide comment. The TODO marker and its Optimizing prefetching guide link stay for step 7. Other values such as `prefetch = 'force-disabled'` stay in place.
 
    ```bash
-   npx @next/codemod@latest remove-partial-prefetch ./app
+   npx @next/codemod@canary remove-partial-prefetch ./app
    ```
 
-   The codemod refuses to run on a dirty working tree. Commit or stash unrelated work first, or pass `--force` to let its edits land alongside your WIP. If the codemod isn't available (older `@next/codemod`, sandboxed environment, offline run), reproduce it by hand by removing `export const prefetch = 'partial'` and its generated Partial Prefetching guide comment from every `app/**/{page,layout}.{js,jsx,ts,tsx}` — leave other `prefetch` values in place, and leave the `TODO(per-link-prefetch)` markers and Optimizing prefetching guide links where they are. Don't hand-edit when the codemod can run.
+   Use `./src/app` in a `src/` project and check the reported file count. The codemod refuses to run on a dirty working tree. Commit or stash unrelated work first, or pass `--force` to let its edits land alongside your WIP. If the codemod isn't available (older `@next/codemod`, sandboxed environment, offline run), reproduce it by hand by removing `export const prefetch = 'partial'` and its generated Partial Prefetching guide comment from every `app/**/{page,layout}.{js,jsx,ts,tsx}` — leave other `prefetch` values in place, and leave the `TODO(per-link-prefetch)` markers and Optimizing prefetching guide links where they are. Don't hand-edit when the codemod can run.
 
-## step 3: sweep for URL-data insights (after enabling)
+After the flag and codemod land together, rerun the locked preservation suite when using the test-backed path. Otherwise repeat the documented production comparisons under the final global configuration.
 
-This is a dev-only second pass. The shell check runs only with the flag on, fires at navigation time, and never blocks the build, so it can happen any time after step 2. Build the route queue from a concrete source (the last `next build` route table, or the `app/` tree) and keep it as a todo list.
+## step 5: sweep for URL-data insights (after enabling)
+
+This is a dev-only second pass. The shell check runs only with the flag on, fires at navigation time, and never blocks the build, so it can happen any time after step 4. Build the route queue from a concrete source (the last `next build` route table, or the `app/` tree) and keep it as a todo list.
 
 Sweep feature by feature. A feature is a single product surface — `app/settings/**`, `app/posts/[slug]/**` — not a whole top-level area. Finish one end-to-end before starting the next: load its routes in `next dev` and resolve their insights. The insight never blocks the build and each route is independent, so a partial sweep leaves a working app, and each feature is a self-contained change the user can review or ship on its own.
 
-If the environment can't finish the whole sweep (slow first compiles, a dev server that falls over under load, no browser at all), take the browser-free work as far as it goes before handing off. Adopt every route you can statically: apply the fix from [`URL data`](https://nextjs.org/docs/messages/instant-shell-url-data) (up to a new `<Suspense>` boundary) and opt the route into `prefetch = 'partial'`, gating on type-check. Work the whole queue in one pass — a larger refactor isn't a reason to defer, and asking whether to continue to the next route or tier isn't a checkpoint; keep going. Stop only for a genuine judgment call, and batch those into the single hand-off report: the routes you statically adopted, the ones still needing a live shell check, and the queue.
+If the environment can't finish the whole sweep (slow first compiles, a dev server that falls over under load, no browser at all), take the browser-free work as far as it goes before handing off. Adopt every route you can statically: apply the fix from [`URL data`](https://nextjs.org/docs/messages/instant-shell-url-data) up to a new `<Suspense>` boundary, gating on type-check. Work the whole queue in one pass — a larger refactor isn't a reason to defer, and asking whether to continue to the next route or tier isn't a checkpoint; keep going. Stop only for a genuine judgment call, and batch those into the single hand-off report: the routes you statically adopted, the ones still needing a live shell check, and the queue.
 
 Watch the Insights tab and the dev log for `Next.js encountered … data` lines. The signal this step adds is [`URL data`](https://nextjs.org/docs/messages/instant-shell-url-data): a `params` or `searchParams` read too high in the suspended subtree ties the shared shell to one URL. This insight is narrow; it most reliably appears on a `generateStaticParams` route where `params` is already under `<Suspense>`, but still awaited before the URL-specific leaf boundary. If a `blocking-prerender-*` error fires instead, apply the same structural fix.
 
@@ -111,13 +145,15 @@ Loading a route with the flag on prerenders its App Shell, which validates more 
 
 These fixes rarely involve the user — each insight names the offending read and its docs page has the fix, so apply it and keep sweeping. Collect the rare exceptions for one batched question at the end: a page that is entirely one URL-dependent region (wrapping it all leaves an empty shell), or a route that should arguably stay opted out. Don't narrate the refactor with comments — the `<Suspense>` boundaries speak for themselves.
 
-## step 4: verify
+## step 6: verify
 
 Checklist before checking in with the user:
 
 - **An empty sweep is expected when Cache Components adoption finished cleanly.** A quiet log is success, not a missing signal. If you deliberately probe the validation path, use a `generateStaticParams` route with `params` read inside `<Suspense>` but before the URL-specific leaf boundary; other shapes may surface `blocking-prerender-*` instead.
 - The App Shells are real: for each route you changed, confirm the first paint after a navigation shows the intended shared content, not an empty shell or a stuck fallback. A `<Suspense>` around the whole page body passes validation with an empty shell, which defeats the point.
-- The insights validate shell _structure_, not that a prefetch actually happened. Confirm on the production run (prefetching is prod-only) that navigating a changed link lands on the shared shell instantly.
+- The insights validate shell _structure_, not that a prefetch actually happened. Confirm on the production run (automatic prefetching runs only in production) that navigating a changed link lands on the shared shell instantly.
+- For test-backed preservation, every locked `instant()` test for an audited `<Link prefetch={true}>` passes against the production run. For manual preservation, the before/after inventory and any deferred test follow-ups are recorded.
+- Any caching or invalidation changed to preserve the target is verified through an applicable existing test suite or a recorded manual check when the project has no such coverage.
 - **If the app prefetches imperatively**, the insight sweep does not cover it, so an empty sweep is not proof the prefetch survived the flag. Verify the call under `next start`: compare the `_rsc` prefetch response or resource timing before/after, and make sure any intentionally preserved full prefetch still carries the data the old call was warming. If it now returns only the App Shell, migrate that call site using the same decision as the nearest `<Link prefetch={true}>` destination — cache the data, or move per-link-prefetch behavior to a docs-supported `<Link prefetch={true}>`.
 - **Before blaming a broken route on the flag, reproduce it with `partialPrefetching` off** (or on the pre-flag branch). The flag surfaces existing issues — a fragile request-time auth gate, a rewrite, deployment skew — earlier and more visibly, but rarely causes them. If it breaks flag-off too, it isn't a Partial Prefetching problem; fix it there, not here.
 - `next build` still passes.
@@ -126,19 +162,23 @@ Then check in with the user. Speak their language — no insight slugs or step l
 
 - What you did: which links you audited, which destinations you adopted, and what each link now prefetches.
 - What changed: dropped props, `use cache` boundaries added, and which routes carry a `TODO(per-link-prefetch)` marker for later.
-- Demo against a production run. Prefetching is limited in development, so `next dev` won't show the result — run `next build` and `next start`, and hand the user that URL. That run needs the app's real environment (database, auth, secrets), and a partial or stale install or leftover generated artifacts can fail the build for reasons unrelated to the adoption. Set the expectation up front that verification is a complete, credentialed production run, not a quick check.
+- Demo against a production run. Automatic prefetching runs only in production, so `next dev` won't show the result — run `next build` and `next start`, and hand the user that URL. That run needs the app's real environment (database, auth, secrets), and a partial or stale install or leftover generated artifacts can fail the build for reasons unrelated to the adoption. Set the expectation up front that verification is a complete, credentialed production run, not a quick check.
 - Show, don't tell: drive one link live in the headed browser against the production server, so they see the shared App Shell paint instantly and the URL-specific region stream in. Attach before/after screenshots only when a live browser isn't possible.
 - Give them the click-through: a table of each changed route — the link to click, and what to expect after the click (what paints instantly, what streams in) — so they can verify each result themselves.
 - The question: "Want to commit this (or open the PR) before we look at which routes should also prefetch their URL-specific content?" Wait for the answer — adoption and per-link prefetching read best as their own changes.
 
-## step 5: per-link prefetching (optional)
+## step 7: per-link prefetching (optional)
 
-The audit marked the candidates instead of deciding them. Grep for `TODO(per-link-prefetch)` and walk the list with the user in one conversation. The question per route is whether they want the URL-dependent content prefetched ahead of the click, or streaming in after navigation is fine. A per-link prefetch costs a server invocation per prefetchable link — the guide's [trade-offs](https://nextjs.org/docs/app/guides/optimizing-prefetching#trade-offs) section is the checklist. Don't make these calls alone.
+The audit marked candidates beyond the already-preserved legacy contract instead of deciding them. Grep for `TODO(per-link-prefetch)` and walk the list with the user in one conversation. The question per route is whether they want the additional URL-dependent content prefetched ahead of the click, or streaming in after navigation is fine. A per-link prefetch costs a server invocation per prefetchable link — the guide's [trade-offs](https://nextjs.org/docs/app/guides/optimizing-prefetching#trade-offs) section is the checklist. Don't make these calls alone.
 
-Where the answer is yes, follow the [Optimizing prefetching guide](https://nextjs.org/docs/app/guides/optimizing-prefetching): keep [`<Link prefetch={true}>`](https://nextjs.org/docs/app/api-reference/components/link#prefetch) on the links that should resolve more than the App Shell, and cache the content behind the URL-data read using the guide's patterns (`use cache` with the runtime value passed in, or `use cache: private` for per-user data). Each per-link prefetch is a server render when the destination needs non-static data, so use the guide's [per-link trade-offs](https://nextjs.org/docs/app/guides/optimizing-prefetching#trade-offs) to decide when viewport prefetching is worth it and when [hover-triggered prefetch](https://nextjs.org/docs/app/guides/prefetching#hover-triggered-prefetch) is a better fit. Where it's no, delete the marker and leave the route on the App Shell default. Either way no `TODO(per-link-prefetch)` marker survives this step. Confirm the opted-in links against a production run (`next build` and `next start` — the per-link prefetch runs there, not in `next dev`), give the user the same click-through for them, and keep this as its own commit or PR.
+Where the answer is no, delete the marker and leave the route on the App Shell default. Where the answer is yes, follow the [Optimizing prefetching guide](https://nextjs.org/docs/app/guides/optimizing-prefetching), confirm the opted-in link against a production run, and delete the marker when the selected result is verified.
+
+No `TODO(per-link-prefetch)` marker survives the finished step. Per-link optimization remains a separate commit or PR from adoption.
+
+Finally, show any effective `prefetch={false}` links in a concise `Navigation | Why it may no longer be needed` table. Explain that `false` disables all prefetching, while Partial Prefetching's default `auto` behavior prefetches only the shared App Shell, so opt-outs added to avoid legacy full-route prefetching may now be unnecessary. Invite the user to revisit them separately.
 
 ## further reading
 
 - [Instant navigation](https://nextjs.org/docs/app/guides/instant-navigation) — the broader validation model and loading-state tooling.
-- [Prevent regressions with e2e tests](https://nextjs.org/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests) — the `@next/playwright` `instant()` helper locks in what a navigation shows immediately; recommend it once the sweep is clean, since nothing else guards these in CI.
+- [Prevent regressions with e2e tests](https://nextjs.org/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests) — use the `@next/playwright` `instant()` helper to build the flag-off baseline suite, then keep it as the CI regression guard.
 - [`next-cache-components-optimizer`](https://github.com/vercel/next.js/tree/canary/skills/next-cache-components-optimizer) — grows each route's static shell so the App Shell carries more.

--- a/skills/next-partial-prefetching-adoption/rig-template.md
+++ b/skills/next-partial-prefetching-adoption/rig-template.md
@@ -1,0 +1,172 @@
+# Production `instant()` rig
+
+The preservation suite needs a production build that exposes the Next.js
+testing API, a stable URL for that build, and a Playwright command that can
+drive the audited Links. Discover this setup once, record it in
+`instant-nav.rig.md`, and reuse it throughout adoption.
+
+Read an existing `instant-nav.rig.md` before creating one. Inspect the
+repository before asking the user:
+
+- `package.json` scripts for build, start, and end-to-end tests
+- `playwright.config.*` for `baseURL`, `webServer`, projects, and authentication
+- `next.config.*` for existing `experimental` options
+- CI, preview deployment, container, and hosting configuration
+- test helpers for login, `storageState`, fixtures, flags, and seeded data
+
+Ask only for details the repository cannot answer, such as unavailable
+credentials or which remote environment may expose the testing API.
+
+## What the rig must define
+
+### Production build and server
+
+Use `next build` followed by `next start`, or a remote artifact produced by the
+same production build. Automatic prefetching does not run in `next dev`, so a
+development server cannot verify preservation.
+
+Record separate build and start commands. For a local rig, record the port,
+stop any previous server before starting, fail on `EADDRINUSE`, and confirm the
+new process owns the port before running Playwright. `next start` can fork a
+`next-server` child, so the launcher process ID may not own the port. Start the
+server in a process group that the rig can stop as a unit, or discover and stop
+the process listening on the recorded port before the next build.
+
+### Testing API
+
+An `instant()` test against a production build requires
+`experimental.exposeTestingApiInProductionBuild`. Gate it so real production
+builds do not expose the API:
+
+```ts filename="next.config.ts" highlight={3,8-10}
+import type { NextConfig } from 'next'
+
+const exposeTestingApi = process.env.EXPOSE_TESTING_API === '1'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    exposeTestingApiInProductionBuild: exposeTestingApi,
+  },
+}
+
+export default nextConfig
+```
+
+Merge the option into an existing `experimental` object instead of replacing
+the project's other experimental options.
+
+Set the condition while running `next build`. Setting it only for `next start`
+is too late because the testing API is compiled into the production artifact.
+When the artifact was built without it, Next.js does not activate the
+navigation lock, so the test cannot distinguish prefetched UI from streamed
+dynamic content. Rebuild with the condition enabled before interpreting the
+results. Use the project's existing environment naming when it already
+distinguishes test, staging, preview, and production builds.
+
+### Test command and base URL
+
+Record the exact Playwright command and how it receives the measured build's
+URL. Reuse the project's package manager, Playwright configuration, projects,
+and reporters. The suite must import `instant()` from `@next/playwright`. If
+the dependencies are absent, install `@next/playwright` on the same release
+line as the project's `next`, alongside `@playwright/test`.
+
+For a local rig, a typical sequence is:
+
+```bash filename="Terminal"
+EXPOSE_TESTING_API=1 pnpm build
+pnpm start --port 3000
+BASE_URL=http://localhost:3000 pnpm playwright test tests/prefetch-preservation.spec.ts
+```
+
+Adapt the script names and port to the project. Keep the production server
+running while the test command executes. Follow the public
+[client-navigation test](https://nextjs.org/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests): load the source route, confirm the real
+Link is visible, then enter `instant()`, click, wait for the destination URL,
+and assert the prefetched UI.
+
+### Test context
+
+Record the state required to reach the audited Links and destination UI:
+
+- Use `public; no authentication` when the navigation is public.
+- Otherwise record the test account and login mechanism, including a fixture,
+  `storageState`, API login, or seeded session.
+- Record flags, plan, role, locale, seeded data, and other state that can change
+  which UI the test sees.
+
+A test user is not required. The field exists to make authenticated and
+state-dependent tests reproducible when the app needs one.
+
+### Drift
+
+List differences between the state used to choose the preservation target and
+the state used by Playwright. Feature flags, permissions, empty test data, and
+locale differences can make an assertion fail because the target is
+unreachable, not because Partial Prefetching removed it. Write `none known`
+only after checking the test context.
+
+### Iteration loop
+
+Record the complete loop the agent can repeat without rediscovering commands:
+
+- Local: build with the testing API, start the new artifact, run the focused
+  suite, stop the server, edit, and repeat.
+- Remote: push, wait for the measured artifact, verify it matches `HEAD`, run
+  the focused suite against its URL, edit, and repeat.
+
+Note any step the agent cannot perform without the user, including deployment
+approval, protected branches, secrets, or multi-factor authentication.
+
+### Artifact liveness
+
+For a remote rig, record how the test proves the deployment matches `HEAD`.
+Prefer an endpoint or response header that exposes the deployed commit SHA. If
+the app has neither, use the deployment provider's API to select the artifact
+whose commit SHA matches `HEAD`.
+
+A freshly completed local `build` followed by `start` does not need a SHA
+probe. Record `n/a; local build and start`.
+
+### Walls
+
+Record build and run obstacles with their working resolution, such as required
+environment variables, server-only imports that fail during prerendering,
+unavailable credentials, or a process that keeps reclaiming the test port.
+Reuse these notes on the next iteration.
+
+## Write `instant-nav.rig.md`
+
+Place this file at the repository root or next to the end-to-end configuration:
+
+```md
+# instant-nav rig: <project>
+
+- BUILD: <commands or platform that builds and serves the measured production artifact>
+- EXPOSE: <condition that enables exposeTestingApiInProductionBuild during build>
+- RUN: <focused Playwright command and how it receives BASE_URL>
+- TEST USER: <public/no auth, or account and login>; state: <flags, role, data, locale>
+- DRIFT: <differences that could change the asserted UI>
+- LOOP: <local build → start → test, or push → deploy → test>; agent limits: <...>
+- LIVENESS: <deployed SHA check, or n/a for a local build and start>
+- WALLS: <project-specific obstacles and their resolutions>
+```
+
+Every field needs a concrete value. `n/a` is valid only with a reason, such as
+`TEST USER: public; no authentication` or `LIVENESS: n/a; local build and
+start`.
+
+## Check the rig before writing the baseline
+
+Before recording the legacy prefetched UI:
+
+1. Build with the testing API condition enabled.
+2. Start or locate that exact artifact and confirm the base URL responds.
+3. Run one focused `instant()` smoke test through a real `<Link>` navigation.
+4. Confirm the test can reach its source Link and eventual destination UI in
+   the recorded test context.
+
+Fix the rig before interpreting a preservation failure. A missing testing API,
+stale deployment, unreachable target, or wrong test state is an environment
+failure rather than evidence that the migration changed the prefetch.


### PR DESCRIPTION
## Summary

- docs: explain origin matching for allowedOrigins and allowedDevOrigins (#97805)
- docs: improve discovery summaries (#97982)
- docs(skills): preserve prefetched UI during Partial Prefetching adoption (#97712)
- docs: add layout stability guidance for videos and iframes (#98070)
- docs: document preloading with Cache Components (#97864)
- docs: note that experimental.taint taints process.env (#98145)
- docs: add API reference pages for skipProxyUrlNormalize and skipTrailingSlashRedirect (#97967)
- docs: keep generateStaticParams during Cache Components migration (docs part of #98209)
- docs: Remove version label from Turbopack in Pages Router (#98316)