### PR TITLE
Add hashes of inline scripts to the CSP of cacheable responses

### DIFF
--- a/docs/01-app/02-guides/content-security-policy.mdx
+++ b/docs/01-app/02-guides/content-security-policy.mdx
@@ -455,7 +455,7 @@ module.exports = {
 
 ## Subresource Integrity (Experimental)
 
-As an alternative to nonces, Next.js offers experimental support for hash-based CSP using Subresource Integrity (SRI). This approach allows you to maintain static generation while still having a strict CSP.
+Next.js offers experimental support for Subresource Integrity (SRI), which lets the browser verify the JavaScript files it downloads. SRI covers files served from a URL; the inline scripts of a page are admitted by a nonce or by their hash, which [`inlineScriptHashes`](#hashes-for-inline-scripts-experimental) provides.
 
 > **Good to know**: This feature is experimental and available in App Router applications.
 
@@ -524,7 +524,7 @@ module.exports = {
 }
 ```
 
-### Benefits of SRI over nonces
+### Benefits of SRI
 
 - **Static generation**: Pages can be statically generated and cached
 - **CDN compatibility**: Static pages work with CDN caching
@@ -536,6 +536,50 @@ module.exports = {
 - **Experimental**: Feature may change or be removed
 - **App Router only**: Not supported in Pages Router
 - **Build-time only**: Cannot handle dynamically generated scripts
+- **External files only**: `integrity` is not consulted when a policy decides whether an inline script may run
+
+## Hashes for Inline Scripts (Experimental)
+
+Next.js inlines the payload of a page as `<script>` elements, and a policy without `'unsafe-inline'` blocks them unless it carries their hashes. `inlineScriptHashes` takes the hashes from the finished document of a cacheable response and adds them to the directive that governs script elements — `script-src-elem` where the policy has one, otherwise `script-src`, otherwise `default-src`.
+
+```js filename="next.config.js"
+const cspHeader = `
+    default-src 'self';
+    script-src 'self';
+    style-src 'self' 'unsafe-inline';
+    object-src 'none';
+    base-uri 'self';
+    form-action 'self';
+    frame-ancestors 'none';
+`
+
+module.exports = {
+  experimental: {
+    inlineScriptHashes: {
+      algorithm: 'sha256', // or 'sha384' or 'sha512'
+    },
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: cspHeader.replace(/\n/g, ''),
+          },
+        ],
+      },
+    ]
+  },
+}
+```
+
+The hashes are stored next to the cached body, so every hit served from the cache carries the policy that belongs to the document it returns.
+
+> **Good to know**: The hashes are only known once the document is complete, so a cacheable response is buffered instead of streamed. Dynamic responses keep streaming and still need a nonce.
+
+A policy that already carries `'unsafe-inline'` is left as it is: adding a hash makes browsers ignore `'unsafe-inline'`, which would block the inline scripts the policy admits today. Drop `'unsafe-inline'` from the directive to opt in.
 
 </AppOnly>
 

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -1061,13 +1061,16 @@ export function createAppPageEntrypoint({
 
         // The hashes of the inline scripts are only known once the document is
         // complete, so a response that carries them is buffered rather than
-        // streamed. They travel in the cached headers, which keeps them with
-        // the body they belong to for every later hit.
+        // streamed. Only a cached response is: it is served again from the
+        // cache with the headers it was stored with, while a dynamic one keeps
+        // streaming and is admitted by a nonce instead.
         const inlineScriptHashes = nextConfig.experimental.inlineScriptHashes
+        const isCached = isSSG && cacheControl?.revalidate !== 0
         let html = result
 
         if (
           inlineScriptHashes &&
+          isCached &&
           result.contentType !== RSC_CONTENT_TYPE_HEADER &&
           metadata.postponed === undefined
         ) {

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -841,6 +841,12 @@ export function createAppPageEntrypoint({
 
         renderOperation: AppPageRenderOperation
       }): Promise<ResponseCacheEntry> => {
+        // A render that answers the request itself streams to the client: a
+        // dynamic response, or the resume of a postponed shell.
+        const respondsDynamically =
+          renderOperation === 'render' &&
+          (typeof postponed === 'string' || supportsDynamicResponse)
+
         const context: AppPageRouteHandlerContext = {
           query,
           params,
@@ -868,9 +874,7 @@ export function createAppPageEntrypoint({
             postponed,
             allowEmptyStaticShell,
             serveStreamingMetadata,
-            supportsDynamicResponse:
-              renderOperation === 'render' &&
-              (typeof postponed === 'string' || supportsDynamicResponse),
+            supportsDynamicResponse: respondsDynamically,
             buildManifest,
             nextFontManifest,
             reactLoadableManifest,
@@ -1065,7 +1069,8 @@ export function createAppPageEntrypoint({
         // cache with the headers it was stored with, while a dynamic one keeps
         // streaming and is admitted by a nonce instead.
         const inlineScriptHashes = nextConfig.experimental.inlineScriptHashes
-        const isCached = isSSG && cacheControl?.revalidate !== 0
+        const isCached =
+          isSSG && !respondsDynamically && cacheControl?.revalidate !== 0
         let html = result
 
         if (

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -68,10 +68,15 @@ import {
   CACHE_ONE_YEAR_SECONDS,
   HTML_CONTENT_TYPE_HEADER,
   NEXT_CACHE_TAGS_HEADER,
+  NEXT_INLINE_SCRIPT_HASHES_HEADER,
   NEXT_NAV_DEPLOYMENT_ID_HEADER,
   NEXT_RESUME_HEADER,
   NEXT_RESUME_STATE_LENGTH_HEADER,
 } from '../../lib/constants' with { 'turbopack-transition': 'next-server-utility' }
+import {
+  collectInlineScriptHashes,
+  withInlineScriptHashes,
+} from '../../server/app-render/inline-script-hashes' with { 'turbopack-transition': 'next-server-utility' }
 import type { CacheControl } from '../../server/lib/cache-control'
 import { ENCODED_TAGS } from '../../server/stream-utils/encoded-tags' with { 'turbopack-transition': 'next-server-utility' }
 import { sendRenderResult } from '../../server/send-payload' with { 'turbopack-transition': 'next-server-utility' }
@@ -938,6 +943,7 @@ export function createAppPageEntrypoint({
                 nextConfig.experimental.optimisticRouting
               ),
               inlineCss: Boolean(nextConfig.experimental.inlineCss),
+              inlineScriptHashes: nextConfig.experimental.inlineScriptHashes,
               prefetchInlining:
                 nextConfig.experimental.prefetchInlining ?? false,
               authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
@@ -1053,10 +1059,38 @@ export function createAppPageEntrypoint({
           throw err
         }
 
+        // The hashes of the inline scripts are only known once the document is
+        // complete, so a response that carries them is buffered rather than
+        // streamed. They travel in the cached headers, which keeps them with
+        // the body they belong to for every later hit.
+        const inlineScriptHashes = nextConfig.experimental.inlineScriptHashes
+        let html = result
+
+        if (
+          inlineScriptHashes &&
+          result.contentType !== RSC_CONTENT_TYPE_HEADER &&
+          metadata.postponed === undefined
+        ) {
+          const document = await result.toUnchunkedString(true)
+          const hashes = collectInlineScriptHashes(
+            document,
+            inlineScriptHashes.algorithm ?? 'sha256'
+          )
+
+          if (hashes.length > 0) {
+            headers[NEXT_INLINE_SCRIPT_HASHES_HEADER] = hashes.join(' ')
+          }
+
+          html = RenderResult.fromStatic(
+            document,
+            result.contentType ?? HTML_CONTENT_TYPE_HEADER
+          )
+        }
+
         return {
           value: {
             kind: CachedRouteKind.APP_PAGE,
-            html: result,
+            html,
             headers,
             rscData: metadata.flightData,
             postponed: metadata.postponed,
@@ -1847,6 +1881,24 @@ export function createAppPageEntrypoint({
 
           if (!isMinimalMode || !isSSG) {
             delete headers[NEXT_CACHE_TAGS_HEADER]
+          }
+
+          const inlineScriptHashes = headers[NEXT_INLINE_SCRIPT_HASHES_HEADER]
+          delete headers[NEXT_INLINE_SCRIPT_HASHES_HEADER]
+
+          if (typeof inlineScriptHashes === 'string') {
+            const hashes = inlineScriptHashes.split(' ')
+
+            for (const name of [
+              'content-security-policy',
+              'content-security-policy-report-only',
+            ]) {
+              const policy = res.getHeader(name)
+
+              if (typeof policy === 'string') {
+                res.setHeader(name, withInlineScriptHashes(policy, hashes))
+              }
+            }
           }
 
           for (let [key, value] of Object.entries(headers)) {

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -68,7 +68,6 @@ import {
   CACHE_ONE_YEAR_SECONDS,
   HTML_CONTENT_TYPE_HEADER,
   NEXT_CACHE_TAGS_HEADER,
-  NEXT_INLINE_SCRIPT_HASHES_HEADER,
   NEXT_NAV_DEPLOYMENT_ID_HEADER,
   NEXT_RESUME_HEADER,
   NEXT_RESUME_STATE_LENGTH_HEADER,
@@ -1068,13 +1067,15 @@ export function createAppPageEntrypoint({
         // streamed. Only a cached response is: it is served again from the
         // cache with the headers it was stored with, while a dynamic one keeps
         // streaming and is admitted by a nonce instead.
-        const inlineScriptHashes = nextConfig.experimental.inlineScriptHashes
+        const inlineScriptHashesConfig =
+          nextConfig.experimental.inlineScriptHashes
         const isCached =
           isSSG && !respondsDynamically && cacheControl?.revalidate !== 0
         let html = result
+        let inlineScriptHashes: string[] | undefined
 
         if (
-          inlineScriptHashes &&
+          inlineScriptHashesConfig &&
           isCached &&
           result.contentType !== RSC_CONTENT_TYPE_HEADER &&
           metadata.postponed === undefined
@@ -1082,11 +1083,11 @@ export function createAppPageEntrypoint({
           const document = await result.toUnchunkedString(true)
           const hashes = collectInlineScriptHashes(
             document,
-            inlineScriptHashes.algorithm ?? 'sha256'
+            inlineScriptHashesConfig.algorithm
           )
 
           if (hashes.length > 0) {
-            headers[NEXT_INLINE_SCRIPT_HASHES_HEADER] = hashes.join(' ')
+            inlineScriptHashes = hashes
           }
 
           html = RenderResult.fromStatic(
@@ -1100,6 +1101,7 @@ export function createAppPageEntrypoint({
             kind: CachedRouteKind.APP_PAGE,
             html,
             headers,
+            inlineScriptHashes,
             rscData: metadata.flightData,
             postponed: metadata.postponed,
             status: metadata.statusCode,
@@ -1504,6 +1506,7 @@ export function createAppPageEntrypoint({
                 postponed,
                 segmentData: undefined,
                 headers: undefined,
+                inlineScriptHashes: undefined,
                 status: undefined,
               } satisfies CachedAppPageValue,
             }
@@ -1884,29 +1887,29 @@ export function createAppPageEntrypoint({
           if (finished) return null
         }
 
+        // The hashes admit the inline scripts of the body being served, so they
+        // are added to the policy of every response carrying it, cached or not.
+        if (cachedData.inlineScriptHashes) {
+          for (const name of [
+            'content-security-policy',
+            'content-security-policy-report-only',
+          ]) {
+            const policy = res.getHeader(name)
+
+            if (typeof policy === 'string') {
+              res.setHeader(
+                name,
+                withInlineScriptHashes(policy, cachedData.inlineScriptHashes)
+              )
+            }
+          }
+        }
+
         if (cachedData.headers) {
           const headers = { ...cachedData.headers }
 
           if (!isMinimalMode || !isSSG) {
             delete headers[NEXT_CACHE_TAGS_HEADER]
-          }
-
-          const inlineScriptHashes = headers[NEXT_INLINE_SCRIPT_HASHES_HEADER]
-          delete headers[NEXT_INLINE_SCRIPT_HASHES_HEADER]
-
-          if (typeof inlineScriptHashes === 'string') {
-            const hashes = inlineScriptHashes.split(' ')
-
-            for (const name of [
-              'content-security-policy',
-              'content-security-policy-report-only',
-            ]) {
-              const policy = res.getHeader(name)
-
-              if (typeof policy === 'string') {
-                res.setHeader(name, withInlineScriptHashes(policy, hashes))
-              }
-            }
           }
 
           for (let [key, value] of Object.entries(headers)) {

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -171,6 +171,7 @@ async function requestHandler(
         dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
         optimisticRouting: Boolean(nextConfig.experimental.optimisticRouting),
         inlineCss: Boolean(nextConfig.experimental.inlineCss),
+        inlineScriptHashes: nextConfig.experimental.inlineScriptHashes,
         prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
         authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
         reactBrowserBailout: Boolean(

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -521,6 +521,7 @@ async function exportAppImpl(
       dynamicOnHover: nextConfig.experimental.dynamicOnHover ?? false,
       optimisticRouting: nextConfig.experimental.optimisticRouting ?? false,
       inlineCss: nextConfig.experimental.inlineCss ?? false,
+      inlineScriptHashes: nextConfig.experimental.inlineScriptHashes,
       prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
       authInterrupts: !!nextConfig.experimental.authInterrupts,
       reactBrowserBailout: nextConfig.experimental.reactBrowserBailout ?? false,

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -11,11 +11,13 @@ import type {
 import { isDynamicUsageError } from '../helpers/is-dynamic-usage-error'
 import {
   NEXT_CACHE_TAGS_HEADER,
+  NEXT_INLINE_SCRIPT_HASHES_HEADER,
   NEXT_META_SUFFIX,
   RSC_SUFFIX,
   RSC_SEGMENTS_DIR_SUFFIX,
   RSC_SEGMENT_SUFFIX,
 } from '../../lib/constants'
+import { collectInlineScriptHashes } from '../../server/app-render/inline-script-hashes'
 import { hasNextSupport } from '../../server/ci-info'
 import { lazyPrerenderAppPage } from '../../server/route-modules/app-page/module.render'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
@@ -188,6 +190,22 @@ export async function exportAppPage(
 
     // If we're writing the file to disk, we know it's a prerender.
     headers[NEXT_IS_PRERENDER_HEADER] = '1'
+
+    // The hashes of the inline scripts travel with the prerendered document, so
+    // the response can be served under a policy without `'unsafe-inline'`. A
+    // postponed shell is completed at request time, where the rest is hashed.
+    const inlineScriptHashes = renderOpts.experimental.inlineScriptHashes
+
+    if (inlineScriptHashes && !postponed) {
+      const hashes = collectInlineScriptHashes(
+        html,
+        inlineScriptHashes.algorithm ?? 'sha256'
+      )
+
+      if (hashes.length > 0) {
+        headers[NEXT_INLINE_SCRIPT_HASHES_HEADER] = hashes.join(' ')
+      }
+    }
 
     if (fetchTags) {
       headers[NEXT_CACHE_TAGS_HEADER] = fetchTags

--- a/packages/next/src/export/routes/app-page.ts
+++ b/packages/next/src/export/routes/app-page.ts
@@ -11,7 +11,6 @@ import type {
 import { isDynamicUsageError } from '../helpers/is-dynamic-usage-error'
 import {
   NEXT_CACHE_TAGS_HEADER,
-  NEXT_INLINE_SCRIPT_HASHES_HEADER,
   NEXT_META_SUFFIX,
   RSC_SUFFIX,
   RSC_SEGMENTS_DIR_SUFFIX,
@@ -191,22 +190,6 @@ export async function exportAppPage(
     // If we're writing the file to disk, we know it's a prerender.
     headers[NEXT_IS_PRERENDER_HEADER] = '1'
 
-    // The hashes of the inline scripts travel with the prerendered document, so
-    // the response can be served under a policy without `'unsafe-inline'`. A
-    // postponed shell is completed at request time, where the rest is hashed.
-    const inlineScriptHashes = renderOpts.experimental.inlineScriptHashes
-
-    if (inlineScriptHashes && !postponed) {
-      const hashes = collectInlineScriptHashes(
-        html,
-        inlineScriptHashes.algorithm ?? 'sha256'
-      )
-
-      if (hashes.length > 0) {
-        headers[NEXT_INLINE_SCRIPT_HASHES_HEADER] = hashes.join(' ')
-      }
-    }
-
     if (fetchTags) {
       headers[NEXT_CACHE_TAGS_HEADER] = fetchTags
     }
@@ -235,11 +218,23 @@ export async function exportAppPage(
       status = res.statusCode
     }
 
+    // The hashes of the inline scripts travel with the prerendered document, so
+    // the response can be served under a policy without `'unsafe-inline'`. A
+    // postponed shell is completed at request time and streams, so it stays out.
+    const inlineScriptHashesConfig = renderOpts.experimental.inlineScriptHashes
+    const inlineScriptHashes =
+      inlineScriptHashesConfig && !postponed
+        ? collectInlineScriptHashes(html, inlineScriptHashesConfig.algorithm)
+        : undefined
+
     // Writing the request metadata to a file.
     const meta: RouteMetadata = {
       status,
       headers,
       postponed,
+      inlineScriptHashes: inlineScriptHashes?.length
+        ? inlineScriptHashes
+        : undefined,
       segmentPaths,
       prefetchHints,
     }

--- a/packages/next/src/export/routes/types.ts
+++ b/packages/next/src/export/routes/types.ts
@@ -5,6 +5,7 @@ export type RouteMetadata = {
   status: number | undefined
   headers: OutgoingHttpHeaders | undefined
   postponed: string | undefined
+  inlineScriptHashes: Array<string> | undefined
   segmentPaths: Array<string> | undefined
   prefetchHints: PrefetchHints | undefined
 }

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -22,6 +22,7 @@ export const NEXT_BODY_SUFFIX = '.body'
 export const NEXT_NAV_DEPLOYMENT_ID_HEADER = 'x-nextjs-deployment-id'
 
 export const NEXT_CACHE_TAGS_HEADER = 'x-next-cache-tags'
+export const NEXT_INLINE_SCRIPT_HASHES_HEADER = 'x-next-inline-script-hashes'
 export const NEXT_CACHE_REVALIDATED_TAGS_HEADER = 'x-next-revalidated-tags'
 export const NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER =
   'x-next-revalidate-tag-token'

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -22,7 +22,6 @@ export const NEXT_BODY_SUFFIX = '.body'
 export const NEXT_NAV_DEPLOYMENT_ID_HEADER = 'x-nextjs-deployment-id'
 
 export const NEXT_CACHE_TAGS_HEADER = 'x-next-cache-tags'
-export const NEXT_INLINE_SCRIPT_HASHES_HEADER = 'x-next-inline-script-hashes'
 export const NEXT_CACHE_REVALIDATED_TAGS_HEADER = 'x-next-revalidated-tags'
 export const NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER =
   'x-next-revalidate-tag-token'

--- a/packages/next/src/server/app-render/inline-script-hashes.test.ts
+++ b/packages/next/src/server/app-render/inline-script-hashes.test.ts
@@ -1,0 +1,91 @@
+import { createHash } from 'crypto'
+
+import {
+  collectInlineScriptHashes,
+  withInlineScriptHashes,
+} from './inline-script-hashes'
+
+const hashOf = (body: string) =>
+  `'sha256-${createHash('sha256').update(body, 'utf8').digest('base64')}'`
+
+describe('collectInlineScriptHashes', () => {
+  it('hashes the body of every inline script', () => {
+    const html =
+      '<html><body><script>self.__next_f.push([1,"a"])</script>' +
+      '<script type="application/json">{"a":1}</script></body></html>'
+
+    expect(collectInlineScriptHashes(html, 'sha256')).toEqual([
+      hashOf('self.__next_f.push([1,"a"])'),
+      hashOf('{"a":1}'),
+    ])
+  })
+
+  it('skips scripts served from a URL and empty ones', () => {
+    const html =
+      '<script src="/_next/static/chunk.js"></script>' +
+      '<script src="/other.js" defer></script>' +
+      '<script></script>'
+
+    expect(collectInlineScriptHashes(html, 'sha256')).toEqual([])
+  })
+
+  it('reports repeated bodies once', () => {
+    const html = '<script>hydrate()</script><script>hydrate()</script>'
+
+    expect(collectInlineScriptHashes(html, 'sha256')).toEqual([
+      hashOf('hydrate()'),
+    ])
+  })
+})
+
+describe('withInlineScriptHashes', () => {
+  const hashes = [hashOf('hydrate()')]
+
+  it('adds the hashes to script-src', () => {
+    expect(
+      withInlineScriptHashes(`default-src 'self'; script-src 'self'`, hashes)
+    ).toBe(`default-src 'self'; script-src 'self' ${hashes[0]}`)
+  })
+
+  it('prefers script-src-elem where the policy has one', () => {
+    expect(
+      withInlineScriptHashes(
+        `script-src 'self'; script-src-elem 'self'`,
+        hashes
+      )
+    ).toBe(`script-src 'self'; script-src-elem 'self' ${hashes[0]}`)
+  })
+
+  it('falls back to default-src', () => {
+    expect(withInlineScriptHashes(`default-src 'self'`, hashes)).toBe(
+      `default-src 'self' ${hashes[0]}`
+    )
+  })
+
+  it('leaves a policy with unsafe-inline alone', () => {
+    const policy = `script-src 'self' 'unsafe-inline'`
+
+    expect(withInlineScriptHashes(policy, hashes)).toBe(policy)
+  })
+
+  it('leaves a policy without a governing directive alone', () => {
+    const policy = `img-src 'self'`
+
+    expect(withInlineScriptHashes(policy, hashes)).toBe(policy)
+  })
+
+  it('handles a header carrying several policies', () => {
+    expect(
+      withInlineScriptHashes(
+        `script-src 'self', script-src 'self' 'unsafe-inline'`,
+        hashes
+      )
+    ).toBe(`script-src 'self' ${hashes[0]}, script-src 'self' 'unsafe-inline'`)
+  })
+
+  it('returns the header untouched when there is nothing to add', () => {
+    expect(withInlineScriptHashes(`script-src 'self'`, [])).toBe(
+      `script-src 'self'`
+    )
+  })
+})

--- a/packages/next/src/server/app-render/inline-script-hashes.ts
+++ b/packages/next/src/server/app-render/inline-script-hashes.ts
@@ -1,0 +1,90 @@
+import { createHash } from 'crypto'
+
+import type { SubresourceIntegrityAlgorithm } from '../../build/webpack/plugins/subresource-integrity-plugin'
+
+const INLINE_SCRIPT_REGEX =
+  /<script(?<attributes>[^>]*)>(?<body>[\s\S]*?)<\/script\s*>/gi
+const SRC_ATTRIBUTE_REGEX = /\ssrc[\s=]/i
+const UNSAFE_INLINE_SOURCE = `'unsafe-inline'`
+
+/**
+ * Collects the CSP hash sources of every inline script of a document.
+ *
+ * @param html the rendered document
+ * @param algorithm the digest algorithm to use
+ */
+export function collectInlineScriptHashes(
+  html: string,
+  algorithm: SubresourceIntegrityAlgorithm
+): string[] {
+  const hashes = new Set<string>()
+
+  for (const match of html.matchAll(INLINE_SCRIPT_REGEX)) {
+    const { attributes = '', body = '' } = match.groups ?? {}
+
+    // Scripts with a src are external resources, which the policy admits by
+    // their URL rather than by the content of the element.
+    if (SRC_ATTRIBUTE_REGEX.test(attributes) || !body) {
+      continue
+    }
+
+    const digest = createHash(algorithm).update(body, 'utf8').digest('base64')
+
+    hashes.add(`'${algorithm}-${digest}'`)
+  }
+
+  return Array.from(hashes)
+}
+
+/**
+ * Adds hash sources to the directive that governs script elements of every
+ * policy in a `Content-Security-Policy` header value.
+ *
+ * A policy that already carries `'unsafe-inline'` is left alone: adding a hash
+ * source makes browsers ignore `'unsafe-inline'`, which would block the inline
+ * scripts the policy admits today.
+ *
+ * @param cspHeaderValue the header value, which may carry several policies
+ * @param hashes the hash sources to add
+ */
+export function withInlineScriptHashes(
+  cspHeaderValue: string,
+  hashes: string[]
+): string {
+  if (hashes.length === 0) {
+    return cspHeaderValue
+  }
+
+  // A header carries one policy per ',', each enforced on its own.
+  return cspHeaderValue
+    .split(',')
+    .map((policy) => addHashesToPolicy(policy, hashes))
+    .join(',')
+}
+
+function addHashesToPolicy(policy: string, hashes: string[]): string {
+  const directives = policy.split(';')
+
+  // Script elements are governed by 'script-src-elem' where it is present, and
+  // fall back to 'script-src' and then 'default-src'.
+  const index =
+    findDirective(directives, 'script-src-elem') ??
+    findDirective(directives, 'script-src') ??
+    findDirective(directives, 'default-src')
+
+  if (index === undefined || directives[index].includes(UNSAFE_INLINE_SOURCE)) {
+    return policy
+  }
+
+  directives[index] = `${directives[index].trimEnd()} ${hashes.join(' ')}`
+
+  return directives.join(';')
+}
+
+function findDirective(directives: string[], name: string): number | undefined {
+  const index = directives.findIndex(
+    (directive) => directive.trim().split(/\s+/)[0]?.toLowerCase() === name
+  )
+
+  return index === -1 ? undefined : index
+}

--- a/packages/next/src/server/app-render/inline-script-hashes.ts
+++ b/packages/next/src/server/app-render/inline-script-hashes.ts
@@ -6,6 +6,7 @@ const INLINE_SCRIPT_REGEX =
   /<script(?<attributes>[^>]*)>(?<body>[\s\S]*?)<\/script\s*>/gi
 const SRC_ATTRIBUTE_REGEX = /\ssrc[\s=]/i
 const UNSAFE_INLINE_SOURCE = `'unsafe-inline'`
+const DEFAULT_ALGORITHM: SubresourceIntegrityAlgorithm = 'sha256'
 
 /**
  * Collects the CSP hash sources of every inline script of a document.
@@ -15,7 +16,7 @@ const UNSAFE_INLINE_SOURCE = `'unsafe-inline'`
  */
 export function collectInlineScriptHashes(
   html: string,
-  algorithm: SubresourceIntegrityAlgorithm
+  algorithm: SubresourceIntegrityAlgorithm = DEFAULT_ALGORITHM
 ): string[] {
   const hashes = new Set<string>()
 

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -164,6 +164,7 @@ export interface RenderOptsPartial {
     dynamicOnHover: boolean
     optimisticRouting: boolean
     inlineCss: boolean
+    inlineScriptHashes: ExperimentalConfig['inlineScriptHashes']
     prefetchInlining: PrefetchInliningConfig
     authInterrupts: boolean
     reactBrowserBailout: boolean

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -606,6 +606,7 @@ export default abstract class Server<
         optimisticRouting:
           this.nextConfig.experimental.optimisticRouting ?? false,
         inlineCss: this.nextConfig.experimental.inlineCss ?? false,
+        inlineScriptHashes: this.nextConfig.experimental.inlineScriptHashes,
         prefetchInlining:
           this.nextConfig.experimental.prefetchInlining ?? false,
         authInterrupts: !!this.nextConfig.experimental.authInterrupts,

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -246,6 +246,11 @@ export const experimentalSchema = {
   disablePostcssPresetEnv: z.boolean().optional(),
   cacheComponents: z.boolean().optional(),
   inlineCss: z.boolean().optional(),
+  inlineScriptHashes: z
+    .object({
+      algorithm: z.enum(['sha256', 'sha384', 'sha512']).optional(),
+    })
+    .optional(),
   esmExternals: z.union([z.boolean(), z.literal('loose')]).optional(),
   serverActions: z
     .object({

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -727,6 +727,19 @@ export interface ExperimentalConfig {
     algorithm?: SubresourceIntegrityAlgorithm
   }
 
+  /**
+   * Adds the hashes of the inline scripts of a cacheable response to the
+   * directive that governs script elements of its `Content-Security-Policy`, so
+   * the response can be served under a policy without `'unsafe-inline'`.
+   *
+   * Cacheable responses are buffered instead of streamed, since the hashes are
+   * only known once the document is complete. Dynamic responses keep streaming
+   * and still need a nonce.
+   */
+  inlineScriptHashes?: {
+    algorithm?: SubresourceIntegrityAlgorithm
+  }
+
   webVitalsAttribution?: Array<(typeof WEB_VITALS)[number]>
 
   /**
@@ -2474,6 +2487,7 @@ export interface NextConfigRuntime {
     | 'caseSensitiveRoutes'
     | 'validateRSCRequestHeaders'
     | 'sri'
+    | 'inlineScriptHashes'
     | 'useSkewCookie'
     | 'preloadEntriesOnStart'
     | 'hideLogsAfterAbort'
@@ -2543,6 +2557,7 @@ export function getNextConfigRuntime(
     caseSensitiveRoutes: ex.caseSensitiveRoutes,
     validateRSCRequestHeaders: ex.validateRSCRequestHeaders,
     sri: ex.sri,
+    inlineScriptHashes: ex.inlineScriptHashes,
     useSkewCookie: ex.useSkewCookie,
     preloadEntriesOnStart: ex.preloadEntriesOnStart,
     hideLogsAfterAbort: ex.hideLogsAfterAbort,

--- a/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
+++ b/packages/next/src/server/lib/incremental-cache/file-system-cache.ts
@@ -250,6 +250,7 @@ export default class FileSystemCache implements CacheHandler {
                 rscData,
                 postponed: meta?.postponed,
                 headers: meta?.headers,
+                inlineScriptHashes: meta?.inlineScriptHashes,
                 status: meta?.status,
                 segmentData: maybeSegmentData,
               },
@@ -378,6 +379,7 @@ export default class FileSystemCache implements CacheHandler {
         headers: data.headers,
         status: data.status,
         postponed: undefined,
+        inlineScriptHashes: undefined,
         segmentPaths: undefined,
         prefetchHints: undefined,
       }
@@ -432,6 +434,7 @@ export default class FileSystemCache implements CacheHandler {
           headers: data.headers,
           status: data.status,
           postponed: data.postponed,
+          inlineScriptHashes: data.inlineScriptHashes,
           segmentPaths,
           prefetchHints: undefined,
         }

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -77,6 +77,7 @@ export interface CachedAppPageValue {
   status: number | undefined
   postponed: string | undefined
   headers: OutgoingHttpHeaders | undefined
+  inlineScriptHashes: Array<string> | undefined
   segmentData: Map<string, Buffer> | undefined
 }
 
@@ -117,6 +118,7 @@ export interface IncrementalCachedAppPageValue {
   html: string
   rscData: Buffer | undefined
   headers: OutgoingHttpHeaders | undefined
+  inlineScriptHashes: Array<string> | undefined
   postponed: string | undefined
   status: number | undefined
   segmentData: Map<string, Buffer> | undefined

--- a/packages/next/src/server/response-cache/utils.ts
+++ b/packages/next/src/server/response-cache/utils.ts
@@ -32,6 +32,7 @@ export async function fromResponseCacheEntry(
               postponed: cacheEntry.value.postponed,
               rscData: cacheEntry.value.rscData,
               headers: cacheEntry.value.headers,
+              inlineScriptHashes: cacheEntry.value.inlineScriptHashes,
               status: cacheEntry.value.status,
               segmentData: cacheEntry.value.segmentData,
             }
@@ -70,6 +71,7 @@ export async function toResponseCacheEntry(
               ),
               rscData: response.value.rscData,
               headers: response.value.headers,
+              inlineScriptHashes: response.value.inlineScriptHashes,
               status: response.value.status,
               postponed: response.value.postponed,
               segmentData: response.value.segmentData,

--- a/test/e2e/app-dir/inline-script-hashes-ppr/app/layout.js
+++ b/test/e2e/app-dir/inline-script-hashes-ppr/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/inline-script-hashes-ppr/app/ppr/page.js
+++ b/test/e2e/app-dir/inline-script-hashes-ppr/app/ppr/page.js
@@ -1,0 +1,19 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function Dynamic() {
+  await connection()
+
+  return <span id="dynamic">{Date.now()}</span>
+}
+
+export default function Page() {
+  return (
+    <p id="ppr">
+      shell
+      <Suspense fallback={<span id="fallback">loading</span>}>
+        <Dynamic />
+      </Suspense>
+    </p>
+  )
+}

--- a/test/e2e/app-dir/inline-script-hashes-ppr/inline-script-hashes-ppr.test.ts
+++ b/test/e2e/app-dir/inline-script-hashes-ppr/inline-script-hashes-ppr.test.ts
@@ -1,0 +1,20 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('inline script hashes with a resumed shell', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped || isNextDev) return
+
+  it('leaves the resume streaming and the policy untouched', async () => {
+    const res = await next.fetch('/ppr')
+    const html = await res.text()
+
+    expect(res.headers.get('content-security-policy')).toBe(
+      "default-src 'self'; script-src 'self'"
+    )
+    expect(html).toContain('id="dynamic"')
+  })
+})

--- a/test/e2e/app-dir/inline-script-hashes-ppr/next.config.js
+++ b/test/e2e/app-dir/inline-script-hashes-ppr/next.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  cacheComponents: true,
+  experimental: {
+    inlineScriptHashes: { algorithm: 'sha256' },
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: "default-src 'self'; script-src 'self'",
+          },
+        ],
+      },
+    ]
+  },
+}

--- a/test/e2e/app-dir/inline-script-hashes/app/dynamic/page.js
+++ b/test/e2e/app-dir/inline-script-hashes/app/dynamic/page.js
@@ -1,0 +1,5 @@
+export const dynamic = 'force-dynamic'
+
+export default function Page() {
+  return <p id="dynamic">{Date.now()}</p>
+}

--- a/test/e2e/app-dir/inline-script-hashes/app/layout.js
+++ b/test/e2e/app-dir/inline-script-hashes/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/inline-script-hashes/app/on-demand/[slug]/page.js
+++ b/test/e2e/app-dir/inline-script-hashes/app/on-demand/[slug]/page.js
@@ -1,0 +1,11 @@
+export const revalidate = 10
+
+export function generateStaticParams() {
+  return []
+}
+
+export default async function Page({ params }) {
+  const { slug } = await params
+
+  return <p id="slug">{slug}</p>
+}

--- a/test/e2e/app-dir/inline-script-hashes/app/page.js
+++ b/test/e2e/app-dir/inline-script-hashes/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="static">static</p>
+}

--- a/test/e2e/app-dir/inline-script-hashes/app/unsafe-inline/page.js
+++ b/test/e2e/app-dir/inline-script-hashes/app/unsafe-inline/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="unsafe-inline">unsafe-inline</p>
+}

--- a/test/e2e/app-dir/inline-script-hashes/inline-script-hashes.test.ts
+++ b/test/e2e/app-dir/inline-script-hashes/inline-script-hashes.test.ts
@@ -1,0 +1,94 @@
+import { createHash } from 'crypto'
+import { nextTestSetup } from 'e2e-utils'
+
+const INLINE_SCRIPT_REGEX =
+  /<script(?![^>]*\ssrc[\s=])[^>]*>([\s\S]*?)<\/script\s*>/g
+
+function inlineScriptHashes(html: string): string[] {
+  const hashes = new Set<string>()
+
+  for (const [, body] of html.matchAll(INLINE_SCRIPT_REGEX)) {
+    if (!body) continue
+
+    hashes.add(
+      `'sha256-${createHash('sha256').update(body, 'utf8').digest('base64')}'`
+    )
+  }
+
+  return Array.from(hashes)
+}
+
+async function policyOf(res: Response): Promise<string> {
+  const policy = res.headers.get('content-security-policy')
+
+  expect(policy).not.toBeNull()
+
+  return policy as string
+}
+
+describe('inline script hashes', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) return
+
+  // The hashes are known once the document is complete, which only happens for
+  // a response that is cached; the development server serves every request from
+  // a fresh render and streams it.
+  if (isNextDev) {
+    it('leaves the policy alone in development', async () => {
+      const res = await next.fetch('/')
+
+      expect(await policyOf(res)).toBe("default-src 'self'; script-src 'self'")
+    })
+
+    return
+  }
+
+  it('admits every inline script of a prerendered page', async () => {
+    const res = await next.fetch('/')
+    const policy = await policyOf(res)
+    const hashes = inlineScriptHashes(await res.text())
+
+    expect(hashes.length).toBeGreaterThan(0)
+    expect(policy).not.toContain("'unsafe-inline'")
+
+    for (const hash of hashes) {
+      expect(policy).toContain(hash)
+    }
+  })
+
+  it('admits the inline scripts of a page rendered on demand', async () => {
+    const res = await next.fetch('/on-demand/first')
+    const policy = await policyOf(res)
+    const hashes = inlineScriptHashes(await res.text())
+
+    expect(hashes.length).toBeGreaterThan(0)
+
+    for (const hash of hashes) {
+      expect(policy).toContain(hash)
+    }
+  })
+
+  it('serves the same policy and body from the cache', async () => {
+    const first = await next.fetch('/on-demand/second')
+    const firstPolicy = await policyOf(first)
+    const firstHtml = await first.text()
+
+    const second = await next.fetch('/on-demand/second')
+    const secondPolicy = await policyOf(second)
+
+    expect(await second.text()).toBe(firstHtml)
+    expect(secondPolicy).toBe(firstPolicy)
+  })
+
+  it('leaves a policy that carries unsafe-inline alone', async () => {
+    const res = await next.fetch('/unsafe-inline')
+
+    expect(await policyOf(res)).toBe(
+      "default-src 'self'; script-src 'self' 'unsafe-inline'"
+    )
+  })
+})

--- a/test/e2e/app-dir/inline-script-hashes/inline-script-hashes.test.ts
+++ b/test/e2e/app-dir/inline-script-hashes/inline-script-hashes.test.ts
@@ -84,6 +84,12 @@ describe('inline script hashes', () => {
     expect(secondPolicy).toBe(firstPolicy)
   })
 
+  it('leaves a dynamic response streaming and unhashed', async () => {
+    const res = await next.fetch('/dynamic')
+
+    expect(await policyOf(res)).toBe("default-src 'self'; script-src 'self'")
+  })
+
   it('leaves a policy that carries unsafe-inline alone', async () => {
     const res = await next.fetch('/unsafe-inline')
 

--- a/test/e2e/app-dir/inline-script-hashes/next.config.js
+++ b/test/e2e/app-dir/inline-script-hashes/next.config.js
@@ -1,0 +1,27 @@
+module.exports = {
+  experimental: {
+    inlineScriptHashes: { algorithm: 'sha256' },
+  },
+  async headers() {
+    return [
+      {
+        source: '/unsafe-inline',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: "default-src 'self'; script-src 'self' 'unsafe-inline'",
+          },
+        ],
+      },
+      {
+        source: '/((?!unsafe-inline).*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: "default-src 'self'; script-src 'self'",
+          },
+        ],
+      },
+    ]
+  },
+}


### PR DESCRIPTION
Fixes #95354.

`experimental.sri` puts an `integrity` attribute on the scripts Next.js emits, but a policy never consults that attribute when it decides whether an inline script may run. So a page served under `script-src 'self'` still has its inlined payload blocked, and the docs promised the opposite. A nonce is the only way out today, and a cached page cannot use one — the value would be baked into the body that every visitor gets.

`experimental.inlineScriptHashes` takes the hashes of the inline scripts from the finished document of a cacheable response and adds them to the directive that governs script elements: `script-src-elem` when the policy has one, otherwise `script-src`, otherwise `default-src`.

- a prerendered route is hashed while it is written out at build time, and the hashes travel in `.meta` with the rest of its response headers;
- a route rendered on demand is hashed when the response goes into the cache, so every later hit serves the same body under the same policy;
- while a response is cacheable it is buffered rather than streamed, since the hashes are only known once the document is complete. Dynamic responses keep streaming and still need a nonce;
- a policy that already carries `'unsafe-inline'` is left as it is: adding a hash makes browsers ignore `'unsafe-inline'`, which would block the inline scripts that policy admits today. Dropping `'unsafe-inline'` from the directive is what opts a route in.

Docs: the SRI section claimed it gives a strict CSP together with static generation, which `integrity` cannot do; that is corrected, and the new option is documented next to it.

Tests: unit tests for collecting the hashes and composing the policy, plus e2e over a prerendered route, a route rendered on demand, a cached hit and the `'unsafe-inline'` case.

I picked this shape after finding that the build-time manifest I first suggested in the issue cannot work: anything on ISR is rendered at request time, and React emits its own inline instructions for Suspense boundaries, so only the finished document carries the full set. Happy to reshape it — in particular, buffering cacheable responses is the price here, and if you would rather pay it somewhere else, say where and I will move it.
