### PR TITLE
[turbopack] Defer lazy import canonicalization

### DIFF
--- a/test/development/app-dir/lazy-dynamic-imports/app/client-next-dynamic/page.tsx
+++ b/test/development/app-dir/lazy-dynamic-imports/app/client-next-dynamic/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { useState } from 'react'
+
+const Target = dynamic(() => import('./target'))
+
+export default function Page() {
+  const [show, setShow] = useState(false)
+
+  return (
+    <>
+      <button id="show-next-dynamic" onClick={() => setShow(true)}>
+        show
+      </button>
+      {show ? <Target /> : <p id="next-dynamic-idle">not rendered</p>}
+    </>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-imports/app/client-next-dynamic/target.tsx
+++ b/test/development/app-dir/lazy-dynamic-imports/app/client-next-dynamic/target.tsx
@@ -1,0 +1,3 @@
+export default function Target() {
+  return <p>next-dynamic-parse-marker</p>
+}

--- a/test/development/app-dir/lazy-dynamic-imports/app/direct-css/direct-css-demo.tsx
+++ b/test/development/app-dir/lazy-dynamic-imports/app/direct-css/direct-css-demo.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useState } from 'react'
+
+export function DirectCssDemo() {
+  const [result, setResult] = useState('direct CSS idle')
+  const [moduleClass, setModuleClass] = useState('')
+
+  return (
+    <>
+      <button
+        id="load-direct-css"
+        onClick={async () => {
+          await import('../direct.css')
+          setResult(
+            getComputedStyle(document.querySelector('#direct-css-result')!)
+              .color
+          )
+        }}
+      >
+        load direct CSS
+      </button>
+      <p className="direct-css-target" id="direct-css-result">
+        {result}
+      </p>
+      <button
+        id="load-direct-css-module"
+        onClick={async () => {
+          const namespace = await import('../direct.module.css')
+          setModuleClass(namespace.default.target)
+        }}
+      >
+        load direct CSS Module
+      </button>
+      <p className={moduleClass} id="direct-css-module-result">
+        {moduleClass || 'direct CSS Module idle'}
+      </p>
+    </>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-imports/app/direct-css/page.tsx
+++ b/test/development/app-dir/lazy-dynamic-imports/app/direct-css/page.tsx
@@ -1,0 +1,5 @@
+import { DirectCssDemo } from './direct-css-demo'
+
+export default function Page() {
+  return <DirectCssDemo />
+}

--- a/test/development/app-dir/lazy-dynamic-imports/app/direct.css
+++ b/test/development/app-dir/lazy-dynamic-imports/app/direct.css
@@ -1,0 +1,4 @@
+.direct-css-target {
+  color: rgb(12, 34, 56);
+  --direct-css-marker: direct-css-marker-f6a1;
+}

--- a/test/development/app-dir/lazy-dynamic-imports/app/direct.module.css
+++ b/test/development/app-dir/lazy-dynamic-imports/app/direct.module.css
@@ -1,0 +1,3 @@
+.target {
+  color: rgb(70, 80, 90);
+}

--- a/test/development/app-dir/lazy-dynamic-imports/app/duplicate/duplicate-demo.tsx
+++ b/test/development/app-dir/lazy-dynamic-imports/app/duplicate/duplicate-demo.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { useState } from 'react'
+import { loadTarget } from './load-target'
 
 export function DuplicateDemo() {
   const [first, setFirst] = useState('first idle')
   const [second, setSecond] = useState('second idle')
+  const [third, setThird] = useState('third idle')
 
   return (
     <>
@@ -19,6 +21,12 @@ export function DuplicateDemo() {
         onClick={async () => setSecond((await import('./target')).value)}
       >
         {second}
+      </button>
+      <button
+        id="load-third"
+        onClick={async () => setThird(await loadTarget())}
+      >
+        {third}
       </button>
     </>
   )

--- a/test/development/app-dir/lazy-dynamic-imports/app/duplicate/load-target.ts
+++ b/test/development/app-dir/lazy-dynamic-imports/app/duplicate/load-target.ts
@@ -1,0 +1,3 @@
+export async function loadTarget() {
+  return (await import('./target')).value
+}

--- a/test/development/app-dir/lazy-dynamic-imports/app/proxy-identity/page.tsx
+++ b/test/development/app-dir/lazy-dynamic-imports/app/proxy-identity/page.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function Page() {
+  const [first, setFirst] = useState('first idle')
+  const [second, setSecond] = useState('second idle')
+
+  return (
+    <>
+      <button
+        id="load-extensionless"
+        onClick={async () => setFirst((await import('./target')).value)}
+      >
+        {first}
+      </button>
+      <button
+        id="load-explicit-extension"
+        onClick={async () => setSecond((await import('./target.ts')).value)}
+      >
+        {second}
+      </button>
+    </>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-imports/app/proxy-identity/target.ts
+++ b/test/development/app-dir/lazy-dynamic-imports/app/proxy-identity/target.ts
@@ -1,0 +1,1 @@
+export const value = 'proxy identity target'

--- a/test/development/app-dir/lazy-dynamic-imports/app/top-level-await/page.tsx
+++ b/test/development/app-dir/lazy-dynamic-imports/app/top-level-await/page.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function Page() {
+  const [result, setResult] = useState('top-level await idle')
+
+  return (
+    <button
+      id="load-top-level-await"
+      onClick={async () => setResult((await import('./target')).value)}
+    >
+      {result}
+    </button>
+  )
+}

--- a/test/development/app-dir/lazy-dynamic-imports/app/top-level-await/target.ts
+++ b/test/development/app-dir/lazy-dynamic-imports/app/top-level-await/target.ts
@@ -1,0 +1,1 @@
+export const value = await Promise.resolve('top-level await target')

--- a/test/development/app-dir/lazy-dynamic-imports/lazy-dynamic-imports.test.ts
+++ b/test/development/app-dir/lazy-dynamic-imports/lazy-dynamic-imports.test.ts
@@ -322,5 +322,48 @@ export const invalid = ;`
         )
       ).toHaveLength(0)
     })
+
+    it('supports direct dynamic CSS imports', async () => {
+      const cssPath = path.join('app', 'direct.css')
+      const originalCss = await next.readFile(cssPath)
+
+      try {
+        const browser = await next.browser('/direct-css')
+        await browser.elementByCss('#load-direct-css').click()
+        await retry(async () => {
+          expect(await browser.elementByCss('#direct-css-result').text()).toBe(
+            'rgb(12, 34, 56)'
+          )
+        })
+        expect(
+          await assetsContaining('direct-css-marker-f6a1')
+        ).not.toHaveLength(0)
+
+        await browser.elementByCss('#load-direct-css-module').click()
+        await retry(async () => {
+          expect(
+            await browser.eval(
+              `getComputedStyle(document.querySelector('#direct-css-module-result')).color`
+            )
+          ).toBe('rgb(70, 80, 90)')
+        })
+
+        const timeOrigin = await browser.eval('performance.timeOrigin')
+        await next.patchFile(
+          cssPath,
+          originalCss.replace('rgb(12, 34, 56)', 'rgb(65, 43, 21)')
+        )
+        await retry(async () => {
+          expect(
+            await browser.eval(
+              `getComputedStyle(document.querySelector('#direct-css-result')).color`
+            )
+          ).toBe('rgb(65, 43, 21)')
+        })
+        expect(await browser.eval('performance.timeOrigin')).toBe(timeOrigin)
+      } finally {
+        await next.patchFile(cssPath, originalCss)
+      }
+    })
   }
 )

--- a/test/development/app-dir/lazy-dynamic-imports/lazy-dynamic-imports.test.ts
+++ b/test/development/app-dir/lazy-dynamic-imports/lazy-dynamic-imports.test.ts
@@ -265,14 +265,48 @@ export const invalid = ;`
       }
     })
 
+    it('parses a client next/dynamic target before it is rendered', async () => {
+      const targetPath = path.join('app', 'client-next-dynamic', 'target.tsx')
+      const originalTarget = await next.readFile(targetPath)
+
+      try {
+        await next.patchFile(
+          targetPath,
+          `${originalTarget}\nexport const invalid = ;`
+        )
+        const browser = await next.browser('/client-next-dynamic')
+
+        await waitForRedbox(browser)
+        expect(await getRedboxSource(browser)).toContain(
+          './app/client-next-dynamic/target.tsx'
+        )
+      } finally {
+        await next.patchFile(targetPath, originalTarget)
+      }
+    })
+
     it('activates a pattern import without colliding with its target', async () => {
       const browser = await next.browser('/pattern')
+      const getActivationKeys = async (): Promise<string[]> =>
+        browser.eval(`
+          [...new Set(performance.getEntriesByType('resource')
+            .map((entry) => entry.name.match(/lazy-compilation-([0-9a-f]{16})/)?.[1])
+            .filter(Boolean))]
+        `)
+      const initialManifests = await getActivationKeys()
+
       await browser.elementByCss('#load-pattern').click()
       await retry(async () => {
         expect(await browser.elementByCss('#load-pattern').text()).toBe(
           'pattern a'
         )
       })
+      const manifestsAfterA = await getActivationKeys()
+      expect(
+        manifestsAfterA.filter(
+          (pathname) => !initialManifests.includes(pathname)
+        )
+      ).toHaveLength(1)
 
       await browser.eval(`location.hash = 'b'`)
       await browser.elementByCss('#load-pattern').click()
@@ -281,6 +315,12 @@ export const invalid = ;`
           'pattern b'
         )
       })
+      const manifestsAfterB = await getActivationKeys()
+      expect(
+        manifestsAfterB.filter(
+          (pathname) => !manifestsAfterA.includes(pathname)
+        )
+      ).toHaveLength(1)
     })
 
     it('shares a proxy for repeated imports', async () => {
@@ -321,6 +361,69 @@ export const invalid = ;`
           (pathname) => !manifestsAfterFirst.includes(pathname)
         )
       ).toHaveLength(0)
+
+      await browser.elementByCss('#load-third').click()
+      await retry(async () => {
+        expect(await browser.elementByCss('#load-third').text()).toBe(
+          'duplicate target'
+        )
+      })
+      const manifestsAfterThird = await getActivationKeys()
+      expect(
+        manifestsAfterThird.filter(
+          (pathname) => !manifestsAfterSecond.includes(pathname)
+        )
+      ).toHaveLength(0)
+    })
+
+    it('supports different requests from one origin resolving to the same target', async () => {
+      const browser = await next.browser('/proxy-identity')
+      const getActivationKeys = async (): Promise<string[]> =>
+        browser.eval(`
+          [...new Set(performance.getEntriesByType('resource')
+            .map((entry) => entry.name.match(/lazy-compilation-([0-9a-f]{16})/)?.[1])
+            .filter(Boolean))]
+        `)
+      const initialManifests = await getActivationKeys()
+
+      await browser.elementByCss('#load-extensionless').click()
+      await retry(async () => {
+        expect(await browser.elementByCss('#load-extensionless').text()).toBe(
+          'proxy identity target'
+        )
+      })
+      const manifestsAfterFirst = await getActivationKeys()
+      expect(
+        manifestsAfterFirst.filter(
+          (pathname) => !initialManifests.includes(pathname)
+        )
+      ).toHaveLength(1)
+      await browser.elementByCss('#load-explicit-extension').click()
+      await retry(async () => {
+        expect(
+          await browser.elementByCss('#load-explicit-extension').text()
+        ).toBe('proxy identity target')
+      })
+      const manifestsAfterSecond = await getActivationKeys()
+      expect(
+        manifestsAfterSecond.filter(
+          (pathname) => !manifestsAfterFirst.includes(pathname)
+        )
+      ).toHaveLength(0)
+    })
+
+    it('waits for top-level await in an activated target', async () => {
+      const browser = await next.browser('/top-level-await')
+
+      expect(await browser.elementByCss('#load-top-level-await').text()).toBe(
+        'top-level await idle'
+      )
+      await browser.elementByCss('#load-top-level-await').click()
+      await retry(async () => {
+        expect(await browser.elementByCss('#load-top-level-await').text()).toBe(
+          'top-level await target'
+        )
+      })
     })
 
     it('supports direct dynamic CSS imports', async () => {

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -32,7 +32,9 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::{
     async_chunk::module::AsyncLoaderModule,
-    chunk::{EcmascriptChunk, EcmascriptChunkContent, EcmascriptChunkType},
+    chunk::{
+        EcmascriptChunk, EcmascriptChunkContent, EcmascriptChunkPlaceable, EcmascriptChunkType,
+    },
     manifest::{chunk_asset::ManifestAsyncModule, loader_module::ManifestLoaderModule},
 };
 use turbopack_ecmascript_runtime::RuntimeType;
@@ -1225,7 +1227,12 @@ impl ChunkingContext for BrowserChunkingContext {
             .emit();
             return Ok(module.as_chunk_item(module_graph, *chunking_context));
         }
-        Ok(if self.await?.manifest_chunks {
+        let use_manifest = self.await?.manifest_chunks
+            && ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(
+                module.to_resolved().await?,
+            )
+            .is_some();
+        Ok(if use_manifest {
             let manifest_asset = ManifestAsyncModule::new(
                 module,
                 module_graph,
@@ -1245,7 +1252,12 @@ impl ChunkingContext for BrowserChunkingContext {
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
     ) -> Result<Vc<AssetIdent>> {
-        Ok(if self.await?.manifest_chunks {
+        let use_manifest = self.await?.manifest_chunks
+            && ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(
+                module.to_resolved().await?,
+            )
+            .is_some();
+        Ok(if use_manifest {
             ManifestLoaderModule::asset_ident_for(module)
         } else {
             AsyncLoaderModule::asset_ident_for(module)

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -61,6 +61,7 @@ pub enum EcmaScriptModulesReferenceSubType {
         module_type: Option<RcStr>,
     },
     DynamicImport,
+    LazyDynamicImport,
     Emit,
     Custom(u8),
     #[default]
@@ -331,6 +332,18 @@ impl ReferenceTypeCondition {
     pub fn includes(&self, other: &ReferenceType) -> bool {
         if matches!(
             self,
+            ReferenceTypeCondition::EcmaScriptModules(Some(
+                EcmaScriptModulesReferenceSubType::DynamicImport
+            ))
+        ) && matches!(
+            other,
+            ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::LazyDynamicImport)
+        ) {
+            return true;
+        }
+
+        if matches!(
+            self,
             ReferenceTypeCondition::Css(Some(CssReferenceSubType::AtImport(_)))
         ) && matches!(other, ReferenceType::Css(CssReferenceSubType::AtImport(_)))
         {
@@ -381,5 +394,22 @@ impl ReferenceTypeCondition {
         );
 
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EcmaScriptModulesReferenceSubType, ReferenceType, ReferenceTypeCondition};
+
+    #[test]
+    fn lazy_dynamic_import_matches_dynamic_import_condition() {
+        assert!(
+            ReferenceTypeCondition::EcmaScriptModules(Some(
+                EcmaScriptModulesReferenceSubType::DynamicImport
+            ))
+            .includes(&ReferenceType::EcmaScriptModules(
+                EcmaScriptModulesReferenceSubType::LazyDynamicImport
+            ))
+        );
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/proxy.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/proxy.rs
@@ -1,18 +1,7 @@
-use std::sync::Arc;
-
-use anyhow::Result;
+use anyhow::{Result, bail};
 use indoc::formatdoc;
-use swc_core::{
-    common::DUMMY_SP,
-    ecma::{
-        ast::{self, Expr, ExprStmt, Lit, ModuleItem, Stmt},
-        codegen::{Emitter, text_writer::JsWriter},
-    },
-    quote_expr,
-};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, State, ValueToString, Vc};
-use turbo_tasks_fs::rope::Rope;
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
     chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext, ChunkingType},
@@ -20,48 +9,19 @@ use turbopack_core::{
     module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     reference::{ModuleReference, ModuleReferences},
-    resolve::{
-        BindingUsage, ExportUsage, ImportUsage, ModuleResolveResult, origin::ResolveOrigin,
-        parse::Request,
-    },
+    resolve::{BindingUsage, ExportUsage, ImportUsage, ModuleResolveResult},
 };
 
 use crate::{
+    EcmascriptModuleAsset,
     chunk::{
         EcmascriptChunkItemContent, EcmascriptChunkPlaceable, EcmascriptExports,
         ecmascript_chunk_item,
     },
-    references::pattern_mapping::{PatternMapping, ResolveType},
+    module_canonicalization::{EcmascriptModuleCanonicalization, canonicalize_ecmascript_module},
     runtime_functions::{TURBOPACK_ASYNC_LOADER, TURBOPACK_EXPORT_NAMESPACE},
     utils::{StringifyJs, StringifyModuleId},
 };
-
-fn proxy_import_code(import: Expr) -> Result<Rope> {
-    let expr = quote_expr!(
-        "$export_namespace($import)",
-        export_namespace: Expr = TURBOPACK_EXPORT_NAMESPACE.into(),
-        import: Expr = import,
-    );
-    let module = ast::Module {
-        span: DUMMY_SP,
-        body: vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
-            span: DUMMY_SP,
-            expr,
-        }))],
-        shebang: None,
-    };
-    let source_map: Arc<swc_core::common::SourceMap> = Default::default();
-    let mut bytes = Vec::new();
-    let writer = JsWriter::new(source_map.clone(), "\n", &mut bytes, None);
-    let mut emitter = Emitter {
-        cfg: swc_core::ecma::codegen::Config::default(),
-        cm: source_map,
-        comments: None,
-        wr: writer,
-    };
-    emitter.emit_module(&module)?;
-    Ok(bytes.into())
-}
 
 #[turbo_tasks::value(serialization = "skip", evict = "never")]
 pub struct LazyCompilationState {
@@ -120,15 +80,83 @@ pub fn lazy_compilation_state(key: RcStr) -> Vc<LazyCompilationState> {
 }
 
 #[turbo_tasks::value]
-enum LazyCompilationTarget {
-    Unresolved {
-        reference: ResolvedVc<Box<dyn ModuleReference>>,
-        request: ResolvedVc<Request>,
-        request_string: RcStr,
-        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
-        import_externals: bool,
+#[derive(ValueToString)]
+#[value_to_string("lazy compilation target")]
+pub enum LazyCompilationTarget {
+    Deferred {
+        module: ResolvedVc<EcmascriptModuleAsset>,
+        canonicalization: EcmascriptModuleCanonicalization,
     },
-    Resolved(ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>),
+    Direct(ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>),
+}
+
+#[turbo_tasks::value_impl]
+impl LazyCompilationTarget {
+    #[turbo_tasks::function]
+    pub fn deferred(
+        module: ResolvedVc<EcmascriptModuleAsset>,
+        canonicalization: EcmascriptModuleCanonicalization,
+    ) -> Vc<Self> {
+        Self::cell(Self::Deferred {
+            module,
+            canonicalization,
+        })
+    }
+
+    #[turbo_tasks::function]
+    pub fn direct(module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>) -> Vc<Self> {
+        Self::cell(Self::Direct(module))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn proxy_ident(&self) -> Result<Vc<AssetIdent>> {
+        let ident = match self {
+            Self::Deferred {
+                module,
+                canonicalization,
+            } => module
+                .ident()
+                .owned()
+                .await?
+                .with_modifier(format!("lazy compilation proxy {canonicalization:?}").into()),
+            Self::Direct(module) => module
+                .ident()
+                .owned()
+                .await?
+                .with_modifier(rcstr!("lazy compilation proxy")),
+        };
+        Ok(ident.into_vc())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ModuleReference for LazyCompilationTarget {
+    #[turbo_tasks::function]
+    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
+        let module = match self {
+            Self::Deferred {
+                module,
+                canonicalization,
+            } => {
+                canonicalize_ecmascript_module(**module, canonicalization.clone())
+                    .to_resolved()
+                    .await?
+            }
+            Self::Direct(module) => *module,
+        };
+        Ok(*ModuleResolveResult::module(ResolvedVc::upcast(module)))
+    }
+
+    fn chunking_type(&self) -> Option<ChunkingType> {
+        Some(ChunkingType::Async)
+    }
+
+    fn binding_usage(&self) -> BindingUsage {
+        BindingUsage {
+            import: ImportUsage::TopLevel,
+            export: ExportUsage::All,
+        }
+    }
 }
 
 #[turbo_tasks::value]
@@ -142,40 +170,10 @@ pub struct LazyCompilationProxyModule {
 #[turbo_tasks::value_impl]
 impl LazyCompilationProxyModule {
     #[turbo_tasks::function]
-    pub fn new_unresolved(
-        reference: ResolvedVc<Box<dyn ModuleReference>>,
-        request: ResolvedVc<Request>,
-        request_string: RcStr,
-        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
-        import_externals: bool,
-        ident: ResolvedVc<AssetIdent>,
-        key: RcStr,
-    ) -> Vc<Self> {
-        Self::cell(Self {
-            target: LazyCompilationTarget::Unresolved {
-                reference,
-                request,
-                request_string,
-                origin,
-                import_externals,
-            }
-            .resolved_cell(),
-            ident,
-            key,
-        })
-    }
-
-    #[turbo_tasks::function]
-    pub fn new_resolved(
-        target: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
-        ident: ResolvedVc<AssetIdent>,
-        key: RcStr,
-    ) -> Vc<Self> {
-        Self::cell(Self {
-            target: LazyCompilationTarget::Resolved(target).resolved_cell(),
-            ident,
-            key,
-        })
+    pub async fn new(target: ResolvedVc<LazyCompilationTarget>) -> Result<Vc<Self>> {
+        let ident = target.proxy_ident().to_resolved().await?;
+        let key = activation_key(&ident.to_string().await?);
+        Ok(Self::cell(Self { target, ident, key }))
     }
 }
 
@@ -197,15 +195,7 @@ impl Module for LazyCompilationProxyModule {
             return Ok(ModuleReferences::empty());
         }
 
-        match &*self.target.await? {
-            LazyCompilationTarget::Unresolved { reference, .. } => Ok(Vc::cell(vec![*reference])),
-            LazyCompilationTarget::Resolved(target) => {
-                let reference = LazyCompilationTargetReference::new(**target);
-                Ok(Vc::cell(vec![ResolvedVc::upcast(
-                    reference.to_resolved().await?,
-                )]))
-            }
-        }
+        Ok(Vc::cell(vec![ResolvedVc::upcast(self.target)]))
     }
 
     #[turbo_tasks::function]
@@ -247,49 +237,27 @@ impl EcmascriptChunkPlaceable for LazyCompilationProxyModule {
         }
 
         let state = lazy_compilation_state(this.key.clone()).await?;
-        let inner_code: Rope = if state.is_active() {
-            match &*this.target.await? {
-                LazyCompilationTarget::Resolved(target) => {
-                    let loader_ident =
-                        chunking_context.async_loader_chunk_item_ident(Vc::upcast(**target));
-                    let loader_id = chunking_context
-                        .chunk_item_id_strategy()
-                        .await?
-                        .get_id_from_ident(loader_ident)
-                        .await?;
-                    formatdoc! {
-                        r#"
-                        {TURBOPACK_EXPORT_NAMESPACE}({TURBOPACK_ASYNC_LOADER}({loader_id}));
-                    "#,
-                        loader_id = StringifyModuleId(&loader_id),
-                    }
-                    .into()
-                }
-                LazyCompilationTarget::Unresolved {
-                    reference,
-                    request,
-                    request_string,
-                    origin,
-                    import_externals,
-                } => {
-                    let mapping = PatternMapping::resolve_request(
-                        **request,
-                        **origin,
-                        chunking_context,
-                        reference.resolve_reference(),
-                        if chunking_context.chunk_loading().await?.can_split_async() {
-                            ResolveType::AsyncChunkLoader
-                        } else {
-                            ResolveType::ChunkItem
-                        },
-                        Some(**reference),
-                    )
-                    .await?;
-                    proxy_import_code(mapping.create_import(
-                        Expr::Lit(Lit::Str(request_string.as_str().into())),
-                        *import_externals,
-                    ))?
-                }
+        let inner_code = if state.is_active() {
+            let result = this.target.resolve_reference().await?;
+            let Some(module) = result.first_module().await? else {
+                bail!("lazy compilation target did not resolve to a module");
+            };
+            let Some(target) =
+                ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(module)
+            else {
+                bail!("lazy compilation target is not an ecmascript chunk placeable module");
+            };
+            let loader_ident = chunking_context.async_loader_chunk_item_ident(Vc::upcast(*target));
+            let loader_id = chunking_context
+                .chunk_item_id_strategy()
+                .await?
+                .get_id_from_ident(loader_ident)
+                .await?;
+            formatdoc! {
+                r#"
+                    {TURBOPACK_EXPORT_NAMESPACE}({TURBOPACK_ASYNC_LOADER}({loader_id}));
+                "#,
+                loader_id = StringifyModuleId(&loader_id),
             }
         } else {
             // The manifest chunk that lists this chunk is only served once the proxy is active,
@@ -303,11 +271,10 @@ impl EcmascriptChunkPlaceable for LazyCompilationProxyModule {
                     this.ident.to_string().await?
                 )),
             }
-            .into()
         };
 
         Ok(EcmascriptChunkItemContent {
-            inner_code,
+            inner_code: inner_code.into(),
             ..Default::default()
         }
         .cell())
@@ -331,40 +298,6 @@ impl EcmascriptChunkPlaceable for LazyCompilationProxyModule {
                 rcstr!("inactive")
             })
             .into_vc())
-    }
-}
-
-#[turbo_tasks::value]
-#[derive(ValueToString)]
-#[value_to_string("lazy compilation target")]
-struct LazyCompilationTargetReference {
-    target: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
-}
-
-#[turbo_tasks::value_impl]
-impl LazyCompilationTargetReference {
-    #[turbo_tasks::function]
-    fn new(target: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>) -> Vc<Self> {
-        Self::cell(Self { target })
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ModuleReference for LazyCompilationTargetReference {
-    #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        *ModuleResolveResult::module(ResolvedVc::upcast(self.target))
-    }
-
-    fn chunking_type(&self) -> Option<ChunkingType> {
-        Some(ChunkingType::Async)
-    }
-
-    fn binding_usage(&self) -> BindingUsage {
-        BindingUsage {
-            import: ImportUsage::TopLevel,
-            export: ExportUsage::All,
-        }
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -24,6 +24,7 @@ pub mod magic_identifier;
 pub mod manifest;
 mod merged_module;
 pub mod minify;
+pub mod module_canonicalization;
 pub mod module_fragments;
 pub mod parse;
 mod path_visitor;

--- a/turbopack/crates/turbopack-ecmascript/src/module_canonicalization.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/module_canonicalization.rs
@@ -1,0 +1,95 @@
+use anyhow::{Result, bail};
+use bincode::{Decode, Encode};
+use turbo_tasks::{ResolvedVc, Vc, trace::TraceRawVcs};
+use turbopack_core::resolve::ModulePart;
+
+use crate::{
+    EcmascriptModuleAsset,
+    chunk::EcmascriptChunkPlaceable,
+    module_fragments::part::module::EcmascriptModulePartAsset,
+    references::{FollowExportsResult, follow_reexports},
+    rename::module::EcmascriptModuleRenameModule,
+    side_effect_optimization::{
+        facade::module::EcmascriptModuleFacadeModule, locals::module::EcmascriptModuleLocalsModule,
+    },
+};
+
+#[turbo_tasks::task_input]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, TraceRawVcs, Encode, Decode)]
+pub enum EcmascriptModuleCanonicalization {
+    None,
+    ModuleFragments(ModulePart),
+    FollowReexports(Option<ModulePart>),
+}
+
+#[turbo_tasks::function]
+pub async fn canonicalize_ecmascript_module(
+    module: ResolvedVc<EcmascriptModuleAsset>,
+    canonicalization: EcmascriptModuleCanonicalization,
+) -> Result<Vc<Box<dyn EcmascriptChunkPlaceable>>> {
+    Ok(match canonicalization {
+        EcmascriptModuleCanonicalization::None => Vc::upcast(*module),
+        EcmascriptModuleCanonicalization::ModuleFragments(part) => {
+            EcmascriptModulePartAsset::select_part(*module, part)
+        }
+        EcmascriptModuleCanonicalization::FollowReexports(part) => {
+            if *module.get_exports().split_locals_and_reexports().await? {
+                if let Some(part) = part {
+                    match part {
+                        ModulePart::Evaluation => {
+                            Vc::upcast(EcmascriptModuleLocalsModule::new(*module))
+                        }
+                        ModulePart::Export(_) => {
+                            apply_reexport_tree_shaking(
+                                Vc::upcast(
+                                    *EcmascriptModuleFacadeModule::new(Vc::upcast(*module))
+                                        .to_resolved()
+                                        .await?,
+                                ),
+                                part,
+                            )
+                            .await?
+                        }
+                        _ => bail!(
+                            "Invalid module part \"{}\" for reexports only tree shaking mode",
+                            part
+                        ),
+                    }
+                } else {
+                    Vc::upcast(EcmascriptModuleFacadeModule::new(Vc::upcast(*module)))
+                }
+            } else {
+                Vc::upcast(*module)
+            }
+        }
+    })
+}
+
+async fn apply_reexport_tree_shaking(
+    module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
+    part: ModulePart,
+) -> Result<Vc<Box<dyn EcmascriptChunkPlaceable>>> {
+    if let ModulePart::Export(export) = &part {
+        let FollowExportsResult {
+            module: final_module,
+            export_name: new_export,
+            ..
+        } = &*follow_reexports(module, export.clone(), true).await?;
+        return Ok(if let Some(new_export) = new_export {
+            if *new_export == *export {
+                **final_module
+            } else {
+                Vc::upcast(EcmascriptModuleRenameModule::new(
+                    **final_module,
+                    ModulePart::renamed_export(new_export.clone(), export.clone()),
+                ))
+            }
+        } else {
+            Vc::upcast(EcmascriptModuleRenameModule::new(
+                **final_module,
+                ModulePart::renamed_namespace(export.clone()),
+            ))
+        });
+    }
+    Ok(module)
+}

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -5,19 +5,17 @@ use swc_core::{
     ecma::ast::{CallExpr, Callee, Expr, ExprOrSpread, Lit},
     quote_expr,
 };
-use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbopack_core::{
     chunk::{ChunkingContext, ChunkingType},
-    ident::AssetIdent,
     issue::IssueSource,
     module::Module,
     reference::ModuleReference,
     reference_type::EcmaScriptModulesReferenceSubType,
     resolve::{
-        BindingUsage, ExportUsage, ModuleResolveResult, ModuleResolveResultItem, ResolveErrorMode,
+        BindingUsage, ExportUsage, ModuleResolveResult, ResolveErrorMode,
         origin::{ResolveOrigin, ResolveOriginExt},
         parse::Request,
     },
@@ -26,7 +24,7 @@ use turbopack_resolve::ecmascript::esm_resolve;
 
 use crate::{
     analyzer::imports::ImportAnnotations,
-    async_chunk::proxy::{LazyCompilationProxyModule, activation_key},
+    async_chunk::proxy::{LazyCompilationProxyModule, LazyCompilationTarget},
     chunk::EcmascriptChunkPlaceable,
     code_gen::{CodeGen, CodeGeneration, IntoCodeGenReference},
     create_visitor,
@@ -50,7 +48,6 @@ pub struct EsmAsyncAssetReference {
     /// callback destructuring, or webpackExports/turbopackExports comments.
     pub export_usage: ExportUsage,
     pub resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
-    pub request_string: Option<RcStr>,
     /// Whether the target is compiled only after its runtime proxy is activated.
     pub lazy_compilation: bool,
 }
@@ -66,7 +63,6 @@ impl EsmAsyncAssetReference {
         import_externals: bool,
         export_usage: ExportUsage,
         resolve_override: Option<ResolvedVc<Box<dyn Module>>>,
-        request_string: Option<RcStr>,
         lazy_compilation: bool,
     ) -> Result<Self> {
         // Apply any annotation-driven transition eagerly so the stored origin is final and the
@@ -88,127 +84,41 @@ impl EsmAsyncAssetReference {
             import_externals,
             export_usage,
             resolve_override,
-            request_string,
             lazy_compilation,
         })
     }
-}
-
-#[turbo_tasks::function]
-fn lazy_compilation_target_reference(
-    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
-    request: ResolvedVc<Request>,
-    issue_source: IssueSource,
-    error_mode: ResolveErrorMode,
-    import_externals: bool,
-) -> Vc<EsmAsyncAssetReference> {
-    EsmAsyncAssetReference {
-        origin,
-        request,
-        issue_source,
-        error_mode,
-        import_externals,
-        export_usage: ExportUsage::All,
-        resolve_override: None,
-        request_string: None,
-        lazy_compilation: false,
-    }
-    .cell()
 }
 
 #[turbo_tasks::value_impl]
 impl ModuleReference for EsmAsyncAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        if self.lazy_compilation && self.resolve_override.is_none() {
-            let request = self.request.await?;
-            // Pattern requests need their resolved result map for runtime dispatch. A constant
-            // request can use one proxy and defer resolution and processing until activation.
-            if let Some(request_string) = &self.request_string {
-                let origin = self.origin.into_trait_ref().await?;
-                let ident = AssetIdent::from_path(origin.origin_path())
-                    .with_layer(origin.asset_context().into_trait_ref().await?.layer())
-                    .with_modifier(format!("lazy compilation proxy {request:?}").into())
-                    .into_vc()
+        if let Some(resolved) = self.resolve_override {
+            if self.lazy_compilation
+                && let Some(module) =
+                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(resolved)
+            {
+                let target = LazyCompilationTarget::direct(*module).to_resolved().await?;
+                let proxy = LazyCompilationProxyModule::new(*target)
                     .to_resolved()
                     .await?;
-                let key = activation_key(&ident.to_string().await?);
-                let target = lazy_compilation_target_reference(
-                    *self.origin,
-                    *self.request,
-                    self.issue_source.without_range(),
-                    self.error_mode,
-                    self.import_externals,
-                )
-                .to_resolved()
-                .await?;
-                let proxy = LazyCompilationProxyModule::new_unresolved(
-                    *ResolvedVc::upcast(target),
-                    *self.request,
-                    request_string.clone(),
-                    *self.origin,
-                    self.import_externals,
-                    *ident,
-                    key,
-                )
-                .to_resolved()
-                .await?;
                 return Ok(*ModuleResolveResult::module(ResolvedVc::upcast(proxy)));
             }
+            return Ok(*ModuleResolveResult::module(resolved));
         }
 
-        let result = if let Some(resolved) = &self.resolve_override {
-            *ModuleResolveResult::module(*resolved)
-        } else {
-            esm_resolve(
-                *self.origin,
-                *self.request,
-                EcmaScriptModulesReferenceSubType::DynamicImport,
-                self.error_mode,
-                Some(self.issue_source),
-            )
-            .await?
-        };
-
-        if !self.lazy_compilation {
-            return Ok(result);
-        }
-
-        let result = result.await?;
-        let mut primary = Vec::with_capacity(result.primary.len());
-        for (key, item) in result.primary.iter() {
-            let item = if let ModuleResolveResultItem::Module(module) = item
-                && let Some(target) =
-                    ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*module)
-            {
-                let proxy_ident = target
-                    .ident()
-                    .owned()
-                    .await?
-                    .with_modifier(rcstr!("lazy compilation proxy"))
-                    .into_vc()
-                    .to_resolved()
-                    .await?;
-                let ident = proxy_ident.to_string().await?;
-                let proxy = LazyCompilationProxyModule::new_resolved(
-                    *target,
-                    *proxy_ident,
-                    activation_key(&ident),
-                )
-                .to_resolved()
-                .await?;
-                ModuleResolveResultItem::Module(ResolvedVc::upcast(proxy))
+        esm_resolve(
+            *self.origin,
+            *self.request,
+            if self.lazy_compilation {
+                EcmaScriptModulesReferenceSubType::LazyDynamicImport
             } else {
-                item.clone()
-            };
-            primary.push((key.clone(), item));
-        }
-
-        Ok(ModuleResolveResult {
-            primary: primary.into_boxed_slice(),
-            affecting_sources: result.affecting_sources.clone(),
-        }
-        .cell())
+                EcmaScriptModulesReferenceSubType::DynamicImport
+            },
+            self.error_mode,
+            Some(self.issue_source),
+        )
+        .await
     }
 
     fn chunking_type(&self) -> Option<ChunkingType> {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1859,9 +1859,8 @@ async fn handle_dynamic_import_with_linked_args(
             }
         }
 
-        let request_string = pat.as_constant_string().cloned();
         let resolve_override = if let Some(inner_assets) = &inner_assets
-            && let Some(req) = &request_string
+            && let Some(req) = pat.as_constant_string()
             && let Some(a) = inner_assets.get(req)
         {
             Some(*a)
@@ -1879,7 +1878,6 @@ async fn handle_dynamic_import_with_linked_args(
                 import_externals,
                 export_usage,
                 resolve_override,
-                request_string,
                 lazy_compilation,
             )
             .await?,

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -717,7 +717,12 @@ impl ChunkingContext for NodeJsChunkingContext {
             Vc::upcast::<Box<dyn ChunkingContext>>(self)
                 .to_resolved()
                 .await?;
-        Ok(if self.await?.manifest_chunks {
+        let use_manifest = self.await?.manifest_chunks
+            && ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(
+                module.to_resolved().await?,
+            )
+            .is_some();
+        Ok(if use_manifest {
             let manifest_asset = ManifestAsyncModule::new(
                 module,
                 module_graph,
@@ -739,7 +744,12 @@ impl ChunkingContext for NodeJsChunkingContext {
         self: Vc<Self>,
         module: Vc<Box<dyn ChunkableModule>>,
     ) -> Result<Vc<AssetIdent>> {
-        Ok(if self.await?.manifest_chunks {
+        let use_manifest = self.await?.manifest_chunks
+            && ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkPlaceable>>(
+                module.to_resolved().await?,
+            )
+            .is_some();
+        Ok(if use_manifest {
             ManifestLoaderModule::asset_ident_for(module)
         } else {
             AsyncLoaderModule::asset_ident_for(module)

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/dynamic-import/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/dynamic-import/input/index.js
@@ -1,3 +1,10 @@
+import { identity as staticIdentity } from './modules/identity'
+
+it('should share module identity between static and dynamic imports', async () => {
+  const { identity: dynamicIdentity } = await import('./modules/identity')
+  expect(dynamicIdentity).toBe(staticIdentity)
+})
+
 it('should mark all exports as used with non-destructured dynamic import', async () => {
   const lib = await import('./modules/all')
   expect(lib.cat).toBe('cat')

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/dynamic-import/input/modules/identity.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/tree-shaking/dynamic-import/input/modules/identity.js
@@ -1,0 +1,1 @@
+export const identity = {}

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -50,16 +50,10 @@ use turbopack_css::{CssModule, EcmascriptCssModule};
 use turbopack_ecmascript::{
     AnalyzeMode, EcmascriptInputTransforms, EcmascriptModuleAsset, EcmascriptModuleAssetType,
     EcmascriptOptions,
-    chunk::EcmascriptChunkPlaceable,
-    module_fragments::part::module::EcmascriptModulePartAsset,
-    references::{
-        FollowExportsResult,
-        external_module::{CachedExternalModule, CachedExternalTracingMode, CachedExternalType},
-        follow_reexports,
-    },
-    rename::module::EcmascriptModuleRenameModule,
-    side_effect_optimization::{
-        facade::module::EcmascriptModuleFacadeModule, locals::module::EcmascriptModuleLocalsModule,
+    async_chunk::proxy::{LazyCompilationProxyModule, LazyCompilationTarget},
+    module_canonicalization::{EcmascriptModuleCanonicalization, canonicalize_ecmascript_module},
+    references::external_module::{
+        CachedExternalModule, CachedExternalTracingMode, CachedExternalType,
     },
 };
 use turbopack_node::transforms::webpack::{WebpackLoaderItem, WebpackLoaderItems, WebpackLoaders};
@@ -100,6 +94,10 @@ async fn apply_module_type(
         _ => None,
     };
     let is_evaluation = matches!(&part, Some(ModulePart::Evaluation));
+    let is_lazy_dynamic_import = matches!(
+        &reference_type,
+        ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::LazyDynamicImport)
+    );
 
     let module_type = &*module_type.await?;
     let module = match module_type {
@@ -200,46 +198,32 @@ async fn apply_module_type(
                     }
                 }
 
-                if module_fragments_enabled {
-                    Vc::upcast(EcmascriptModulePartAsset::select_part(
-                        *module,
-                        part.cloned().unwrap_or(ModulePart::facade()),
-                    ))
+                let canonicalization = if module_fragments_enabled {
+                    EcmascriptModuleCanonicalization::ModuleFragments(
+                        part.cloned().unwrap_or_else(ModulePart::facade),
+                    )
                 } else if follow_reexports {
-                    if *module.get_exports().split_locals_and_reexports().await? {
-                        if let Some(part) = part {
-                            match part {
-                                ModulePart::Evaluation => {
-                                    Vc::upcast(EcmascriptModuleLocalsModule::new(*module))
-                                }
-                                ModulePart::Export(_) => {
-                                    apply_reexport_tree_shaking(
-                                        Vc::upcast(
-                                            *EcmascriptModuleFacadeModule::new(Vc::upcast(*module))
-                                                .to_resolved()
-                                                .await?,
-                                        ),
-                                        part.clone(),
-                                    )
-                                    .await?
-                                }
-                                _ => bail!(
-                                    "Invalid module part \"{}\" for reexports only tree shaking \
-                                     mode",
-                                    part
-                                ),
-                            }
-                        } else {
-                            Vc::upcast(EcmascriptModuleFacadeModule::new(Vc::upcast(*module)))
-                        }
-                    } else {
-                        Vc::upcast(*module)
-                    }
+                    EcmascriptModuleCanonicalization::FollowReexports(part.cloned())
                 } else {
-                    Vc::upcast(*module)
+                    EcmascriptModuleCanonicalization::None
+                };
+
+                if is_lazy_dynamic_import {
+                    let target = LazyCompilationTarget::deferred(*module, canonicalization)
+                        .to_resolved()
+                        .await?;
+                    ResolvedVc::upcast(
+                        LazyCompilationProxyModule::new(*target)
+                            .to_resolved()
+                            .await?,
+                    )
+                } else {
+                    ResolvedVc::upcast(
+                        canonicalize_ecmascript_module(*module, canonicalization)
+                            .to_resolved()
+                            .await?,
+                    )
                 }
-                .to_resolved()
-                .await?
             }
         }
         ModuleType::Raw => ResolvedVc::upcast(RawModule::new(*source).to_resolved().await?),
@@ -305,36 +289,6 @@ async fn apply_module_type(
     }
 
     Ok(ProcessResult::Module(module).cell())
-}
-
-async fn apply_reexport_tree_shaking(
-    module: Vc<Box<dyn EcmascriptChunkPlaceable>>,
-    part: ModulePart,
-) -> Result<Vc<Box<dyn Module>>> {
-    if let ModulePart::Export(export) = &part {
-        let FollowExportsResult {
-            module: final_module,
-            export_name: new_export,
-            ..
-        } = &*follow_reexports(module, export.clone(), true).await?;
-        let module = if let Some(new_export) = new_export {
-            if *new_export == *export {
-                Vc::upcast(**final_module)
-            } else {
-                Vc::upcast(EcmascriptModuleRenameModule::new(
-                    **final_module,
-                    ModulePart::renamed_export(new_export.clone(), export.clone()),
-                ))
-            }
-        } else {
-            Vc::upcast(EcmascriptModuleRenameModule::new(
-                **final_module,
-                ModulePart::renamed_namespace(export.clone()),
-            ))
-        };
-        return Ok(module);
-    }
-    Ok(Vc::upcast(module))
 }
 
 #[turbo_tasks::value]


### PR DESCRIPTION
 Previously I had a bunch of special cases that felt rather ad-hoc. Part of this was in attempt to isolate some changes. Here I think I have a solution that is a bit less ad-hoc. It did require refactoring some code into this "canonicalization" setup. So that when a lazy proxy is forced, it can be transformed into exactly the code it would have been had their been no lazy proxy (modulo a proxy of course).

This let me handle more cases I wasn't handling before. I've added more tests. Trying out v0/chat. I've looked at visualizations of graphs in various scenarios and this matches my intuition of how the feature ought to work.

One thing that isn't as clear to me is the exact boundaries of where code belongs. I sadly had to move things between crates for dependency sake. I think I got an okay clean setup. But not 100% sure it is right.

I think the end result is way less ad-hoc. I know Niklas didn't want this new LazyDynamic enum here. But after trying some variations and running into problems with duplication, this refactoring out of the "canonicalization" came to me and I think the end result is decently clean.
