### PR TITLE
fix(eslint-plugin-next): treat Windows paths in no-img-element

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-img-element.ts
+++ b/packages/eslint-plugin-next/src/rules/no-img-element.ts
@@ -18,8 +18,8 @@ export default defineRule({
   create(context) {
     // Get relative path of the file
     const relativePath = context.filename
-      .replace(path.sep, '/')
-      .replace(context.cwd, '')
+      .replace(/\\/g, '/')
+      .replace(context.cwd.replace(/\\/g, '/'), '')
       .replace(/^\//, '')
 
     const isAppDir = /^(src\/)?app\//.test(relativePath)

--- a/test/unit/eslint-plugin-next/no-img-element.test.ts
+++ b/test/unit/eslint-plugin-next/no-img-element.test.ts
@@ -63,6 +63,23 @@ export default function icon() {
     (
       <img
         alt="avatar"
+        src="https://example.com/image.png"
+      />
+    )
+  );
+}
+`,
+      filename: `src\\app\\icon.js`,
+    },
+    {
+      code: `\
+import { ImageResponse } from "next/og";
+
+export default function icon() {
+  return new ImageResponse(
+    (
+      <img
+        alt="avatar"
         style={{ borderRadius: "100%" }}
         width="100%"
         height="100%"


### PR DESCRIPTION
## why

`no-img-element` only replaced the first `path.sep`, so Windows paths like `src\\app\\icon.js` were not recognized as App Router metadata files and still got the `<img>` warning.

## what

replace all backslashes on filename and cwd, then run the metadata-route check. add a windows-style filename test.