### PR TITLE
[ci] Align build-and-deploy triggers with build-and-test

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -3,12 +3,6 @@ name: build-and-deploy
 
 on:
   push:
-    # Same branch trigger as build_and_test.yml so that change detection
-    # (`git diff HEAD~1`) evaluates the same commits in both workflows.
-    # PR branches are covered by the `pull_request` event below, where the
-    # checkout is the merge commit and HEAD~1 covers the whole PR. On branch
-    # pushes HEAD~1 would only cover the last commit of the push.
-    # create-release-branch.js rewrites this list for release branches.
     branches: ['canary']
     # Run on release tags so publishing is driven by the tag push rather than
     # the release-commit branch push (see the deploy-target step).

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -3,9 +3,13 @@ name: build-and-deploy
 
 on:
   push:
-    # Don't run when graphite base branches are pushed
-    branches-ignore:
-      - 'graphite-base/**'
+    # Same branch trigger as build_and_test.yml so that change detection
+    # (`git diff HEAD~1`) evaluates the same commits in both workflows.
+    # PR branches are covered by the `pull_request` event below, where the
+    # checkout is the merge commit and HEAD~1 covers the whole PR. On branch
+    # pushes HEAD~1 would only cover the last commit of the push.
+    # create-release-branch.js rewrites this list for release branches.
+    branches: ['canary']
     # Run on release tags so publishing is driven by the tag push rather than
     # the release-commit branch push (see the deploy-target step).
     tags:
@@ -45,9 +49,6 @@ env:
 jobs:
   deploy-target:
     runs-on: ubuntu-latest
-    # Don't trigger this job on `pull_request` events from upstream branches.
-    # Those would already run this job on the `push` event
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork }}
     outputs:
       value: ${{ steps.deploy-target.outputs.value }}
       release_environment: ${{ steps.deploy-target.outputs.release_environment }}
@@ -605,9 +606,14 @@ jobs:
           path: crates/wasm
 
       - name: Create tarballs
-        # github.event.after is available on push and pull_request#synchronize events.
-        # For workflow_dispatch events, github.sha is the head commit.
-        run: node scripts/create-preview-tarballs.js "${{ github.event.after || github.sha }}" "${{ runner.temp }}/preview-tarballs" "${{ vars.PREVIEW_BUILDS_BASE_URL }}"
+        # The tarballs are published under (upload_preview_tarballs.yml) and
+        # looked up by (tests via getGitInfo) the head commit of the
+        # triggering ref. For pull_request events that's
+        # pull_request.head.sha: github.event.after only exists on
+        # synchronize, and github.sha is the merge commit. For pushes,
+        # github.event.after is the pushed head commit. For
+        # workflow_dispatch, github.sha is the head commit.
+        run: node scripts/create-preview-tarballs.js "${{ github.event.pull_request.head.sha || github.event.after || github.sha }}" "${{ runner.temp }}/preview-tarballs" "${{ vars.PREVIEW_BUILDS_BASE_URL }}"
 
       - name: Persist tarballs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/scripts/create-release-branch.js
+++ b/scripts/create-release-branch.js
@@ -102,7 +102,11 @@ async function main() {
   const buildAndDeploy = await fs.promises.readFile(buildAndDeployPath, 'utf8')
   await fs.promises.writeFile(
     buildAndDeployPath,
-    buildAndDeploy.replace(/refs\/heads\/canary/g, `refs/heads/${branchName}`)
+    buildAndDeploy
+      // The push trigger is limited to the default branch, same as
+      // build_and_test.yml below, so point it at the release branch as well.
+      .replace(`branches: ['canary']`, `branches: ['${branchName}']`)
+      .replace(/refs\/heads\/canary/g, `refs/heads/${branchName}`)
   )
 
   const buildAndTestPath = path.join(


### PR DESCRIPTION
Change detection (`git diff HEAD~1`) only covers the whole change set when the checkout is the PR merge commit. `build-and-test` runs on `pull_request` while `build-and-deploy` ran on `push` for upstream PR branches, so a multi-commit push whose last commit was docs-only made `build-and-deploy` skip the preview build while deploy tests in `build-and-test` waited up to 30 minutes for a preview tarball that never got published.

`build-and-deploy` now triggers on the same events as `build-and-test` (`push` to the default branch and `pull_request`), while still accepting release tags and workflow dispatch. The `deploy-target` fork guard is removed since upstream PRs are no longer covered by a push run, and `create-release-branch.js` now rewrites the workflow's branch list alongside the existing `refs/heads/canary` replacement so release branches keep their staging deploys.

Preview tarball creation now uses the PR head sha instead of falling back to the merge-commit sha on `pull_request` `opened` events (`github.event.after` only exists on `synchronize`), matching the sha that `upload_preview_tarballs.yml` publishes under and that tests poll for. This fallback was a pre-existing bug that only affected fork PRs; it would have started affecting every upstream PR's first run once previews moved to the `pull_request` event.

## test plan

- [determine deploy target detects two file changes even the last commit only changed one file](https://github.com/vercel/next.js/actions/runs/34203720949/job/101988232190?pr=98331#step:6:65)
