### PR TITLE
Make next-dev-loop browser headless by default

### DIFF
--- a/skills/next-cache-components-adoption/SKILL.md
+++ b/skills/next-cache-components-adoption/SKILL.md
@@ -202,7 +202,7 @@ Per route:
 ### loop notes
 
 - The [three blocker classes from background](#background) often get missed when fixing in place. Caching a downstream fetch (`getThing(id)`) doesn't clear an `await params` at the top of the page body — push the param promise into the `<Suspense>`-wrapped child.
-- Ambiguous calls are user check-ins, not agent judgment. When you're not sure which fix fits, the blocking code looks security-sensitive, or the user might want to keep the route blocking on purpose — read [references/per-page-decisions.md](./references/per-page-decisions.md) before editing. Show the route while you ask: the `next-dev-loop` session runs the browser headed, so drive to the page and leave it on screen so the user is looking at the thing they're deciding about, with a screenshot as the fallback when a headed browser isn't possible. "Should this stay blocking?" is much easier to answer while looking at the page than at a file path.
+- Ambiguous calls are user check-ins, not agent judgment. When you're not sure which fix fits, the blocking code looks security-sensitive, or the user might want to keep the route blocking on purpose — read [references/per-page-decisions.md](./references/per-page-decisions.md) before editing. Show the route while you ask: leave it on screen when the harness exposes the browser, with a screenshot as the fallback. "Should this stay blocking?" is much easier to answer while looking at the page than at a file path.
 - Don't narrate the refactor with comments. The only comment the codemod (or you) should leave is `// TODO: Cache Components adoption` on opt-outs, and the user's existing comments. Don't annotate every `<Suspense>` boundary or `"use cache"` call with what it does — the code says that. Drop a comment only when the _why_ isn't clear from the code (e.g. a deliberate Block with a reason).
 - For many routes with the same mechanical fix, verify one representative route first. Then batch disjoint route groups using the same recipe, and run the shared build and browser checks together.
 
@@ -221,7 +221,7 @@ Then check in with the user. Same rule as the pre-step: speak their language. Do
 
 - What you did: which routes you touched, and the user-visible result per route (e.g. "the post page now streams the article body behind a skeleton while the layout stays static").
 - What changed: opt-outs removed, fallbacks added, caching boundaries introduced.
-- Show, don't tell. The `next-dev-loop` session runs the browser headed, so drive the route live for the user so they see the static shell → fallback → final content sequence in real time. If you can't drive a live browser, attach the before/after screenshots you captured instead.
+- Show, don't tell. When the harness exposes the browser, drive the route live so the user sees the static shell → fallback → final content sequence in real time. Otherwise, attach the before/after screenshots you captured.
 - Give them the click-through: a short table of the feature's routes — the URL to open and what to look for (what renders instantly, which fallbacks appear, what streams in) — so they can verify each one themselves.
 - The question: "Want to open this feature as a PR and move on to the next, or stop here?" Wait for the answer.
 

--- a/skills/next-dev-loop/SKILL.md
+++ b/skills/next-dev-loop/SKILL.md
@@ -65,7 +65,7 @@ Once per session, confirm both views are live.
    Then open the target URL:
 
    ```bash
-   agent-browser --session "$SESSION" --restore --headed --enable react-devtools open <url>
+   agent-browser --session "$SESSION" --restore --enable react-devtools open <url>
    ```
 
    `--scope worktree` keeps parallel worktrees and copied checkouts
@@ -75,11 +75,11 @@ Once per session, confirm both views are live.
    launch flags on `open`; agent-browser will reuse, relaunch, or restart
    its scoped background state as needed.
 
-   The browser is the user's. If state was not restored (first run,
-   expired session) and the page is gated, the user drives the login —
+   If state was not restored (first run, expired session) and the page is
+   gated, let the user log in through the harness's browser controls, then
    pause until they confirm. After login, continue using the same session
-   and restore context; `agent-browser close` saves the cookie state so
-   the next `open` restores it.
+   and restore context; `agent-browser close` saves the cookie state so the
+   next `open` restores it.
 
 2. Probe `/_next/mcp` (`tools/list`) — confirm it's reachable and
    lists `get_compilation_issues`. First read the port off the


### PR DESCRIPTION
## Summary

Remove `--headed` from `next-dev-loop` and make related browser guidance defer to the harness.

## Verification

- `pnpm prettier --with-node-modules --ignore-path .prettierignore --check skills/next-dev-loop/SKILL.md skills/next-cache-components-adoption/SKILL.md`
- Not run: test suite (skill instructions only)

<!-- NEXT_JS_LLM -->
