### PR TITLE
Support Variants on adapter deployments

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -15,7 +15,11 @@ import {
   normalizeAppPath,
   selectAppPageEntry,
 } from '../../shared/lib/router/utils/app-paths'
-import { AdapterOutputType, type PHASE_TYPE } from '../../shared/lib/constants'
+import {
+  AdapterOutputType,
+  VARIANTS_MANIFEST,
+  type PHASE_TYPE,
+} from '../../shared/lib/constants'
 import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-path'
 import { normalizePathSep } from '../../shared/lib/page-path/normalize-path-sep'
 import {
@@ -44,8 +48,11 @@ import {
   HTML_CONTENT_TYPE_HEADER,
   JSON_CONTENT_TYPE_HEADER,
   NEXT_QUERY_PARAM_PREFIX,
+  NEXT_VARIANTS_QUERY_PARAM,
   NEXT_RESUME_HEADER,
+  VARIANTS_PATH_PREFIX,
 } from '../../lib/constants'
+import { splitVariantsPrefix } from '../../server/variants/prefix'
 
 import { normalizeLocalePath } from '../../shared/lib/i18n/normalize-locale-path'
 import { getStaticMetadataPrerenderPathname } from '../../lib/metadata/get-metadata-route'
@@ -613,6 +620,7 @@ export async function handleBuildComplete({
   serverPropsPages,
   hasNodeMiddleware,
   prerenderManifest,
+  variantDynamicOutputPathnames,
   middlewareManifest,
   requiredServerFiles,
   hasInstrumentationHook,
@@ -644,6 +652,7 @@ export async function handleBuildComplete({
   routesManifest: RoutesManifest
   hasInstrumentationHook: boolean
   prerenderManifest: PrerenderManifest
+  variantDynamicOutputPathnames: ReadonlySet<string>
   middlewareManifest: MiddlewareManifest
   appPageKeys?: readonly string[] | undefined
   functionsConfigManifest: FunctionsConfigManifest
@@ -653,6 +662,10 @@ export async function handleBuildComplete({
   ) as NextAdapter
 
   if (typeof adapterMod.onBuildComplete === 'function') {
+    const variantRoutePages = config.experimental.variants
+      ? new Set(Object.keys(prerenderManifest.variantCombinationGroups))
+      : undefined
+
     const outputs: AdapterOutputs = {
       pages: [],
       pagesApi: [],
@@ -1092,6 +1105,27 @@ export async function handleBuildComplete({
           middlewareFile,
           'neutral'
         )
+
+        // Include the variants manifest in the Node proxy output. The proxy
+        // reads it from a computed path at request time, and static generation
+        // writes it after compilation traces the proxy, so file tracing cannot
+        // discover it.
+        if (config.experimental.variants) {
+          const variantsManifestFile = path.join(
+            distDir,
+            'server',
+            VARIANTS_MANIFEST
+          )
+          await pushAsset(
+            assets,
+            assetsHashes,
+            path.relative(repoRoot, variantsManifestFile),
+            variantsManifestFile,
+            bundler,
+            config.outputHashSalt || ''
+          )
+        }
+
         const functionConfig =
           functionsConfigManifest.functions['/_middleware'] || {}
 
@@ -1430,7 +1464,7 @@ export async function handleBuildComplete({
 
         let allowQuery: string[] | undefined
         const routeKeys = routesManifest.dynamicRoutes.find(
-          (item) => item.page === srcRoute
+          (item) => item.page === srcRoute && !item.variantsPrefixed
         )?.routeKeys
 
         if (!isDynamicRoute(route)) {
@@ -1719,16 +1753,26 @@ export async function handleBuildComplete({
           experimentalBypassFor,
         } = prerenderManifest.dynamicRoutes[dynamicRoute]
 
-        const srcRoute = fallbackSourceRoute || dynamicRoute
+        const variantsPrefix = config.experimental.variants
+          ? splitVariantsPrefix(dynamicRoute, undefined)
+          : null
+        const routePathname = variantsPrefix?.pathname ?? dynamicRoute
+        const srcRoute = fallbackSourceRoute || routePathname
         const parentOutput = getParentOutput(srcRoute, dynamicRoute)
         const isAppPage = Boolean(appOutputMap[srcRoute])
 
         const meta = await getAppRouteMeta(dynamicRoute, isAppPage)
         const routeKeys =
           routesManifest.dynamicRoutes.find(
-            (item) => item.page === dynamicRoute
+            (item) => item.page === routePathname && !item.variantsPrefixed
           )?.routeKeys || {}
-        const allowQuery = Object.values(routeKeys)
+
+        // A deployment translates the variants prefix into this query value.
+        // Preserve it alongside route params so the origin can recover the
+        // static tier.
+        const allowQuery = variantRoutePages?.has(srcRoute)
+          ? [...Object.values(routeKeys), NEXT_VARIANTS_QUERY_PARAM]
+          : Object.values(routeKeys)
         const partialFallback =
           // Partial fallback shells are only emitted when Partial Prefetching
           // is enabled in the app's Next.js config.
@@ -1805,13 +1849,31 @@ export async function handleBuildComplete({
           didFilterBlockingAllowQuery = true
         }
 
+        // Parameter filtering controls which dynamic params partition a shell.
+        // The variant combination hash is independent and must remain available
+        // to the origin.
+        if (
+          variantRoutePages?.has(srcRoute) &&
+          !htmlAllowQuery.includes(NEXT_VARIANTS_QUERY_PARAM)
+        ) {
+          htmlAllowQuery = [...htmlAllowQuery, NEXT_VARIANTS_QUERY_PARAM]
+        }
+
+        // Keep `fallback` as the bare route pattern the runtime combines with
+        // params. A variant-specific fallback file is written under the
+        // prefixed manifest key, so only the file lookup uses that pathname.
+        const fallbackPathname =
+          typeof fallback === 'string' && variantsPrefix
+            ? dynamicRoute
+            : fallback
+
         // app router dynamic route fallbacks don't have the extension so
         // ensure it's added here
         const fallbackHtmlFile =
-          typeof fallback === 'string'
-            ? fallback.endsWith('.html')
-              ? fallback
-              : `${fallback}.html`
+          typeof fallbackPathname === 'string'
+            ? fallbackPathname.endsWith('.html')
+              ? fallbackPathname
+              : `${fallbackPathname}.html`
             : undefined
 
         const fallbackHtmlPath =
@@ -2083,6 +2145,9 @@ export async function handleBuildComplete({
     const dynamicRoutes: DynamicRouteItem[] = []
     const dynamicDataRoutes: DynamicRouteItem[] = []
     const dynamicSegmentRoutes: DynamicRouteItem[] = []
+    const variantsPathExclusion = config.experimental.variants
+      ? `(?![/]?/${VARIANTS_PATH_PREFIX}/)`
+      : ''
 
     const getDestinationQuery = (routeKeys: Record<string, string>) => {
       const items = Object.entries(routeKeys ?? {})
@@ -2112,6 +2177,13 @@ export async function handleBuildComplete({
       : undefined
 
     for (const route of routesManifest.dynamicRoutes) {
+      // The deployment function uses this alias to resolve an artifact path to
+      // a page module. The external routing rule comes from the canonical page
+      // entry below, so processing the alias would emit that rule twice.
+      if (route.variantsPrefixed) {
+        continue
+      }
+
       // An earlier entry in this loop serves this shell.
       if (fallbackShellRuns?.replacedPages.has(route.page)) {
         continue
@@ -2152,10 +2224,19 @@ export async function handleBuildComplete({
         ? path.posix.join('/', '$shellPrefix', fallbackShellRun.tail)
         : route.page
 
-      const sourceRegex = pagePattern.replace(
-        '^',
-        `^${config.basePath && config.basePath !== '/' ? path.posix.join('/', config.basePath || '') : ''}[/]?${shouldLocalize ? '(?<nextLocale>[^/]{1,})' : ''}`
-      )
+      // Build the source regex for the ordinary page path and for the same path
+      // under a variants prefix. `pathPrefix` belongs after `basePath` and
+      // before the locale. Starting from `pagePattern` keeps a collapsed
+      // shell's `shellPrefix` group in both regexes. Ordinary matchers exclude
+      // the artifact namespace before the optional slash, so backtracking
+      // cannot bypass the exclusion.
+      const buildSourceRegex = (pathPrefix: string) =>
+        pagePattern.replace(
+          '^',
+          `^${config.basePath && config.basePath !== '/' ? path.posix.join('/', config.basePath || '') : ''}${pathPrefix ? '' : variantsPathExclusion}[/]?${pathPrefix}${shouldLocalize ? '(?<nextLocale>[^/]{1,})' : ''}`
+        )
+
+      const sourceRegex = buildSourceRegex('')
       const destination =
         path.posix.join(
           '/',
@@ -2236,17 +2317,100 @@ export async function handleBuildComplete({
         })
       }
 
-      // The entry above resolves a per-segment request on its own, because its
-      // suffix group accepts a segment path. A build that turns the collapse
-      // off emits a dedicated route for each segment, and the table lists those
-      // before that entry.
+      // Add separate matchers for variant-prefixed artifact paths. They recover
+      // the combination hash and keep the public route params separate from the
+      // prefix.
+      //
+      // TODO(variants): Remove these per-page routes when deployment
+      // infrastructure can select a prerender through non-path cache-key inputs
+      // and invoke it with the clean route pathname.
+
+      // A partial shell uses the static variant combinations of its source page.
+      if (variantRoutePages?.has(route.sourcePage ?? route.page)) {
+        // A route with a prefixed output keeps the prefix to select it. Other
+        // routes have no output under the prefix, so their destination remains
+        // the bare page.
+        const variantsDestination = variantDynamicOutputPathnames.has(
+          route.page
+        )
+          ? path.posix.join(
+              '/',
+              config.basePath,
+              `/${VARIANTS_PATH_PREFIX}/$${NEXT_VARIANTS_QUERY_PARAM}`,
+              shouldLocalize ? '/$nextLocale' : '',
+              pagePath
+            ) + getDestinationQuery(route.routeKeys)
+          : destination
+
+        // Match the hash alphabet so a root payload suffix cannot become part
+        // of the hash.
+        const variantsSourceRegex = buildSourceRegex(
+          `/${VARIANTS_PATH_PREFIX}/(?<${NEXT_VARIANTS_QUERY_PARAM}>[0-9a-z]+)`
+        )
+
+        // The source captures the combination hash from the prefix. The query
+        // carries it to the origin, where the route recovers its static variant
+        // values.
+        const withCombination = (destinationPath: string) =>
+          destinationPath +
+          `${destinationPath.includes('?') ? '&' : '?'}${NEXT_VARIANTS_QUERY_PARAM}=$${NEXT_VARIANTS_QUERY_PARAM}`
+
+        // Insert the captured suffix before the query. An empty capture then
+        // produces the document destination unchanged.
+        const rscDestination = variantsDestination.replace(
+          /($|\?)/,
+          '$rscSuffix$1'
+        )
+
+        if (canMergeSuffixedAndPlain) {
+          // The prefix does not change the suffix relation that lets the
+          // ordinary route merge document, RSC, and segment requests.
+          dynamicRoutes.push({
+            source: pagePath,
+            sourceRegex: variantsSourceRegex.replace(
+              new RegExp(escapeStringRegexp('(?:/)?$')),
+              '(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$'
+            ),
+            destination: withCombination(rscDestination),
+            has: plainHas,
+            missing: undefined,
+          })
+        } else {
+          if (hasAppPages) {
+            // Match a payload or segment before the document route. A dynamic
+            // param in the document matcher could otherwise consume its suffix.
+            dynamicRoutes.push({
+              source: pagePath + '.rsc',
+              sourceRegex: variantsSourceRegex.replace(
+                new RegExp(escapeStringRegexp('(?:/)?$')),
+                '(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc)(?:/)?$'
+              ),
+              destination: withCombination(rscDestination),
+              has: suffixedHas,
+              missing: undefined,
+            })
+          }
+
+          dynamicRoutes.push({
+            source: pagePath,
+            sourceRegex: variantsSourceRegex,
+            destination: withCombination(variantsDestination),
+            has: plainHas,
+            missing: undefined,
+          })
+        }
+      }
+
+      // With route collapsing, the suffix groups above resolve per-segment
+      // requests. Without it, the table emits one dedicated route per segment
+      // before these page routes.
       if (!config.experimental.collapseAdapterRoutes) {
         for (const segmentRoute of route.prefetchSegmentDataRoutes || []) {
           dynamicSegmentRoutes.push({
             source: route.page,
             sourceRegex: segmentRoute.source.replace(
               '^',
-              `^${config.basePath && config.basePath !== '/' ? path.posix.join('/', config.basePath || '') : ''}[/]?`
+              `^${config.basePath && config.basePath !== '/' ? path.posix.join('/', config.basePath || '') : ''}${variantsPathExclusion}[/]?`
             ),
             destination: path.posix.join(
               '/',

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -37,6 +37,8 @@ import {
   NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER,
   NEXT_CACHE_REVALIDATED_TAGS_HEADER,
   MATCHED_PATH_HEADER,
+  NEXT_VARIANTS_HEADER,
+  VARIANTS_PATH_PREFIX,
   type RSC_SEGMENTS_DIR_SUFFIX,
   type RSC_SEGMENT_SUFFIX,
 } from '../lib/constants'
@@ -219,6 +221,7 @@ import { generatePreviewKeys } from './preview-key-utils'
 import { handleBuildComplete } from './adapter/build-complete'
 import type { VariantCombinationGroups } from '../server/variants/combinations'
 import { buildVariantsManifest, recordVariantOutput } from './variants/manifest'
+import { buildVariantRouteAliases } from './variants/route-aliases'
 import { getVariantOutputPath } from '../server/variants/prefix'
 import {
   sortPageObjects,
@@ -553,6 +556,12 @@ export type ManifestRoute = ManifestBuiltRoute & {
    * routers.
    */
   skipInternalRouting?: boolean
+
+  /**
+   * Marks an alias whose regexes carry a Variants prefix while its `page` does
+   * not. A consumer cannot derive this entry's matchers from `page`.
+   */
+  variantsPrefixed?: boolean
 }
 
 type ManifestDataRoute = {
@@ -2192,6 +2201,7 @@ export default async function build(
         VariantCombinationGroups
       >()
       const variantOutputHashesByPage = new Map<string, Set<string>>()
+      const variantDynamicOutputPathnames = new Set<string>()
       const prerenderRouteMatchers = new Map<string, PrerenderRouteMatcher[]>()
       const appNormalizedPaths = new Map<string, string>()
       const fallbackModes = new Map<string, FallbackMode>()
@@ -3061,6 +3071,18 @@ export default async function build(
         variantCombinationGroups: {},
       }
 
+      // `allowHeader` forwards a header without adding it to the cache key.
+      // Every prerender in a project with Variants enabled accepts this header
+      // because the build cannot identify which routes can reach a variant
+      // reader. Static variant combinations cannot answer that: a route can
+      // read a variant without declaring a combination.
+      //
+      // TODO(variants): Narrow this list with emit and collect data that
+      // identifies routes which can reach a variant reader.
+      const allowHeader: string[] = config.experimental.variants
+        ? [...ALLOWED_HEADERS, NEXT_VARIANTS_HEADER]
+        : ALLOWED_HEADERS
+
       // Accumulate per-route segment inlining decisions for
       // prefetch-hints.json. First-writer-wins: if multiple param
       // combinations exist for the same route pattern, use the first one.
@@ -3460,6 +3482,20 @@ export default async function build(
                     },
                   ]
                 : []),
+              // A non-PPR prerender cannot leave runtime-tier variant values as
+              // holes. Bypass the platform prerender when the proxy forwards
+              // any such value, so the request uses a request render instead. A
+              // blocking prerender cannot preserve the runtime tier.
+              //
+              // The proxy omits values assigned by a declared variant
+              // combination from this header. The header is absent when that
+              // combination assigns every resolved variant, so the request can
+              // use its prerender.
+              ...(config.experimental.variants &&
+              !isRoutePPREnabled &&
+              variantCombinationGroupsByPage.get(page)?.length
+                ? [{ type: 'header' as const, key: NEXT_VARIANTS_HEADER }]
+                : []),
             ]
 
             // Candidates without unknown params can become concrete static
@@ -3655,7 +3691,7 @@ export default async function build(
                   srcRoute: page,
                   dataRoute,
                   prefetchDataRoute,
-                  allowHeader: ALLOWED_HEADERS,
+                  allowHeader,
                 }
 
                 recordVariantOutput(
@@ -3835,7 +3871,30 @@ export default async function build(
                     }
                   }
 
-                  if (metadata?.segmentPaths) {
+                  // Build a combined prefetch segment data route from the page
+                  // segment metadata, and attach it to the logical dynamic
+                  // route. Its source accepts both the full
+                  // `.../__PAGE__.segment.rsc` form and the shorter
+                  // `.segment.rsc` form, so one entry serves both requests.
+                  //
+                  // A builder that consumes `routes-manifest.json` directly
+                  // needs this route. An adapter also emits it when
+                  // `collapseAdapterRoutes` is off. When the collapse is on,
+                  // the merged RSC suffix matcher handles segment requests
+                  // instead.
+                  //
+                  // A page without variant combinations has at most one
+                  // candidate per pathname. Static variant combinations create
+                  // several candidates with the same pathname and segment
+                  // metadata. The first candidate of such a page attaches the
+                  // shared route, and later candidates skip this block. Pages
+                  // without combinations keep the existing per-candidate
+                  // behavior.
+                  if (
+                    metadata?.segmentPaths &&
+                    (!variantCombinationGroupsByPage.has(page) ||
+                      !dynamicRoute.prefetchSegmentDataRoutes)
+                  ) {
                     const pageSegmentPath = metadata.segmentPaths.find((item) =>
                       item.endsWith('__PAGE__')
                     )
@@ -3843,9 +3902,6 @@ export default async function build(
                       throw new Error(`Invariant: missing __PAGE__ segmentPath`)
                     }
 
-                    // We build a combined segment data route from the
-                    // page segment as we need to limit the number of
-                    // routes we output and they can be shared
                     const builtSegmentDataRoute = buildPrefetchSegmentDataRoute(
                       route.pathname,
                       pageSegmentPath
@@ -4004,14 +4060,18 @@ export default async function build(
                           excludeOptionalTrailingSlash: true,
                         }).re.source
                       ),
-                  allowHeader: ALLOWED_HEADERS,
+                  allowHeader,
                 }
 
-                recordVariantOutput(
-                  variantOutputHashesByPage,
-                  page,
-                  prerenderCandidate?.variantValues
-                )
+                const variantValues = prerenderCandidate?.variantValues
+                if (variantValues) {
+                  recordVariantOutput(
+                    variantOutputHashesByPage,
+                    page,
+                    variantValues
+                  )
+                  variantDynamicOutputPathnames.add(route.pathname)
+                }
               }
             }
           })
@@ -4255,7 +4315,7 @@ export default async function build(
                         `${localePage}.json`
                       ),
                       prefetchDataRoute: undefined,
-                      allowHeader: ALLOWED_HEADERS,
+                      allowHeader,
                     }
                   }
                 } else {
@@ -4285,7 +4345,7 @@ export default async function build(
                     ),
                     // Pages does not have a prefetch data route.
                     prefetchDataRoute: undefined,
-                    allowHeader: ALLOWED_HEADERS,
+                    allowHeader,
                   }
                 }
                 if (pageInfo) {
@@ -4324,7 +4384,7 @@ export default async function build(
                     ),
                     // Pages does not have a prefetch data route.
                     prefetchDataRoute: undefined,
-                    allowHeader: ALLOWED_HEADERS,
+                    allowHeader,
                   }
 
                   if (pageInfo) {
@@ -4337,6 +4397,28 @@ export default async function build(
 
           await writeManifest(pagesManifestPath, pagesManifest)
         })
+
+        if (config.experimental.variants) {
+          // Exclude artifact paths from ordinary origin matchers before adding
+          // aliases. A broad dynamic route can otherwise consume the prefix
+          // instead of capturing the hash.
+          for (const route of dynamicRoutes) {
+            route.regex = route.regex.replace(
+              '^',
+              `^(?![/]?/${VARIANTS_PATH_PREFIX}/)`
+            )
+            if (route.namedRegex !== undefined) {
+              route.namedRegex = route.namedRegex.replace(
+                '^',
+                `^(?![/]?/${VARIANTS_PATH_PREFIX}/)`
+              )
+            }
+          }
+
+          dynamicRoutes.push(
+            ...buildVariantRouteAliases(variantOutputHashesByPage.keys())
+          )
+        }
 
         // As we may have modified the dynamicRoutes, we need to sort the
         // dynamic routes by page.
@@ -4468,7 +4550,7 @@ export default async function build(
             // Pages does not have a prefetch data route.
             prefetchDataRoute: undefined,
             prefetchDataRouteRegex: undefined,
-            allowHeader: ALLOWED_HEADERS,
+            allowHeader,
           }
         })
 
@@ -4664,6 +4746,7 @@ export default async function build(
               appPageKeys: emittedAppPageKeys,
               routesManifest,
               prerenderManifest,
+              variantDynamicOutputPathnames,
               middlewareManifest,
               functionsConfigManifest,
               hasStatic404: useStaticPages404,

--- a/packages/next/src/build/variants/route-aliases.ts
+++ b/packages/next/src/build/variants/route-aliases.ts
@@ -1,0 +1,49 @@
+import type { DynamicManifestRoute } from '../utils'
+
+import {
+  NEXT_VARIANTS_QUERY_PARAM,
+  VARIANTS_PATH_PREFIX,
+} from '../../lib/constants'
+import { normalizeRouteRegex } from '../../lib/load-custom-routes'
+import { getNamedRouteRegex } from '../../shared/lib/router/utils/route-regex'
+
+/**
+ * Resolves a variant-prefixed artifact pathname to its unprefixed page.
+ *
+ * A deployment may invoke the route's function to fill or revalidate a
+ * prerender. It can construct that request from the artifact pathname without
+ * repeating external routing. The prefix remains when the deployment handler
+ * resolves which page module to load.
+ *
+ * `page` stays unprefixed and names the module. The regexes carry the prefix,
+ * and the named regex captures the hash as `nxtV`. One alias matches every hash
+ * for a page.
+ */
+export function buildVariantRouteAliases(
+  pages: Iterable<string>
+): DynamicManifestRoute[] {
+  const aliases: DynamicManifestRoute[] = []
+
+  for (const page of pages) {
+    const routeRegex = getNamedRouteRegex(page, { prefixRouteKeys: true })
+
+    // Root aliases omit the page slash because root artifacts end at the hash.
+    aliases.push({
+      page,
+      sourcePage: undefined,
+      regex: normalizeRouteRegex(routeRegex.re.source).replace(
+        page === '/' ? '^/' : '^',
+        `^/${VARIANTS_PATH_PREFIX}/[^/]+`
+      ),
+      routeKeys: routeRegex.routeKeys,
+      namedRegex: routeRegex.namedRegex.replace(
+        page === '/' ? '^/' : '^',
+        `^/${VARIANTS_PATH_PREFIX}/(?<${NEXT_VARIANTS_QUERY_PARAM}>[^/]+)`
+      ),
+      skipInternalRouting: true,
+      variantsPrefixed: true,
+    })
+  }
+
+  return aliases
+}

--- a/packages/next/src/server/route-modules/app-page/module.ts
+++ b/packages/next/src/server/route-modules/app-page/module.ts
@@ -1,9 +1,15 @@
 import type { AppPageRouteDefinition } from '../../route-definitions/app-page-route-definition'
 import type RenderResult from '../../render-result'
 import type { RenderOpts } from '../../app-render/types'
-import { addRequestMeta, type NextParsedUrlQuery } from '../../request-meta'
+import {
+  addRequestMeta,
+  getRequestMeta,
+  type NextParsedUrlQuery,
+} from '../../request-meta'
 import type { LoaderTree } from '../../lib/app-dir-module'
 import type { PrerenderManifest } from '../../../build'
+import type { NextConfigRuntime } from '../../config-shared'
+import { splitVariantsPrefix } from '../../variants/prefix'
 
 import {
   prerenderToHTMLOrFlight,
@@ -118,7 +124,9 @@ export class AppPageRouteModule extends RouteModule<
 
   public normalizeUrl(
     req: IncomingMessage | BaseNextRequest,
-    parsedUrl: UrlWithParsedQuery
+    parsedUrl: UrlWithParsedQuery,
+    nextConfig?: DeepReadonly<NextConfigRuntime>,
+    isWrappedByNextServer?: boolean
   ) {
     if (this.normalizers.segmentPrefetchRSC.match(parsedUrl.pathname || '/')) {
       const result = this.normalizers.segmentPrefetchRSC.extract(
@@ -146,7 +154,24 @@ export class AppPageRouteModule extends RouteModule<
       // Mark the request as a RSC request.
       req.headers[RSC_HEADER] = '1'
     } else {
-      super.normalizeUrl(req, parsedUrl)
+      super.normalizeUrl(req, parsedUrl, nextConfig, isWrappedByNextServer)
+    }
+
+    // Remove the artifact prefix before matching route params. Self-hosted
+    // routing does this when it processes the proxy rewrite; direct minimal
+    // invocations do not.
+    if (
+      nextConfig?.experimental.variants &&
+      getRequestMeta(req, 'minimalMode') === true &&
+      !isWrappedByNextServer
+    ) {
+      const variantPath = splitVariantsPrefix(
+        parsedUrl.pathname || '/',
+        undefined
+      )
+      if (variantPath) {
+        parsedUrl.pathname = variantPath.pathname
+      }
     }
 
     // Minimal adapters can bypass base-server request normalization and invoke

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -172,7 +172,9 @@ export abstract class RouteModule<
 
   public normalizeUrl(
     _req: IncomingMessage | BaseNextRequest,
-    _parsedUrl: UrlWithParsedQuery
+    _parsedUrl: UrlWithParsedQuery,
+    _nextConfig?: DeepReadonly<NextConfigRuntime>,
+    _isWrappedByNextServer?: boolean
   ) {}
 
   public async instrumentationOnRequestError(
@@ -754,7 +756,12 @@ export abstract class RouteModule<
       isNextDataRequest = true
       parsedUrl.pathname = normalizeDataPath(parsedUrl.pathname || '/')
     }
-    this.normalizeUrl(req, parsedUrl)
+    this.normalizeUrl(
+      req,
+      parsedUrl,
+      nextConfig,
+      routerServerContext?.isWrappedByNextServer
+    )
     let originalPathname = parsedUrl.pathname || '/'
     const originalQuery = { ...parsedUrl.query }
     const pageIsDynamic = isDynamicRoute(srcPage)

--- a/test/e2e/app-dir/variants-partial-shells/variants-partial-shells-collapsed.test.ts
+++ b/test/e2e/app-dir/variants-partial-shells/variants-partial-shells-collapsed.test.ts
@@ -1,4 +1,3 @@
-process.env.BASE_PATH = '/base'
 process.env.COLLAPSE_ADAPTER_ROUTES = '1'
 
 require('./variants-partial-shells.test')

--- a/test/e2e/app-dir/variants-partial-shells/variants-partial-shells.test.ts
+++ b/test/e2e/app-dir/variants-partial-shells/variants-partial-shells.test.ts
@@ -6,13 +6,14 @@ import { createRouterAct } from 'router-act'
 import { basePath, url } from '../variants/base-path'
 
 // The assertions distinguish build-time preludes from request-time rendering.
-// TODO(variants): Add deployment coverage for partially resolved shells.
-// @force-gate start && turbopack
+// @force-gate turbopack && !dev && (!deploy || adapter)
 describe('Variants on partially resolved shells', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     env: {
       BASE_PATH: basePath,
+      COLLAPSE_ADAPTER_ROUTES:
+        process.env.COLLAPSE_ADAPTER_ROUTES === '1' ? '1' : '0',
     },
   })
 

--- a/test/e2e/app-dir/variants-root-catchall/app/[...slug]/page.tsx
+++ b/test/e2e/app-dir/variants-root-catchall/app/[...slug]/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense, type JSX } from 'react'
+import { theme } from '../../variants'
+
+export function generateStaticParams(): Array<{ slug: string[] }> {
+  return [{ slug: ['built'] }]
+}
+
+export function unstable_generateStaticVariants(): [typeof theme, string][][] {
+  return [[[theme, 'dark']], [[theme, 'light']]]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>
+}): Promise<JSX.Element> {
+  const { slug } = await params
+
+  return (
+    <>
+      <p id="slug">{slug.join('/')}</p>
+      <Suspense fallback={<p id="theme-pending">pending</p>}>
+        <p id="theme">{theme()}</p>
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/variants-root-catchall/app/[section]/[category]/[item]/page.tsx
+++ b/test/e2e/app-dir/variants-root-catchall/app/[section]/[category]/[item]/page.tsx
@@ -1,0 +1,5 @@
+import type { JSX } from 'react'
+
+export default function Page(): JSX.Element {
+  return <p id="plain">plain route</p>
+}

--- a/test/e2e/app-dir/variants-root-catchall/app/layout.tsx
+++ b/test/e2e/app-dir/variants-root-catchall/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { JSX, ReactNode } from 'react'
+
+export default function Root({
+  children,
+}: {
+  children: ReactNode
+}): JSX.Element {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/variants-root-catchall/app/link-accordion.tsx
+++ b/test/e2e/app-dir/variants-root-catchall/app/link-accordion.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import Link from 'next/link'
+import { useState, type JSX } from 'react'
+
+export function LinkAccordion({ href }: { href: string }): JSX.Element {
+  const [isVisible, setIsVisible] = useState(false)
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? <Link href={href}>Catch-all page</Link> : null}
+    </>
+  )
+}

--- a/test/e2e/app-dir/variants-root-catchall/app/page.tsx
+++ b/test/e2e/app-dir/variants-root-catchall/app/page.tsx
@@ -1,0 +1,27 @@
+import { Suspense, type JSX } from 'react'
+import { LinkAccordion } from './link-accordion'
+
+export default function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ slug?: string }>
+}): JSX.Element {
+  return (
+    <Suspense>
+      <PrefetchLink searchParams={searchParams} />
+    </Suspense>
+  )
+}
+
+async function PrefetchLink({
+  searchParams,
+}: {
+  searchParams: Promise<{ slug?: string }>
+}): Promise<JSX.Element | null> {
+  const { slug } = await searchParams
+  if (!slug) {
+    return null
+  }
+
+  return <LinkAccordion href={`/${slug}`} />
+}

--- a/test/e2e/app-dir/variants-root-catchall/next.config.js
+++ b/test/e2e/app-dir/variants-root-catchall/next.config.js
@@ -2,8 +2,6 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  cacheComponents: true,
-  partialPrefetching: true,
   experimental: {
     variants: true,
     collapseAdapterRoutes: process.env.COLLAPSE_ADAPTER_ROUTES === '1',

--- a/test/e2e/app-dir/variants-root-catchall/proxy.ts
+++ b/test/e2e/app-dir/variants-root-catchall/proxy.ts
@@ -1,0 +1,11 @@
+import { wrapProxy } from 'next/dist/server/variants/wrap-proxy'
+import { theme } from './variants'
+
+export const proxy = wrapProxy({
+  '/[section]/[category]/[item]': [],
+  '/[...slug]': [theme],
+})
+
+export const config = {
+  matcher: ['/((?!_next/|favicon\\.ico$).*)'],
+}

--- a/test/e2e/app-dir/variants-root-catchall/variants-root-catchall-base-path.test.ts
+++ b/test/e2e/app-dir/variants-root-catchall/variants-root-catchall-base-path.test.ts
@@ -1,0 +1,3 @@
+process.env.BASE_PATH = '/base'
+
+require('./variants-root-catchall.test')

--- a/test/e2e/app-dir/variants-root-catchall/variants-root-catchall-collapsed.test.ts
+++ b/test/e2e/app-dir/variants-root-catchall/variants-root-catchall-collapsed.test.ts
@@ -1,0 +1,3 @@
+process.env.COLLAPSE_ADAPTER_ROUTES = '1'
+
+require('./variants-root-catchall.test')

--- a/test/e2e/app-dir/variants-root-catchall/variants-root-catchall.test.ts
+++ b/test/e2e/app-dir/variants-root-catchall/variants-root-catchall.test.ts
@@ -1,0 +1,123 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { retry } from 'next-test-utils'
+import { createRouterAct } from 'router-act'
+import { basePath, url } from '../variants/base-path'
+
+// @force-gate turbopack && (!deploy || adapter)
+describe('Variants on a root catch-all', () => {
+  const { next, isNextDeploy, skipped } = nextTestSetup({
+    files: __dirname,
+    env: {
+      BASE_PATH: basePath,
+      COLLAPSE_ADAPTER_ROUTES:
+        process.env.COLLAPSE_ADAPTER_ROUTES === '1' ? '1' : '0',
+    },
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should preserve the more-specific route without Variants', async () => {
+    for (const pathname of [
+      '/plain/path/value',
+      '/__variants-extra/path/value',
+      '/plain/__variants/value',
+    ]) {
+      const $ = await next.render$(url(pathname))
+      expect($('#plain').text()).toBe('plain route')
+    }
+  })
+
+  it('should resolve unenumerated catch-all params for each combination', async () => {
+    for (const slug of ['document', 'nested/document']) {
+      for (const theme of ['dark', 'light']) {
+        const $ = await next.render$(url(`/${slug}`), undefined, {
+          headers: { cookie: `theme=${theme}` },
+        })
+
+        expect($('#slug').text()).toBe(slug)
+        expect($('#theme').text()).toBe(theme)
+      }
+    }
+  })
+
+  // @force-gate prefetching
+  it('should prefetch catch-all params without the internal prefix or payload suffix', async () => {
+    const slug = `prefetch-${Date.now()}/child`
+    const pathname = `/${slug}`
+
+    async function prefetch() {
+      let page: Playwright.Page | undefined
+
+      try {
+        const browser = await next.browser(url(`/?slug=${slug}`), {
+          async beforePageLoad(capturedPage: Playwright.Page) {
+            page = capturedPage
+            await capturedPage
+              .context()
+              .addCookies([{ name: 'theme', value: 'dark', url: next.url }])
+          },
+        })
+
+        if (!page) {
+          throw new Error('The page was not captured before it loaded.')
+        }
+
+        const act = createRouterAct(page, { includeAppShellRequests: true })
+
+        await act(async () => {
+          await browser
+            .elementByCss(`input[data-link-accordion="${pathname}"]`)
+            .click()
+        }, [
+          { includes: `"id":"slug","children":"${slug}"`, kind: 'static' },
+          { includes: `"id":"slug","children":"${slug}.rsc"`, block: 'reject' },
+          { includes: '"id":"slug","children":"__variants/', block: 'reject' },
+        ])
+
+        return { browser, act }
+      } catch (error) {
+        if (page) {
+          await page.context().clearCookies()
+          await page.close()
+        }
+        throw error
+      }
+    }
+
+    if (isNextDeploy) {
+      // Warm the server through real prefetches. Each attempt uses a fresh page
+      // so the client router cannot reuse its cached fallback.
+      //
+      // TODO: Investigate whether deploy should serve the same cold-prefetch
+      // content as `next start`. The difference also occurs without Variants.
+      await retry(async () => {
+        const { browser } = await prefetch()
+        await using _ = defer(async () => {
+          await browser.deleteCookies()
+          await browser.close()
+        })
+      }, 15000)
+    }
+
+    const { browser, act } = await prefetch()
+    await using _ = defer(async () => {
+      await browser.deleteCookies()
+      await browser.close()
+    })
+
+    await act(async () => {
+      await browser.elementByCss(`a[href="${url(pathname)}"]`).click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#slug').text()).toBe(slug)
+    expect(await browser.elementByCss('#theme').text()).toBe('dark')
+    expect(await browser.eval('location.pathname')).toBe(url(pathname))
+  })
+})
+
+function defer(callback: () => Promise<void>) {
+  return { [Symbol.asyncDispose]: callback }
+}

--- a/test/e2e/app-dir/variants-root-catchall/variants.ts
+++ b/test/e2e/app-dir/variants-root-catchall/variants.ts
@@ -1,0 +1,9 @@
+'use variants'
+
+import { unstable_variant } from 'next/variants'
+
+export const theme = unstable_variant(
+  (request) =>
+    request.cookies.get('theme')?.value === 'dark' ? 'dark' : 'light',
+  'theme@variants.ts'
+)

--- a/test/e2e/app-dir/variants-root-optional-catchall/app/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/variants-root-optional-catchall/app/[[...slug]]/page.tsx
@@ -1,0 +1,33 @@
+import { Suspense, type JSX } from 'react'
+import { theme } from '../../variants'
+
+export function generateStaticParams(): Array<{ slug: string[] }> {
+  return [{ slug: ['built'] }]
+}
+
+export function unstable_generateStaticVariants(): [typeof theme, string][][] {
+  return [[[theme, 'dark']], [[theme, 'light']]]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug?: string[] }>
+}): Promise<JSX.Element> {
+  const { slug } = await params
+  const pathname = slug === undefined ? '/' : `/${slug.join('/')}`
+
+  return (
+    <Suspense fallback={<p>pending</p>}>
+      <Content pathname={pathname} />
+    </Suspense>
+  )
+}
+
+async function Content({
+  pathname,
+}: {
+  pathname: string
+}): Promise<JSX.Element> {
+  return <p id="result">{`${pathname}:${await theme()}`}</p>
+}

--- a/test/e2e/app-dir/variants-root-optional-catchall/app/hub/page.tsx
+++ b/test/e2e/app-dir/variants-root-optional-catchall/app/hub/page.tsx
@@ -1,0 +1,6 @@
+import type { JSX } from 'react'
+import { LinkAccordion } from '../link-accordion'
+
+export default function Page(): JSX.Element {
+  return <LinkAccordion href="/" />
+}

--- a/test/e2e/app-dir/variants-root-optional-catchall/app/layout.tsx
+++ b/test/e2e/app-dir/variants-root-optional-catchall/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { JSX, ReactNode } from 'react'
+
+export default function Root({
+  children,
+}: {
+  children: ReactNode
+}): JSX.Element {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/variants-root-optional-catchall/app/link-accordion.tsx
+++ b/test/e2e/app-dir/variants-root-optional-catchall/app/link-accordion.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import Link from 'next/link'
+import { useState, type JSX } from 'react'
+
+export function LinkAccordion({ href }: { href: string }): JSX.Element {
+  const [isVisible, setIsVisible] = useState(false)
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? <Link href={href}>Root page</Link> : null}
+    </>
+  )
+}

--- a/test/e2e/app-dir/variants-root-optional-catchall/next.config.js
+++ b/test/e2e/app-dir/variants-root-optional-catchall/next.config.js
@@ -2,8 +2,6 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  cacheComponents: true,
-  partialPrefetching: true,
   experimental: {
     variants: true,
     collapseAdapterRoutes: process.env.COLLAPSE_ADAPTER_ROUTES === '1',

--- a/test/e2e/app-dir/variants-root-optional-catchall/proxy.ts
+++ b/test/e2e/app-dir/variants-root-optional-catchall/proxy.ts
@@ -1,0 +1,8 @@
+import { wrapProxy } from 'next/dist/server/variants/wrap-proxy'
+import { theme } from './variants'
+
+export const proxy = wrapProxy({ '/hub': [], '/[[...slug]]': [theme] })
+
+export const config = {
+  matcher: ['/', '/((?!_next/|favicon\\.ico$).*)'],
+}

--- a/test/e2e/app-dir/variants-root-optional-catchall/variants-root-optional-catchall-base-path.test.ts
+++ b/test/e2e/app-dir/variants-root-optional-catchall/variants-root-optional-catchall-base-path.test.ts
@@ -1,4 +1,4 @@
 process.env.BASE_PATH = '/base'
 process.env.COLLAPSE_ADAPTER_ROUTES = '1'
 
-require('./variants-partial-shells.test')
+require('./variants-root-optional-catchall.test')

--- a/test/e2e/app-dir/variants-root-optional-catchall/variants-root-optional-catchall-collapsed.test.ts
+++ b/test/e2e/app-dir/variants-root-optional-catchall/variants-root-optional-catchall-collapsed.test.ts
@@ -1,0 +1,3 @@
+process.env.COLLAPSE_ADAPTER_ROUTES = '1'
+
+require('./variants-root-optional-catchall.test')

--- a/test/e2e/app-dir/variants-root-optional-catchall/variants-root-optional-catchall.test.ts
+++ b/test/e2e/app-dir/variants-root-optional-catchall/variants-root-optional-catchall.test.ts
@@ -1,0 +1,107 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { retry } from 'next-test-utils'
+import { createRouterAct } from 'router-act'
+import { basePath, url } from '../variants/base-path'
+
+// @force-gate turbopack && (!deploy || adapter)
+describe('Variants on an optional root catch-all', () => {
+  const { next, isNextDeploy, skipped } = nextTestSetup({
+    files: __dirname,
+    env: {
+      BASE_PATH: basePath,
+      COLLAPSE_ADAPTER_ROUTES:
+        process.env.COLLAPSE_ADAPTER_ROUTES === '1' ? '1' : '0',
+    },
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should serve the built param for each combination', async () => {
+    for (const theme of ['dark', 'light']) {
+      const $ = await next.render$(url('/built'), undefined, {
+        headers: { cookie: `theme=${theme}` },
+      })
+      expect($('#result').text()).toBe(`/built:${theme}`)
+    }
+  })
+
+  // @force-gate prefetching
+  it('should prefetch the unenumerated root without changing the combination hash', async () => {
+    for (const theme of ['dark', 'light']) {
+      async function prefetch() {
+        let page: Playwright.Page | undefined
+
+        try {
+          const browser = await next.browser(url('/hub'), {
+            async beforePageLoad(capturedPage: Playwright.Page) {
+              page = capturedPage
+              await capturedPage
+                .context()
+                .addCookies([{ name: 'theme', value: theme, url: next.url }])
+            },
+          })
+
+          if (!page) {
+            throw new Error('The page was not captured before it loaded.')
+          }
+
+          const act = createRouterAct(page, { includeAppShellRequests: true })
+          await act(
+            async () => {
+              await browser
+                .elementByCss('input[data-link-accordion="/"]')
+                .click()
+            },
+            {
+              includes: `"id":"result","children":"/:${theme}"`,
+              kind: 'static',
+            }
+          )
+
+          return { browser, act }
+        } catch (error) {
+          if (page) {
+            await page.context().clearCookies()
+            await page.close()
+          }
+          throw error
+        }
+      }
+
+      if (isNextDeploy) {
+        // Warm only through prefetches so no document request can prepare the
+        // missing root artifact.
+        //
+        // TODO: Investigate whether deploy should serve the same cold-prefetch
+        // content as `next start`. The difference also occurs without Variants.
+        await retry(async () => {
+          const { browser } = await prefetch()
+          await using _ = defer(async () => {
+            await browser.deleteCookies()
+            await browser.close()
+          })
+        }, 15000)
+      }
+
+      const { browser, act } = await prefetch()
+      await using _ = defer(async () => {
+        await browser.deleteCookies()
+        await browser.close()
+      })
+
+      await act(async () => {
+        await browser.elementByCss(`a[href="${url('/')}"]`).click()
+      }, 'no-requests')
+
+      expect(await browser.elementByCss('#result').text()).toBe(`/:${theme}`)
+      expect(await browser.eval('location.pathname')).toBe(url('/'))
+    }
+  })
+})
+
+function defer(callback: () => Promise<void>) {
+  return { [Symbol.asyncDispose]: callback }
+}

--- a/test/e2e/app-dir/variants-root-optional-catchall/variants.ts
+++ b/test/e2e/app-dir/variants-root-optional-catchall/variants.ts
@@ -1,0 +1,9 @@
+'use variants'
+
+import { unstable_variant } from 'next/variants'
+
+export const theme = unstable_variant(
+  (request) =>
+    request.cookies.get('theme')?.value === 'dark' ? 'dark' : 'light',
+  'theme@variants.ts'
+)

--- a/test/e2e/app-dir/variants/fixtures/cache-lifetime/app/page.tsx
+++ b/test/e2e/app-dir/variants/fixtures/cache-lifetime/app/page.tsx
@@ -1,0 +1,37 @@
+import { Suspense, type JSX } from 'react'
+import { cacheLife, cacheTag } from 'next/cache'
+import { theme } from '../variants'
+
+export function unstable_generateStaticVariants(): [typeof theme, string][][] {
+  return [[[theme, 'dark']], [[theme, 'light']]]
+}
+
+async function cachedByTheme(
+  currentTheme: string
+): Promise<{ currentTheme: string; renderedAt: string }> {
+  'use cache'
+
+  cacheTag('lifetime-root')
+  cacheLife('hours')
+
+  return { currentTheme, renderedAt: new Date().toISOString() }
+}
+
+async function Cached(): Promise<JSX.Element> {
+  const cached = await cachedByTheme(await theme())
+
+  return (
+    <>
+      <p id="theme">{cached.currentTheme}</p>
+      <p id="rendered-at">{cached.renderedAt}</p>
+    </>
+  )
+}
+
+export default function Page(): JSX.Element {
+  return (
+    <Suspense fallback={<p id="cached">pending</p>}>
+      <Cached />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/variants/fixtures/cache-lifetime/proxy.ts
+++ b/test/e2e/app-dir/variants/fixtures/cache-lifetime/proxy.ts
@@ -4,8 +4,8 @@ import { theme } from './variants'
 // The variants transform will wrap the proxy automatically, synthesize one when
 // the project has none, and derive each route's variants from its module graph,
 // layouts included. Wired by hand until then.
-export const proxy = wrapProxy({ '/lifetime/[slug]': [theme] })
+export const proxy = wrapProxy({ '/': [theme], '/lifetime/[slug]': [theme] })
 
 export const config = {
-  matcher: ['/lifetime/:slug'],
+  matcher: ['/', '/lifetime/:slug'],
 }

--- a/test/e2e/app-dir/variants/variants-cache-lifetime.test.ts
+++ b/test/e2e/app-dir/variants/variants-cache-lifetime.test.ts
@@ -5,15 +5,13 @@ import { retry } from 'next-test-utils'
 import { basePath, url } from './base-path'
 
 // Variants are supported with Turbopack only, and enabling them rejects a
-// webpack build, which `variants-webpack.test.ts` covers.
-// @force-gate turbopack
+// webpack build, which `variants-webpack.test.ts` covers. Deployments require
+// the adapter's Variants routing and prerender outputs. Self-hosted dev and
+// start do not require an adapter.
+// @force-gate turbopack && (!deploy || adapter)
 describe('variants with a cache lifetime per combination', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/cache-lifetime',
-    // TODO(variants): enable this for a deployment. A platform serves a
-    // combination from the routing rules the adapter emits, and those do not
-    // exist yet, so every assertion here is about a self-hosted server.
-    skipDeployment: true,
     // Handed to the build rather than read from `process.env` there, so that
     // a deployed build receives it too: only what goes through here is
     // forwarded to the remote build.
@@ -24,35 +22,39 @@ describe('variants with a cache lifetime per combination', () => {
     return
   }
 
-  it('should resolve a variant while revalidating a stale prerender', async () => {
-    // A tag rather than the route's own lifetime, so the entry goes stale at
-    // once instead of after an hour.
-    const before = await next.render$(url('/lifetime/r'), undefined, {
-      headers: { cookie: 'theme=dark' },
-    })
-
-    expect(before('#theme').text()).toBe('dark')
-
-    const renderedAt = before('#rendered-at').text()
-    expect(renderedAt).not.toBe('')
-
-    const revalidateRes = await next.fetch(url('/revalidate?tag=lifetime-r'))
-    expect(revalidateRes.status).toBe(200)
-
-    // The stamp is what shows the entry was replaced. The variant reads
-    // `dark` before and after, so a response carrying the old stamp is the
-    // stale entry served while the revalidation runs behind it, and asserting
-    // on the variant alone would pass without that render happening.
-    await retry(async () => {
-      const after = await next.render$(url('/lifetime/r'), undefined, {
+  for (const [pathname, tag] of [
+    ['/lifetime/r', 'lifetime-r'],
+    ['/', 'lifetime-root'],
+  ]) {
+    it(`should resolve a variant while revalidating a stale prerender at ${pathname}`, async () => {
+      // Expire this route's tagged entries without waiting for their cache
+      // lifetime.
+      const before = await next.render$(url(pathname), undefined, {
         headers: { cookie: 'theme=dark' },
       })
 
-      expect(after('#rendered-at').text()).not.toBe(renderedAt)
+      expect(before('#theme').text()).toBe('dark')
 
-      expect(after('#theme').text()).toBe('dark')
+      const renderedAt = before('#rendered-at').text()
+      expect(renderedAt).not.toBe('')
+
+      const revalidateRes = await next.fetch(url(`/revalidate?tag=${tag}`))
+      expect(revalidateRes.status).toBe(200)
+
+      // Require a new timestamp to distinguish regenerated content from the
+      // stale prerender. The variant value stays the same across revalidation.
+      await retry(async () => {
+        const after = await next.render$(url(pathname), undefined, {
+          headers: { cookie: 'theme=dark' },
+        })
+
+        expect(after('#rendered-at').text()).not.toBe('')
+        expect(after('#rendered-at').text()).not.toBe(renderedAt)
+
+        expect(after('#theme').text()).toBe('dark')
+      })
     })
-  })
+  }
 
   it('should resolve the variant the cache lifetime is selected from', async () => {
     const $ = await next.render$(url('/lifetime/a'), undefined, {

--- a/test/e2e/app-dir/variants/variants-fallback-upgrade.test.ts
+++ b/test/e2e/app-dir/variants/variants-fallback-upgrade.test.ts
@@ -2,15 +2,13 @@ import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 // Variants are supported with Turbopack only, and enabling them rejects a
-// webpack build, which `variants-webpack.test.ts` covers.
-// @force-gate turbopack
+// webpack build, which `variants-webpack.test.ts` covers. Deployments require
+// the adapter's Variants routing and prerender outputs. Self-hosted dev and
+// start do not require an adapter.
+// @force-gate turbopack && (!deploy || adapter)
 describe('variants on an upgraded fallback shell', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/fallback-upgrade',
-    // TODO(variants): enable this for a deployment. A platform serves a
-    // combination from the routing rules the adapter emits, and those do not
-    // exist yet, so every assertion here is about a self-hosted server.
-    skipDeployment: true,
   })
 
   if (skipped) {

--- a/test/e2e/app-dir/variants/variants-on-demand-param.test.ts
+++ b/test/e2e/app-dir/variants/variants-on-demand-param.test.ts
@@ -4,15 +4,13 @@ const CONTROL = '/control'
 const DECLARED = '/declared'
 
 // Variants are supported with Turbopack only, and enabling them rejects a
-// webpack build, which `variants-webpack.test.ts` covers.
-// @force-gate turbopack
+// webpack build, which `variants-webpack.test.ts` covers. Deployments require
+// the adapter's Variants routing and prerender outputs. Self-hosted dev and
+// start do not require an adapter.
+// @force-gate turbopack && (!deploy || adapter)
 describe('variants with a param the build did not name', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/on-demand-param',
-    // TODO(variants): enable this for a deployment. A platform serves a
-    // combination from the routing rules the adapter emits, and those do not
-    // exist yet, so every assertion here is about a self-hosted server.
-    skipDeployment: true,
   })
 
   if (skipped) {

--- a/test/e2e/app-dir/variants/variants.test.ts
+++ b/test/e2e/app-dir/variants/variants.test.ts
@@ -7,15 +7,13 @@ import { basePath, url } from './base-path'
 import { startExternalServer } from './external-server.mjs'
 
 // Variants are supported with Turbopack only, and enabling them rejects a
-// webpack build, which `variants-webpack.test.ts` covers.
-// @force-gate turbopack
+// webpack build, which `variants-webpack.test.ts` covers. Deployments require
+// the adapter's Variants routing and prerender outputs. Self-hosted dev and
+// start do not require an adapter.
+// @force-gate turbopack && (!deploy || adapter)
 describe('variants', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname + '/fixtures/default',
-    // TODO(variants): enable this for a deployment. A platform serves a
-    // combination from the routing rules the adapter emits, and those do not
-    // exist yet, so every assertion here is about a self-hosted server.
-    skipDeployment: true,
     // Handed to the build rather than read from `process.env` there, so that a
     // deployed build receives it too: only what goes through here is forwarded
     // to the remote build.
@@ -109,11 +107,15 @@ describe('variants', () => {
     expect($('#theme').length).toBe(0)
     expect($('#pending').text()).toBe('pending')
 
-    await retry(async () => {
-      expect(next.cliOutput).toContain(
-        'read variant `theme@variants.ts`, but no value was resolved for this request'
-      )
-    })
+    // A deployment exposes build logs here, not logs from the function that
+    // served the request. The response assertions above cover both modes.
+    if (!isNextDeploy) {
+      await retry(async () => {
+        expect(next.cliOutput).toContain(
+          'read variant `theme@variants.ts`, but no value was resolved for this request'
+        )
+      })
+    }
   })
 
   it('should fail a read on a route the proxy does not match', async () => {
@@ -124,11 +126,13 @@ describe('variants', () => {
     expect($('#pending').text()).toBe('pending')
     expect($('#theme').length).toBe(0)
 
-    await retry(async () => {
-      expect(next.cliOutput).toContain(
-        'read variant `theme@variants.ts`, but no value was resolved for this request'
-      )
-    })
+    if (!isNextDeploy) {
+      await retry(async () => {
+        expect(next.cliOutput).toContain(
+          'read variant `theme@variants.ts`, but no value was resolved for this request'
+        )
+      })
+    }
   })
 
   it('should resolve a variant on the route the proxy rewrote to', async () => {
@@ -551,6 +555,29 @@ describe('variants', () => {
           }
           throw error
         }
+      }
+
+      if (isNextDeploy) {
+        // Warm the server entry before the final prefetch assertion. A segment
+        // fallback can omit the concrete param until background generation
+        // completes.
+        //
+        // TODO: Investigate whether deploy should serve the same cold-prefetch
+        // content as `next start`. The difference also occurs without Variants.
+        const $ = await next.render$(url(pathname), undefined, {
+          headers: { cookie: 'theme=light; locale=en' },
+        })
+        expect($('#slug').text()).toBe(slug)
+
+        await retry(async () => {
+          // Each attempt uses a fresh page so the client router cannot reuse
+          // its cached fallback.
+          const { browser } = await prefetch()
+          await using _ = defer(async () => {
+            await browser.deleteCookies()
+            await browser.close()
+          })
+        }, 15000)
       }
 
       const { browser, act } = await prefetch()

--- a/test/production/app-dir/adapter-variants/adapter-variants.test.ts
+++ b/test/production/app-dir/adapter-variants/adapter-variants.test.ts
@@ -1,0 +1,155 @@
+import { nextTestSetup } from 'e2e-utils'
+import type { NextAdapter } from 'next'
+import {
+  serializeDynamicRoutes,
+  type AdapterRouting,
+} from '../adapter-dynamic-routes/dynamic-routes-snapshot'
+
+type BuildCompleteContext = Parameters<NextAdapter['onBuildComplete']>[0]
+
+type SnapshottableContext = BuildCompleteContext & {
+  routing: AdapterRouting
+}
+
+// These assertions inspect local production build outputs.
+// @force-gate start && turbopack
+describe('adapter-variants', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  // The hook performs three production builds. A timeout must not orphan a
+  // build process that a retry then mistakes for a running Next.js instance.
+  jest.setTimeout(360_000)
+
+  let twoCombinations: BuildCompleteContext
+  let fourCombinations: BuildCompleteContext
+  let collapsed: SnapshottableContext
+
+  beforeAll(async () => {
+    await next.build({ env: { VARIANT_LOCALES: '1' } })
+    twoCombinations = await next.readJSON('build-complete.json')
+
+    await next.build({ env: { VARIANT_LOCALES: '2' } })
+    fourCombinations = await next.readJSON('build-complete.json')
+
+    await next.build({
+      env: { VARIANT_LOCALES: '2', COLLAPSE_ADAPTER_ROUTES: '1' },
+    })
+    collapsed = await next.readJSON('build-complete.json')
+  })
+
+  const countByEntry = (context: BuildCompleteContext) => {
+    const counts = new Map<string, number>()
+
+    for (const route of context.routing.dynamicRoutes) {
+      const key = JSON.stringify(route)
+      counts.set(key, (counts.get(key) ?? 0) + 1)
+    }
+
+    return counts
+  }
+
+  it('should emit every routing entry once', () => {
+    // Routing takes the first match. Every identical entry after it is
+    // unreachable but still increases every deployment's routing table.
+    for (const context of [twoCombinations, fourCombinations, collapsed]) {
+      const repeated = Array.from(countByEntry(context))
+        .filter(([, count]) => count > 1)
+        .map(([route, count]) => ({ count, route: JSON.parse(route) }))
+
+      expect(repeated).toEqual([])
+    }
+  })
+
+  it('should keep routing and its order independent of the combination count', () => {
+    // Routing captures any combination hash. Increasing the number of hashes
+    // must multiply prerenders, not routing entries.
+    expect(fourCombinations.routing.dynamicRoutes).toEqual(
+      twoCombinations.routing.dynamicRoutes
+    )
+  })
+
+  it('should route prefixed payloads before prefixed documents', () => {
+    const routes = fourCombinations.routing.dynamicRoutes.filter((route) =>
+      route.sourceRegex.includes('(?<nxtV>')
+    )
+
+    expect(routes).toHaveLength(2)
+    // The payload matcher also accepts segment prefetches and comes first so
+    // the document's dynamic param cannot consume either suffix.
+    expect(routes[0].sourceRegex).toContain('rscSuffix')
+    expect(routes[0].sourceRegex).toContain('\\.segments/')
+    expect(routes[1].sourceRegex).not.toContain('rscSuffix')
+  })
+
+  const prerendersByCombination = (
+    context: BuildCompleteContext,
+    route: string
+  ) => {
+    const groups = new Map<string, string[]>()
+
+    for (const prerender of context.outputs.prerenders) {
+      if (prerender.route !== route) {
+        continue
+      }
+
+      const match = /^\/__variants\/([0-9a-z]+)(?:\/|$)/.exec(
+        prerender.pathname
+      )
+      const combination = match ? match[1] : 'none'
+      const pathnames = groups.get(combination)
+
+      if (pathnames) {
+        pathnames.push(prerender.pathname)
+      } else {
+        groups.set(combination, [prerender.pathname])
+      }
+    }
+
+    return groups
+  }
+
+  it('should write one set of prerenders per combination', () => {
+    const two = prerendersByCombination(twoCombinations, '/concrete')
+    const four = prerendersByCombination(fourCombinations, '/concrete')
+
+    expect(two.size).toBe(1 + 2)
+    expect(four.size).toBe(1 + 4)
+
+    // Every combination produces the same artifact forms. An uneven group
+    // means one form was dropped while routing remained unchanged.
+    const sizes = new Set(
+      [...two.values(), ...four.values()].map((pathnames) => pathnames.length)
+    )
+
+    expect(Array.from(sizes)).toHaveLength(1)
+  })
+
+  it('should collapse every form of a prefixed request into one entry', () => {
+    // The prefixed page and payload follow the same collapse as the ordinary
+    // route. The prefix does not participate in the suffix group.
+    expect(serializeDynamicRoutes(collapsed.routing.dynamicRoutes))
+      .toMatchInlineSnapshot(`
+       "2 entries
+
+       /dynamic/[slug]
+         ^(?![/]?/__variants/)[/]?/dynamic/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+         -> /dynamic/[slug]$rscSuffix?nxtPslug=$nxtPslug
+
+       /dynamic/[slug]
+         ^[/]?/__variants/(?<nxtV>[0-9a-z]+)/dynamic/(?<nxtPslug>[^/]+?)(?<rscSuffix>\\.rsc|\\.segments/.+\\.segment\\.rsc|)(?:/)?$
+         -> /__variants/$nxtV/dynamic/[slug]$rscSuffix?nxtPslug=$nxtPslug&nxtV=$nxtV"
+      `)
+  })
+
+  it('should leave prerenders unchanged by the collapse', () => {
+    // This option changes routing only. It must not merge or remove the
+    // per-combination prerender outputs themselves.
+    const pathnamesOf = (context: BuildCompleteContext) =>
+      context.outputs.prerenders.map((prerender) => prerender.pathname).sort()
+
+    expect(pathnamesOf(collapsed)).toEqual(pathnamesOf(fourCombinations))
+  })
+})

--- a/test/production/app-dir/adapter-variants/app/concrete/page.tsx
+++ b/test/production/app-dir/adapter-variants/app/concrete/page.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from 'react'
+
+import { combinations } from '../../combinations'
+import { locale, theme } from '../../variants'
+
+// This route has no dynamic segments. Its combinations produce exact outputs,
+// so they multiply prerenders without adding dynamic routing entries.
+export function unstable_generateStaticVariants() {
+  return combinations()
+}
+
+export default function Page() {
+  return (
+    <>
+      <Suspense fallback={<p id="theme-pending">pending</p>}>
+        <p id="theme">{theme()}</p>
+      </Suspense>
+      <Suspense fallback={<p id="locale-pending">pending</p>}>
+        <p id="locale">{locale()}</p>
+      </Suspense>
+    </>
+  )
+}

--- a/test/production/app-dir/adapter-variants/app/dynamic/[slug]/page.tsx
+++ b/test/production/app-dir/adapter-variants/app/dynamic/[slug]/page.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from 'react'
+
+import { combinations } from '../../../combinations'
+import { locale, theme } from '../../../variants'
+
+export function generateStaticParams() {
+  return [{ slug: 'a' }]
+}
+
+// This route contributes the dynamic routing entries under test. Their matcher
+// captures any combination hash, so the entries must not multiply with the
+// number of combinations.
+export function unstable_generateStaticVariants() {
+  return combinations()
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  return (
+    <>
+      <Suspense fallback={<p id="theme-pending">pending</p>}>
+        <p id="theme">{theme()}</p>
+      </Suspense>
+      <Suspense fallback={<p id="locale-pending">pending</p>}>
+        <p id="locale">{locale()}</p>
+      </Suspense>
+      <p id="slug">{slug}</p>
+    </>
+  )
+}

--- a/test/production/app-dir/adapter-variants/app/layout.tsx
+++ b/test/production/app-dir/adapter-variants/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/adapter-variants/combinations.ts
+++ b/test/production/app-dir/adapter-variants/combinations.ts
@@ -1,0 +1,17 @@
+import { locale, theme } from './variants'
+
+/**
+ * Returns two or four combinations without changing their variant keys.
+ * `VARIANT_LOCALES` selects the count, so the test can vary only that axis.
+ */
+export function combinations() {
+  const themes = ['light', 'dark']
+  const locales = process.env.VARIANT_LOCALES === '2' ? ['en', 'de'] : ['en']
+
+  return locales.flatMap((localeValue) =>
+    themes.map((themeValue) => [
+      [theme, themeValue],
+      [locale, localeValue],
+    ])
+  )
+}

--- a/test/production/app-dir/adapter-variants/my-adapter.mjs
+++ b/test/production/app-dir/adapter-variants/my-adapter.mjs
@@ -1,0 +1,9 @@
+import fs from 'fs/promises'
+
+/** @type {import('next').NextAdapter} */
+export default {
+  name: 'variants-build-output',
+  async onBuildComplete(context) {
+    await fs.writeFile('build-complete.json', JSON.stringify(context, null, 2))
+  },
+}

--- a/test/production/app-dir/adapter-variants/next.config.js
+++ b/test/production/app-dir/adapter-variants/next.config.js
@@ -3,15 +3,11 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  partialPrefetching: true,
   experimental: {
     variants: true,
     collapseAdapterRoutes: process.env.COLLAPSE_ADAPTER_ROUTES === '1',
   },
-}
-
-if (process.env.BASE_PATH) {
-  nextConfig.basePath = process.env.BASE_PATH
+  adapterPath: require.resolve('./my-adapter.mjs'),
 }
 
 module.exports = nextConfig

--- a/test/production/app-dir/adapter-variants/proxy.ts
+++ b/test/production/app-dir/adapter-variants/proxy.ts
@@ -1,0 +1,15 @@
+import { wrapProxy } from 'next/dist/server/variants/wrap-proxy'
+import { locale, theme } from './variants'
+
+// The variants transform will wrap the proxy and derive this table from each
+// route's module graph. The fixture supplies it until that transform exists.
+const variantsByRoute = {
+  '/concrete': [locale, theme],
+  '/dynamic/[slug]': [locale, theme],
+}
+
+export const proxy = wrapProxy(variantsByRoute, () => undefined)
+
+export const config = {
+  matcher: ['/concrete', '/dynamic/:slug'],
+}

--- a/test/production/app-dir/adapter-variants/variants.ts
+++ b/test/production/app-dir/adapter-variants/variants.ts
@@ -1,0 +1,16 @@
+'use variants'
+
+import { unstable_variant } from 'next/variants'
+
+// The variants transform will inject each identity. The fixture supplies them
+// until that transform exists.
+export const theme = unstable_variant(
+  (request) =>
+    request.cookies.get('theme')?.value === 'dark' ? 'dark' : 'light',
+  'theme@variants.ts'
+)
+
+export const locale = unstable_variant(
+  (request) => (request.cookies.get('locale')?.value === 'de' ? 'de' : 'en'),
+  'locale@variants.ts'
+)


### PR DESCRIPTION
This change extends `experimental.variants` to adapter-based deployments. The adapter emits per-combination prerender outputs and routes document, RSC, and segment-prefetch requests to them. The Node Proxy output includes the Variants manifest so request-time resolution can select the available static variant combinations.

Deployment requests preserve the selected combination through on-demand prerendering, partially resolved shells, and revalidation. The origin receives runtime variant values, and non-PPR prerenders bypass their cache when those values require a request render. Public route parameters remain separate from internal artifact paths.

The routing handles root paths, required and optional catch-all routes, base paths, and route collapsing. Additional combinations produce separate prerender outputs without multiplying routing entries. Collapsed routes preserve the selected shell and requested payload form without changing prerender output paths.

The existing Variants suites now run against adapter deployments. Additional regression coverage checks routing precedence, prefetches, partially resolved shells, and root revalidation. Adapter tests verify route uniqueness, stable ordering, and routing size independent of the combination count.

Deployment support requires the adapter API. The legacy deployment builder is not supported, while self-hosted dev and start continue to work without an adapter. Variants remains experimental, with the existing Turbopack and Node Proxy requirements.

Anti-forgery checks for client-supplied variant prefixes and `nxtV` follow in the next change in this stack.

Verified by running the [full deploy test matrix](https://github.com/vercel/next.js/actions/runs/34237192428) against this PR.

---
Extracted from #96832