### PR TITLE
fix(types): AppType getInitialProps should return AppInitialProps

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -30,7 +30,7 @@ export type DocumentType = NextComponentType<
 
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
-  P,
+  AppInitialProps<P>,
   AppPropsType<any, P>
 >
 

--- a/test/e2e/typescript/pages/_app.tsx
+++ b/test/e2e/typescript/pages/_app.tsx
@@ -4,6 +4,6 @@ const MyApp: AppType<{ foo: string }> = ({ Component, pageProps }) => {
   return <Component {...pageProps} />
 }
 
-MyApp.getInitialProps = () => ({ foo: 'bar' })
+MyApp.getInitialProps = () => ({ pageProps: { foo: 'bar' } })
 
 export default MyApp


### PR DESCRIPTION
## why

`AppType<P>['getInitialProps']` was typed as returning `P`. Next.js actually requires `{ pageProps }` (`AppInitialProps<P>`), so a correct `_app` implementation failed typecheck and a wrong `{ foo: 'bar' }` return typechecked.

## what

- type `getInitialProps` as `AppInitialProps<P>`
- update the typescript e2e `_app` fixture to return `{ pageProps }`

related https://github.com/vercel/next.js/issues/42846