### PR TITLE
docs: document output values, fix redirect try/catch and JSDoc drift

### DIFF
--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -1583,8 +1583,8 @@ export default async function handler(
 
   // Check if the user has the 'admin' role
   if (session.user.role !== 'admin') {
-    res.status(401).json({
-      error: 'Unauthorized access: User does not have admin privileges.',
+    res.status(403).json({
+      error: 'Forbidden: User does not have admin privileges.',
     })
     return
   }
@@ -1608,8 +1608,8 @@ export default async function handler(req, res) {
 
   // Check if the user has the 'admin' role
   if (session.user.role !== 'admin') {
-    res.status(401).json({
-      error: 'Unauthorized access: User does not have admin privileges.',
+    res.status(403).json({
+      error: 'Forbidden: User does not have admin privileges.',
     })
     return
   }

--- a/docs/01-app/02-guides/upgrading/version-15.mdx
+++ b/docs/01-app/02-guides/upgrading/version-15.mdx
@@ -57,6 +57,8 @@ bun add next@latest react@latest react-dom@latest eslint-config-next@latest
 
 > **Good to know:** If you are using TypeScript, ensure you also upgrade `@types/react` and `@types/react-dom` to their latest versions.
 
+<AppOnly>
+
 ## Async Request APIs (Breaking change)
 
 Previously synchronous Request-time APIs that rely on request information are now **asynchronous**:
@@ -472,13 +474,9 @@ export async function GET(request, segmentData) {
 }
 ```
 
-<AppOnly>
-
 ## `runtime` configuration (Breaking change)
 
 The `runtime` [segment configuration](/docs/app/api-reference/file-conventions/route-segment-config/runtime) previously supported a value of `experimental-edge` in addition to `edge`. Both configurations refer to the same thing, and to simplify the options, we will now error if `experimental-edge` is used. To fix this, update your `runtime` configuration to `edge`. A [codemod](/docs/app/guides/upgrading/codemods#app-dir-runtime-config-experimental-edge) is available to automatically do this.
-
-</AppOnly>
 
 ## `fetch` requests
 
@@ -541,6 +539,8 @@ module.exports = nextConfig
 ```
 
 [Layouts](/docs/app/api-reference/file-conventions/layout) and [loading states](/docs/app/api-reference/file-conventions/loading) are still cached and reused on navigation.
+
+</AppOnly>
 
 ## `next/font`
 

--- a/docs/01-app/03-api-reference/03-file-conventions/route.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/route.mdx
@@ -309,6 +309,8 @@ export async function GET(request) {
 }
 ```
 
+Because [`redirect`](/docs/app/api-reference/functions/redirect) throws, call it **outside** the `try` block when using `try/catch` statements. A `try/catch` around the call suppresses the redirect. If you need to catch errors near the call, use [`unstable_rethrow`](/docs/app/api-reference/functions/unstable_rethrow) to let the interrupt through first.
+
 ### Dynamic Route Segments
 
 Route Handlers can use [Dynamic Segments](/docs/app/api-reference/file-conventions/dynamic-routes) to create request handlers from dynamic data.

--- a/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
@@ -194,7 +194,7 @@ export function InteractiveComponent() {
 > - If metadata doesn't depend on request information, it should be defined using the static [`metadata` object](#the-metadata-object) rather than `generateMetadata`.
 > - `fetch` requests are automatically memoized for the same data across `generateMetadata`, `generateStaticParams`, Layouts, Pages, and Server Components. React [`cache` can be used](https://react.dev/reference/react/cache) if `fetch` is unavailable.
 > - `searchParams` are only available in `page.js` segments.
-> - The [`redirect()`](/docs/app/api-reference/functions/redirect) and [`notFound()`](/docs/app/api-reference/functions/not-found) Next.js methods can also be used inside `generateMetadata`.
+> - The [`redirect()`](/docs/app/api-reference/functions/redirect) and [`notFound()`](/docs/app/api-reference/functions/not-found) Next.js methods can also be used inside `generateMetadata`. A redirect thrown here does not produce an HTTP redirect response: the route responds with a 200 and the redirect is performed on the client, so it requires JavaScript. If the page component redirects as well, the page's redirect is the one that takes effect. Redirect from the page component, or from [Proxy](/docs/app/api-reference/file-conventions/proxy), when you need an HTTP redirect.
 
 ### Metadata Fields
 

--- a/docs/01-app/03-api-reference/04-functions/permanentRedirect.mdx
+++ b/docs/01-app/03-api-reference/04-functions/permanentRedirect.mdx
@@ -45,7 +45,7 @@ The `type` parameter has no effect when used in Server Components.
 
 ## Behavior
 
-- In Server Actions and Route Handlers, `permanentRedirect` should be called **outside** the `try` block when using `try/catch` statements because it throws an error.
+- Because `permanentRedirect` throws, call it **outside** the `try` block when using `try/catch` statements. A `try/catch` around the call suppresses the redirect. If you need to catch errors near the call, use [`unstable_rethrow`](/docs/app/api-reference/functions/unstable_rethrow) to let the interrupt through first.
 - If you prefer to return a 307 (Temporary) HTTP redirect instead of 308 (Permanent), you can use the [`redirect` function](/docs/app/api-reference/functions/redirect) instead.
 
 ## Example

--- a/docs/01-app/03-api-reference/04-functions/redirect.mdx
+++ b/docs/01-app/03-api-reference/04-functions/redirect.mdx
@@ -53,6 +53,7 @@ The `type` parameter has no effect when used in Server Components.
 - `redirect` can be called in Client Components during the rendering process but not in event handlers. You can use the [`useRouter` hook](/docs/app/api-reference/functions/use-router) instead.
 - An error boundary of your own that wraps the calling component catches the redirect on a client-side navigation, and the fallback renders instead of the navigation happening. The initial server render is not affected. Keep your error boundaries outside components that redirect during rendering.
 - Calling `redirect` in [`generateMetadata`](/docs/app/api-reference/functions/generate-metadata) does not produce an HTTP redirect response. The route responds with a 200 and the redirect happens on the client. A redirect from the page component takes precedence over one from `generateMetadata`.
+- Redirecting to the route you are already on remounts the page segment, so client state in the page is reset. State in layouts above the page is preserved. A client-side navigation to the same route with different search params keeps the page mounted.
 - `redirect` also accepts absolute URLs and can be used to redirect to external links.
 - If you'd like to redirect before the render process, use [`next.config.js`](/docs/app/guides/redirecting#redirects-in-nextconfigjs) or [Proxy](/docs/app/guides/redirecting#nextresponseredirect-in-proxy).
 

--- a/docs/01-app/03-api-reference/04-functions/redirect.mdx
+++ b/docs/01-app/03-api-reference/04-functions/redirect.mdx
@@ -51,6 +51,8 @@ The `type` parameter has no effect when used in Server Components.
 - Because `redirect` throws, call it **outside** the `try` block when using `try/catch` statements. A `try/catch` around the call suppresses the redirect. If you need to catch errors near the call, use [`unstable_rethrow`](/docs/app/api-reference/functions/unstable_rethrow) to let the interrupt through first.
 - If you prefer to return a 308 (Permanent) HTTP redirect instead of 307 (Temporary), you can use the [`permanentRedirect` function](/docs/app/api-reference/functions/permanentRedirect) instead.
 - `redirect` can be called in Client Components during the rendering process but not in event handlers. You can use the [`useRouter` hook](/docs/app/api-reference/functions/use-router) instead.
+- An error boundary of your own that wraps the calling component catches the redirect on a client-side navigation, and the fallback renders instead of the navigation happening. The initial server render is not affected. Keep your error boundaries outside components that redirect during rendering.
+- Calling `redirect` in [`generateMetadata`](/docs/app/api-reference/functions/generate-metadata) does not produce an HTTP redirect response. The route responds with a 200 and the redirect happens on the client. A redirect from the page component takes precedence over one from `generateMetadata`.
 - `redirect` also accepts absolute URLs and can be used to redirect to external links.
 - If you'd like to redirect before the render process, use [`next.config.js`](/docs/app/guides/redirecting#redirects-in-nextconfigjs) or [Proxy](/docs/app/guides/redirecting#nextresponseredirect-in-proxy).
 

--- a/docs/01-app/03-api-reference/04-functions/redirect.mdx
+++ b/docs/01-app/03-api-reference/04-functions/redirect.mdx
@@ -48,9 +48,8 @@ The `type` parameter has no effect when used in Server Components.
 
 ## Behavior
 
-- In Server Actions and Route Handlers, redirect should be called **outside** the `try` block when using `try/catch` statements.
+- Because `redirect` throws, call it **outside** the `try` block when using `try/catch` statements. A `try/catch` around the call suppresses the redirect. If you need to catch errors near the call, use [`unstable_rethrow`](/docs/app/api-reference/functions/unstable_rethrow) to let the interrupt through first.
 - If you prefer to return a 308 (Permanent) HTTP redirect instead of 307 (Temporary), you can use the [`permanentRedirect` function](/docs/app/api-reference/functions/permanentRedirect) instead.
-- `redirect` throws an error so it should be called **outside** the `try` block when using `try/catch` statements.
 - `redirect` can be called in Client Components during the rendering process but not in event handlers. You can use the [`useRouter` hook](/docs/app/api-reference/functions/use-router) instead.
 - `redirect` also accepts absolute URLs and can be used to redirect to external links.
 - If you'd like to redirect before the render process, use [`next.config.js`](/docs/app/guides/redirecting#redirects-in-nextconfigjs) or [Proxy](/docs/app/guides/redirecting#nextresponseredirect-in-proxy).

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/output.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/output.mdx
@@ -1,9 +1,20 @@
 ---
 title: output
-description: Next.js automatically traces which files are needed by each page to allow for easy deployment of your application. Learn how it works here.
+description: Configure how Next.js builds your application for deployment with the `output` option, and learn how output file tracing works.
 ---
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
+
+The `output` config option accepts two values:
+
+| Value          | Description                                                                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `'standalone'` | Copies only the files needed for a production deployment into a `standalone` folder. See [Automatically Copying Traced Files](#automatically-copying-traced-files) below. |
+| `'export'`     | Produces a static site that can be served without a Node.js server. See the [Static Exports](/docs/app/guides/static-exports) guide.                                      |
+
+Leaving `output` unset produces the default build, which requires a Node.js server to run `next start`.
+
+The rest of this page covers output file tracing, which is what `'standalone'` builds on.
 
 During a build, Next.js will automatically trace each page and its dependencies to determine all of the files that are needed for deploying a production version of your application.
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/redirects.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/redirects.mdx
@@ -38,6 +38,8 @@ module.exports = {
 
 Redirects are checked before the filesystem which includes pages and `/public` files.
 
+The `redirects` function runs at build time, so the returned list is baked into the build output. A redirect that needs to change per request, or based on runtime values, belongs in [Proxy](/docs/app/api-reference/file-conventions/proxy) instead.
+
 When using the Pages Router, redirects are not applied to client-side routing (`Link`, `router.push`) unless [Proxy](/docs/app/api-reference/file-conventions/proxy) is present and matches the path.
 
 When a redirect is applied, any query values provided in the request will be passed through to the redirect destination. For example, see the following redirect configuration:

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/rewrites.mdx
@@ -95,7 +95,7 @@ The order Next.js routes are checked is:
 5. static files from the [public directory](/docs/app/api-reference/file-conventions/public-folder), `_next/static` files, and non-dynamic pages are checked/served
 6. `afterFiles` rewrites are tried in order. If a `source`, `has`, and `missing` matches the request, it's rewritten to `destination`; the first rewrite that resolves to a static file, page, or dynamic route is served.
 7. dynamic routes (e.g., `app/blog/[slug]/page.tsx`) are matched against the current path
-8. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked. If you use [fallback: true/'blocking'](/docs/pages/api-reference/functions/get-static-paths#fallback-true) in `getStaticPaths`, those dynamic routes take priority over the fallback `rewrites` defined in your `next.config.js`.
+8. `fallback` rewrites are checked/applied, these are applied before rendering the 404 page and after dynamic routes/all static assets have been checked. With the default [`dynamicParams: true`](/docs/app/api-reference/file-conventions/route-segment-config/dynamicParams), a matching dynamic route takes priority over the fallback `rewrites` defined in your `next.config.js`. With `dynamicParams: false`, params that were not returned by [`generateStaticParams`](/docs/app/api-reference/functions/generate-static-params) fall through to the fallback `rewrites`.
 
 </AppOnly>
 
@@ -161,7 +161,11 @@ module.exports = {
 }
 ```
 
+<PagesOnly>
+
 > **Good to know**: Static pages from [Automatic Static Optimization](/docs/pages/building-your-application/rendering/automatic-static-optimization) or [prerendering](/docs/pages/building-your-application/data-fetching/get-static-props) params from rewrites will be parsed on the client after hydration and provided in the query.
+
+</PagesOnly>
 
 ## Path Matching
 

--- a/docs/01-app/03-api-reference/05-config/03-eslint.mdx
+++ b/docs/01-app/03-api-reference/05-config/03-eslint.mdx
@@ -183,6 +183,17 @@ const eslintConfig = defineConfig([
 export default eslintConfig
 ```
 
+To turn a rule off for a single file or line instead, use ESLint's [inline comments](https://eslint.org/docs/latest/use/configure/rules#disabling-rules):
+
+```jsx filename="app/page.js"
+export default function Page() {
+  // eslint-disable-next-line @next/next/no-img-element
+  return <img src="/hero.png" alt="Hero" />
+}
+```
+
+Place `/* eslint-disable @next/next/no-img-element */` at the top of a file to turn the rule off for that whole file.
+
 ### With Core Web Vitals
 
 Enable the `eslint-config-next/core-web-vitals` configuration in your ESLint config.

--- a/docs/02-pages/02-guides/upgrading/version-15.mdx
+++ b/docs/02-pages/02-guides/upgrading/version-15.mdx
@@ -1,0 +1,8 @@
+---
+title: How to upgrade to version 15
+nav_title: Version 15
+description: Upgrade your Next.js Application from Version 14 to 15.
+source: app/guides/upgrading/version-15
+---
+
+{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/docs/02-pages/02-guides/upgrading/version-16.mdx
+++ b/docs/02-pages/02-guides/upgrading/version-16.mdx
@@ -1,0 +1,8 @@
+---
+title: How to upgrade to version 16
+nav_title: Version 16
+description: Upgrade your Next.js Application from Version 15 to 16.
+source: app/guides/upgrading/version-16
+---
+
+{/* DO NOT EDIT. The content of this doc is generated from the source above. To edit the content of this page, navigate to the source page in your editor. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}

--- a/errors/no-html-link-for-pages.mdx
+++ b/errors/no-html-link-for-pages.mdx
@@ -6,13 +6,23 @@ title: No HTML link for pages
 
 ## Why This Error Occurred
 
-An `<a>` element was used to navigate to a page route without using the `next/link` component, causing unnecessary full-page refreshes.
+There are two separate situations that lead to this page.
 
-The `Link` component is required to enable client-side route transitions between pages and provide a single-page app experience.
+The first is a lint error on a specific line: an `<a>` element was used to navigate to a page route without using the `next/link` component, causing unnecessary full-page refreshes. See [Use `Link` for internal navigation](#use-link-for-internal-navigation).
+
+The second is a warning printed once per ESLint run, not attached to any line of code:
+
+```bash filename="Terminal"
+Pages directory cannot be found at <root>/pages or <root>/src/pages. If using a custom path, please configure with the `no-html-link-for-pages` rule in your eslint config file.
+```
+
+That warning means the rule could not find the routes of your application, so it skipped the `<a>` check entirely for that run. It is not saying your file contains an `<a>` element. See [Resolve the routes directory](#resolve-the-routes-directory).
 
 ## Possible Ways to Fix It
 
-Make sure to import the `Link` component and wrap anchor elements that route to different page routes.
+### Use `Link` for internal navigation
+
+Import the `Link` component and use it in place of anchor elements that route to different page routes.
 
 **Before:**
 
@@ -42,24 +52,64 @@ function Home() {
 export default Home
 ```
 
-### Options
+The rule only reports anchors it can match against a discovered route. It ignores absolute and protocol-relative URLs, anchors carrying `target="_blank"` or `download`, and anchors whose `href` is not a string literal.
 
-#### `pagesDir`
+### Resolve the routes directory
 
-This rule can normally locate your `pages` directory automatically.
+To know which `href` values point at your own routes, the rule reads your routes from disk. For each root directory it checks four locations:
 
-If you're working in a monorepo, we recommend configuring the [`rootDir`](/docs/pages/api-reference/config/eslint#specifying-a-root-directory-within-a-monorepo) setting in `eslint-plugin-next`, which `pagesDir` will use to locate your `pages` directory.
+- `pages`
+- `src/pages`
+- `app`
+- `src/app`
 
-In some cases, you may also need to configure this rule directly by providing a `pages` directory. This can be a path or an array of paths.
+The root directory defaults to the directory ESLint is running in. If any one of those four locations exists, the rule works and no warning is printed. Either router satisfies it, so an application that uses only the App Router does not need a `pages` directory and does not trigger this warning.
 
-```json filename="eslint.config.json"
-{
-  "rules": {
-    "@next/next/no-html-link-for-pages": ["error", "packages/my-app/pages/"]
-  }
-}
+The warning is printed only when none of the four exists under any root directory. In practice that points at one of the following.
+
+**ESLint is running from a directory that is not your project root.** The four locations are resolved from the ESLint working directory, so a lint invocation started from a subdirectory, or from a repository root above the application, resolves them against the wrong place. Run ESLint from the directory that contains your `app` or `pages` folder, or set a root directory as described below.
+
+**The application lives somewhere else in the repository.** Set the [`rootDir`](/docs/app/api-reference/config/eslint#specifying-a-root-directory-within-a-monorepo) setting so the rule knows where to look. It accepts a path, a glob, or an array of either.
+
+```js filename="eslint.config.mjs"
+import { defineConfig } from 'eslint/config'
+import nextVitals from 'eslint-config-next/core-web-vitals'
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  {
+    settings: {
+      next: {
+        rootDir: 'packages/my-app/',
+      },
+    },
+  },
+])
+
+export default eslintConfig
 ```
+
+**Your routes are in a directory with a different name.** Pass the path to the rule directly. This can be a path or an array of paths, and it replaces the `pages` and `src/pages` candidates.
+
+```js filename="eslint.config.mjs"
+import { defineConfig } from 'eslint/config'
+import nextVitals from 'eslint-config-next/core-web-vitals'
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  {
+    rules: {
+      '@next/next/no-html-link-for-pages': ['error', 'packages/my-app/routes/'],
+    },
+  },
+])
+
+export default eslintConfig
+```
+
+> **Good to know**: The warning names only the `pages` candidates, even though the `app` candidates were also checked. It is also printed at most once per ESLint process, and the results of the directory lookups are cached for the lifetime of that process, so a directory created while a long-running editor ESLint server is active is not picked up until that process restarts.
 
 ## Useful Links
 
-- [next/link API Reference](/docs/pages/api-reference/components/link)
+- [next/link API Reference](/docs/app/api-reference/components/link)
+- [ESLint configuration](/docs/app/api-reference/config/eslint)

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -60,8 +60,7 @@ export type ProxyMatcher = {
 
 export type ProxyConfig = {
   /**
-   * The matcher for the proxy. Read more: [Next.js Docs: Proxy `matcher`](https://nextjs.org/docs/app/api-reference/file-conventions/proxy#matcher),
-   * [Next.js Docs: Proxy matching paths](https://nextjs.org/docs/app/building-your-application/routing/proxy#matching-paths)
+   * The matcher for the proxy. Read more: [Next.js Docs: Proxy `matcher`](https://nextjs.org/docs/app/api-reference/file-conventions/proxy#matcher)
    */
   matchers?: ProxyMatcher[]
 

--- a/packages/next/src/client/components/redirect.ts
+++ b/packages/next/src/client/components/redirect.ts
@@ -18,10 +18,11 @@ export function getRedirectError(
 }
 
 /**
- * This function allows you to redirect the user to another URL. It can be used in
- * [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components),
- * [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers), and
- * [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
+ * This function allows you to redirect the user to another URL. It can be used while
+ * rendering in
+ * [Server and Client Components](https://nextjs.org/docs/app/getting-started/server-and-client-components),
+ * [Route Handlers](https://nextjs.org/docs/app/api-reference/file-conventions/route), and
+ * [Server Functions](https://nextjs.org/docs/app/getting-started/mutating-data).
  *
  * - In a Server Component, this will insert a meta tag to redirect the user to the target page.
  * - In a Route Handler, it will serve a 307 to the caller.
@@ -41,10 +42,11 @@ export function redirect(
 }
 
 /**
- * This function allows you to redirect the user to another URL. It can be used in
- * [Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components),
- * [Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers), and
- * [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations).
+ * This function allows you to redirect the user to another URL. It can be used while
+ * rendering in
+ * [Server and Client Components](https://nextjs.org/docs/app/getting-started/server-and-client-components),
+ * [Route Handlers](https://nextjs.org/docs/app/api-reference/file-conventions/route), and
+ * [Server Functions](https://nextjs.org/docs/app/getting-started/mutating-data).
  *
  * - In a Server Component, this will insert a meta tag to redirect the user to the target page.
  * - In a Route Handler, it will serve a 308 to the caller.


### PR DESCRIPTION
Fixes #83099, fixes #64540, fixes #79562, fixes #80051, fixes #49684, fixes #61297, fixes #53113, fixes #51710, fixes #74549, fixes #80879, fixes #62458, fixes #64913