### PR TITLE
Create next.config.ts when generating apps with `pnpm new-test`

### DIFF
--- a/test/e2e/app-dir/test-template/{{ toFileName name }}/app/layout.tsx
+++ b/test/e2e/app-dir/test-template/{{ toFileName name }}/app/layout.tsx
@@ -1,4 +1,5 @@
-import { ReactNode } from 'react'
+import type { ReactNode } from 'react'
+
 export default function Root({ children }: { children: ReactNode }) {
   return (
     <html>

--- a/test/e2e/app-dir/test-template/{{ toFileName name }}/next.config.js
+++ b/test/e2e/app-dir/test-template/{{ toFileName name }}/next.config.js
@@ -1,6 +1,0 @@
-/**
- * @type {import('next').NextConfig}
- */
-const nextConfig = {}
-
-module.exports = nextConfig

--- a/test/e2e/app-dir/test-template/{{ toFileName name }}/next.config.ts
+++ b/test/e2e/app-dir/test-template/{{ toFileName name }}/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {}
+
+export default nextConfig


### PR DESCRIPTION
Updates the template used by `pnpm new-test` for app-dir tests to create a `next.config.ts` instead of `next.config.js`.