### PR TITLE
fix(router): keep scroll position on a same-URL retry and on a non-redirecting server action

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -454,7 +454,14 @@ export function serverActionReducer(
       const redirectUrl =
         redirectLocation !== undefined ? redirectLocation : currentUrl
       const currentFlightRouterState = state.tree
-      const scrollBehavior = ScrollBehavior.Default
+      // Only a redirect is a navigation the user should be scrolled for. An
+      // action that revalidated without redirecting re-renders the URL that is
+      // already on screen, and that must keep the scroll position — exactly
+      // like `router.refresh()` does.
+      const scrollBehavior =
+        redirectLocation !== undefined
+          ? ScrollBehavior.Default
+          : ScrollBehavior.NoScroll
 
       // If the action triggered a revalidation of the cache, we should also
       // refresh all the dynamic data.

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -48,7 +48,17 @@ export function serverPatchReducer(
   // (`HistoryTraversal`), since the data we received is correct.
   const retryCanonicalUrl = createHrefFromUrl(retryUrl)
   const retryNextUrl = action.nextUrl
-  const scrollBehavior = ScrollBehavior.Default
+  // A retry aimed at the URL that is already on screen is a refresh, and a
+  // refresh never scrolls. This matters after an external
+  // `history.replaceState` changed the search params: the restored state
+  // keeps the previous `renderedSearch`, so the next `router.refresh()`
+  // predicts a page segment key without the new params, the server answers
+  // with the real one, and the mismatch lands here. The original refresh was
+  // dispatched with `NoScroll`; the retry must not turn it into a scroll.
+  const scrollBehavior =
+    retryCanonicalUrl === state.canonicalUrl
+      ? ScrollBehavior.NoScroll
+      : ScrollBehavior.Default
   const navigationLock = getCurrentNavigationLock()
   const now = Date.now()
   return navigateToKnownRoute(

--- a/test/e2e/app-dir/router-autoscroll/app/replace-state-refresh/page.tsx
+++ b/test/e2e/app-dir/router-autoscroll/app/replace-state-refresh/page.tsx
@@ -1,0 +1,23 @@
+import { connection } from 'next/server'
+import { refreshAction } from '../server-action-refresh/actions'
+import { Search } from './search'
+
+export default async function Page() {
+  await connection()
+
+  const timestamp = Date.now()
+
+  return (
+    <>
+      <div style={{ height: '200vh' }} />
+      <Search />
+      <form action={refreshAction}>
+        <button id="refresh-button" type="submit">
+          Refresh
+        </button>
+      </form>
+      <div id="server-timestamp">{timestamp}</div>
+      <div style={{ height: '200vh' }} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/router-autoscroll/app/replace-state-refresh/search.tsx
+++ b/test/e2e/app-dir/router-autoscroll/app/replace-state-refresh/search.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+
+export function Search() {
+  const searchParams = useSearchParams()
+
+  return <div id="search">{searchParams.toString()}</div>
+}

--- a/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+++ b/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
@@ -234,6 +234,67 @@ describe('router autoscrolling on navigation', () => {
     })
   })
 
+  describe('refresh after history.replaceState', () => {
+    it('should not scroll when router.refresh() follows a replaceState that changed the search params', async () => {
+      const browser = await next.browser('/replace-state-refresh')
+
+      const initialTimestamp = await browser
+        .elementByCss('#server-timestamp')
+        .text()
+
+      await scrollTo(browser, { x: 0, y: 1000 })
+
+      // The documented native History API pattern. The router adopts the new
+      // URL but keeps the previous `renderedSearch`, so the refresh below
+      // mismatches the server tree and is retried.
+      await browser.eval(
+        `window.history.replaceState(null, '', '/replace-state-refresh?open=1')`
+      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#search').text()).toBe('open=1')
+      })
+
+      await browser.eval(`window.router.refresh()`)
+
+      await retry(async () => {
+        const newTimestamp = await browser
+          .elementByCss('#server-timestamp')
+          .text()
+        expect(newTimestamp).not.toBe(initialTimestamp)
+      })
+
+      await waitForScrollToComplete(browser, { x: 0, y: 1000 })
+    })
+
+    it('should not scroll when a revalidating server action follows a replaceState that changed the search params', async () => {
+      const browser = await next.browser('/replace-state-refresh')
+
+      const initialTimestamp = await browser
+        .elementByCss('#server-timestamp')
+        .text()
+
+      await scrollTo(browser, { x: 0, y: 1000 })
+
+      await browser.eval(
+        `window.history.replaceState(null, '', '/replace-state-refresh?open=1')`
+      )
+      await retry(async () => {
+        expect(await browser.elementByCss('#search').text()).toBe('open=1')
+      })
+
+      await browser.elementByCss('#refresh-button').click()
+
+      await retry(async () => {
+        const newTimestamp = await browser
+          .elementByCss('#server-timestamp')
+          .text()
+        expect(newTimestamp).not.toBe(initialTimestamp)
+      })
+
+      await waitForScrollToComplete(browser, { x: 0, y: 1000 })
+    })
+  })
+
   describe('bugs', () => {
     it('Should scroll to the top of the layout when the first child is display none', async () => {
       const browser = await next.browser('/')


### PR DESCRIPTION
Fixes #98323

### What?

Two same-URL re-render paths in the client router hard-code `ScrollBehavior.Default` and can therefore mint a live `ScrollRef` for a page that is already on screen, which `layout-router` then obeys by writing `documentElement.scrollTop = 0`:

- `serverPatchReducer` — the tree-mismatch retry. Now `NoScroll` when the retry's canonical URL is the URL already shown (the retry is completing a refresh).
- `serverActionReducer` — an action that revalidated without redirecting. Now `NoScroll` unless the action redirected (a redirect is the one case that is a real navigation).

### Why?

`router.refresh()` is dispatched with `NoScroll`, and #91348 sets the model as "refresh creates no new CacheNodes, so nothing scrolls". That holds only while the refresh does not have to retry. After the documented native History API pattern — `window.history.replaceState(null, '', '?open=1')` — `restoreReducer` adopts the new `canonicalUrl` but keeps the previous `renderedSearch`, so the next refresh predicts `__PAGE__`, the server answers `__PAGE__?{"open":"1"}`, `finishNavigationTask` reports a mismatch, and the retry re-navigates with `Default`. The page leaf diverges, `accumulateScrollRef` assigns a live ref, and the page jumps to the top. A revalidating server action after the same `replaceState` fails the same way through its own `Default`.

Reproduction (6 files, Playwright probe printing the writer of every scroll that moved the page): https://github.com/onyxdevs/next-replacestate-refresh-scroll — fails on 16.2.3, 16.3.4 and 16.4.0-canary.19, passes with the `replaceState` step removed.

### How?

The minimal fix at the two call sites, keeping every real navigation's scroll behaviour untouched: a retry for a different URL (a redirect discovered during the retry) still scrolls, and a redirecting action still scrolls. A follow-up could carry the original navigation's `scrollBehavior` on the retry action instead of inferring it from the URL, which is probably also what #98021 needs (a retry that should scroll and does not).

Tests: two cases added to `router-autoscroll` on a new `/replace-state-refresh` page — `replaceState` then `router.refresh()`, and `replaceState` then a revalidating server action — both asserting the position holds at `y: 1000`. They mirror the `server-action-refresh` test from #91348.

Verified as a patch on `next@16.2.3` against the reproduction above and against our app's own Playwright suite, where the same sequence (drawer opened via `replaceState`, then a mutation + `router.refresh()`) went from a deterministic jump to a held position. I was not able to run the Next.js e2e harness locally, so the added tests are untested against it — happy to adjust.
