### PR TITLE
[test] Resolve `workspace:*` packages to the version under test

### DIFF
--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -101,7 +101,7 @@ async function main() {
   // PR number endpoint (which resolves the PR to a SHA on every request).
   const nextTestVersion =
     testMode === 'deploy'
-      ? previewTarballUrl(previewBuildsBaseUrl, commitSha)
+      ? previewTarballUrl(previewBuildsBaseUrl, commitSha, 'next')
       : undefined
 
   if (nextTestVersion) {

--- a/scripts/wait-for-preview-tarball.mjs
+++ b/scripts/wait-for-preview-tarball.mjs
@@ -83,16 +83,40 @@ export function createPreviewBuildsReadTokenGetter() {
 }
 
 /**
- * URL of the `next` preview tarball for a commit. `vercel-packages` answers
- * with a redirect to Vercel Blob, which only serves the tarball once
+ * URL of the preview tarball of `packageName` for a commit. `vercel-packages`
+ * answers with a redirect to Vercel Blob, which only serves the tarball once
  * `upload-preview-tarballs` has published it.
  *
  * @param {string | undefined} baseUrl
  * @param {string} commitSha
+ * @param {string} packageName
  * @returns {string}
  */
-export function previewTarballUrl(baseUrl, commitSha) {
-  return `${baseUrl || DEFAULT_PREVIEW_BUILDS_BASE_URL}/commits/${commitSha}/next`
+export function previewTarballUrl(baseUrl, commitSha, packageName) {
+  return `${baseUrl || DEFAULT_PREVIEW_BUILDS_BASE_URL}/commits/${commitSha}/${packageName}`
+}
+
+/**
+ * The reverse of `previewTarballUrl`: the commit that a preview build URL
+ * refers to, or null when `url` was not built from `baseUrl`.
+ *
+ * @param {string | undefined} url
+ * @param {string | undefined} baseUrl
+ * @returns {string | null} the commit
+ */
+export function getCommitFromPreviewBuildUrl(url, baseUrl) {
+  if (url === undefined) {
+    return null
+  }
+  const commitsPrefix = `${baseUrl || DEFAULT_PREVIEW_BUILDS_BASE_URL}/commits/`
+  if (!url.startsWith(commitsPrefix)) {
+    return null
+  }
+  const [commitSha] = url.slice(commitsPrefix.length).split('/')
+  if (commitSha.length === 0) {
+    return null
+  }
+  return commitSha
 }
 
 /**
@@ -213,7 +237,7 @@ export async function assertPreviewTarballPublished({
   previewBuildsBaseUrl,
   getReadToken,
 }) {
-  const url = previewTarballUrl(previewBuildsBaseUrl, commitSha)
+  const url = previewTarballUrl(previewBuildsBaseUrl, commitSha, 'next')
   const { published, lastResponse, responseHeaders } = await probeTarball(
     url,
     await requestHeaders(getReadToken ?? (async () => null))
@@ -247,7 +271,7 @@ export async function waitForPreviewTarball({
   getReadToken = async () => null,
   pollIntervalMs = POLL_INTERVAL_MS,
 }) {
-  const url = previewTarballUrl(previewBuildsBaseUrl, commitSha)
+  const url = previewTarballUrl(previewBuildsBaseUrl, commitSha, 'next')
   const startedAt = Date.now()
   const deadline = startedAt + timeoutMs
   let lastProgressLogAt = startedAt

--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -102,7 +102,6 @@
       "test/e2e/app-dir/app-routes/app-custom-route-base-path.test.ts",
       "test/e2e/app-dir/mdx/mdx.test.ts",
       "test/e2e/app-dir/modularizeimports/modularizeimports.test.ts",
-      "test/e2e/app-dir/third-parties/basic.test.ts",
       "test/e2e/app-dir/app-static/app-static-custom-handler.test.ts",
       "test/e2e/app-dir/revalidate-dynamic/revalidate-dynamic.test.ts",
       "test/e2e/app-dir/syntax-highlighter-crash/syntax-highlighter-crash.test.ts",

--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -10,7 +10,7 @@ describe('ReactRefreshRegression app', () => {
     files: new FileRef(path.join(__dirname, 'fixtures', 'default-template')),
     dependencies: {
       'styled-components': '6.1.16',
-      '@next/mdx': 'canary',
+      '@next/mdx': 'workspace:*',
       '@mdx-js/loader': '2.2.1',
       '@mdx-js/react': '2.2.1',
     },

--- a/test/development/acceptance-app/app-hmr-changes.test.ts
+++ b/test/development/acceptance-app/app-hmr-changes.test.ts
@@ -8,7 +8,7 @@ describe('Error overlay - RSC build errors', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'fixtures', 'app-hmr-changes')),
     dependencies: {
-      '@next/mdx': 'canary',
+      '@next/mdx': 'workspace:*',
       'react-wrap-balancer': '^0.2.4',
       'react-tweet': '^3.2.0',
       '@mdx-js/react': '^2.3.0',

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -11,7 +11,7 @@ describe('ReactRefreshRegression', () => {
     skipStart: true,
     dependencies: {
       'styled-components': '6.1.16',
-      '@next/mdx': 'canary',
+      '@next/mdx': 'workspace:*',
       '@mdx-js/loader': '2.2.1',
       '@mdx-js/react': '2.2.1',
     },

--- a/test/development/next-font/deprecated-package.test.ts
+++ b/test/development/next-font/deprecated-package.test.ts
@@ -8,7 +8,7 @@ describe('Deprecated @next/font warning', () => {
       'pages/index.js': '',
     },
     dependencies: {
-      '@next/font': 'canary',
+      '@next/font': 'workspace:*',
     },
     skipStart: true,
   })

--- a/test/development/plugin-mdx-rs/plugin-mdx-rs.test.ts
+++ b/test/development/plugin-mdx-rs/plugin-mdx-rs.test.ts
@@ -4,7 +4,7 @@ describe('MDX-rs Plugin support', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      '@next/mdx': 'canary',
+      '@next/mdx': 'workspace:*',
       '@mdx-js/loader': '*',
       '@mdx-js/react': '*',
     },
@@ -27,7 +27,7 @@ describe('MDX-rs Plugin support with mdx transform options', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      '@next/mdx': 'canary',
+      '@next/mdx': 'workspace:*',
       '@mdx-js/loader': '*',
       '@mdx-js/react': '*',
     },

--- a/test/e2e/app-dir/app-css/index.test.ts
+++ b/test/e2e/app-dir/app-css/index.test.ts
@@ -8,7 +8,7 @@ describe('app dir - css', () => {
     dependencies: {
       '@picocss/pico': '1.5.7',
       sass: 'latest',
-      '@next/mdx': 'canary',
+      '@next/mdx': 'workspace:*',
     },
   })
 

--- a/test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts
+++ b/test/e2e/app-dir/mdx-font-preload/mdx-font-preload.test.ts
@@ -4,7 +4,7 @@ describe('mdx-font-preload', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      '@next/mdx': 'canary',
+      '@next/mdx': 'workspace:*',
       '@mdx-js/loader': '^2.2.1',
       '@mdx-js/react': '^2.2.1',
     },

--- a/test/e2e/app-dir/mdx-no-mdx-components/mdx.test.ts
+++ b/test/e2e/app-dir/mdx-no-mdx-components/mdx.test.ts
@@ -4,7 +4,7 @@ describe(`mdx`, () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      '@next/mdx': 'canary',
+      '@next/mdx': 'workspace:*',
       '@mdx-js/loader': '^2.2.1',
     },
   })

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -5,7 +5,7 @@ for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
     const { next } = nextTestSetup({
       files: __dirname,
       dependencies: {
-        '@next/mdx': 'canary',
+        '@next/mdx': 'workspace:*',
         '@mdx-js/loader': '^2.2.1',
         '@mdx-js/react': '^2.2.1',
         'recma-export-filepath': '1.2.0',

--- a/test/e2e/app-dir/modularizeimports/modularizeimports.test.ts
+++ b/test/e2e/app-dir/modularizeimports/modularizeimports.test.ts
@@ -4,7 +4,7 @@ describe('modularizeImports', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      '@next/mdx': 'canary',
+      '@next/mdx': 'workspace:*',
       '@mdx-js/loader': '^2.2.1',
       '@mdx-js/react': '^2.2.1',
     },

--- a/test/e2e/app-dir/next-font/next-font.test.ts
+++ b/test/e2e/app-dir/next-font/next-font.test.ts
@@ -31,7 +31,7 @@ describe('app dir - next/font', () => {
         'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
       },
       dependencies: {
-        '@next/font': 'canary',
+        '@next/font': 'workspace:*',
       },
       skipDeployment: true,
     })

--- a/test/e2e/app-dir/third-parties/basic.test.ts
+++ b/test/e2e/app-dir/third-parties/basic.test.ts
@@ -4,7 +4,7 @@ describe('@next/third-parties basic usage', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      '@next/third-parties': 'canary',
+      '@next/third-parties': 'workspace:*',
     },
   })
 

--- a/test/e2e/next-font/index.test.ts
+++ b/test/e2e/next-font/index.test.ts
@@ -48,7 +48,7 @@ describe('next/font', () => {
       fonts: new FileRef(join(__dirname, `app/fonts`)),
     },
     dependencies: {
-      '@next/font': 'canary',
+      '@next/font': 'workspace:*',
     },
     env: {
       NEXT_FONT_GOOGLE_MOCKED_RESPONSES: mockedGoogleFontResponses,

--- a/test/e2e/third-parties/index.test.ts
+++ b/test/e2e/third-parties/index.test.ts
@@ -5,7 +5,7 @@ describe('@next/third-parties basic usage', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      '@next/third-parties': 'canary',
+      '@next/third-parties': 'workspace:*',
     },
   })
 

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -247,7 +247,19 @@ async function createNextInstall({
         next: pkgPaths.get('next'),
         ...Object.keys(dependencies).reduce((prev, pkg) => {
           const pkgPath = pkgPaths.get(pkg)
-          prev[pkg] = pkgPath || dependencies[pkg]
+          const version = dependencies[pkg]
+          if (version === 'workspace:*') {
+            if (pkgPath) {
+              prev[pkg] = pkgPath
+            } else {
+              throw new Error(
+                `"${pkg}" is declared as "workspace:*" but no packed tarball was found for it. ` +
+                  `Only packages in this repository with a "pack-for-isolated-tests" script can be used with "workspace:*".`
+              )
+            }
+          } else {
+            prev[pkg] = pkgPath || version
+          }
           return prev
         }, {}),
       }

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -8,6 +8,10 @@ import { ChildProcess } from 'child_process'
 import spawn from 'cross-spawn'
 import { quote as shellQuote } from 'shell-quote'
 import { createNextInstall } from '../create-next-install'
+import {
+  getCommitFromPreviewBuildUrl,
+  previewTarballUrl,
+} from '../../../scripts/wait-for-preview-tarball.mjs'
 import { Span } from 'next/dist/trace'
 import webdriver from '../next-webdriver'
 import {
@@ -286,6 +290,46 @@ export class NextInstance {
         }
 
         if (skipInstall || skipIsolatedNext) {
+          // Dependencies declared as `workspace:*` must install the build of
+          // the tested commit rather than a published version. Deploy tests
+          // install `next` from the preview build of the tested commit via
+          // NEXT_TEST_VERSION, so workspace dependencies resolve to the
+          // preview tarball of the same commit: the published version would
+          // not contain the changes under test, and its `peerDependencies`
+          // ranges (e.g. `^16.0.0-beta.0`) reject prerelease preview versions
+          // such as `16.4.0-preview-<sha>-<date>`, failing `npm install` with
+          // ERESOLVE. The preview tarballs rewrite their monorepo (peer)
+          // dependencies to the preview URLs of the same commit (see
+          // `scripts/create-preview-tarballs.js`). Without a preview build,
+          // workspace dependencies track whatever `next` is installed with
+          // (e.g. the version the release workflow pins), since all packages
+          // in this repository are published in lockstep.
+          const nextVersion =
+            process.env.NEXT_TEST_VERSION ||
+            require('next/package.json').version
+          const previewCommitSha = getCommitFromPreviewBuildUrl(
+            process.env.NEXT_TEST_VERSION,
+            process.env.NEXT_TEST_PREVIEW_BUILDS_BASE_URL
+          )
+          for (const dependencyName of Object.keys(finalDependencies)) {
+            if (finalDependencies[dependencyName] !== 'workspace:*') {
+              continue
+            }
+            if (previewCommitSha === null) {
+              finalDependencies[dependencyName] = nextVersion
+              continue
+            }
+            const previewBuildUrl = previewTarballUrl(
+              process.env.NEXT_TEST_PREVIEW_BUILDS_BASE_URL,
+              previewCommitSha,
+              dependencyName
+            )
+            require('console').log(
+              `Resolving ${dependencyName}@workspace:* to the preview build: ${previewBuildUrl}`
+            )
+            finalDependencies[dependencyName] = previewBuildUrl
+          }
+
           const pkgScripts = (this.packageJson['scripts'] as {}) || {}
           // Pin the same pnpm version the repo uses so corepack resolves a
           // consistent pnpm across isolated test dirs. Mirrors the logic in
@@ -312,9 +356,7 @@ export class NextInstance {
                 }),
                 dependencies: {
                   ...finalDependencies,
-                  next:
-                    process.env.NEXT_TEST_VERSION ||
-                    require('next/package.json').version,
+                  next: nextVersion,
                 },
                 ...(this.resolutions ? { resolutions: this.resolutions } : {}),
                 scripts: {

--- a/test/production/jest/index.test.ts
+++ b/test/production/jest/index.test.ts
@@ -127,7 +127,7 @@ describe('next/jest', () => {
       ),
     },
     dependencies: {
-      '@next/font': 'canary',
+      '@next/font': 'workspace:*',
       jest: '29.7.0',
       'jest-environment-jsdom': '29.7.0',
       '@testing-library/jest-dom': '5.16.1',

--- a/test/production/typescript-basic/index.test.ts
+++ b/test/production/typescript-basic/index.test.ts
@@ -6,7 +6,7 @@ describe('TypeScript basic', () => {
   const { next } = nextTestSetup({
     files: new FileRef(path.join(__dirname, 'app')),
     dependencies: {
-      '@next/bundle-analyzer': 'canary',
+      '@next/bundle-analyzer': 'workspace:*',
       '@types/react': 'latest',
       '@types/react-dom': 'latest',
     },


### PR DESCRIPTION
Test fixtures that depend on monorepo packages (for example `@next/third-parties` and `@next/mdx`) declared them at the `canary` dist-tag, which installs the published npm canary instead of the build under test. In deploy tests this also broke the remote install entirely: the published canary's `peerDependencies` ranges (for example `^16.0.0-beta.0`) reject the prerelease preview versions that `NEXT_TEST_VERSION` installs for `next` (for example `16.4.0-preview-<sha>-<date>`), so `npm install` failed with ERESOLVE.

Test dependencies can now be declared as `workspace:*`, which resolves to the build from the current checkout in every test mode:

- dev/start: the locally packed tarball from `pack-for-isolated-tests`, with a descriptive error when the package has no pack task or is not part of the repository.
- deploy: the preview tarball of the tested commit when `NEXT_TEST_VERSION` points at a preview build (preview tarballs already rewrite their monorepo peer dependencies to the same preview URLs, so peer resolution succeeds), falling back to the version in the worktree otherwise. Private packages without published preview tarballs fail with a descriptive error.

All existing tests that used `canary` for monorepo packages are migrated to `workspace:*`.


## test plan

- [new tests deployed passes on this PR (i.e. CI green)](https://github.com/vercel/next.js/actions/runs/34220919474/job/102106546757?pr=98330#step:35:156)

