### PR TITLE
test(evals): accept LayoutProps in App Router migration

### DIFF
--- a/evals/evals/agent-030-app-router-migration-hard/EVAL.ts
+++ b/evals/evals/agent-030-app-router-migration-hard/EVAL.ts
@@ -33,8 +33,11 @@ test('Root layout exists and replaces _app/_document', () => {
   // Should include metadata (replacing Head in _document.js)
   expect(layoutContent).toMatch(/metadata|Metadata/)
 
-  // Should accept children prop with ReactNode type
-  expect(layoutContent).toMatch(/children.*ReactNode/)
+  // Should accept children using either an inline ReactNode type or the
+  // globally available LayoutProps helper.
+  const layoutCode = stripComments(layoutContent)
+  expect(layoutCode).toMatch(/children/)
+  expect(layoutCode).toMatch(/(?:React\.)?ReactNode|LayoutProps\s*</)
 })
 
 // The "is it a Server Component fetching data" check is semantic, so it uses the


### PR DESCRIPTION
### What?

Updates the App Router migration eval to accept the generated LayoutProps helper as valid typing for root layout children.

### Why?

The current docs support both an inline ReactNode annotation and the globally available LayoutProps helper. Opus 5 followed that guidance in all four AGENTS.md runs, but the eval rejected LayoutProps and reported a false regression.

### How?

The assertion still requires children and now accepts either documented type form.

### Testing

- Prettier check
- ESLint
- Focused assertion check covering both valid forms and an untyped invalid form

<!-- NEXT_JS_LLM -->