### PR TITLE
[test] Move fixtures off `node-fetch`

### DIFF
--- a/test/e2e/api-support/api-support.test.ts
+++ b/test/e2e/api-support/api-support.test.ts
@@ -12,7 +12,6 @@ describe('API routes', () => {
     dependencies: {
       'http-proxy': 'latest',
       cors: 'latest',
-      'node-fetch': '2.6.7',
     },
     skipDeployment: true,
     disableAutoSkewProtection: true,
@@ -602,7 +601,6 @@ describe('API routes output export error', () => {
     dependencies: {
       'http-proxy': 'latest',
       cors: 'latest',
-      'node-fetch': '2.6.7',
     },
     skipStart: true,
     skipDeployment: true,

--- a/test/e2e/api-support/pages/api/test-res-pipe.js
+++ b/test/e2e/api-support/pages/api/test-res-pipe.js
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch'
+import { Readable } from 'stream'
 
 export default async (req, res) => {
   const dataRes = await fetch(
@@ -6,5 +6,5 @@ export default async (req, res) => {
   )
 
   res.status(dataRes.status)
-  dataRes.body.pipe(res)
+  Readable.fromWeb(dataRes.body).pipe(res)
 }

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -21,10 +21,6 @@ function streamingBody(stream: Readable) {
 describe('app-custom-routes', () => {
   const { next, isNextDeploy, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    dependencies: {
-      // pin with repo's version of node-fetch
-      '@types/node-fetch': '2.6.1',
-    },
   })
 
   describe('works with api prefix correctly', () => {

--- a/test/e2e/cancel-request/stream-cancel.test.ts
+++ b/test/e2e/cancel-request/stream-cancel.test.ts
@@ -1,48 +1,37 @@
 import { nextTestSetup } from 'e2e-utils'
-import { sleep } from './sleep'
-import { get } from 'http'
 
 describe('streaming responses cancel inner stream after disconnect', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })
 
-  function prime(url: string, noData?: boolean) {
-    return new Promise<void>((resolve, reject) => {
-      url = new URL(url, next.url).href
+  async function prime(url: string, noData?: boolean) {
+    url = new URL(url, next.url).href
 
-      // There's a bug in node-fetch v2 where aborting the fetch will never abort
-      // the connection, because the body is a transformed stream that doesn't
-      // close the connection stream.
-      // https://github.com/node-fetch/node-fetch/pull/670
-      const req = get(url, async (res) => {
-        while (true) {
-          const value = res.read(1)
-          if (value) break
-          await sleep(5)
+    const controller = new AbortController()
+
+    if (noData) {
+      const promise = fetch(url, { signal: controller.signal })
+      setTimeout(() => {
+        controller.abort()
+      }, 100)
+
+      // Swallow the AbortError that happens if you abort before the
+      // response connection is received.
+      await promise.catch((err) => {
+        if (err.name !== 'AbortError') {
+          throw err
         }
-
-        res.destroy()
-        resolve()
       })
-      req.on('error', reject)
-      req.end()
+      return
+    }
 
-      if (noData) {
-        req.on('error', (e) => {
-          // Swallow the "socket hang up" message that happens if you abort
-          // before the a response connection is received.
-          if ((e as any).code !== 'ECONNRESET') {
-            throw e
-          }
-        })
-
-        setTimeout(() => {
-          req.abort()
-          resolve()
-        }, 100)
-      }
-    })
+    const res = await fetch(url, { signal: controller.signal })
+    const reader = res.body!.getReader()
+    // Wait for the first byte of the response body, then abort the
+    // connection abruptly so the server observes a client disconnect.
+    await reader.read()
+    controller.abort()
   }
 
   describe.each([

--- a/test/e2e/custom-server/custom-server.test.ts
+++ b/test/e2e/custom-server/custom-server.test.ts
@@ -285,10 +285,9 @@ describe.each([
       serverReadyPattern: /- Local:/,
       env: {
         USE_HTTPS: useHttps,
-        POLYFILL_FETCH: 'true',
         NODE_ENV: sharedNodeEnv,
       },
-      dependencies: { ...sharedDeps, 'node-fetch': '2.6.7' },
+      dependencies: sharedDeps,
       skipDeployment: true,
       disableAutoSkewProtection: true,
     })

--- a/test/e2e/custom-server/server.js
+++ b/test/e2e/custom-server/server.js
@@ -1,14 +1,5 @@
 // @ts-check
 
-if (process.env.POLYFILL_FETCH) {
-  // @ts-expect-error
-  global.fetch = require('node-fetch').default
-  // @ts-expect-error
-  global.Request = require('node-fetch').Request
-  // @ts-expect-error
-  global.Headers = require('node-fetch').Headers
-}
-
 const { readFileSync } = require('fs')
 
 /** @type {import('next').default} */

--- a/test/e2e/node-fetch-keep-alive/node-fetch-keep-alive.test.ts
+++ b/test/e2e/node-fetch-keep-alive/node-fetch-keep-alive.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import { createServer, Server } from 'http'
 
-describe('node-fetch-keep-alive', () => {
+describe('fetch-keep-alive', () => {
   let mockServer: Server
 
   const { next, skipped } = nextTestSetup({

--- a/test/rspack-build-tests-manifest.json
+++ b/test/rspack-build-tests-manifest.json
@@ -20157,16 +20157,16 @@
     "flakey": [],
     "runtimeError": false
   },
-  "test/integration/node-fetch-keep-alive/test/index.test.ts": {
+  "test/integration/fetch-keep-alive/test/index.test.ts": {
     "passed": [
-      "node-fetch-keep-alive dev should send keep-alive for getServerSideProps",
-      "node-fetch-keep-alive dev should send keep-alive for getStaticPaths",
-      "node-fetch-keep-alive dev should send keep-alive for getStaticProps",
-      "node-fetch-keep-alive dev should send keep-alive for json API",
-      "node-fetch-keep-alive production mode should send keep-alive for getServerSideProps",
-      "node-fetch-keep-alive production mode should send keep-alive for getStaticPaths",
-      "node-fetch-keep-alive production mode should send keep-alive for getStaticProps",
-      "node-fetch-keep-alive production mode should send keep-alive for json API"
+      "fetch-keep-alive dev should send keep-alive for getServerSideProps",
+      "fetch-keep-alive dev should send keep-alive for getStaticPaths",
+      "fetch-keep-alive dev should send keep-alive for getStaticProps",
+      "fetch-keep-alive dev should send keep-alive for json API",
+      "fetch-keep-alive production mode should send keep-alive for getServerSideProps",
+      "fetch-keep-alive production mode should send keep-alive for getStaticPaths",
+      "fetch-keep-alive production mode should send keep-alive for getStaticProps",
+      "fetch-keep-alive production mode should send keep-alive for json API"
     ],
     "failed": [],
     "pending": [],

--- a/test/rspack-dev-tests-manifest.json
+++ b/test/rspack-dev-tests-manifest.json
@@ -22611,19 +22611,19 @@
     "flakey": [],
     "runtimeError": false
   },
-  "test/integration/node-fetch-keep-alive/test/index.test.ts": {
+  "test/integration/fetch-keep-alive/test/index.test.ts": {
     "passed": [
-      "node-fetch-keep-alive dev should send keep-alive for getServerSideProps",
-      "node-fetch-keep-alive dev should send keep-alive for getStaticPaths",
-      "node-fetch-keep-alive dev should send keep-alive for getStaticProps",
-      "node-fetch-keep-alive dev should send keep-alive for json API"
+      "fetch-keep-alive dev should send keep-alive for getServerSideProps",
+      "fetch-keep-alive dev should send keep-alive for getStaticPaths",
+      "fetch-keep-alive dev should send keep-alive for getStaticProps",
+      "fetch-keep-alive dev should send keep-alive for json API"
     ],
     "failed": [],
     "pending": [
-      "node-fetch-keep-alive production mode should send keep-alive for getServerSideProps",
-      "node-fetch-keep-alive production mode should send keep-alive for getStaticPaths",
-      "node-fetch-keep-alive production mode should send keep-alive for getStaticProps",
-      "node-fetch-keep-alive production mode should send keep-alive for json API"
+      "fetch-keep-alive production mode should send keep-alive for getServerSideProps",
+      "fetch-keep-alive production mode should send keep-alive for getStaticPaths",
+      "fetch-keep-alive production mode should send keep-alive for getStaticProps",
+      "fetch-keep-alive production mode should send keep-alive for json API"
     ],
     "flakey": [],
     "runtimeError": false


### PR DESCRIPTION
I don't believe they tested `node-fetch` specifically and rather used it because Node.js didn't have a built-in `fetch` implementation.