### PR TITLE
test: stabilize server action HMR update

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1050,9 +1050,12 @@ describe('app-dir action handling', () => {
 
           await retry(async () => {
             await browser.elementByCss('#inc').click()
+            await browser.waitForIdleNetwork()
             const val = Number(await browser.elementById('count').text())
-            expect(val).toBeGreaterThan(1000)
-          })
+            // An unrelated Fast Refresh can reload the page while the test is
+            // running, resetting the counter before the updated action runs.
+            expect(val).toBeGreaterThanOrEqual(1000)
+          }, 10_000)
         } finally {
           await next.patchFile(filePath, origContent)
         }


### PR DESCRIPTION
### What?

Stabilize the development-mode server action HMR test when an unrelated Fast Refresh reload occurs while the patched action is being applied.

### Why?

The test retried by dispatching another click before the previous asynchronous server action had settled. Under CI load, those requests overlapped with HMR and an unrelated full-page Fast Refresh reload. The reload reset the client counter, so the correctly updated action returned exactly `1000`, which the test rejected because it assumed the pre-reload state was preserved.

### How?

Wait for network idle after each action invocation so retries do not observe an in-flight response, allow the valid post-reload value of `1000`, and use a retry window that accommodates CI HMR latency. The assertion still distinguishes the updated `+1000` action from the original `+1` implementation without requiring client state to survive an unrelated reload.

### Verification

- `pnpm test-dev-turbo test/e2e/app-dir/actions/app-action-node-middleware.test.ts -t "should support updating the action"` (10 consecutive passes)
- `pnpm test-dev-webpack test/e2e/app-dir/actions/app-action-node-middleware.test.ts -t "should support updating the action"` (4 consecutive passes)
- Prettier and ESLint on `test/e2e/app-dir/actions/app-action.test.ts`

<!-- NEXT_JS_LLM -->


<!-- fleet 5793f439-a569-44be-ad19-d456ce9b641c -->