### PR TITLE
Turbo Tasks: abort unneeded in-flight work

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -44,6 +44,7 @@ bitfield = { workspace = true }
 crossbeam-utils = { workspace = true }
 dashmap = { workspace = true, features = ["raw-api"]}
 fs-err = { workspace = true }
+futures = { workspace = true }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }
 jiff = "0.2.10"
@@ -69,7 +70,6 @@ thread_local = { workspace = true }
 [dev-dependencies]
 async-trait = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
-futures = { workspace = true }
 indoc = { workspace = true }
 regex = { workspace = true }
 tempfile = { workspace = true }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2111,7 +2111,7 @@ impl TurboTasksBackend {
             return None;
         };
         let InProgressState::InProgress(in_progress) = in_progress else {
-            // Shutdown cancellation or re-scheduling won the race. Preserve that state.
+            // Another state transition won the race. Preserve that state.
             let old = task.set_in_progress(in_progress);
             debug_assert!(old.is_none(), "InProgress already exists");
             return None;
@@ -2154,21 +2154,12 @@ impl TurboTasksBackend {
             decrease_active_counts_of_new_children(new_children, &mut ctx);
             return Some(priority);
         }
-        let immutable = task.immutable();
         drop(task);
 
         decrease_active_counts_of_new_children(new_children, &mut ctx);
 
-        if immutable {
-            // An immutable result never needs to be re-executed. This can happen when losing
-            // activeness races with the final completion bookkeeping.
-            done_event.notify(usize::MAX);
-            drop(in_progress_cells);
-            return None;
-        }
-
-        // Unlike shutdown cancellation, an unneeded abortion is recoverable: discard the current
-        // execution state and make the task dirty without scheduling it while it is disconnected.
+        // Discard the aborted execution state and make the task dirty without scheduling it while
+        // it is disconnected.
         let mut queue = AggregationUpdateQueue::new();
         let mut task = ctx.task(task_id, TaskDataCategory::All);
         make_task_dirty_internal(
@@ -2257,14 +2248,14 @@ impl TurboTasksBackend {
                     _ => None,
                 };
             }
-            let (abort_handle, registration) = AbortHandle::new_pair();
-            abort_registration = registration;
-            let abort_handle = match &task_type {
+            let (abort_handle, registration) = match &task_type {
                 TaskType::Cached(task_type) if task_type.native_fn.is_cancelable => {
-                    Some(abort_handle)
+                    let (abort_handle, registration) = AbortHandle::new_pair();
+                    (Some(abort_handle), Some(registration))
                 }
-                _ => None,
+                _ => (None, None),
             };
+            abort_registration = registration;
             let old = task.set_in_progress(InProgressState::InProgress(Box::new(
                 InProgressStateInner {
                     stale: false,
@@ -2519,6 +2510,12 @@ impl TurboTasksBackend {
         has_invalidator: bool,
     ) -> Result<TaskExecutionCompletePrepareResult, TaskPriority> {
         let mut task = ctx.task(task_id, TaskDataCategory::All);
+        if let Some(InProgressState::InProgress(in_progress)) = task.get_in_progress_mut() {
+            // The task future completed without observing a concurrent abort request. From this
+            // point on, use the ordinary completion bookkeeping: stale tasks re-execute and
+            // inactive tasks finalize into a state a later GC pass can collect.
+            in_progress.disarm_abort();
+        }
         let is_recomputation = task.is_dirty().is_none();
         // Without dependency tracking, the SessionDependent dirty state is never read (no session
         // restore), so skip the work

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2255,7 +2255,12 @@ impl TurboTasksBackend {
             }
             let (abort_handle, registration) = AbortHandle::new_pair();
             abort_registration = registration;
-            let abort_handle = matches!(&task_type, TaskType::Cached(_)).then_some(abort_handle);
+            let abort_handle = match &task_type {
+                TaskType::Cached(task_type) if task_type.native_fn.is_cancelable => {
+                    Some(abort_handle)
+                }
+                _ => None,
+            };
             let old = task.set_in_progress(InProgressState::InProgress(Box::new(
                 InProgressStateInner {
                     stale: false,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2103,8 +2103,15 @@ impl TurboTasksBackend {
     ) -> Option<TaskPriority> {
         let mut ctx = self.execute_context(turbo_tasks);
         let mut task = ctx.task(task_id, TaskDataCategory::All);
-        let Some(InProgressState::InProgress(in_progress)) = task.take_in_progress() else {
-            panic!("Task execution aborted, but task is not in progress: {task:#?}");
+        let Some(in_progress) = task.take_in_progress() else {
+            // Completion or another abort callback won the race.
+            return None;
+        };
+        let InProgressState::InProgress(in_progress) = in_progress else {
+            // Shutdown cancellation or re-scheduling won the race. Preserve that state.
+            let old = task.set_in_progress(in_progress);
+            debug_assert!(old.is_none(), "InProgress already exists");
+            return None;
         };
         let InProgressStateInner {
             stale,
@@ -2144,9 +2151,18 @@ impl TurboTasksBackend {
             decrease_active_counts_of_new_children(new_children, &mut ctx);
             return Some(priority);
         }
+        let immutable = task.immutable();
         drop(task);
 
         decrease_active_counts_of_new_children(new_children, &mut ctx);
+
+        if immutable {
+            // An immutable result never needs to be re-executed. This can happen when losing
+            // activeness races with the final completion bookkeeping.
+            done_event.notify(usize::MAX);
+            drop(in_progress_cells);
+            return None;
+        }
 
         // Unlike shutdown cancellation, an unneeded abortion is recoverable: discard the current
         // execution state and make the task dirty without scheduling it while it is disconnected.
@@ -2154,10 +2170,13 @@ impl TurboTasksBackend {
         let mut task = ctx.task(task_id, TaskDataCategory::All);
         make_task_dirty_internal(
             &mut task,
-            true,
+            // The aborted execution's in-progress state was already taken above, so there is
+            // nothing left to mark stale.
+            /* make_stale */
             false,
+            /* schedule_when_active */ false,
             #[cfg(feature = "task_dirty_cause")]
-            TaskDirtyCause::ExecutionAborted,
+            TaskDirtyCause::BecameInactive,
             &mut queue,
             &mut ctx,
         );
@@ -2167,6 +2186,15 @@ impl TurboTasksBackend {
         // A connection may race with dropping the aborted future. Re-check liveness after the
         // dirty transition so a revived task is not left dirty but unscheduled.
         let mut task = ctx.task(task_id, TaskDataCategory::All);
+        if task.get_in_progress().is_some() {
+            // A reader/connection already scheduled (or started) the dirty task while the abort
+            // callback propagated its dirty transition. Keep that execution and only release
+            // listeners attached to the aborted execution.
+            done_event.notify(usize::MAX);
+            drop(task);
+            drop(in_progress_cells);
+            return None;
+        }
         let should_schedule = if self.should_track_activeness() {
             task.has_activeness()
         } else {
@@ -2836,7 +2864,7 @@ impl TurboTasksBackend {
             make_task_dirty_internal(
                 &mut dependent,
                 make_stale,
-                true,
+                /* schedule_when_active */ true,
                 #[cfg(feature = "task_dirty_cause")]
                 cause.clone(),
                 queue,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -18,7 +18,10 @@ use std::{
     hash::BuildHasherDefault,
     mem::take,
     pin::Pin,
-    sync::{Arc, LazyLock},
+    sync::{
+        Arc, LazyLock,
+        atomic::{AtomicBool, Ordering},
+    },
     time::SystemTime,
 };
 
@@ -70,9 +73,9 @@ use crate::{
         operation::{
             AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext,
             CleanupOldEdgesOperation, ConnectChildOperation, ExecuteContext, ExecuteContextImpl,
-            LeafDistanceUpdateQueue, Operation, OutdatedEdge, TaskGuard, TaskType, TaskTypeRef,
-            capture_all_outgoing_edges, connect_children, get_aggregation_number, get_uppers,
-            make_task_dirty_internal, prepare_new_children,
+            LeafDistanceUpdateQueue, MakeTaskDirtyOptions, Operation, OutdatedEdge, TaskGuard,
+            TaskType, TaskTypeRef, capture_all_outgoing_edges, connect_children,
+            get_aggregation_number, get_uppers, make_task_dirty_internal, prepare_new_children,
         },
         snapshot_coordinator::{OperationGuard, SnapshotCoordinator},
         storage::Storage,
@@ -2170,13 +2173,14 @@ impl TurboTasksBackend {
         let mut task = ctx.task(task_id, TaskDataCategory::All);
         make_task_dirty_internal(
             &mut task,
-            // The aborted execution's in-progress state was already taken above, so there is
-            // nothing left to mark stale.
-            /* make_stale */
-            false,
-            /* schedule_when_active */ false,
-            #[cfg(feature = "task_dirty_cause")]
-            TaskDirtyCause::BecameInactive,
+            MakeTaskDirtyOptions {
+                // The aborted execution's in-progress state was already taken above, so there is
+                // nothing left to mark stale.
+                make_stale: false,
+                schedule_when_active: false,
+                #[cfg(feature = "task_dirty_cause")]
+                cause: TaskDirtyCause::BecameInactive,
+            },
             &mut queue,
             &mut ctx,
         );
@@ -2868,10 +2872,12 @@ impl TurboTasksBackend {
             }
             make_task_dirty_internal(
                 &mut dependent,
-                make_stale,
-                /* schedule_when_active */ true,
-                #[cfg(feature = "task_dirty_cause")]
-                cause.clone(),
+                MakeTaskDirtyOptions {
+                    make_stale,
+                    schedule_when_active: true,
+                    #[cfg(feature = "task_dirty_cause")]
+                    cause: cause.clone(),
+                },
                 queue,
                 ctx,
             );

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -24,6 +24,7 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use auto_hash_map::{AutoMap, AutoSet};
+use futures::future::AbortHandle;
 use gc::DEFAULT_GC_ROOT_TTL;
 pub use gc::TtlCounter;
 use hashbrown::hash_table::Entry;
@@ -110,6 +111,22 @@ fn compute_stale_priority(task: &impl TaskGuard) -> TaskPriority {
             .distance,
     )
     .in_parent(task.is_dirty().unwrap_or(TaskPriority::leaf()))
+}
+
+/// Undoes the speculative active-count increments an aborted execution made for children it
+/// connected for the first time.
+fn decrease_active_counts_of_new_children(
+    new_children: FxHashSet<TaskId>,
+    ctx: &mut impl ExecuteContext<'_>,
+) {
+    if !new_children.is_empty() {
+        AggregationUpdateQueue::run(
+            AggregationUpdateJob::DecreaseActiveCounts {
+                task_ids: new_children.into_iter().collect(),
+            },
+            ctx,
+        );
+    }
 }
 
 #[derive(PartialEq, Eq)]
@@ -2079,6 +2096,99 @@ impl TurboTasksBackend {
         drop(in_progress_cells);
     }
 
+    fn task_execution_aborted(
+        &self,
+        task_id: TaskId,
+        turbo_tasks: &TurboTasks<TurboTasksBackend>,
+    ) -> Option<TaskPriority> {
+        let mut ctx = self.execute_context(turbo_tasks);
+        let mut task = ctx.task(task_id, TaskDataCategory::All);
+        let Some(InProgressState::InProgress(in_progress)) = task.take_in_progress() else {
+            panic!("Task execution aborted, but task is not in progress: {task:#?}");
+        };
+        let InProgressStateInner {
+            stale,
+            done_event,
+            mut new_children,
+            abort_when_unneeded,
+            ..
+        } = *in_progress;
+        let aborted_as_unneeded = abort_when_unneeded.load(Ordering::Acquire);
+
+        // Only children that were not already connected received a speculative active-count
+        // increment during this execution.
+        for child in task.iter_children() {
+            new_children.remove(&child);
+        }
+
+        let in_progress_cells = if aborted_as_unneeded {
+            task.take_in_progress_cells()
+        } else {
+            None
+        };
+        if let Some(cells) = &in_progress_cells {
+            for state in cells.values() {
+                state.event.notify(usize::MAX);
+            }
+        }
+
+        if !aborted_as_unneeded {
+            debug_assert!(stale, "only stale or unneeded executions may be aborted");
+            let priority = compute_stale_priority(&task);
+            let old = task.set_in_progress(InProgressState::Scheduled {
+                done_event,
+                reason: TaskExecutionReason::Stale,
+            });
+            debug_assert!(old.is_none(), "InProgress already exists");
+            drop(task);
+            decrease_active_counts_of_new_children(new_children, &mut ctx);
+            return Some(priority);
+        }
+        drop(task);
+
+        decrease_active_counts_of_new_children(new_children, &mut ctx);
+
+        // Unlike shutdown cancellation, an unneeded abortion is recoverable: discard the current
+        // execution state and make the task dirty without scheduling it while it is disconnected.
+        let mut queue = AggregationUpdateQueue::new();
+        let mut task = ctx.task(task_id, TaskDataCategory::All);
+        make_task_dirty_internal(
+            &mut task,
+            true,
+            false,
+            #[cfg(feature = "task_dirty_cause")]
+            TaskDirtyCause::ExecutionAborted,
+            &mut queue,
+            &mut ctx,
+        );
+        drop(task);
+        queue.execute(&mut ctx);
+
+        // A connection may race with dropping the aborted future. Re-check liveness after the
+        // dirty transition so a revived task is not left dirty but unscheduled.
+        let mut task = ctx.task(task_id, TaskDataCategory::All);
+        let should_schedule = if self.should_track_activeness() {
+            task.has_activeness()
+        } else {
+            !task.is_gc_collectible()
+        };
+        let priority = if should_schedule {
+            let priority = compute_stale_priority(&task);
+            let old = task.set_in_progress(InProgressState::Scheduled {
+                done_event,
+                reason: TaskExecutionReason::Stale,
+            });
+            debug_assert!(old.is_none(), "InProgress already exists");
+            Some(priority)
+        } else {
+            done_event.notify(usize::MAX);
+            None
+        };
+        drop(task);
+        drop(in_progress_cells);
+        priority
+    }
+
     fn try_start_task_execution(
         &self,
         task_id: TaskId,
@@ -2087,6 +2197,7 @@ impl TurboTasksBackend {
     ) -> Option<TaskExecutionSpec<'_>> {
         let execution_reason;
         let task_type;
+        let abort_registration;
         #[cfg(feature = "task_dirty_cause")]
         let cause;
         {
@@ -2114,6 +2225,9 @@ impl TurboTasksBackend {
                     _ => None,
                 };
             }
+            let (abort_handle, registration) = AbortHandle::new_pair();
+            abort_registration = registration;
+            let abort_handle = matches!(&task_type, TaskType::Cached(_)).then_some(abort_handle);
             let old = task.set_in_progress(InProgressState::InProgress(Box::new(
                 InProgressStateInner {
                     stale: false,
@@ -2121,6 +2235,8 @@ impl TurboTasksBackend {
                     done_event,
                     marked_as_completed: false,
                     new_children: Default::default(),
+                    abort_handle,
+                    abort_when_unneeded: AtomicBool::new(false),
                 },
             )));
             debug_assert!(old.is_none(), "InProgress already exists");
@@ -2201,7 +2317,11 @@ impl TurboTasksBackend {
                 (span, future)
             }
         };
-        Some(TaskExecutionSpec { future, span })
+        Some(TaskExecutionSpec {
+            future,
+            span,
+            abort_registration,
+        })
     }
 
     /// Returns `Some(priority)` if the task became stale during execution and needs to be
@@ -2716,6 +2836,7 @@ impl TurboTasksBackend {
             make_task_dirty_internal(
                 &mut dependent,
                 make_stale,
+                true,
                 #[cfg(feature = "task_dirty_cause")]
                 cause.clone(),
                 queue,
@@ -2864,6 +2985,7 @@ impl TurboTasksBackend {
             stale,
             marked_as_completed: _,
             new_children,
+            ..
         }) = in_progress
         else {
             panic!("Task execution completed, but task is not in progress: {task:#?}");
@@ -3818,6 +3940,14 @@ impl Backend for TurboTasksBackend {
 
     fn task_execution_canceled(&self, task: TaskId, turbo_tasks: &TurboTasks<Self>) {
         self.task_execution_canceled(task, turbo_tasks)
+    }
+
+    fn task_execution_aborted(
+        &self,
+        task: TaskId,
+        turbo_tasks: &TurboTasks<Self>,
+    ) -> Option<TaskPriority> {
+        self.task_execution_aborted(task, turbo_tasks)
     }
 
     fn try_start_task_execution(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -18,10 +18,7 @@ use std::{
     hash::BuildHasherDefault,
     mem::take,
     pin::Pin,
-    sync::{
-        Arc, LazyLock,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, LazyLock, atomic::AtomicU8},
     time::SystemTime,
 };
 
@@ -2106,6 +2103,10 @@ impl TurboTasksBackend {
     ) -> Option<TaskPriority> {
         let mut ctx = self.execute_context(turbo_tasks);
         let mut task = ctx.task(task_id, TaskDataCategory::All);
+        let TaskTypeRef::Cached(task_type) = task.get_task_type() else {
+            unreachable!("only cached native tasks have abort handles")
+        };
+        let native_fn = task_type.native_fn;
         let Some(in_progress) = task.take_in_progress() else {
             // Completion or another abort callback won the race.
             return None;
@@ -2116,14 +2117,28 @@ impl TurboTasksBackend {
             debug_assert!(old.is_none(), "InProgress already exists");
             return None;
         };
+        let abort_reason = in_progress
+            .abort_reason()
+            .expect("an observed abort must have a recorded trigger");
+        self.task_statistics
+            .map(|stats| stats.increment_abort_observed(native_fn, abort_reason));
+        Span::current().record("abort_trigger", abort_reason.as_str());
+        tracing::event!(
+            name: "turbo_tasks::abort_observed",
+            target: "turbo_tasks::abort",
+            tracing::Level::TRACE,
+            event = "observed",
+            task_id = %task_id,
+            function = native_fn.name(),
+            trigger = abort_reason.as_str(),
+        );
+        let aborted_as_unneeded = in_progress.abort_when_unneeded();
         let InProgressStateInner {
             stale,
             done_event,
             mut new_children,
-            abort_when_unneeded,
             ..
         } = *in_progress;
-        let aborted_as_unneeded = abort_when_unneeded.load(Ordering::Acquire);
 
         // Only children that were not already connected received a speculative active-count
         // increment during this execution.
@@ -2248,12 +2263,15 @@ impl TurboTasksBackend {
                     _ => None,
                 };
             }
-            let (abort_handle, registration) = match &task_type {
-                TaskType::Cached(task_type) if task_type.native_fn.is_cancelable => {
-                    let (abort_handle, registration) = AbortHandle::new_pair();
-                    (Some(abort_handle), Some(registration))
-                }
-                _ => (None, None),
+            let native_fn = match &task_type {
+                TaskType::Cached(task_type) => Some(task_type.native_fn),
+                TaskType::Transient(_) => None,
+            };
+            let (abort_handle, registration) = if native_fn.is_some_and(|f| f.is_cancelable) {
+                let (abort_handle, registration) = AbortHandle::new_pair();
+                (Some(abort_handle), Some(registration))
+            } else {
+                (None, None)
             };
             abort_registration = registration;
             let old = task.set_in_progress(InProgressState::InProgress(Box::new(
@@ -2263,8 +2281,9 @@ impl TurboTasksBackend {
                     done_event,
                     marked_as_completed: false,
                     new_children: Default::default(),
+                    native_fn,
                     abort_handle,
-                    abort_when_unneeded: AtomicBool::new(false),
+                    abort_state: AtomicU8::new(0),
                 },
             )));
             debug_assert!(old.is_none(), "InProgress already exists");
@@ -2320,8 +2339,11 @@ impl TurboTasksBackend {
                     this,
                     arg,
                 } = &*task_type;
+                self.task_statistics
+                    .map(|stats| stats.increment_execution_started(native_fn));
                 (
                     native_fn.span(
+                        task_id,
                         task_id.persistence(),
                         execution_reason,
                         priority,
@@ -2510,11 +2532,34 @@ impl TurboTasksBackend {
         has_invalidator: bool,
     ) -> Result<TaskExecutionCompletePrepareResult, TaskPriority> {
         let mut task = ctx.task(task_id, TaskDataCategory::All);
+        let native_fn = match task.get_task_type() {
+            TaskTypeRef::Cached(task_type) => Some(task_type.native_fn),
+            TaskTypeRef::Transient(_) => None,
+        };
+        if let Some(native_fn) = native_fn {
+            self.task_statistics
+                .map(|stats| stats.increment_execution_completed(native_fn));
+        }
         if let Some(InProgressState::InProgress(in_progress)) = task.get_in_progress_mut() {
             // The task future completed without observing a concurrent abort request. From this
             // point on, use the ordinary completion bookkeeping: stale tasks re-execute and
             // inactive tasks finalize into a state a later GC pass can collect.
-            in_progress.disarm_abort();
+            if let Some(reason) = in_progress.disarm_abort()
+                && let Some(native_fn) = native_fn
+            {
+                self.task_statistics
+                    .map(|stats| stats.increment_abort_raced_completion(native_fn, reason));
+                Span::current().record("abort_trigger", reason.as_str());
+                tracing::event!(
+                    name: "turbo_tasks::abort_raced_completion",
+                    target: "turbo_tasks::abort",
+                    tracing::Level::TRACE,
+                    event = "raced_completion",
+                    task_id = %task_id,
+                    function = native_fn.name(),
+                    trigger = reason.as_str(),
+                );
+            }
         }
         let is_recomputation = task.is_dirty().is_none();
         // Without dependency tracking, the SessionDependent dirty state is never read (no session

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2096,6 +2096,22 @@ impl TurboTasksBackend {
         drop(in_progress_cells);
     }
 
+    fn rollback_aborted_collectibles(
+        &self,
+        task_id: TaskId,
+        collectible_deltas: FxHashMap<CollectibleRef, i32>,
+        turbo_tasks: &TurboTasks<TurboTasksBackend>,
+    ) {
+        for (collectible, delta) in collectible_deltas {
+            operation::UpdateCollectibleOperation::run_rollback(
+                task_id,
+                collectible,
+                -delta,
+                self.execute_context(turbo_tasks),
+            );
+        }
+    }
+
     fn task_execution_aborted(
         &self,
         task_id: TaskId,
@@ -2107,15 +2123,14 @@ impl TurboTasksBackend {
             unreachable!("only cached native tasks have abort handles")
         };
         let native_fn = task_type.native_fn;
-        let Some(in_progress) = task.take_in_progress() else {
-            // Completion or another abort callback won the race.
-            return None;
-        };
-        let InProgressState::InProgress(in_progress) = in_progress else {
-            // Another state transition won the race. Preserve that state.
-            let old = task.set_in_progress(in_progress);
-            debug_assert!(old.is_none(), "InProgress already exists");
-            return None;
+        // This callback is reached only from CaptureFutureOutcome::Aborted. That outcome is
+        // mutually exclusive with successful completion, and no other abort request or connection
+        // transition consumes a running execution's state.
+        let in_progress = match task.take_in_progress() {
+            Some(InProgressState::InProgress(in_progress)) => in_progress,
+            state => panic!(
+                "aborted task execution must own InProgressState::InProgress, found {state:?}"
+            ),
         };
         let abort_reason = in_progress
             .abort_reason()
@@ -2133,10 +2148,21 @@ impl TurboTasksBackend {
             trigger = abort_reason.as_str(),
         );
         let aborted_as_unneeded = in_progress.abort_when_unneeded();
+        // `outdated_collectibles` is generation-local bookkeeping initialized at execution start.
+        // The aborted generation will never reach completion cleanup, so discard it before
+        // reversing that generation's actual current-collectible deltas below.
+        let outdated_collectibles = task
+            .iter_outdated_collectibles()
+            .map(|(collectible, _)| *collectible)
+            .collect::<Vec<_>>();
+        for collectible in outdated_collectibles {
+            task.remove_outdated_collectibles(&collectible);
+        }
         let InProgressStateInner {
             stale,
             done_event,
             mut new_children,
+            collectible_deltas,
             ..
         } = *in_progress;
 
@@ -2166,17 +2192,20 @@ impl TurboTasksBackend {
             });
             debug_assert!(old.is_none(), "InProgress already exists");
             drop(task);
+            self.rollback_aborted_collectibles(task_id, collectible_deltas, turbo_tasks);
             decrease_active_counts_of_new_children(new_children, &mut ctx);
             return Some(priority);
         }
-        drop(task);
-
-        decrease_active_counts_of_new_children(new_children, &mut ctx);
 
         // Discard the aborted execution state and make the task dirty without scheduling it while
-        // it is disconnected.
+        // it is disconnected. Queue child decrements first, but execute all recursive aggregation
+        // work only after releasing the parent guard.
         let mut queue = AggregationUpdateQueue::new();
-        let mut task = ctx.task(task_id, TaskDataCategory::All);
+        if !new_children.is_empty() {
+            queue.push(AggregationUpdateJob::DecreaseActiveCounts {
+                task_ids: new_children.drain().collect(),
+            });
+        }
         make_task_dirty_internal(
             &mut task,
             MakeTaskDirtyOptions {
@@ -2191,6 +2220,7 @@ impl TurboTasksBackend {
             &mut ctx,
         );
         drop(task);
+        self.rollback_aborted_collectibles(task_id, collectible_deltas, turbo_tasks);
         queue.execute(&mut ctx);
 
         // A connection may race with dropping the aborted future. Re-check liveness after the
@@ -2282,6 +2312,7 @@ impl TurboTasksBackend {
                     marked_as_completed: false,
                     new_children: Default::default(),
                     native_fn,
+                    collectible_deltas: Default::default(),
                     abort_handle,
                     abort_state: AtomicU8::new(0),
                 },

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -36,7 +36,10 @@ use tracing::span::Span;
 use tracing::trace_span;
 #[cfg(feature = "task_dirty_cause")]
 use turbo_tasks::TaskDirtyCause;
-use turbo_tasks::{FxIndexMap, TaskExecutionReason, TaskId, TaskPriority, event::EventDescription};
+use turbo_tasks::{
+    FxIndexMap, TaskExecutionReason, TaskId, TaskPriority, backend::TaskExecutionAbortReason,
+    event::EventDescription,
+};
 
 use crate::{
     backend::{
@@ -3189,7 +3192,14 @@ impl AggregationUpdateQueue {
             task.take_activeness();
         }
         if is_zero && let Some(InProgressState::InProgress(in_progress)) = task.get_in_progress() {
-            in_progress.abort_unneeded();
+            let native_fn = in_progress.native_fn;
+            let outcome = in_progress.request_abort(TaskExecutionAbortReason::Inactive);
+            ctx.track_abort_request(
+                task_id,
+                native_fn,
+                TaskExecutionAbortReason::Inactive,
+                outcome,
+            );
         }
         debug_assert!(
             !(is_new && is_zero),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -3191,6 +3191,7 @@ impl AggregationUpdateQueue {
         if is_empty {
             task.take_activeness();
         }
+        // If activeness dropped to zero, no caller cares anymore, abort it if in flight.
         if is_zero && let Some(InProgressState::InProgress(in_progress)) = task.get_in_progress() {
             let native_fn = in_progress.native_fn;
             let outcome = in_progress.request_abort(TaskExecutionAbortReason::Inactive);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -47,7 +47,7 @@ use crate::{
         },
         storage_schema::TaskStorageAccessors,
     },
-    data::{ActivenessState, AggregationNumber, CollectibleRef},
+    data::{ActivenessState, AggregationNumber, CollectibleRef, InProgressState},
     utils::swap_retain,
 };
 
@@ -3187,6 +3187,9 @@ impl AggregationUpdateQueue {
         let is_empty = state.is_empty();
         if is_empty {
             task.take_activeness();
+        }
+        if is_zero && let Some(InProgressState::InProgress(in_progress)) = task.get_in_progress() {
+            in_progress.abort_unneeded();
         }
         debug_assert!(
             !(is_new && is_zero),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -80,7 +80,9 @@ impl ConnectChildOperation {
             let Some(InProgressState::InProgress(InProgressStateInner { new_children, .. })) =
                 parent_task.get_in_progress()
             else {
-                panic!("Task is not in progress while calling another task: {parent_task:?}");
+                // The parent execution was aborted before this connect operation acquired its
+                // first guard. Ignore the child call from the dropped execution.
+                return;
             };
 
             // Quick skip if the child was already connected before
@@ -167,7 +169,18 @@ impl ConnectChildOperation {
             let Some(InProgressState::InProgress(InProgressStateInner { new_children, .. })) =
                 parent_task.get_in_progress_mut()
             else {
-                panic!("Task is not in progress while calling another task: {parent_task:?}");
+                // Abortion can race while the aggregation update above temporarily releases the
+                // parent guard. Undo the speculative child activeness that update added.
+                drop(parent_task);
+                if ctx.should_track_activeness() {
+                    AggregationUpdateQueue::run(
+                        AggregationUpdateJob::DecreaseActiveCount {
+                            task: child_task_id,
+                        },
+                        &mut ctx,
+                    );
+                }
+                return;
             };
 
             // Really add the child to the new children set

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -9,7 +9,7 @@ use crate::{
             aggregation_update::{
                 AggregationUpdateJob, AggregationUpdateQueue, get_aggregation_number, is_root_node,
             },
-            invalidate::make_task_dirty_internal,
+            invalidate::{MakeTaskDirtyOptions, make_task_dirty_internal},
         },
         storage_schema::TaskStorageAccessors,
     },
@@ -45,10 +45,12 @@ pub(super) fn resurrect_deleted<'e, C: ExecuteContext<'e>>(
         // shouldn't matter for resolving this rare race condition.
         make_task_dirty_internal(
             &mut task,
-            /* make_stale */ true,
-            /* schedule_when_active */ true,
-            #[cfg(feature = "task_dirty_cause")]
-            turbo_tasks::TaskDirtyCause::Resurrected,
+            MakeTaskDirtyOptions {
+                make_stale: true,
+                schedule_when_active: true,
+                #[cfg(feature = "task_dirty_cause")]
+                cause: turbo_tasks::TaskDirtyCause::Resurrected,
+            },
             queue,
             ctx,
         );
@@ -82,6 +84,10 @@ impl ConnectChildOperation {
             else {
                 // The parent execution was aborted before this connect operation acquired its
                 // first guard. Ignore the child call from the dropped execution.
+                debug_assert!(
+                    parent_task.is_dirty().is_some(),
+                    "child call escaped from a clean parent that is not executing: {parent_task:?}"
+                );
                 return;
             };
 
@@ -171,6 +177,10 @@ impl ConnectChildOperation {
             else {
                 // Abortion can race while the aggregation update above temporarily releases the
                 // parent guard. Undo the speculative child activeness that update added.
+                debug_assert!(
+                    parent_task.is_dirty().is_some(),
+                    "child connect lost a clean parent that is not executing: {parent_task:?}"
+                );
                 drop(parent_task);
                 if ctx.should_track_activeness() {
                     AggregationUpdateQueue::run(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_child.rs
@@ -46,6 +46,7 @@ pub(super) fn resurrect_deleted<'e, C: ExecuteContext<'e>>(
         make_task_dirty_internal(
             &mut task,
             /* make_stale */ true,
+            /* schedule_when_active */ true,
             #[cfg(feature = "task_dirty_cause")]
             turbo_tasks::TaskDirtyCause::Resurrected,
             queue,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -11,8 +11,10 @@ use turbo_tasks::{
 use crate::backend::{
     operation::{
         AggregationUpdateJob, AggregationUpdateQueue, ChildExecuteContext, ExecuteContext,
-        Operation, TaskGuard, aggregation_update::InnerOfUppersHasNewFollowersJob,
-        get_aggregation_number, get_uppers, invalidate::make_task_dirty_internal,
+        Operation, TaskGuard,
+        aggregation_update::InnerOfUppersHasNewFollowersJob,
+        get_aggregation_number, get_uppers,
+        invalidate::{MakeTaskDirtyOptions, make_task_dirty_internal},
         is_aggregating_node,
     },
     storage_schema::TaskStorageAccessors,
@@ -81,10 +83,12 @@ pub fn connect_children(
                 if !child.has_output() {
                     make_task_dirty_internal(
                         &mut child,
-                        false,
-                        /* schedule_when_active */ true,
-                        #[cfg(feature = "task_dirty_cause")]
-                        TaskDirtyCause::InitialDirty,
+                        MakeTaskDirtyOptions {
+                            make_stale: false,
+                            schedule_when_active: true,
+                            #[cfg(feature = "task_dirty_cause")]
+                            cause: TaskDirtyCause::InitialDirty,
+                        },
                         &mut queue,
                         ctx,
                     );

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -82,7 +82,7 @@ pub fn connect_children(
                     make_task_dirty_internal(
                         &mut child,
                         false,
-                        true,
+                        /* schedule_when_active */ true,
                         #[cfg(feature = "task_dirty_cause")]
                         TaskDirtyCause::InitialDirty,
                         &mut queue,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/connect_children.rs
@@ -82,6 +82,7 @@ pub fn connect_children(
                     make_task_dirty_internal(
                         &mut child,
                         false,
+                        true,
                         #[cfg(feature = "task_dirty_cause")]
                         TaskDirtyCause::InitialDirty,
                         &mut queue,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -2,7 +2,10 @@ use bincode::{Decode, Encode};
 use smallvec::SmallVec;
 #[cfg(feature = "task_dirty_cause")]
 use turbo_tasks::TaskDirtyCause;
-use turbo_tasks::{TaskExecutionReason, TaskId, TaskPriority, event::EventDescription};
+use turbo_tasks::{
+    TaskExecutionReason, TaskId, TaskPriority, backend::TaskExecutionAbortReason,
+    event::EventDescription,
+};
 
 use crate::{
     backend::{
@@ -168,7 +171,14 @@ pub fn make_task_dirty_internal<'e, E: ExecuteContext<'e>>(
             .entered();
             in_progress.stale = true;
         }
-        in_progress.abort_invalidated();
+        let native_fn = in_progress.native_fn;
+        let outcome = in_progress.request_abort(TaskExecutionAbortReason::Invalidation);
+        ctx.track_abort_request(
+            task.id(),
+            native_fn,
+            TaskExecutionAbortReason::Invalidation,
+            outcome,
+        );
     }
     let current = task.get_dirty();
     let parent_priority = ctx.get_current_task_priority();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -98,7 +98,7 @@ pub fn make_task_dirty(
     make_task_dirty_internal(
         &mut task,
         true,
-        true,
+        /* schedule_when_active */ true,
         #[cfg(feature = "task_dirty_cause")]
         cause,
         queue,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -88,6 +88,20 @@ impl Operation for InvalidateOperation {
     }
 }
 
+/// Options for [`make_task_dirty_internal`].
+pub struct MakeTaskDirtyOptions {
+    /// Also mark an in-progress execution stale (and abort it, when it is cancelable), so the
+    /// currently running execution is discarded in favor of a fresh one.
+    pub make_stale: bool,
+    /// Schedule the task when it is (or is treated as) active. Pass `false` to record the dirty
+    /// state without scheduling, e.g. for a task whose execution was aborted because nothing needs
+    /// it anymore.
+    pub schedule_when_active: bool,
+    /// Diagnostic reason recorded with the dirty state.
+    #[cfg(feature = "task_dirty_cause")]
+    pub cause: TaskDirtyCause,
+}
+
 pub fn make_task_dirty(
     task_id: TaskId,
     #[cfg(feature = "task_dirty_cause")] cause: TaskDirtyCause,
@@ -97,10 +111,12 @@ pub fn make_task_dirty(
     let mut task = ctx.task(task_id, TaskDataCategory::All);
     make_task_dirty_internal(
         &mut task,
-        true,
-        /* schedule_when_active */ true,
-        #[cfg(feature = "task_dirty_cause")]
-        cause,
+        MakeTaskDirtyOptions {
+            make_stale: true,
+            schedule_when_active: true,
+            #[cfg(feature = "task_dirty_cause")]
+            cause,
+        },
         queue,
         ctx,
     );
@@ -108,16 +124,19 @@ pub fn make_task_dirty(
 
 /// Requires the guard to be allocated with [TaskDataCategory::All].
 ///
-/// `schedule_when_active` is false when an unneeded execution is aborted: the dirty transition
-/// must propagate, but the disconnected task must remain unscheduled until it becomes live again.
+/// See [`MakeTaskDirtyOptions`] for how staleness and scheduling are controlled.
 pub fn make_task_dirty_internal<'e, E: ExecuteContext<'e>>(
     task: &mut E::TaskGuardImpl,
-    make_stale: bool,
-    schedule_when_active: bool,
-    #[cfg(feature = "task_dirty_cause")] cause: TaskDirtyCause,
+    options: MakeTaskDirtyOptions,
     queue: &mut AggregationUpdateQueue,
     ctx: &mut E,
 ) {
+    let MakeTaskDirtyOptions {
+        make_stale,
+        schedule_when_active,
+        #[cfg(feature = "task_dirty_cause")]
+        cause,
+    } = options;
     // There must be no way to invalidate immutable tasks. If there would be a way the task is not
     // immutable.
     #[cfg(any(debug_assertions, feature = "verify_immutable"))]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         storage_schema::TaskStorageAccessors,
     },
-    data::{Dirtyness, InProgressState, InProgressStateInner},
+    data::{Dirtyness, InProgressState},
 };
 
 #[derive(Encode, Decode, Clone, Default)]
@@ -98,6 +98,7 @@ pub fn make_task_dirty(
     make_task_dirty_internal(
         &mut task,
         true,
+        true,
         #[cfg(feature = "task_dirty_cause")]
         cause,
         queue,
@@ -105,10 +106,14 @@ pub fn make_task_dirty(
     );
 }
 
-/// Requires the guard to be allocated with [TaskDataCategory::All]
+/// Requires the guard to be allocated with [TaskDataCategory::All].
+///
+/// `schedule_when_active` is false when an unneeded execution is aborted: the dirty transition
+/// must propagate, but the disconnected task must remain unscheduled until it becomes live again.
 pub fn make_task_dirty_internal<'e, E: ExecuteContext<'e>>(
     task: &mut E::TaskGuardImpl,
     make_stale: bool,
+    schedule_when_active: bool,
     #[cfg(feature = "task_dirty_cause")] cause: TaskDirtyCause,
     queue: &mut AggregationUpdateQueue,
     ctx: &mut E,
@@ -131,20 +136,20 @@ pub fn make_task_dirty_internal<'e, E: ExecuteContext<'e>>(
 
     #[cfg(feature = "trace_task_dirty")]
     let task_name = task.get_task_name();
-    if make_stale
-        && let Some(InProgressState::InProgress(InProgressStateInner { stale, .. })) =
-            task.get_in_progress_mut()
-        && !*stale
+    if make_stale && let Some(InProgressState::InProgress(in_progress)) = task.get_in_progress_mut()
     {
-        #[cfg(feature = "trace_task_dirty")]
-        let _span = tracing::trace_span!(
-            "make task stale",
-            task_id = display(task_id),
-            name = task_name,
-            cause = %cause
-        )
-        .entered();
-        *stale = true;
+        if !in_progress.stale {
+            #[cfg(feature = "trace_task_dirty")]
+            let _span = tracing::trace_span!(
+                "make task stale",
+                task_id = display(task_id),
+                name = task_name,
+                cause = %cause
+            )
+            .entered();
+            in_progress.stale = true;
+        }
+        in_progress.abort_invalidated();
     }
     let current = task.get_dirty();
     let parent_priority = ctx.get_current_task_priority();
@@ -256,7 +261,8 @@ pub fn make_task_dirty_internal<'e, E: ExecuteContext<'e>>(
         queue.extend(AggregationUpdateJob::data_update(task, aggregated_update));
     }
 
-    let should_schedule = !ctx.should_track_activeness() || task.has_activeness();
+    let should_schedule =
+        schedule_when_active && (!ctx.should_track_activeness() || task.has_activeness());
 
     if should_schedule {
         let description = EventDescription::new(|| task.get_task_desc_fn());

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1208,7 +1208,10 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
                 // This should be rare: activeness normally aborts disconnected work before GC
                 // reaches it. Don't enqueue collection yet; abort completion is asynchronous, so
                 // the collector's authoritative recheck would still reject the in-progress task.
-                // A later GC pass can collect it after the abort callback settles it as dirty.
+                // If the final root scan runs first, `gc_is_root` temporarily classifies the task
+                // as a root and its debug validation accepts the in-progress state as the transient
+                // pin. Once the abort settles it as dirty, a later pass drops that resident root
+                // entry and collects the task.
                 in_progress.abort_unneeded();
             }
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -20,7 +20,8 @@ use tracing::info_span;
 use tracing::trace_span;
 use turbo_tasks::{
     CellId, DynTaskInputs, FxIndexMap, RawVc, SharedReference, TaskExecutionReason, TaskId,
-    TaskPriority, TurboTasks, TurboTasksCallApi, ValueTypePersistence, backend::CachedTaskTypeArc,
+    TaskPriority, TurboTasks, TurboTasksCallApi, ValueTypePersistence,
+    backend::{CachedTaskTypeArc, TaskExecutionAbortReason},
     macro_helpers::NativeFunction,
 };
 
@@ -33,7 +34,10 @@ use crate::{
         storage::{SpecificTaskDataCategory, StorageWriteGuard, TrackOutcome},
         storage_schema::{TaskStorage, TaskStorageAccessors},
     },
-    data::{ActivenessState, CollectibleRef, Dirtyness, InProgressState, TransientTask},
+    data::{
+        AbortRequestOutcome, ActivenessState, CollectibleRef, Dirtyness, InProgressState,
+        TransientTask,
+    },
 };
 
 pub trait Operation: Encode + Decode<()> + Default + TryFrom<AnyOperation, Error = ()> {
@@ -144,6 +148,13 @@ pub trait ExecuteContext<'e>: Sized {
     ///
     /// Only effective in a gc context see [`Self::collects_gc_candidates`].
     fn note_maybe_collectible(&mut self, task: &impl TaskGuard);
+    fn track_abort_request(
+        &self,
+        task_id: TaskId,
+        native_fn: Option<&'static NativeFunction>,
+        reason: TaskExecutionAbortReason,
+        outcome: AbortRequestOutcome,
+    );
     /// Whether [`Self::note_maybe_collectible`] does anything, i.e. this is a GC context.
     ///
     /// Lets a caller skip work that only exists to feed the collector — in particular opening a
@@ -1212,8 +1223,73 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
                 // as a root and its debug validation accepts the in-progress state as the transient
                 // pin. Once the abort settles it as dirty, a later pass drops that resident root
                 // entry and collects the task.
-                in_progress.abort_unneeded();
+                let native_fn = in_progress.native_fn;
+                let outcome = in_progress.request_abort(TaskExecutionAbortReason::Gc);
+                self.track_abort_request(
+                    task.id(),
+                    native_fn,
+                    TaskExecutionAbortReason::Gc,
+                    outcome,
+                );
             }
+        }
+    }
+
+    fn track_abort_request(
+        &self,
+        task_id: TaskId,
+        native_fn: Option<&'static NativeFunction>,
+        reason: TaskExecutionAbortReason,
+        outcome: AbortRequestOutcome,
+    ) {
+        let Some(native_fn) = native_fn else {
+            return;
+        };
+        if !matches!(outcome, AbortRequestOutcome::Duplicate) {
+            self.backend.task_statistics.map(|stats| {
+                stats.increment_abort_requested(native_fn, reason);
+                match outcome {
+                    AbortRequestOutcome::Accepted | AbortRequestOutcome::Duplicate => {}
+                    AbortRequestOutcome::Skipped => {
+                        stats.increment_abort_skipped(native_fn, reason)
+                    }
+                    AbortRequestOutcome::RacedCompletion => {
+                        stats.increment_abort_raced_completion(native_fn, reason)
+                    }
+                }
+            });
+            tracing::event!(
+                name: "turbo_tasks::abort_requested",
+                target: "turbo_tasks::abort",
+                tracing::Level::TRACE,
+                event = "requested",
+                task_id = %task_id,
+                function = native_fn.name(),
+                trigger = reason.as_str(),
+                cancelable = native_fn.is_cancelable,
+            );
+        }
+        match outcome {
+            AbortRequestOutcome::Skipped => tracing::event!(
+                name: "turbo_tasks::abort_skipped",
+                target: "turbo_tasks::abort",
+                tracing::Level::TRACE,
+                event = "skipped",
+                task_id = %task_id,
+                function = native_fn.name(),
+                trigger = reason.as_str(),
+                reason = "non_cancelable",
+            ),
+            AbortRequestOutcome::RacedCompletion => tracing::event!(
+                name: "turbo_tasks::abort_raced_completion",
+                target: "turbo_tasks::abort",
+                tracing::Level::TRACE,
+                event = "raced_completion",
+                task_id = %task_id,
+                function = native_fn.name(),
+                trigger = reason.as_str(),
+            ),
+            AbortRequestOutcome::Accepted | AbortRequestOutcome::Duplicate => {}
         }
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1199,10 +1199,14 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
     }
 
     fn note_maybe_collectible(&mut self, task: &impl TaskGuard) {
-        if let ExecutePhase::Gc(collector) = self.phase
-            && task.is_gc_collectible()
-        {
-            collector(task.id());
+        if let ExecutePhase::Gc(collector) = self.phase {
+            if task.is_gc_collectible() {
+                collector(task.id());
+            } else if task.is_gc_collectible_ignoring_in_progress()
+                && let Some(InProgressState::InProgress(in_progress)) = task.get_in_progress()
+            {
+                in_progress.abort_unneeded();
+            }
         }
     }
 
@@ -1414,6 +1418,11 @@ pub trait TaskGuard: Debug + TaskStorageAccessors {
         // collected.
         self.check_access(SpecificTaskDataCategory::Meta);
         !self.id().is_transient() && self.typed().gc_maybe_collectible()
+    }
+
+    fn is_gc_collectible_ignoring_in_progress(&self) -> bool {
+        self.check_access(SpecificTaskDataCategory::Meta);
+        !self.id().is_transient() && self.typed().gc_maybe_collectible_ignoring_in_progress()
     }
 
     fn invalidate_serialization(&mut self);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1205,6 +1205,10 @@ impl<'e> ExecuteContext<'e> for ExecuteContextImpl<'e> {
             } else if task.is_gc_collectible_ignoring_in_progress()
                 && let Some(InProgressState::InProgress(in_progress)) = task.get_in_progress()
             {
+                // This should be rare: activeness normally aborts disconnected work before GC
+                // reaches it. Don't enqueue collection yet; abort completion is asynchronous, so
+                // the collector's authoritative recheck would still reject the in-progress task.
+                // A later GC pass can collect it after the abort callback settles it as dirty.
                 in_progress.abort_unneeded();
             }
         }
@@ -1938,7 +1942,7 @@ pub use self::{
     },
     cleanup_old_edges::{OutdatedEdge, capture_all_outgoing_edges},
     connect_children::connect_children,
-    invalidate::make_task_dirty_internal,
+    invalidate::{MakeTaskDirtyOptions, make_task_dirty_internal},
     prepare_new_children::prepare_new_children,
     update_collectible::UpdateCollectibleOperation,
 };

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -329,6 +329,7 @@ impl Operation for UpdateCellOperation {
                         make_task_dirty_internal(
                             &mut dependent,
                             make_stale,
+                            true,
                             #[cfg(feature = "task_dirty_cause")]
                             TaskDirtyCause::CellChange {
                                 value_type: cell_ref.cell.type_id(),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -329,7 +329,7 @@ impl Operation for UpdateCellOperation {
                         make_task_dirty_internal(
                             &mut dependent,
                             make_stale,
-                            true,
+                            /* schedule_when_active */ true,
                             #[cfg(feature = "task_dirty_cause")]
                             TaskDirtyCause::CellChange {
                                 value_type: cell_ref.cell.type_id(),

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -16,7 +16,7 @@ use crate::{
         TaskDataCategory,
         operation::{
             AggregationUpdateQueue, ExecuteContext, Operation, TaskGuard,
-            invalidate::make_task_dirty_internal,
+            invalidate::{MakeTaskDirtyOptions, make_task_dirty_internal},
         },
         storage_schema::TaskStorageAccessors,
     },
@@ -328,12 +328,16 @@ impl Operation for UpdateCellOperation {
                         }
                         make_task_dirty_internal(
                             &mut dependent,
-                            make_stale,
-                            /* schedule_when_active */ true,
-                            #[cfg(feature = "task_dirty_cause")]
-                            TaskDirtyCause::CellChange {
-                                value_type: cell_ref.cell.type_id(),
-                                keys: has_updated_key_hashes.then_some(keys).unwrap_or_default(),
+                            MakeTaskDirtyOptions {
+                                make_stale,
+                                schedule_when_active: true,
+                                #[cfg(feature = "task_dirty_cause")]
+                                cause: TaskDirtyCause::CellChange {
+                                    value_type: cell_ref.cell.type_id(),
+                                    keys: has_updated_key_hashes
+                                        .then_some(keys)
+                                        .unwrap_or_default(),
+                                },
                             },
                             queue,
                             ctx,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
@@ -12,7 +12,7 @@ use crate::{
         },
         storage_schema::TaskStorageAccessors,
     },
-    data::CollectibleRef,
+    data::{CollectibleRef, InProgressState},
 };
 
 pub struct UpdateCollectibleOperation;
@@ -21,11 +21,34 @@ impl UpdateCollectibleOperation {
     pub fn run(
         task_id: TaskId,
         collectible: CollectibleRef,
+        count: i32,
+        ctx: impl ExecuteContext<'_>,
+    ) {
+        Self::run_internal(task_id, collectible, count, false, ctx);
+    }
+
+    /// Reverses a collectible update made by an aborted execution. Unlike a user-level `unemit`,
+    /// rollback may remove a collectible from a non-root emitter: `root` is required to *read* or
+    /// explicitly remove collectibles, but any task may emit them.
+    pub(in crate::backend) fn run_rollback(
+        task_id: TaskId,
+        collectible: CollectibleRef,
+        count: i32,
+        ctx: impl ExecuteContext<'_>,
+    ) {
+        Self::run_internal(task_id, collectible, count, true, ctx);
+    }
+
+    fn run_internal(
+        task_id: TaskId,
+        collectible: CollectibleRef,
         mut count: i32,
+        rollback: bool,
         mut ctx: impl ExecuteContext<'_>,
     ) {
         let mut task = ctx.task(task_id, TaskDataCategory::All);
-        if count < 0
+        if !rollback
+            && count < 0
             && task
                 .get_persistent_task_type()
                 .is_some_and(|t| !t.native_fn.is_root)
@@ -54,6 +77,21 @@ impl UpdateCollectibleOperation {
             }
         }
         if count != 0 {
+            // Rollback runs after the aborted InProgressState was taken, so it cannot record its
+            // own reversal as a new generation delta.
+            if let Some(InProgressState::InProgress(in_progress)) = task.get_in_progress_mut() {
+                let remove = {
+                    let delta = in_progress
+                        .collectible_deltas
+                        .entry(collectible)
+                        .or_default();
+                    *delta += count;
+                    *delta == 0
+                };
+                if remove {
+                    in_progress.collectible_deltas.remove(&collectible);
+                }
+            }
             if task.update_collectibles_positive_crossing(collectible, count) {
                 let ty = collectible.collectible_type;
                 let dependent: SmallVec<[TaskId; 4]> = task

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_collectible.rs
@@ -24,7 +24,7 @@ impl UpdateCollectibleOperation {
         count: i32,
         ctx: impl ExecuteContext<'_>,
     ) {
-        Self::run_internal(task_id, collectible, count, false, ctx);
+        Self::run_internal(task_id, collectible, count, /* rollback= */ false, ctx);
     }
 
     /// Reverses a collectible update made by an aborted execution. Unlike a user-level `unemit`,
@@ -36,7 +36,7 @@ impl UpdateCollectibleOperation {
         count: i32,
         ctx: impl ExecuteContext<'_>,
     ) {
-        Self::run_internal(task_id, collectible, count, true, ctx);
+        Self::run_internal(task_id, collectible, count, /* rollback= */ true, ctx);
     }
 
     fn run_internal(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -1104,6 +1104,12 @@ mod tests {
         ));
         assert!(!storage.gc_maybe_collectible());
         assert!(storage.gc_maybe_collectible_ignoring_in_progress());
+        assert!(storage.gc_is_root());
+        storage.gc_debug_assert_root_held_by_transient_pin();
+
+        storage.take_in_progress();
+        assert!(storage.gc_maybe_collectible());
+        assert!(!storage.gc_is_root());
 
         storage.set_parent_count(1);
         assert!(!storage.gc_maybe_collectible_ignoring_in_progress());

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -868,6 +868,18 @@ impl TaskStorage {
     /// (which opens `TaskDataCategory::All`, and is what actually gates collection) share this
     /// single predicate.
     pub fn gc_maybe_collectible(&self) -> bool {
+        self.gc_maybe_collectible_inner(false)
+    }
+
+    /// Whether this task would be GC-collectible if it were not currently executing.
+    ///
+    /// Used to abort work that became unreachable during a GC pass, after which the ordinary
+    /// collectibility predicate can select it on the next transition/pass.
+    pub fn gc_maybe_collectible_ignoring_in_progress(&self) -> bool {
+        self.gc_maybe_collectible_inner(true)
+    }
+
+    fn gc_maybe_collectible_inner(&self, ignore_in_progress: bool) -> bool {
         // None of the predicates below are correct without this.
         self.flags.is_restored(TaskDataCategory::Meta)
             // Already collected this session (soft-deleted, awaiting tombstone + hard-delete):
@@ -877,7 +889,7 @@ impl TaskStorage {
             && self.gc_parent_count() == 0
             && self.gc_transient_ref_count() == 0
             && self.get_activeness().is_none()
-            && self.get_in_progress().is_none()
+            && (ignore_in_progress || self.get_in_progress().is_none())
             // It is rare for upper/followers to be present when the ref counts are 0 but it can happen transiently during a concurrent GC pass as uppers are moved around during the cascade.
             && self.upper().is_empty()
             && self.followers().is_none_or(|f| f.is_empty())
@@ -1075,10 +1087,27 @@ impl<K: IsTransient + Hash + Eq, V: IsTransient, const I: usize> DropPartial for
 mod tests {
     use std::mem::size_of;
 
-    use turbo_tasks::{CellId, TaskId};
+    use turbo_tasks::{CellId, TaskExecutionReason, TaskId, event::EventDescription};
 
     use super::*;
-    use crate::data::{AggregationNumber, CellRef, Dirtyness, OutputValue};
+    use crate::data::{AggregationNumber, CellRef, Dirtyness, InProgressState, OutputValue};
+
+    #[test]
+    fn gc_collectibility_can_ignore_only_in_progress_state() {
+        let mut storage = TaskStorage::new();
+        storage.flags.set_meta_restored(true);
+        assert!(storage.gc_maybe_collectible());
+
+        storage.set_in_progress(InProgressState::new_scheduled(
+            TaskExecutionReason::Root,
+            EventDescription::new(|| || "test task".to_string()),
+        ));
+        assert!(!storage.gc_maybe_collectible());
+        assert!(storage.gc_maybe_collectible_ignoring_in_progress());
+
+        storage.set_parent_count(1);
+        assert!(!storage.gc_maybe_collectible_ignoring_in_progress());
+    }
 
     #[test]
     fn test_accessors() {

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -1,11 +1,15 @@
 use std::{
     fmt::{self, Debug, Display},
     pin::Pin,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use anyhow::Result;
 use bincode::{Decode, Encode};
+use futures::future::AbortHandle;
 use parking_lot::Mutex;
 use rustc_hash::FxHashSet;
 #[cfg(feature = "task_dirty_cause")]
@@ -253,6 +257,27 @@ pub struct InProgressStateInner {
     /// Children that should be connected to the task and have their active_count decremented
     /// once the task completes.
     pub new_children: FxHashSet<TaskId>,
+    /// Aborts the currently executing native turbo-task function. Transient root/once tasks do not
+    /// have a handle because their futures cannot necessarily be recreated.
+    pub abort_handle: Option<AbortHandle>,
+    /// Set when abortion was requested because the task became unneeded rather than invalidated.
+    /// Interior mutability lets GC collectibility checks request abortion through a shared guard.
+    pub abort_when_unneeded: AtomicBool,
+}
+
+impl InProgressStateInner {
+    pub fn abort_invalidated(&self) {
+        if let Some(abort_handle) = &self.abort_handle {
+            abort_handle.abort();
+        }
+    }
+
+    pub fn abort_unneeded(&self) {
+        self.abort_when_unneeded.store(true, Ordering::Release);
+        if let Some(abort_handle) = &self.abort_handle {
+            abort_handle.abort();
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use bincode::{Decode, Encode};
 use futures::future::AbortHandle;
 use parking_lot::Mutex;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 #[cfg(feature = "task_dirty_cause")]
 use turbo_tasks::TaskDirtyCause;
 use turbo_tasks::{
@@ -260,6 +260,10 @@ pub struct InProgressStateInner {
     /// The executing native function, kept transiently so Meta-only liveness paths can attribute
     /// abort telemetry without restoring task data.
     pub native_fn: Option<&'static turbo_tasks::macro_helpers::NativeFunction>,
+    /// Actual changes made to the current collectible set by this execution, after re-emissions
+    /// reconciled against `outdated_collectibles`. Abortion reverses these deltas so only the last
+    /// completed generation remains visible.
+    pub collectible_deltas: FxHashMap<CollectibleRef, i32>,
     /// Aborts the currently executing native turbo-task function. Transient root/once tasks do not
     /// have a handle because their futures cannot necessarily be recreated.
     pub abort_handle: Option<AbortHandle>,
@@ -403,6 +407,7 @@ mod abort_state_tests {
             done_event: Event::new(|| || "abort state test".to_string()),
             new_children: FxHashSet::default(),
             native_fn: None,
+            collectible_deltas: FxHashMap::default(),
             abort_handle,
             abort_state: AtomicU8::new(ABORT_NONE),
         }

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -273,10 +273,17 @@ impl InProgressStateInner {
     }
 
     pub fn abort_unneeded(&self) {
-        self.abort_when_unneeded.store(true, Ordering::Release);
         if let Some(abort_handle) = &self.abort_handle {
+            self.abort_when_unneeded.store(true, Ordering::Release);
             abort_handle.abort();
         }
+    }
+
+    /// Prevent new abort requests after the task future completed successfully. Invalidation may
+    /// still mark the task stale, which the ordinary completion bookkeeping handles.
+    pub fn disarm_abort(&mut self) {
+        self.abort_handle = None;
+        self.abort_when_unneeded.store(false, Ordering::Release);
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -3,7 +3,7 @@ use std::{
     pin::Pin,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicU8, Ordering},
     },
 };
 
@@ -16,7 +16,7 @@ use rustc_hash::FxHashSet;
 use turbo_tasks::TaskDirtyCause;
 use turbo_tasks::{
     CellId, RawVc, TaskExecutionReason, TaskId, TaskPriority, TraitTypeId,
-    backend::TransientTaskRoot,
+    backend::{TaskExecutionAbortReason, TransientTaskRoot},
     event::{Event, EventDescription, EventListener},
 };
 
@@ -257,33 +257,210 @@ pub struct InProgressStateInner {
     /// Children that should be connected to the task and have their active_count decremented
     /// once the task completes.
     pub new_children: FxHashSet<TaskId>,
+    /// The executing native function, kept transiently so Meta-only liveness paths can attribute
+    /// abort telemetry without restoring task data.
+    pub native_fn: Option<&'static turbo_tasks::macro_helpers::NativeFunction>,
     /// Aborts the currently executing native turbo-task function. Transient root/once tasks do not
     /// have a handle because their futures cannot necessarily be recreated.
     pub abort_handle: Option<AbortHandle>,
-    /// Set when abortion was requested because the task became unneeded rather than invalidated.
-    /// Interior mutability lets GC collectibility checks request abortion through a shared guard.
-    pub abort_when_unneeded: AtomicBool,
+    /// First-trigger-wins abort lifecycle state. Interior mutability lets GC collectibility checks
+    /// request abortion through a shared guard.
+    pub abort_state: AtomicU8,
+}
+
+const ABORT_REASON_MASK: u8 = 0b0000_0011;
+const ABORT_UNNEEDED: u8 = 0b0000_0100;
+const ABORT_DISARMED: u8 = 0b0000_1000;
+const ABORT_OUTCOME_RECORDED: u8 = 0b0001_0000;
+const ABORT_NONE: u8 = 0;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AbortRequestOutcome {
+    Accepted,
+    Skipped,
+    RacedCompletion,
+    Duplicate,
 }
 
 impl InProgressStateInner {
-    pub fn abort_invalidated(&self) {
-        if let Some(abort_handle) = &self.abort_handle {
-            abort_handle.abort();
+    fn decode_abort_reason(state: u8) -> Option<TaskExecutionAbortReason> {
+        match state & ABORT_REASON_MASK {
+            value if value == TaskExecutionAbortReason::Invalidation as u8 => {
+                Some(TaskExecutionAbortReason::Invalidation)
+            }
+            value if value == TaskExecutionAbortReason::Inactive as u8 => {
+                Some(TaskExecutionAbortReason::Inactive)
+            }
+            value if value == TaskExecutionAbortReason::Gc as u8 => {
+                Some(TaskExecutionAbortReason::Gc)
+            }
+            _ => None,
         }
     }
 
-    pub fn abort_unneeded(&self) {
-        if let Some(abort_handle) = &self.abort_handle {
-            self.abort_when_unneeded.store(true, Ordering::Release);
-            abort_handle.abort();
+    pub fn abort_reason(&self) -> Option<TaskExecutionAbortReason> {
+        Self::decode_abort_reason(self.abort_state.load(Ordering::Acquire))
+    }
+
+    pub fn request_abort(&self, reason: TaskExecutionAbortReason) -> AbortRequestOutcome {
+        let unneeded = matches!(
+            reason,
+            TaskExecutionAbortReason::Inactive | TaskExecutionAbortReason::Gc
+        );
+        let mut state = self.abort_state.load(Ordering::Acquire);
+        loop {
+            if state == ABORT_DISARMED {
+                match self.abort_state.compare_exchange(
+                    ABORT_DISARMED,
+                    ABORT_OUTCOME_RECORDED,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => return AbortRequestOutcome::RacedCompletion,
+                    Err(current) => {
+                        state = current;
+                        continue;
+                    }
+                }
+            }
+            if state == ABORT_OUTCOME_RECORDED {
+                return AbortRequestOutcome::Duplicate;
+            }
+
+            // The first trigger owns telemetry attribution, but every later inactive/GC request
+            // still updates recovery behavior so an unneeded task is not rescheduled.
+            let mut new_state = state;
+            if unneeded {
+                new_state |= ABORT_UNNEEDED;
+            }
+            let first_request = state & ABORT_REASON_MASK == ABORT_NONE;
+            if first_request {
+                new_state |= reason as u8;
+            }
+            if new_state != state {
+                match self.abort_state.compare_exchange(
+                    state,
+                    new_state,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => {}
+                    Err(current) => {
+                        state = current;
+                        continue;
+                    }
+                }
+            }
+            if !first_request {
+                return AbortRequestOutcome::Duplicate;
+            }
+            return if let Some(abort_handle) = &self.abort_handle {
+                abort_handle.abort();
+                AbortRequestOutcome::Accepted
+            } else {
+                AbortRequestOutcome::Skipped
+            };
         }
+    }
+
+    pub fn abort_when_unneeded(&self) -> bool {
+        self.abort_state.load(Ordering::Acquire) & ABORT_UNNEEDED != 0
     }
 
     /// Prevent new abort requests after the task future completed successfully. Invalidation may
     /// still mark the task stale, which the ordinary completion bookkeeping handles.
-    pub fn disarm_abort(&mut self) {
+    pub fn disarm_abort(&mut self) -> Option<TaskExecutionAbortReason> {
+        let state = self.abort_state.load(Ordering::Acquire);
+        let raced = self
+            .abort_handle
+            .as_ref()
+            .is_some_and(AbortHandle::is_aborted)
+            .then(|| Self::decode_abort_reason(state))
+            .flatten();
         self.abort_handle = None;
-        self.abort_when_unneeded.store(false, Ordering::Release);
+        self.abort_state.store(
+            if state == ABORT_NONE {
+                ABORT_DISARMED
+            } else {
+                ABORT_OUTCOME_RECORDED
+            },
+            Ordering::Release,
+        );
+        raced
+    }
+}
+
+#[cfg(test)]
+mod abort_state_tests {
+    use super::*;
+
+    fn in_progress(abortable: bool) -> InProgressStateInner {
+        let abort_handle = abortable.then(|| AbortHandle::new_pair().0);
+        InProgressStateInner {
+            stale: false,
+            once_task: false,
+            marked_as_completed: false,
+            done_event: Event::new(|| || "abort state test".to_string()),
+            new_children: FxHashSet::default(),
+            native_fn: None,
+            abort_handle,
+            abort_state: AtomicU8::new(ABORT_NONE),
+        }
+    }
+
+    #[test]
+    fn first_abort_trigger_wins() {
+        let mut state = in_progress(true);
+        assert_eq!(
+            state.request_abort(TaskExecutionAbortReason::Invalidation),
+            AbortRequestOutcome::Accepted
+        );
+        assert_eq!(
+            state.request_abort(TaskExecutionAbortReason::Inactive),
+            AbortRequestOutcome::Duplicate
+        );
+        assert_eq!(
+            state.abort_reason(),
+            Some(TaskExecutionAbortReason::Invalidation)
+        );
+        assert!(
+            state.abort_when_unneeded(),
+            "a later inactive request must still affect recovery"
+        );
+        assert_eq!(
+            state.disarm_abort(),
+            Some(TaskExecutionAbortReason::Invalidation)
+        );
+    }
+
+    #[test]
+    fn unabortable_execution_is_skipped_once() {
+        let mut state = in_progress(false);
+        assert_eq!(
+            state.request_abort(TaskExecutionAbortReason::Gc),
+            AbortRequestOutcome::Skipped
+        );
+        assert_eq!(
+            state.request_abort(TaskExecutionAbortReason::Invalidation),
+            AbortRequestOutcome::Duplicate
+        );
+        assert_eq!(state.abort_reason(), Some(TaskExecutionAbortReason::Gc));
+        assert!(state.abort_when_unneeded());
+        assert_eq!(state.disarm_abort(), None);
+    }
+
+    #[test]
+    fn request_after_disarm_records_one_completion_race() {
+        let mut state = in_progress(true);
+        assert_eq!(state.disarm_abort(), None);
+        assert_eq!(
+            state.request_abort(TaskExecutionAbortReason::Inactive),
+            AbortRequestOutcome::RacedCompletion
+        );
+        assert_eq!(
+            state.request_abort(TaskExecutionAbortReason::Gc),
+            AbortRequestOutcome::Duplicate
+        );
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/tests/abort_collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/abort_collectibles.rs
@@ -1,0 +1,326 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+
+mod util;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use anyhow::Result;
+use tokio::sync::Notify;
+use turbo_rcstr::RcStr;
+use turbo_tasks::{
+    CollectiblesSource, NonLocalValue, ReadRef, ResolvedVc, State, TransientInstance,
+    ValueToString, Vc, VcValueTrait, backend::Backend, emit, trace::TraceRawVcs,
+};
+use turbo_tasks_testing::{Registration, register, run_once};
+
+use crate::util::create_tt;
+
+static REGISTRATION: Registration = register!();
+
+#[turbo_tasks::value]
+struct ChangingInput {
+    state: State<u32>,
+}
+
+#[turbo_tasks::value]
+struct TestCollectible;
+
+#[turbo_tasks::value_impl]
+impl ValueToString for TestCollectible {
+    #[turbo_tasks::function]
+    fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell("collectible".into())
+    }
+}
+
+#[derive(TraceRawVcs, NonLocalValue)]
+struct ExecutionControl {
+    #[turbo_tasks(trace_ignore)]
+    block_from_generation: usize,
+    #[turbo_tasks(trace_ignore)]
+    started: AtomicUsize,
+    #[turbo_tasks(trace_ignore)]
+    emitted: AtomicUsize,
+    #[turbo_tasks(trace_ignore)]
+    progress_notify: Notify,
+    #[turbo_tasks(trace_ignore)]
+    dropped: AtomicUsize,
+    #[turbo_tasks(trace_ignore)]
+    dropped_notify: Notify,
+    #[turbo_tasks(trace_ignore)]
+    release: Notify,
+}
+
+impl ExecutionControl {
+    fn new(block_from_generation: usize) -> Self {
+        Self {
+            block_from_generation,
+            started: AtomicUsize::new(0),
+            emitted: AtomicUsize::new(0),
+            progress_notify: Notify::new(),
+            dropped: AtomicUsize::new(0),
+            dropped_notify: Notify::new(),
+            release: Notify::new(),
+        }
+    }
+
+    async fn wait_for_started(&self, count: usize) {
+        while self.started.load(Ordering::Acquire) < count {
+            self.progress_notify.notified().await;
+        }
+    }
+
+    async fn wait_for_emitted(&self, count: usize) {
+        while self.emitted.load(Ordering::Acquire) < count {
+            self.progress_notify.notified().await;
+        }
+    }
+
+    async fn wait_for_dropped(&self, count: usize) {
+        while self.dropped.load(Ordering::Acquire) < count {
+            self.dropped_notify.notified().await;
+        }
+    }
+}
+
+struct ExecutionDropGuard {
+    control: TransientInstance<ExecutionControl>,
+}
+
+impl Drop for ExecutionDropGuard {
+    fn drop(&mut self) {
+        self.control.dropped.fetch_add(1, Ordering::Release);
+        self.control.dropped_notify.notify_waiters();
+    }
+}
+
+async fn run_collectible_producer(
+    input: ResolvedVc<ChangingInput>,
+    control: TransientInstance<ExecutionControl>,
+) -> Result<Vc<()>> {
+    let should_emit = *input.await?.state.get() != 0;
+    let generation = control.started.fetch_add(1, Ordering::AcqRel);
+    control.progress_notify.notify_waiters();
+    let _drop_guard = ExecutionDropGuard {
+        control: control.clone(),
+    };
+
+    if should_emit {
+        let collectible: ResolvedVc<Box<dyn ValueToString>> =
+            ResolvedVc::upcast(TestCollectible.resolved_cell());
+        emit(collectible);
+        control.emitted.fetch_add(1, Ordering::Release);
+        control.progress_notify.notify_waiters();
+    }
+
+    if generation >= control.block_from_generation {
+        control.release.notified().await;
+    }
+
+    Ok(Vc::cell(()))
+}
+
+#[turbo_tasks::function(operation, root)]
+async fn collectible_producer(
+    input: ResolvedVc<ChangingInput>,
+    control: TransientInstance<ExecutionControl>,
+) -> Result<Vc<()>> {
+    run_collectible_producer(input, control).await
+}
+
+#[turbo_tasks::function]
+async fn non_root_collectible_producer(
+    input: ResolvedVc<ChangingInput>,
+    control: TransientInstance<ExecutionControl>,
+) -> Result<Vc<()>> {
+    run_collectible_producer(input, control).await
+}
+
+#[turbo_tasks::function(operation, root)]
+async fn conditional_parent(
+    selector: ResolvedVc<ChangingInput>,
+    producer_input: ResolvedVc<ChangingInput>,
+    control: TransientInstance<ExecutionControl>,
+) -> Result<Vc<u32>> {
+    let selected = *selector.await?.state.get();
+    if selected == 0 {
+        let producer = collectible_producer(producer_input, control);
+        producer.connect().await?;
+        return Ok(Vc::cell(
+            producer.peek_collectibles::<Box<dyn ValueToString>>().len() as u32,
+        ));
+    }
+    Ok(Vc::cell(0))
+}
+
+#[turbo_tasks::function(operation, root)]
+async fn conditional_non_root_parent(
+    selector: ResolvedVc<ChangingInput>,
+    producer_input: ResolvedVc<ChangingInput>,
+    control: TransientInstance<ExecutionControl>,
+) -> Result<Vc<()>> {
+    if *selector.await?.state.get() == 0 {
+        non_root_collectible_producer(*producer_input, control).await?;
+    }
+    Ok(Vc::cell(()))
+}
+
+/// A collectible published only by an execution that is later aborted must not be reported by a
+/// strongly-consistent replacement root.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn aborted_first_execution_does_not_report_collectible() {
+    run_once(&REGISTRATION, async || {
+        let selector = ReadRef::new_owned(ChangingInput {
+            state: State::new(0),
+        });
+        let selector_vc = ReadRef::resolved_cell(selector.clone());
+        let producer_input = ReadRef::new_owned(ChangingInput {
+            state: State::new(1),
+        });
+        let producer_input_vc = ReadRef::resolved_cell(producer_input.clone());
+        let control = TransientInstance::new(ExecutionControl::new(0));
+        let parent = conditional_parent(selector_vc, producer_input_vc, control.clone());
+
+        let read_parent = parent.read_strongly_consistent();
+        let disconnect = async {
+            control.wait_for_emitted(1).await;
+            selector.state.set(1);
+            control.wait_for_dropped(1).await;
+            // If reading collectibles revives the producer, its replacement emits nothing and
+            // therefore cannot hide the aborted generation's leaked collectible.
+            producer_input.state.set(0);
+            anyhow::Ok(())
+        };
+        tokio::try_join!(read_parent, disconnect)?;
+
+        let collectibles = collectible_producer(producer_input_vc, control.clone())
+            .peek_collectibles::<Box<dyn ValueToString>>();
+        assert!(
+            collectibles.is_empty(),
+            "an aborted generation reported {} collectible(s)",
+            collectibles.len()
+        );
+
+        // Keep cleanup safe if a failure above leaves the execution parked.
+        control.release.notify_one();
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap();
+}
+
+/// Rollback of an aborted non-root emitter must bypass the user-facing rule that only root tasks
+/// may explicitly remove collectibles.
+///
+/// The emptiness assertion below is weak on its own — a disconnected child stops propagating
+/// collectibles to its parent either way. The load-bearing part of this test is that the rollback
+/// runs at all: routing it through the user-level entry point instead panics with "Removing
+/// collectibles from non-root task".
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn aborted_non_root_execution_does_not_report_collectible() {
+    run_once(&REGISTRATION, async || {
+        let selector = ReadRef::new_owned(ChangingInput {
+            state: State::new(0),
+        });
+        let selector_vc = ReadRef::resolved_cell(selector.clone());
+        let producer_input = ReadRef::new_owned(ChangingInput {
+            state: State::new(1),
+        });
+        let producer_input_vc = ReadRef::resolved_cell(producer_input.clone());
+        let control = TransientInstance::new(ExecutionControl::new(0));
+        let parent = conditional_non_root_parent(selector_vc, producer_input_vc, control.clone());
+
+        let read_parent = parent.read_strongly_consistent();
+        let disconnect = async {
+            control.wait_for_emitted(1).await;
+            selector.state.set(1);
+            control.wait_for_dropped(1).await;
+            producer_input.state.set(0);
+            anyhow::Ok(())
+        };
+        tokio::try_join!(read_parent, disconnect)?;
+
+        assert!(
+            parent
+                .peek_collectibles::<Box<dyn ValueToString>>()
+                .is_empty(),
+            "a non-root aborted generation reported a collectible"
+        );
+
+        control.release.notify_one();
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap();
+}
+
+/// Aborting a recomputation must preserve the collectible published by the last completed
+/// generation, including when the aborted generation re-emitted that same collectible.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn aborted_recomputation_preserves_completed_collectible() {
+    let (tt, _persistence_dir) = create_tt("aborted_recomputation_preserves_completed_collectible");
+    let control = TransientInstance::new(ExecutionControl::new(1));
+
+    // Complete generation 0 and publish its collectible.
+    let (producer_input, producer_input_vc) = turbo_tasks::run_once(tt.clone(), {
+        let control = control.clone();
+        async move {
+            let producer_input = ReadRef::new_owned(ChangingInput {
+                state: State::new(1),
+            });
+            let producer_input_vc = ReadRef::resolved_cell(producer_input.clone());
+            let producer = collectible_producer(producer_input_vc, control);
+            producer.read_strongly_consistent().await?;
+            assert_eq!(
+                producer.peek_collectibles::<Box<dyn ValueToString>>().len(),
+                1,
+                "the completed generation should publish one collectible"
+            );
+            anyhow::Ok((producer_input, producer_input_vc))
+        }
+    })
+    .await
+    .unwrap();
+
+    // Generation 1 re-emits the same collectible and parks. Invalidation aborts it and starts a
+    // non-emitting generation 2, which parks before completion. Once generation 2 has started, the
+    // abort callback (including rollback) is known to have finished. Inspect the backend directly
+    // so the assertion cannot itself reconnect or complete the producer.
+    turbo_tasks::run_once(tt.clone(), {
+        let tt = tt.clone();
+        let control = control.clone();
+        let producer_input = producer_input.clone();
+        async move {
+            producer_input.state.set(2);
+            let producer = collectible_producer(producer_input_vc, control.clone());
+            let read_producer = producer.read_strongly_consistent();
+            let abort_and_inspect = async {
+                control.wait_for_emitted(2).await;
+                producer_input.state.set(0);
+                control.wait_for_dropped(2).await;
+                control.wait_for_started(3).await;
+
+                let collectibles = tt.backend().read_task_collectibles(
+                    producer.task_id(),
+                    <Box<dyn ValueToString> as VcValueTrait>::get_trait_type_id(),
+                    None,
+                    &tt,
+                );
+                assert_eq!(
+                    collectibles.values().sum::<i32>(),
+                    1,
+                    "aborting a recomputation removed the last completed collectible"
+                );
+                control.release.notify_one();
+                anyhow::Ok(())
+            };
+            tokio::try_join!(read_producer, abort_and_inspect)?;
+            anyhow::Ok(())
+        }
+    })
+    .await
+    .unwrap();
+
+    tt.stop_and_wait().await;
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/execution_abort.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/execution_abort.rs
@@ -83,6 +83,21 @@ async fn blocking_task(
     Ok(Vc::cell(value))
 }
 
+#[turbo_tasks::function(root, non_cancelable)]
+async fn non_cancelable_blocking_task(
+    input: ResolvedVc<ChangingInput>,
+    control: TransientInstance<ExecutionControl>,
+) -> Result<Vc<u32>> {
+    let value = *input.await?.state.get();
+    let generation = control.started.fetch_add(1, Ordering::AcqRel);
+    control.started_notify.notify_waiters();
+    let _drop_guard = ExecutionDropGuard {
+        control: control.clone(),
+    };
+    control.releases[generation].notified().await;
+    Ok(Vc::cell(value))
+}
+
 #[turbo_tasks::function]
 async fn blocking_middle(
     child_input: ResolvedVc<ChangingInput>,
@@ -142,6 +157,54 @@ async fn invalidation_aborts_in_flight_execution() {
     })
     .await;
 
+    tt.stop_and_wait().await;
+    result.unwrap();
+}
+
+/// A cancellation-unsafe task opts out: invalidation marks it stale but lets the current future
+/// finish before the fresh execution starts.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn non_cancelable_execution_runs_to_completion() {
+    let (tt, _persistence_dir) = create_tt("non_cancelable_execution_runs_to_completion");
+    let control = TransientInstance::new(ExecutionControl::new());
+    let control_for_run = control.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        let input = ReadRef::resolved_cell(ReadRef::new_owned(ChangingInput {
+            state: State::new(0),
+        }));
+        let output = non_cancelable_blocking_task(*input, control_for_run.clone());
+
+        let read_output = output.strongly_consistent();
+        let drive_invalidation = async {
+            control_for_run.wait_for_started(1).await;
+            input.await?.state.set(1);
+
+            assert!(
+                tokio::time::timeout(
+                    Duration::from_millis(250),
+                    control_for_run.wait_for_dropped(1),
+                )
+                .await
+                .is_err(),
+                "non-cancelable execution was aborted"
+            );
+
+            control_for_run.releases[0].notify_one();
+            control_for_run.wait_for_started(2).await;
+            control_for_run.releases[1].notify_one();
+            anyhow::Ok(())
+        };
+
+        let (value, ()) = tokio::try_join!(read_output, drive_invalidation)?;
+        assert_eq!(*value, 1);
+        assert_eq!(control_for_run.started.load(Ordering::Acquire), 2);
+        anyhow::Ok(())
+    })
+    .await;
+
+    control.releases[0].notify_one();
+    control.releases[1].notify_one();
     tt.stop_and_wait().await;
     result.unwrap();
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/execution_abort.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/execution_abort.rs
@@ -4,13 +4,18 @@
 mod util;
 
 use std::{
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        Barrier,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::Duration,
 };
 
 use anyhow::Result;
 use tokio::sync::Notify;
-use turbo_tasks::{ReadRef, ResolvedVc, State, TransientInstance, Vc, trace::TraceRawVcs};
+use turbo_tasks::{
+    ReadRef, ResolvedVc, State, TransientInstance, TurboTasksApi, Vc, trace::TraceRawVcs,
+};
 
 use crate::util::create_tt;
 
@@ -57,6 +62,26 @@ impl ExecutionControl {
     }
 }
 
+#[derive(TraceRawVcs)]
+struct CompletionRaceControl {
+    #[turbo_tasks(trace_ignore)]
+    started: Notify,
+    #[turbo_tasks(trace_ignore)]
+    generation: AtomicUsize,
+    #[turbo_tasks(trace_ignore)]
+    first_poll_release: Barrier,
+}
+
+impl CompletionRaceControl {
+    fn new() -> Self {
+        Self {
+            started: Notify::new(),
+            generation: AtomicUsize::new(0),
+            first_poll_release: Barrier::new(2),
+        }
+    }
+}
+
 struct ExecutionDropGuard {
     control: TransientInstance<ExecutionControl>,
 }
@@ -80,6 +105,22 @@ async fn blocking_task(
         control: control.clone(),
     };
     control.releases[generation].notified().await;
+    Ok(Vc::cell(value))
+}
+
+#[turbo_tasks::function(root)]
+async fn completion_race_task(
+    input: ResolvedVc<ChangingInput>,
+    control: TransientInstance<CompletionRaceControl>,
+) -> Result<Vc<u32>> {
+    let value = *input.await?.state.get();
+    let generation = control.generation.fetch_add(1, Ordering::AcqRel);
+    if generation == 0 {
+        control.started.notify_waiters();
+        // Keep the current poll in progress while another runtime thread requests abortion. The
+        // future then returns Ready without giving Abortable another chance to observe the request.
+        control.first_poll_release.wait();
+    }
     Ok(Vc::cell(value))
 }
 
@@ -122,6 +163,7 @@ async fn awaits_blocking_subtree(
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn invalidation_aborts_in_flight_execution() {
     let (tt, _persistence_dir) = create_tt("invalidation_aborts_in_flight_execution");
+    tt.task_statistics().enable();
     let control = TransientInstance::new(ExecutionControl::new());
     let control_for_run = control.clone();
 
@@ -157,8 +199,18 @@ async fn invalidation_aborts_in_flight_execution() {
     })
     .await;
 
-    tt.stop_and_wait().await;
     result.unwrap();
+    let stats = tt
+        .task_statistics()
+        .get()
+        .unwrap()
+        .get(&BLOCKING_TASK_FUNCTION);
+    assert_eq!(stats.execution_started, 2);
+    assert_eq!(stats.execution_completed, 1);
+    assert_eq!(stats.abort_requested_invalidation, 1);
+    assert_eq!(stats.abort_observed_invalidation, 1);
+    assert_eq!(stats.abort_raced_completion_invalidation, 0);
+    tt.stop_and_wait().await;
 }
 
 /// A cancellation-unsafe task opts out: invalidation marks it stale but lets the current future
@@ -166,6 +218,7 @@ async fn invalidation_aborts_in_flight_execution() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn non_cancelable_execution_runs_to_completion() {
     let (tt, _persistence_dir) = create_tt("non_cancelable_execution_runs_to_completion");
+    tt.task_statistics().enable();
     let control = TransientInstance::new(ExecutionControl::new());
     let control_for_run = control.clone();
 
@@ -205,8 +258,18 @@ async fn non_cancelable_execution_runs_to_completion() {
 
     control.releases[0].notify_one();
     control.releases[1].notify_one();
-    tt.stop_and_wait().await;
     result.unwrap();
+    let stats = tt
+        .task_statistics()
+        .get()
+        .unwrap()
+        .get(&NON_CANCELABLE_BLOCKING_TASK_FUNCTION);
+    assert_eq!(stats.execution_started, 2);
+    assert_eq!(stats.execution_completed, 2);
+    assert_eq!(stats.abort_requested_invalidation, 1);
+    assert_eq!(stats.abort_skipped_invalidation, 1);
+    assert_eq!(stats.abort_observed_invalidation, 0);
+    tt.stop_and_wait().await;
 }
 
 /// Aborting a parent must recursively undo speculative active-count increments so a blocked
@@ -215,6 +278,7 @@ async fn non_cancelable_execution_runs_to_completion() {
 async fn inactive_subtree_is_aborted_and_restarts_when_reconnected() {
     let (tt, _persistence_dir) =
         create_tt("inactive_subtree_is_aborted_and_restarts_when_reconnected");
+    tt.task_statistics().enable();
     let control = TransientInstance::new(ExecutionControl::new());
     let control_for_run = control.clone();
 
@@ -250,8 +314,61 @@ async fn inactive_subtree_is_aborted_and_restarts_when_reconnected() {
     // Keep cleanup safe if an assertion above exits before the blocked execution is aborted.
     control.releases[0].notify_one();
     control.releases[1].notify_one();
-    tt.stop_and_wait().await;
     result.unwrap();
+    let stats = tt
+        .task_statistics()
+        .get()
+        .unwrap()
+        .get(&BLOCKING_TASK_FUNCTION);
+    assert_eq!(stats.execution_started, 2);
+    assert_eq!(stats.execution_completed, 1);
+    assert_eq!(stats.abort_requested_inactive, 1);
+    assert_eq!(stats.abort_observed_inactive, 1);
+    tt.stop_and_wait().await;
+}
+
+/// A task that returns Ready from the poll during which abortion was requested completes normally,
+/// records the lost race, and uses ordinary stale re-execution.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn successful_completion_records_abort_race() {
+    let (tt, _persistence_dir) = create_tt("successful_completion_records_abort_race");
+    tt.task_statistics().enable();
+    let control = TransientInstance::new(CompletionRaceControl::new());
+    let control_for_run = control.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        let input = ReadRef::resolved_cell(ReadRef::new_owned(ChangingInput {
+            state: State::new(0),
+        }));
+        let output = completion_race_task(*input, control_for_run.clone());
+        let read_output = output.strongly_consistent();
+        let drive_race = async {
+            while control_for_run.generation.load(Ordering::Acquire) < 1 {
+                control_for_run.started.notified().await;
+            }
+            input.await?.state.set(1);
+            control_for_run.first_poll_release.wait();
+            anyhow::Ok(())
+        };
+
+        let (value, ()) = tokio::try_join!(read_output, drive_race)?;
+        assert_eq!(*value, 1);
+        anyhow::Ok(())
+    })
+    .await;
+
+    result.unwrap();
+    let stats = tt
+        .task_statistics()
+        .get()
+        .unwrap()
+        .get(&COMPLETION_RACE_TASK_FUNCTION);
+    assert_eq!(stats.execution_started, 2);
+    assert_eq!(stats.execution_completed, 2);
+    assert_eq!(stats.abort_requested_invalidation, 1);
+    assert_eq!(stats.abort_raced_completion_invalidation, 1);
+    assert_eq!(stats.abort_observed_invalidation, 0);
+    tt.stop_and_wait().await;
 }
 
 /// Completing at the same time as invalidation must either complete the stale poll or abort it,
@@ -260,6 +377,7 @@ async fn inactive_subtree_is_aborted_and_restarts_when_reconnected() {
 async fn completion_racing_invalidation_has_one_fresh_execution() {
     let (tt, _persistence_dir) =
         create_tt("completion_racing_invalidation_has_one_fresh_execution");
+    tt.task_statistics().enable();
 
     let result = turbo_tasks::run_once(tt.clone(), async move {
         for _ in 0..16 {
@@ -294,6 +412,21 @@ async fn completion_racing_invalidation_has_one_fresh_execution() {
     })
     .await;
 
-    tt.stop_and_wait().await;
     result.unwrap();
+    let stats = tt
+        .task_statistics()
+        .get()
+        .unwrap()
+        .get(&BLOCKING_TASK_FUNCTION);
+    assert_eq!(stats.abort_requested_invalidation, 16);
+    assert_eq!(
+        stats.abort_observed_invalidation + stats.abort_raced_completion_invalidation,
+        16
+    );
+    assert_eq!(stats.execution_started, 32);
+    assert_eq!(
+        stats.execution_completed + stats.abort_observed_invalidation,
+        32
+    );
+    tt.stop_and_wait().await;
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/execution_abort.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/execution_abort.rs
@@ -1,0 +1,236 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+
+mod util;
+
+use std::{
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
+};
+
+use anyhow::Result;
+use tokio::sync::Notify;
+use turbo_tasks::{ReadRef, ResolvedVc, State, TransientInstance, Vc, trace::TraceRawVcs};
+
+use crate::util::create_tt;
+
+#[turbo_tasks::value]
+struct ChangingInput {
+    state: State<u32>,
+}
+
+#[derive(TraceRawVcs)]
+struct ExecutionControl {
+    #[turbo_tasks(trace_ignore)]
+    started: AtomicUsize,
+    #[turbo_tasks(trace_ignore)]
+    started_notify: Notify,
+    #[turbo_tasks(trace_ignore)]
+    dropped: AtomicUsize,
+    #[turbo_tasks(trace_ignore)]
+    dropped_notify: Notify,
+    #[turbo_tasks(trace_ignore)]
+    releases: [Notify; 2],
+}
+
+impl ExecutionControl {
+    fn new() -> Self {
+        Self {
+            started: AtomicUsize::new(0),
+            started_notify: Notify::new(),
+            dropped: AtomicUsize::new(0),
+            dropped_notify: Notify::new(),
+            releases: [Notify::new(), Notify::new()],
+        }
+    }
+
+    async fn wait_for_started(&self, count: usize) {
+        while self.started.load(Ordering::Acquire) < count {
+            self.started_notify.notified().await;
+        }
+    }
+
+    async fn wait_for_dropped(&self, count: usize) {
+        while self.dropped.load(Ordering::Acquire) < count {
+            self.dropped_notify.notified().await;
+        }
+    }
+}
+
+struct ExecutionDropGuard {
+    control: TransientInstance<ExecutionControl>,
+}
+
+impl Drop for ExecutionDropGuard {
+    fn drop(&mut self) {
+        self.control.dropped.fetch_add(1, Ordering::Release);
+        self.control.dropped_notify.notify_waiters();
+    }
+}
+
+#[turbo_tasks::function(root)]
+async fn blocking_task(
+    input: ResolvedVc<ChangingInput>,
+    control: TransientInstance<ExecutionControl>,
+) -> Result<Vc<u32>> {
+    let value = *input.await?.state.get();
+    let generation = control.started.fetch_add(1, Ordering::AcqRel);
+    control.started_notify.notify_waiters();
+    let _drop_guard = ExecutionDropGuard {
+        control: control.clone(),
+    };
+    control.releases[generation].notified().await;
+    Ok(Vc::cell(value))
+}
+
+#[turbo_tasks::function]
+async fn blocking_middle(
+    child_input: ResolvedVc<ChangingInput>,
+    control: TransientInstance<ExecutionControl>,
+) -> Result<Vc<u32>> {
+    Ok(Vc::cell(*blocking_task(*child_input, control).await?))
+}
+
+#[turbo_tasks::function(root)]
+async fn awaits_blocking_subtree(
+    selector: ResolvedVc<ChangingInput>,
+    child_input: ResolvedVc<ChangingInput>,
+    control: TransientInstance<ExecutionControl>,
+) -> Result<Vc<u32>> {
+    let selected = *selector.await?.state.get();
+    let child = *blocking_middle(*child_input, control).await?;
+    Ok(Vc::cell(selected + child))
+}
+
+/// Invalidating an executing task should drop the stale future rather than waiting for it to
+/// finish, then run the task once with the new input.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn invalidation_aborts_in_flight_execution() {
+    let (tt, _persistence_dir) = create_tt("invalidation_aborts_in_flight_execution");
+    let control = TransientInstance::new(ExecutionControl::new());
+    let control_for_run = control.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        let input = ReadRef::resolved_cell(ReadRef::new_owned(ChangingInput {
+            state: State::new(0),
+        }));
+        let output = blocking_task(*input, control_for_run.clone());
+
+        let read_output = output.strongly_consistent();
+        let drive_invalidation = async {
+            control_for_run.wait_for_started(1).await;
+            input.await?.state.set(1);
+
+            let aborted = tokio::time::timeout(
+                Duration::from_millis(250),
+                control_for_run.wait_for_dropped(1),
+            )
+            .await
+            .is_ok();
+
+            // Permits make cleanup deterministic on both the pre-fix and fixed paths.
+            control_for_run.releases[0].notify_one();
+            control_for_run.releases[1].notify_one();
+            anyhow::Ok(aborted)
+        };
+
+        let (value, aborted) = tokio::try_join!(read_output, drive_invalidation)?;
+        assert!(aborted, "the stale execution was not aborted");
+        assert_eq!(*value, 1);
+        assert_eq!(control_for_run.started.load(Ordering::Acquire), 2);
+        anyhow::Ok(())
+    })
+    .await;
+
+    tt.stop_and_wait().await;
+    result.unwrap();
+}
+
+/// Aborting a parent must recursively undo speculative active-count increments so a blocked
+/// grandchild becomes inactive and is aborted too. Re-running the subtree starts it from scratch.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn inactive_subtree_is_aborted_and_restarts_when_reconnected() {
+    let (tt, _persistence_dir) =
+        create_tt("inactive_subtree_is_aborted_and_restarts_when_reconnected");
+    let control = TransientInstance::new(ExecutionControl::new());
+    let control_for_run = control.clone();
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        let selector = ReadRef::resolved_cell(ReadRef::new_owned(ChangingInput {
+            state: State::new(0),
+        }));
+        let child_input = ReadRef::resolved_cell(ReadRef::new_owned(ChangingInput {
+            state: State::new(10),
+        }));
+        let output = awaits_blocking_subtree(*selector, *child_input, control_for_run.clone());
+
+        let read_output = output.strongly_consistent();
+        let drive_disconnection = async {
+            control_for_run.wait_for_started(1).await;
+            selector.await?.state.set(1);
+
+            tokio::time::timeout(Duration::from_secs(5), control_for_run.wait_for_dropped(1))
+                .await
+                .expect("the inactive child execution was not aborted");
+            control_for_run.wait_for_started(2).await;
+            control_for_run.releases[1].notify_one();
+            anyhow::Ok(())
+        };
+
+        let (value, ()) = tokio::try_join!(read_output, drive_disconnection)?;
+        assert_eq!(*value, 11);
+        assert_eq!(control_for_run.started.load(Ordering::Acquire), 2);
+        anyhow::Ok(())
+    })
+    .await;
+
+    // Keep cleanup safe if an assertion above exits before the blocked execution is aborted.
+    control.releases[0].notify_one();
+    control.releases[1].notify_one();
+    tt.stop_and_wait().await;
+    result.unwrap();
+}
+
+/// Completing at the same time as invalidation must either complete the stale poll or abort it,
+/// but in both cases exactly one fresh execution must publish the new value.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn completion_racing_invalidation_has_one_fresh_execution() {
+    let (tt, _persistence_dir) =
+        create_tt("completion_racing_invalidation_has_one_fresh_execution");
+
+    let result = turbo_tasks::run_once(tt.clone(), async move {
+        for _ in 0..16 {
+            let control = TransientInstance::new(ExecutionControl::new());
+            let input = ReadRef::resolved_cell(ReadRef::new_owned(ChangingInput {
+                state: State::new(0),
+            }));
+            let output = blocking_task(*input, control.clone());
+
+            let read_output = output.strongly_consistent();
+            let drive_race = async {
+                control.wait_for_started(1).await;
+                let invalidate = async {
+                    input.await?.state.set(1);
+                    anyhow::Ok(())
+                };
+                let complete = async {
+                    control.releases[0].notify_one();
+                    anyhow::Ok(())
+                };
+                tokio::try_join!(invalidate, complete)?;
+                control.wait_for_started(2).await;
+                control.releases[1].notify_one();
+                anyhow::Ok(())
+            };
+
+            let (value, ()) = tokio::try_join!(read_output, drive_race)?;
+            assert_eq!(*value, 1);
+            assert_eq!(control.started.load(Ordering::Acquire), 2);
+        }
+        anyhow::Ok(())
+    })
+    .await;
+
+    tt.stop_and_wait().await;
+    result.unwrap();
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/task_statistics.rs
@@ -327,10 +327,25 @@ fn make_stats_deterministic(mut json: serde_json::Value) -> serde_json::Value {
                 // Replace `duration` with a fixed value to simplify test assertions
                 let mut v = v.clone();
                 let object = v.as_object_mut().unwrap();
-                // These are only populated after the task has finalized execution so it racy to
-                // assert on it.
+                // Execution completion and activeness-driven abort requests can race this broad
+                // cache-statistics snapshot. Dedicated execution-abort tests assert those counters
+                // with explicit synchronization.
                 object.remove("duration");
                 object.remove("executions");
+                object.remove("execution_started");
+                object.remove("execution_completed");
+                object.remove("abort_requested_invalidation");
+                object.remove("abort_requested_inactive");
+                object.remove("abort_requested_gc");
+                object.remove("abort_observed_invalidation");
+                object.remove("abort_observed_inactive");
+                object.remove("abort_observed_gc");
+                object.remove("abort_raced_completion_invalidation");
+                object.remove("abort_raced_completion_inactive");
+                object.remove("abort_raced_completion_gc");
+                object.remove("abort_skipped_invalidation");
+                object.remove("abort_skipped_inactive");
+                object.remove("abort_skipped_gc");
                 map.insert(k, v);
             }
         }

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.stderr
@@ -1,4 +1,4 @@
-error: unexpected token, expected one of: "fs", "network", "operation", "root", or "session_dependent"
+error: unexpected token, expected one of: "fs", "network", "operation", "root", "session_dependent", or "non_cancelable"
   --> tests/function/fail_attribute_invalid_args.rs:10:25
    |
 10 | #[turbo_tasks::function(invalid_argument)]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.stderr
@@ -1,4 +1,4 @@
-error: unexpected token, expected one of: "fs", "network", "operation", "root", or "session_dependent"
+error: unexpected token, expected one of: "fs", "network", "operation", "root", "session_dependent", or "non_cancelable"
   --> tests/function/fail_attribute_invalid_args_inherent_impl.rs:15:29
    |
 15 |     #[turbo_tasks::function(invalid_argument)]

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -754,6 +754,9 @@ pub struct FunctionArguments {
     /// when restored from persistent cache because they depend on external state (filesystem,
     /// environment, network) that may change between sessions.
     pub session_dependent: Option<Span>,
+    /// Should an in-flight execution continue to completion after it is invalidated or becomes
+    /// inactive?
+    pub non_cancelable: Option<Span>,
 }
 
 impl Parse for FunctionArguments {
@@ -784,11 +787,14 @@ impl Parse for FunctionArguments {
                 ("session_dependent", Meta::Path(_)) => {
                     parsed_args.session_dependent = Some(meta.span());
                 }
+                ("non_cancelable", Meta::Path(_)) => {
+                    parsed_args.non_cancelable = Some(meta.span());
+                }
                 (_, meta) => {
                     return Err(syn::Error::new_spanned(
                         meta,
                         "unexpected token, expected one of: \"fs\", \"network\", \"operation\", \
-                         \"root\", or \"session_dependent\"",
+                         \"root\", \"session_dependent\", or \"non_cancelable\"",
                     ));
                 }
             }
@@ -1125,6 +1131,7 @@ pub struct NativeFn {
     pub filter_trait_call_args: Option<FilterTraitCallArgsTokens>,
     pub is_root: bool,
     pub is_session_dependent: bool,
+    pub is_cancelable: bool,
 }
 
 impl NativeFn {
@@ -1138,6 +1145,7 @@ impl NativeFn {
             filter_trait_call_args,
             is_root,
             is_session_dependent,
+            is_cancelable,
         } = self;
 
         let task_fn = if *is_method && *is_self_used {
@@ -1174,6 +1182,7 @@ impl NativeFn {
                     &#task_fn,
                     #is_root,
                     #is_session_dependent,
+                    #is_cancelable,
                 )
             }
         }

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -44,6 +44,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
     let is_self_used = args.operation.is_some() || is_self_used(&block);
     let is_root = args.root.is_some();
     let is_session_dependent = args.session_dependent.is_some();
+    let is_cancelable = args.non_cancelable.is_none();
 
     let Some(turbo_fn) = TurboFn::new(&sig, DefinitionContext::NakedFn, args, is_self_used) else {
         return quote! {
@@ -68,6 +69,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         filter_trait_call_args: None, // not a trait method
         is_root,
         is_session_dependent,
+        is_cancelable,
     };
     let native_function_ident = get_native_function_ident(ident);
     let native_function_def = native_fn.definition();

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -103,6 +103,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
             let is_self_used = func_args.operation.is_some() || is_self_used(block);
             let is_root = func_args.root.is_some();
             let is_session_dependent = func_args.session_dependent.is_some();
+            let is_cancelable = func_args.non_cancelable.is_none();
 
             let Some(turbo_fn) = TurboFn::new(
                 sig,
@@ -126,6 +127,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 filter_trait_call_args: None, // not a trait method
                 is_root,
                 is_session_dependent,
+                is_cancelable,
             };
 
             let native_function_ident = get_inherent_impl_function_ident(ty_ident, ident);
@@ -208,6 +210,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 let is_self_used = func_args.operation.is_some() || is_self_used(block);
                 let is_root = func_args.root.is_some();
                 let is_session_dependent = func_args.session_dependent.is_some();
+                let is_cancelable = func_args.non_cancelable.is_none();
 
                 let Some(turbo_fn) = TurboFn::new(
                     sig,
@@ -242,6 +245,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     filter_trait_call_args: turbo_fn.filter_trait_call_args(),
                     is_root,
                     is_session_dependent,
+                    is_cancelable,
                 };
 
                 let native_function_ident =

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -182,6 +182,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 
         let is_self_used = default.as_ref().map(is_self_used).unwrap_or(false);
         let is_root = func_args.root.is_some();
+        let is_cancelable = func_args.non_cancelable.is_none();
         let Some(turbo_fn) = TurboFn::new(
             sig,
             DefinitionContext::ValueTrait,
@@ -219,6 +220,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                 filter_trait_call_args: turbo_fn.filter_trait_call_args(),
                 is_root: false,
                 is_session_dependent: false,
+                is_cancelable,
             };
 
             let native_function_ident = get_trait_default_impl_function_ident(trait_ident, ident);

--- a/turbopack/crates/turbo-tasks/function.md
+++ b/turbopack/crates/turbo-tasks/function.md
@@ -145,6 +145,16 @@ Note: `session_dependent` should be applied to the **leaf task** that directly r
 Tasks that transitively depend on a session-dependent task do not need this attribute — they will
 naturally re-execute when the session-dependent task they depend on produces a new result.
 
+### `non_cancelable`
+
+Prevents an in-flight execution from being aborted when the task is invalidated or becomes
+inactive. Turbo-task functions are cancelable by default.
+
+Use this only when dropping the function's future can leave external state inconsistent or lose an
+operation that cannot be replayed. Prefer making the unsafe section cancellation-safe or moving it
+into separately spawned work that the task awaits. For example, a request/response bridge may need
+this marker if cancellation can consume a response without recording it for the next execution.
+
 [`OperationVc<T>`]: crate::OperationVc
 
 ## Methods and Self

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -795,6 +795,7 @@ mod cached_task_type_tests {
         &into_task_fn(dummy_fn_a),
         false,
         false,
+        true,
     );
 
     static FN_B: NativeFunction = NativeFunction::new(
@@ -804,6 +805,7 @@ mod cached_task_type_tests {
         &into_task_fn(dummy_fn_b),
         false,
         false,
+        true,
     );
 
     /// Build a `u64` hash for a `CachedTaskType` using its `Hash` impl and a `RandomState`.

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -18,6 +18,7 @@ use bincode::{
     error::{DecodeError, EncodeError},
     impl_borrow_decode,
 };
+use futures::future::AbortRegistration;
 use rustc_hash::FxHasher;
 use smallvec::SmallVec;
 use tracing::Span;
@@ -275,6 +276,7 @@ impl CachedTaskType {
 pub struct TaskExecutionSpec<'a> {
     pub future: Pin<Box<dyn Future<Output = Result<RawVc>> + Send + 'a>>,
     pub span: Span,
+    pub abort_registration: AbortRegistration,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
@@ -621,6 +623,15 @@ pub trait Backend: Sized + Sync + Send {
     ) -> Option<TaskExecutionSpec<'a>>;
 
     fn task_execution_canceled(&self, task: TaskId, turbo_tasks: &TurboTasks<Self>);
+
+    /// Called when an in-flight task execution is aborted because its result is no longer needed.
+    ///
+    /// Returns `Some(priority)` when the task remains live and must be re-run.
+    fn task_execution_aborted(
+        &self,
+        task: TaskId,
+        turbo_tasks: &TurboTasks<Self>,
+    ) -> Option<TaskPriority>;
 
     /// Called when a task's execution finishes.
     ///

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -276,7 +276,7 @@ impl CachedTaskType {
 pub struct TaskExecutionSpec<'a> {
     pub future: Pin<Box<dyn Future<Output = Result<RawVc>> + Send + 'a>>,
     pub span: Span,
-    pub abort_registration: AbortRegistration,
+    pub abort_registration: Option<AbortRegistration>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -273,6 +273,24 @@ impl CachedTaskType {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum TaskExecutionAbortReason {
+    Invalidation = 1,
+    Inactive = 2,
+    Gc = 3,
+}
+
+impl TaskExecutionAbortReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Invalidation => "invalidation",
+            Self::Inactive => "inactive",
+            Self::Gc => "gc",
+        }
+    }
+}
+
 pub struct TaskExecutionSpec<'a> {
     pub future: Pin<Box<dyn Future<Output = Result<RawVc>> + Send + 'a>>,
     pub span: Span,

--- a/turbopack/crates/turbo-tasks/src/capture_future.rs
+++ b/turbopack/crates/turbo-tasks/src/capture_future.rs
@@ -9,6 +9,7 @@ use std::{
 
 use anyhow::Result;
 use bincode::{Decode, Encode};
+use futures::future::{AbortRegistration, Abortable};
 use pin_project_lite::pin_project;
 
 use crate::{backend::TurboTasksExecutionErrorMessage, panic_hooks::LAST_ERROR_LOCATION};
@@ -23,6 +24,39 @@ pin_project! {
 impl<T, F: Future<Output = T>> CaptureFuture<T, F> {
     pub fn new(future: F) -> Self {
         Self { future }
+    }
+}
+
+pub enum CaptureFutureOutcome<T, E> {
+    Value(T),
+    Error(E),
+    Panic(TurboTasksPanic),
+    Aborted,
+}
+
+impl<T, E, F> CaptureFuture<std::result::Result<T, E>, F>
+where
+    F: Future<Output = std::result::Result<T, E>>,
+{
+    /// Captures panics and optionally makes this future abortable, flattening all execution
+    /// outcomes into one semantic enum for the caller.
+    pub async fn with_optional_abort(
+        self,
+        abort_registration: Option<AbortRegistration>,
+    ) -> CaptureFutureOutcome<T, E> {
+        let captured = match abort_registration {
+            Some(abort_registration) => match Abortable::new(self, abort_registration).await {
+                Ok(captured) => captured,
+                Err(_) => return CaptureFutureOutcome::Aborted,
+            },
+            None => self.await,
+        };
+
+        match captured {
+            Ok(Ok(value)) => CaptureFutureOutcome::Value(value),
+            Ok(Err(error)) => CaptureFutureOutcome::Error(error),
+            Err(panic) => CaptureFutureOutcome::Panic(panic),
+        }
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -22,7 +22,7 @@ use anyhow::{Result, anyhow};
 use auto_hash_map::AutoMap;
 use bincode::{Decode, Encode};
 use either::Either;
-use futures::{FutureExt, future::Abortable};
+use futures::FutureExt;
 use rustc_hash::{FxBuildHasher, FxHasher};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -38,7 +38,7 @@ use crate::{
         Backend, CellContent, CellHash, TaskCollectiblesMap, TaskExecutionSpec, TransientTaskType,
         TurboTasksExecutionError, TypedCellContent, VerificationMode,
     },
-    capture_future::CaptureFuture,
+    capture_future::{CaptureFuture, CaptureFutureOutcome},
     dyn_task_inputs::DynTaskInputsStorage,
     event::{Event, EventListener},
     id::{ExecutionId, LocalTaskId, TraitTypeId},
@@ -1544,53 +1544,44 @@ impl<B: Backend> Executor<TurboTasks<B>, ScheduledTask, TaskPriority> for TurboT
                             InlineExecutionSpanSlot::set(&span);
 
                             async {
-                                let result = match abort_registration {
-                                    Some(abort_registration) => {
-                                        Abortable::new(
-                                            CaptureFuture::new(future),
-                                            abort_registration,
-                                        )
-                                        .await
-                                    }
-                                    None => Ok(CaptureFuture::new(future).await),
-                                };
+                                let outcome = CaptureFuture::new(future)
+                                    .with_optional_abort(abort_registration)
+                                    .await;
 
-                                // Wait for all spawned local tasks using `local` to finish. The
-                                // main task future has already been dropped on abort, so local work
-                                // can no longer be added while this drains.
+                                // Wait for all spawned local tasks using `local` to finish.
                                 wait_for_local_tasks().await;
 
                                 let finished_state = this.finish_current_task_state();
                                 let cell_counters = CURRENT_TASK_STATE
                                     .with(|ts| ts.write().unwrap().cell_counters.take().unwrap());
 
-                                match result {
-                                    Err(_) => this.backend.task_execution_aborted(task_id, &*this),
-                                    Ok(result) => {
-                                        let result = match result {
-                                            Ok(Ok(raw_vc)) => {
-                                                // This is safe because we waited for all local
-                                                // tasks to complete above.
-                                                raw_vc
-                                                    .to_non_local_unchecked_sync(&*this)
-                                                    .map_err(|err| err.into())
-                                            }
-                                            Ok(Err(err)) => Err(err.into()),
-                                            Err(err) => {
-                                                Err(TurboTasksExecutionError::Panic(Arc::new(err)))
-                                            }
-                                        };
-                                        this.backend.task_execution_completed(
-                                            task_id,
-                                            result,
-                                            &cell_counters,
-                                            #[cfg(feature = "verify_determinism")]
-                                            finished_state.stateful,
-                                            finished_state.has_invalidator,
-                                            &*this,
-                                        )
+                                let result = match outcome {
+                                    CaptureFutureOutcome::Aborted => {
+                                        return this
+                                            .backend
+                                            .task_execution_aborted(task_id, &*this);
                                     }
-                                }
+                                    CaptureFutureOutcome::Value(raw_vc) => {
+                                        // This is safe because we waited for all local tasks to
+                                        // complete above.
+                                        raw_vc
+                                            .to_non_local_unchecked_sync(&*this)
+                                            .map_err(|err| err.into())
+                                    }
+                                    CaptureFutureOutcome::Error(err) => Err(err.into()),
+                                    CaptureFutureOutcome::Panic(err) => {
+                                        Err(TurboTasksExecutionError::Panic(Arc::new(err)))
+                                    }
+                                };
+                                this.backend.task_execution_completed(
+                                    task_id,
+                                    result,
+                                    &cell_counters,
+                                    #[cfg(feature = "verify_determinism")]
+                                    finished_state.stateful,
+                                    finished_state.has_invalidator,
+                                    &*this,
+                                )
                             }
                             .instrument(span)
                             .await

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1544,9 +1544,16 @@ impl<B: Backend> Executor<TurboTasks<B>, ScheduledTask, TaskPriority> for TurboT
                             InlineExecutionSpanSlot::set(&span);
 
                             async {
-                                let result =
-                                    Abortable::new(CaptureFuture::new(future), abort_registration)
-                                        .await;
+                                let result = match abort_registration {
+                                    Some(abort_registration) => {
+                                        Abortable::new(
+                                            CaptureFuture::new(future),
+                                            abort_registration,
+                                        )
+                                        .await
+                                    }
+                                    None => Ok(CaptureFuture::new(future).await),
+                                };
 
                                 // Wait for all spawned local tasks using `local` to finish. The
                                 // main task future has already been dropped on abort, so local work

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -22,7 +22,7 @@ use anyhow::{Result, anyhow};
 use auto_hash_map::AutoMap;
 use bincode::{Decode, Encode};
 use either::Either;
-use futures::FutureExt;
+use futures::{FutureExt, future::Abortable};
 use rustc_hash::{FxBuildHasher, FxHasher};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -1531,7 +1531,11 @@ impl<B: Backend> Executor<TurboTasks<B>, ScheduledTask, TaskPriority> for TurboT
                                 return None;
                             }
 
-                            let TaskExecutionSpec { future, span } = this
+                            let TaskExecutionSpec {
+                                future,
+                                span,
+                                abort_registration,
+                            } = this
                                 .backend
                                 .try_start_task_execution(task_id, priority, &*this)?;
 
@@ -1540,35 +1544,46 @@ impl<B: Backend> Executor<TurboTasks<B>, ScheduledTask, TaskPriority> for TurboT
                             InlineExecutionSpanSlot::set(&span);
 
                             async {
-                                let result = CaptureFuture::new(future).await;
+                                let result =
+                                    Abortable::new(CaptureFuture::new(future), abort_registration)
+                                        .await;
 
-                                // wait for all spawned local tasks using `local` to finish
+                                // Wait for all spawned local tasks using `local` to finish. The
+                                // main task future has already been dropped on abort, so local work
+                                // can no longer be added while this drains.
                                 wait_for_local_tasks().await;
-
-                                let result = match result {
-                                    Ok(Ok(raw_vc)) => {
-                                        // This is safe because we waited for all local tasks to
-                                        // complete above
-                                        raw_vc
-                                            .to_non_local_unchecked_sync(&*this)
-                                            .map_err(|err| err.into())
-                                    }
-                                    Ok(Err(err)) => Err(err.into()),
-                                    Err(err) => Err(TurboTasksExecutionError::Panic(Arc::new(err))),
-                                };
 
                                 let finished_state = this.finish_current_task_state();
                                 let cell_counters = CURRENT_TASK_STATE
                                     .with(|ts| ts.write().unwrap().cell_counters.take().unwrap());
-                                this.backend.task_execution_completed(
-                                    task_id,
-                                    result,
-                                    &cell_counters,
-                                    #[cfg(feature = "verify_determinism")]
-                                    finished_state.stateful,
-                                    finished_state.has_invalidator,
-                                    &*this,
-                                )
+
+                                match result {
+                                    Err(_) => this.backend.task_execution_aborted(task_id, &*this),
+                                    Ok(result) => {
+                                        let result = match result {
+                                            Ok(Ok(raw_vc)) => {
+                                                // This is safe because we waited for all local
+                                                // tasks to complete above.
+                                                raw_vc
+                                                    .to_non_local_unchecked_sync(&*this)
+                                                    .map_err(|err| err.into())
+                                            }
+                                            Ok(Err(err)) => Err(err.into()),
+                                            Err(err) => {
+                                                Err(TurboTasksExecutionError::Panic(Arc::new(err)))
+                                            }
+                                        };
+                                        this.backend.task_execution_completed(
+                                            task_id,
+                                            result,
+                                            &cell_counters,
+                                            #[cfg(feature = "verify_determinism")]
+                                            finished_state.stateful,
+                                            finished_state.has_invalidator,
+                                            &*this,
+                                        )
+                                    }
+                                }
                             }
                             .instrument(span)
                             .await

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1557,6 +1557,7 @@ impl<B: Backend> Executor<TurboTasks<B>, ScheduledTask, TaskPriority> for TurboT
 
                                 let result = match outcome {
                                     CaptureFutureOutcome::Aborted => {
+                                        Span::current().record("outcome", "aborted");
                                         return this
                                             .backend
                                             .task_execution_aborted(task_id, &*this);
@@ -1564,12 +1565,21 @@ impl<B: Backend> Executor<TurboTasks<B>, ScheduledTask, TaskPriority> for TurboT
                                     CaptureFutureOutcome::Value(raw_vc) => {
                                         // This is safe because we waited for all local tasks to
                                         // complete above.
-                                        raw_vc
+                                        let result = raw_vc
                                             .to_non_local_unchecked_sync(&*this)
-                                            .map_err(|err| err.into())
+                                            .map_err(|err| err.into());
+                                        Span::current().record(
+                                            "outcome",
+                                            if result.is_ok() { "value" } else { "error" },
+                                        );
+                                        result
                                     }
-                                    CaptureFutureOutcome::Error(err) => Err(err.into()),
+                                    CaptureFutureOutcome::Error(err) => {
+                                        Span::current().record("outcome", "error");
+                                        Err(err.into())
+                                    }
                                     CaptureFutureOutcome::Panic(err) => {
+                                        Span::current().record("outcome", "panic");
                                         Err(TurboTasksExecutionError::Panic(Arc::new(err)))
                                     }
                                 };

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -10,7 +10,7 @@ use turbo_tasks_hash::DeterministicHasher;
 #[cfg(feature = "task_dirty_cause")]
 use crate::TaskDirtyCause;
 use crate::{
-    InputResolution, RawVc, TaskExecutionReason, TaskInput, TaskPersistence, TaskPriority,
+    InputResolution, RawVc, TaskExecutionReason, TaskId, TaskInput, TaskPersistence, TaskPriority,
     dyn_task_inputs::{
         DynTaskInputs, DynTaskInputsStorage, HeapDynTaskInputsStorage, StackDynTaskInputsStorage,
         any_as_encode,
@@ -284,8 +284,13 @@ impl NativeFunction {
         }
     }
 
+    pub fn name(&self) -> &'static str {
+        self.ty.name
+    }
+
     pub fn span(
         &'static self,
+        task_id: TaskId,
         persistence: TaskPersistence,
         reason: TaskExecutionReason,
         priority: TaskPriority,
@@ -307,6 +312,10 @@ impl NativeFunction {
                 flags = flags,
                 reason = reason.as_str(),
                 cause = cause.map(tracing::field::display),
+                task_id = %task_id,
+                cancelable = self.is_cancelable,
+                outcome = tracing::field::Empty,
+                abort_trigger = tracing::field::Empty,
                 inline_execution = tracing::field::Empty,
             )
         }
@@ -318,6 +327,10 @@ impl NativeFunction {
                 priority = %priority,
                 flags = flags,
                 reason = reason.as_str(),
+                task_id = %task_id,
+                cancelable = self.is_cancelable,
+                outcome = tracing::field::Empty,
+                abort_trigger = tracing::field::Empty,
                 inline_execution = tracing::field::Empty,
             )
         }

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -217,6 +217,9 @@ pub struct NativeFunction {
     /// re-executed when restored from persistent cache because they depend on external state
     /// (filesystem, environment, network) that may change between sessions.
     pub is_session_dependent: bool,
+
+    /// Whether an in-flight execution may be aborted when invalidated or no longer active.
+    pub is_cancelable: bool,
 }
 impl_ptr_identity!(NativeFunction);
 
@@ -245,6 +248,7 @@ impl NativeFunction {
         ty: RegistryType::new::<()>("", ""),
         is_root: false,
         is_session_dependent: false,
+        is_cancelable: true,
     };
 
     pub const fn new<T: TaskFn>(
@@ -254,6 +258,7 @@ impl NativeFunction {
         implementation: &'static T,
         is_root: bool,
         is_session_dependent: bool,
+        is_cancelable: bool,
     ) -> Self {
         Self {
             ty: RegistryType::new::<T>(name, global_name),
@@ -261,6 +266,7 @@ impl NativeFunction {
             implementation,
             is_root,
             is_session_dependent,
+            is_cancelable,
         }
     }
 

--- a/turbopack/crates/turbo-tasks/src/task_dirty_cause.rs
+++ b/turbopack/crates/turbo-tasks/src/task_dirty_cause.rs
@@ -25,6 +25,8 @@ pub enum TaskDirtyCause {
     /// hard-delete: its edges were scrubbed, so it must re-execute to rebuild them.
     Resurrected,
     Unknown,
+    /// An in-flight execution was aborted because no active work needed it anymore.
+    ExecutionAborted,
 }
 
 // NOTE: `TaskDirtyCause` is formatted for tracing inside `make_task_dirty_internal`, which
@@ -86,6 +88,7 @@ impl std::fmt::Display for TaskDirtyCause {
                 )
             }
             TaskDirtyCause::Invalidator => write!(f, "invalidator"),
+            TaskDirtyCause::ExecutionAborted => write!(f, "execution aborted"),
             TaskDirtyCause::Resurrected => write!(f, "resurrected"),
             TaskDirtyCause::Unknown => write!(f, "unknown"),
         }

--- a/turbopack/crates/turbo-tasks/src/task_dirty_cause.rs
+++ b/turbopack/crates/turbo-tasks/src/task_dirty_cause.rs
@@ -26,7 +26,7 @@ pub enum TaskDirtyCause {
     Resurrected,
     Unknown,
     /// An in-flight execution was aborted because no active work needed it anymore.
-    ExecutionAborted,
+    BecameInactive,
 }
 
 // NOTE: `TaskDirtyCause` is formatted for tracing inside `make_task_dirty_internal`, which
@@ -88,7 +88,9 @@ impl std::fmt::Display for TaskDirtyCause {
                 )
             }
             TaskDirtyCause::Invalidator => write!(f, "invalidator"),
-            TaskDirtyCause::ExecutionAborted => write!(f, "execution aborted"),
+            TaskDirtyCause::BecameInactive => {
+                write!(f, "execution aborted after becoming inactive")
+            }
             TaskDirtyCause::Resurrected => write!(f, "resurrected"),
             TaskDirtyCause::Unknown => write!(f, "unknown"),
         }

--- a/turbopack/crates/turbo-tasks/src/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks/src/task_statistics.rs
@@ -1,8 +1,11 @@
 use std::sync::{Arc, OnceLock};
 
-use serde::{Serialize, Serializer, ser::SerializeMap};
+use serde::{
+    Serialize, Serializer,
+    ser::{SerializeMap, SerializeStruct},
+};
 
-use crate::{FxDashMap, macro_helpers::NativeFunction};
+use crate::{FxDashMap, backend::TaskExecutionAbortReason, macro_helpers::NativeFunction};
 
 /// An API for optionally enabling, updating, and reading aggregated statistics.
 #[derive(Default)]
@@ -46,6 +49,64 @@ impl TaskStatistics {
         self.with_task_type_statistics(native_fn, |stats| stats.cache_miss += 1)
     }
 
+    pub fn increment_execution_started(&self, native_fn: &'static NativeFunction) {
+        self.with_task_type_statistics(native_fn, |stats| stats.execution_started += 1)
+    }
+
+    pub fn increment_execution_completed(&self, native_fn: &'static NativeFunction) {
+        self.with_task_type_statistics(native_fn, |stats| stats.execution_completed += 1)
+    }
+
+    pub fn increment_abort_requested(
+        &self,
+        native_fn: &'static NativeFunction,
+        reason: TaskExecutionAbortReason,
+    ) {
+        self.with_task_type_statistics(native_fn, |stats| match reason {
+            TaskExecutionAbortReason::Invalidation => stats.abort_requested_invalidation += 1,
+            TaskExecutionAbortReason::Inactive => stats.abort_requested_inactive += 1,
+            TaskExecutionAbortReason::Gc => stats.abort_requested_gc += 1,
+        })
+    }
+
+    pub fn increment_abort_observed(
+        &self,
+        native_fn: &'static NativeFunction,
+        reason: TaskExecutionAbortReason,
+    ) {
+        self.with_task_type_statistics(native_fn, |stats| match reason {
+            TaskExecutionAbortReason::Invalidation => stats.abort_observed_invalidation += 1,
+            TaskExecutionAbortReason::Inactive => stats.abort_observed_inactive += 1,
+            TaskExecutionAbortReason::Gc => stats.abort_observed_gc += 1,
+        })
+    }
+
+    pub fn increment_abort_raced_completion(
+        &self,
+        native_fn: &'static NativeFunction,
+        reason: TaskExecutionAbortReason,
+    ) {
+        self.with_task_type_statistics(native_fn, |stats| match reason {
+            TaskExecutionAbortReason::Invalidation => {
+                stats.abort_raced_completion_invalidation += 1
+            }
+            TaskExecutionAbortReason::Inactive => stats.abort_raced_completion_inactive += 1,
+            TaskExecutionAbortReason::Gc => stats.abort_raced_completion_gc += 1,
+        })
+    }
+
+    pub fn increment_abort_skipped(
+        &self,
+        native_fn: &'static NativeFunction,
+        reason: TaskExecutionAbortReason,
+    ) {
+        self.with_task_type_statistics(native_fn, |stats| match reason {
+            TaskExecutionAbortReason::Invalidation => stats.abort_skipped_invalidation += 1,
+            TaskExecutionAbortReason::Inactive => stats.abort_skipped_inactive += 1,
+            TaskExecutionAbortReason::Gc => stats.abort_skipped_gc += 1,
+        })
+    }
+
     fn with_task_type_statistics(
         &self,
         native_fn: &'static NativeFunction,
@@ -60,10 +121,156 @@ impl TaskStatistics {
 }
 
 /// Statistics for an individual function.
-#[derive(Default, Serialize, Clone)]
+#[derive(Default, Clone)]
 pub struct TaskFunctionStatistics {
     pub cache_hit: u32,
     pub cache_miss: u32,
+    pub execution_started: u64,
+    pub execution_completed: u64,
+    pub abort_requested_invalidation: u64,
+    pub abort_requested_inactive: u64,
+    pub abort_requested_gc: u64,
+    pub abort_observed_invalidation: u64,
+    pub abort_observed_inactive: u64,
+    pub abort_observed_gc: u64,
+    pub abort_raced_completion_invalidation: u64,
+    pub abort_raced_completion_inactive: u64,
+    pub abort_raced_completion_gc: u64,
+    pub abort_skipped_invalidation: u64,
+    pub abort_skipped_inactive: u64,
+    pub abort_skipped_gc: u64,
+}
+
+impl TaskFunctionStatistics {
+    fn has_abort_activity(&self) -> bool {
+        self.abort_requested_invalidation != 0
+            || self.abort_requested_inactive != 0
+            || self.abort_requested_gc != 0
+            || self.abort_observed_invalidation != 0
+            || self.abort_observed_inactive != 0
+            || self.abort_observed_gc != 0
+            || self.abort_raced_completion_invalidation != 0
+            || self.abort_raced_completion_inactive != 0
+            || self.abort_raced_completion_gc != 0
+            || self.abort_skipped_invalidation != 0
+            || self.abort_skipped_inactive != 0
+            || self.abort_skipped_gc != 0
+    }
+}
+
+impl Serialize for TaskFunctionStatistics {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let has_abort_activity = self.has_abort_activity();
+        let mut len = 2;
+        if has_abort_activity {
+            len += 2;
+            len += [
+                self.abort_requested_invalidation,
+                self.abort_requested_inactive,
+                self.abort_requested_gc,
+                self.abort_observed_invalidation,
+                self.abort_observed_inactive,
+                self.abort_observed_gc,
+                self.abort_raced_completion_invalidation,
+                self.abort_raced_completion_inactive,
+                self.abort_raced_completion_gc,
+                self.abort_skipped_invalidation,
+                self.abort_skipped_inactive,
+                self.abort_skipped_gc,
+            ]
+            .into_iter()
+            .filter(|value| *value != 0)
+            .count();
+        }
+
+        let mut state = serializer.serialize_struct("TaskFunctionStatistics", len)?;
+        state.serialize_field("cache_hit", &self.cache_hit)?;
+        state.serialize_field("cache_miss", &self.cache_miss)?;
+        if has_abort_activity {
+            state.serialize_field("execution_started", &self.execution_started)?;
+            state.serialize_field("execution_completed", &self.execution_completed)?;
+            macro_rules! serialize_nonzero {
+                ($field:ident) => {
+                    if self.$field != 0 {
+                        state.serialize_field(stringify!($field), &self.$field)?;
+                    }
+                };
+            }
+            serialize_nonzero!(abort_requested_invalidation);
+            serialize_nonzero!(abort_requested_inactive);
+            serialize_nonzero!(abort_requested_gc);
+            serialize_nonzero!(abort_observed_invalidation);
+            serialize_nonzero!(abort_observed_inactive);
+            serialize_nonzero!(abort_observed_gc);
+            serialize_nonzero!(abort_raced_completion_invalidation);
+            serialize_nonzero!(abort_raced_completion_inactive);
+            serialize_nonzero!(abort_raced_completion_gc);
+            serialize_nonzero!(abort_skipped_invalidation);
+            serialize_nonzero!(abort_skipped_inactive);
+            serialize_nonzero!(abort_skipped_gc);
+        }
+        state.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use serde_json::json;
+
+    use super::{TaskFunctionStatistics, TaskStatisticsApi};
+
+    #[test]
+    fn disabled_statistics_do_not_run_updates() {
+        let api = TaskStatisticsApi::default();
+        let called = AtomicBool::new(false);
+        assert!(api.map(|_| called.store(true, Ordering::Relaxed)).is_none());
+        assert!(!called.load(Ordering::Relaxed));
+        assert!(api.get().is_none());
+    }
+
+    #[test]
+    fn cache_only_statistics_keep_existing_shape() {
+        let stats = TaskFunctionStatistics {
+            cache_hit: 3,
+            cache_miss: 2,
+            execution_started: 5,
+            execution_completed: 5,
+            ..Default::default()
+        };
+        assert_eq!(
+            serde_json::to_value(stats).unwrap(),
+            json!({ "cache_hit": 3, "cache_miss": 2 })
+        );
+    }
+
+    #[test]
+    fn abort_activity_adds_denominators_and_nonzero_counters() {
+        let stats = TaskFunctionStatistics {
+            cache_hit: 3,
+            cache_miss: 2,
+            execution_started: 5,
+            execution_completed: 4,
+            abort_requested_invalidation: 1,
+            abort_observed_invalidation: 1,
+            ..Default::default()
+        };
+        assert_eq!(
+            serde_json::to_value(stats).unwrap(),
+            json!({
+                "cache_hit": 3,
+                "cache_miss": 2,
+                "execution_started": 5,
+                "execution_completed": 4,
+                "abort_requested_invalidation": 1,
+                "abort_observed_invalidation": 1,
+            })
+        );
+    }
 }
 
 impl Serialize for TaskStatistics {

--- a/turbopack/crates/turbo-tasks/src/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks/src/task_statistics.rs
@@ -216,6 +216,29 @@ impl Serialize for TaskFunctionStatistics {
     }
 }
 
+impl Serialize for TaskStatistics {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Sort by `global_name` so the emitted JSON is deterministic — the
+        // underlying `FxDashMap` has unspecified iteration order. The map is
+        // small (~1500 entries in practice), so the sort cost is negligible
+        // and not worth optimizing.
+        let mut entries: Vec<_> = self
+            .inner
+            .iter()
+            .map(|e| (e.key().ty.global_name, e.value().clone()))
+            .collect();
+        entries.sort_unstable_by_key(|(name, _)| *name);
+        let mut map = serializer.serialize_map(Some(entries.len()))?;
+        for (name, stats) in &entries {
+            map.serialize_entry(name, stats)?;
+        }
+        map.end()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -270,28 +293,5 @@ mod tests {
                 "abort_observed_invalidation": 1,
             })
         );
-    }
-}
-
-impl Serialize for TaskStatistics {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        // Sort by `global_name` so the emitted JSON is deterministic — the
-        // underlying `FxDashMap` has unspecified iteration order. The map is
-        // small (~1500 entries in practice), so the sort cost is negligible
-        // and not worth optimizing.
-        let mut entries: Vec<_> = self
-            .inner
-            .iter()
-            .map(|e| (e.key().ty.global_name, e.value().clone()))
-            .collect();
-        entries.sort_unstable_by_key(|(name, _)| *name);
-        let mut map = serializer.serialize_map(Some(entries.len()))?;
-        for (name, stats) in &entries {
-            map.serialize_entry(name, stats)?;
-        }
-        map.end()
     }
 }

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -521,7 +521,11 @@ pub async fn get_evaluate_entries(
 
 /// Pass the file you cared as `runtime_entries` to invalidate and reload the
 /// evaluated result automatically.
-#[turbo_tasks::function]
+///
+/// `non_cancelable` for the same reason as [`evaluate_webpack_loader`][crate::transforms::webpack]:
+/// the evaluation drives a Node.js pool operation, and dropping this future mid-operation can lose
+/// a result the pool already produced.
+#[turbo_tasks::function(non_cancelable)]
 pub async fn evaluate(
     entries: ResolvedVc<EvaluateEntries>,
     cwd: FileSystemPath,

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -376,7 +376,10 @@ impl WebpackLoadersProcessedAsset {
     }
 }
 
-#[turbo_tasks::function]
+// The Node.js evaluator pool may consume a loader result before this future resolves. Dropping it
+// mid-operation can lose that result and leave subsequent HMR reads stale, so this task opts out of
+// execution abortion.
+#[turbo_tasks::function(non_cancelable)]
 pub(crate) async fn evaluate_webpack_loader(
     webpack_loader_context: WebpackLoaderContext,
 ) -> Result<Vc<Option<RcStr>>> {


### PR DESCRIPTION
### What?

Abort in-flight Turbo Tasks work when its result is no longer needed:

- invalidated executions stop before doing work that will immediately be discarded
- executions that lose activeness are interrupted recursively with the inactive subtree
- GC can opportunistically interrupt executions that would otherwise be collectible

Aborted tasks remain recoverable and execute again if they become live. The task is kept or made dirty, and ordinary stale/active scheduling performs a clean execution.

The abort lifecycle is also auditable through Turbo Tasks traces and the existing opt-in per-function task statistics.

### Why?

Turbo Tasks executes work asynchronously and sometimes speculatively. Previously, a task always ran to completion after starting, even when invalidation made its result stale or its final active parent disconnected. Besides wasting resources, this delayed the useful replacement execution.

Runtime reporting distinguishes an abort request from work that was actually interrupted, requests that raced successful completion, and requests skipped because a function is not cancellation-safe.

### How?

Each in-progress cancelable native Turbo Task stores a futures abort handle, while the executor polls its future through an abortable wrapper. Invalidation and liveness transitions signal that handle. The backend then performs one of two recovery paths:

- stale work reuses the existing stale-priority scheduling path
- disconnected work becomes dirty without being scheduled until it is live again

Successful completion disarms its abort state before ordinary completion bookkeeping. The abort path reverses speculative child activeness, wakes cell waiters, and rechecks liveness to handle reconnection racing with interruption. Transient root and one-shot futures are not aborted because they cannot necessarily be recreated.

Turbo Task functions are abortable by default. `#[turbo_tasks::function(non_cancelable)]` opts out concrete cancellation-unsafe functions. The Node evaluator entry points use this because dropping them after the process pool produced a result can lose protocol progress.

Abort telemetry uses first-trigger-wins attribution (`invalidation`, `inactive`, or `gc`) while independently preserving whether later liveness changes made the task unneeded. `turbo_tasks::function` spans record task ID, cancelability, execution outcome, and abort trigger. Lifecycle events report requested, observed, raced-completion, and skipped outcomes. The existing opt-in `TaskStatisticsApi` exposes corresponding per-function counters without adding always-on output.

### Risks

Cancellation is equivalent to dropping a future and can violate application-level invariants around `tokio::select!`, channel protocols, partial I/O, and multi-await state transitions. The known Node evaluator boundary is opted out. A broader failpoint-based audit of Node pools and filesystem tasks remains follow-up work.

Telemetry is high-volume when full Turbo Tasks tracing is enabled, but it uses the existing opt-in tracing/statistics facilities and adds no always-on logging.

### Verification

- deterministic invalidation, inactivity, completion-race, and non-cancelable abort tests
- first-trigger-wins and GC/inactivity state tests
- existing per-function task-statistics JSON tests plus new abort counter assertions
- shutdown, dirty-state, graph, and GC regression targets
- `cargo test -p turbo-tasks --lib`
- feature-enabled `cargo check`
- `cargo fmt --all -- --check` and `git diff --check`
- `pnpm build-all`
- filesystem-cache HMR integration test
- manual binary trace capture/query verifying requested → observed/raced reconciliation and skipped non-cancelable records

<!-- NEXT_JS_LLM -->

<!-- fleet d1229ada-58b3-41eb-a779-c83ee947f7a1 -->
