### PR TITLE
test(turbopack): remove remaining test unmarks

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/collectibles.rs
@@ -9,10 +9,7 @@ use auto_hash_map::AutoSet;
 use rustc_hash::FxHashSet;
 use tokio::time::sleep;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{
-    CollectiblesSource, ResolvedVc, ValueToString, Vc, emit,
-    unmark_top_level_task_may_leak_eventually_consistent_state,
-};
+use turbo_tasks::{CollectiblesSource, ResolvedVc, ValueToString, Vc, emit};
 use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
@@ -20,16 +17,21 @@ static REGISTRATION: Registration = register!();
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_transitive_emitting() {
     run_once(&REGISTRATION, async || {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-        let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
-        let result_val = result_op.connect().strongly_consistent().await?;
-        let list = result_op.peek_collectibles::<Box<dyn ValueToString>>();
-        assert_eq!(list.len(), 2);
-        let mut expected = ["123", "42"].into_iter().collect::<FxHashSet<_>>();
-        for collectible in list {
-            assert!(expected.remove(collectible.to_string().await?.as_str()))
+        #[turbo_tasks::function(operation, root)]
+        async fn operation() -> Result<Vc<()>> {
+            let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
+            let result_val = result_op.connect().await?;
+            let list = result_op.peek_collectibles::<Box<dyn ValueToString>>();
+            assert_eq!(list.len(), 2);
+            let mut expected = ["123", "42"].into_iter().collect::<FxHashSet<_>>();
+            for collectible in list {
+                assert!(expected.remove(collectible.to_string().await?.as_str()))
+            }
+            assert_eq!(result_val.0, 0);
+            Ok(Vc::cell(()))
         }
-        assert_eq!(result_val.0, 0);
+
+        operation().read_strongly_consistent().await?;
         anyhow::Ok(())
     })
     .await
@@ -39,16 +41,22 @@ async fn test_transitive_emitting() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_transitive_emitting_indirect() {
     run_once(&REGISTRATION, async || {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-        let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
-        let collectibles_op = my_transitive_emitting_function_collectibles(rcstr!(""), rcstr!(""));
-        let list = collectibles_op.connect().strongly_consistent().await?;
-        assert_eq!(list.len(), 2);
-        let mut expected = ["123", "42"].into_iter().collect::<FxHashSet<_>>();
-        for collectible in list.iter() {
-            assert!(expected.remove(collectible.to_string().await?.as_str()))
+        #[turbo_tasks::function(operation, root)]
+        async fn operation() -> Result<Vc<()>> {
+            let result_op = my_transitive_emitting_function(rcstr!(""), rcstr!(""));
+            let collectibles_op =
+                my_transitive_emitting_function_collectibles(rcstr!(""), rcstr!(""));
+            let list = collectibles_op.connect().await?;
+            assert_eq!(list.len(), 2);
+            let mut expected = ["123", "42"].into_iter().collect::<FxHashSet<_>>();
+            for collectible in list.iter() {
+                assert!(expected.remove(collectible.to_string().await?.as_str()))
+            }
+            assert_eq!(result_op.connect().await?.0, 0);
+            Ok(Vc::cell(()))
         }
-        assert_eq!(result_op.connect().await?.0, 0);
+
+        operation().read_strongly_consistent().await?;
         anyhow::Ok(())
     })
     .await
@@ -58,16 +66,21 @@ async fn test_transitive_emitting_indirect() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_multi_emitting() {
     run_once(&REGISTRATION, async || {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-        let result_op = my_multi_emitting_function();
-        let result_val = result_op.connect().strongly_consistent().await?;
-        let list = result_op.peek_collectibles::<Box<dyn ValueToString>>();
-        assert_eq!(list.len(), 2);
-        let mut expected = ["123", "42"].into_iter().collect::<FxHashSet<_>>();
-        for collectible in list {
-            assert!(expected.remove(collectible.to_string().await?.as_str()))
+        #[turbo_tasks::function(operation, root)]
+        async fn operation() -> Result<Vc<()>> {
+            let result_op = my_multi_emitting_function();
+            let result_val = result_op.connect().await?;
+            let list = result_op.peek_collectibles::<Box<dyn ValueToString>>();
+            assert_eq!(list.len(), 2);
+            let mut expected = ["123", "42"].into_iter().collect::<FxHashSet<_>>();
+            for collectible in list {
+                assert!(expected.remove(collectible.to_string().await?.as_str()))
+            }
+            assert_eq!(result_val.0, 0);
+            Ok(Vc::cell(()))
         }
-        assert_eq!(result_val.0, 0);
+
+        operation().read_strongly_consistent().await?;
         anyhow::Ok(())
     })
     .await

--- a/turbopack/crates/turbo-tasks-backend/tests/errors.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/errors.rs
@@ -7,9 +7,7 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use indoc::indoc;
-use turbo_tasks::{
-    PrettyPrintError, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
-};
+use turbo_tasks::{OperationVc, PrettyPrintError, Vc, VcValueType};
 use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
@@ -18,11 +16,27 @@ static REGISTRATION: Registration = register!();
 // Helper function to test error messages
 // ============================================================================
 
-async fn assert_error<T: Debug>(
+async fn assert_error<T: VcValueType>(
+    operation: OperationVc<T>,
+    expected: &'static str,
+) -> Result<()> {
+    let error = match operation.read_strongly_consistent().await {
+        Ok(_) => panic!("expected an error"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        &PrettyPrintError(&error).to_string(),
+        expected,
+        "{:#?}",
+        error
+    );
+    Ok(())
+}
+
+async fn assert_future_error<T: Debug>(
     future: impl IntoFuture<Output = Result<T>>,
     expected: &'static str,
 ) -> Result<()> {
-    unmark_top_level_task_may_leak_eventually_consistent_state();
     let error = future.into_future().await.unwrap_err();
     assert_eq!(
         &PrettyPrintError(&error).to_string(),
@@ -44,22 +58,22 @@ where
 // Direct error functions
 // ============================================================================
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation, root)]
 fn direct_bail() -> Result<Vc<u32>> {
     bail!("direct bail error")
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation, root)]
 fn direct_bail_with_context() -> Result<Vc<u32>> {
     Err(anyhow::anyhow!("direct bail error")).context("bail-context")
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation, root)]
 fn direct_panic() -> Result<Vc<u32>> {
     panic!("direct panic error")
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation, root)]
 fn direct_panic_with_context() -> Result<Vc<u32>> {
     // Note: panic! is synchronous, so context cannot wrap it
     panic!("direct panic error")
@@ -69,27 +83,27 @@ fn direct_panic_with_context() -> Result<Vc<u32>> {
 // Indirect error functions (call another function that errors)
 // ============================================================================
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation, root)]
 async fn indirect_bail() -> Result<Vc<u32>> {
-    direct_bail().await?;
+    direct_bail().connect().await?;
     Ok(Vc::cell(0))
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation, root)]
 async fn indirect_bail_with_context() -> Result<Vc<u32>> {
-    direct_bail().await.context("indirect-context")?;
+    direct_bail().connect().await.context("indirect-context")?;
     Ok(Vc::cell(0))
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation, root)]
 async fn indirect_panic() -> Result<Vc<u32>> {
-    direct_panic().await?;
+    direct_panic().connect().await?;
     Ok(Vc::cell(0))
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation, root)]
 async fn indirect_panic_with_context() -> Result<Vc<u32>> {
-    direct_panic().await.context("indirect-context")?;
+    direct_panic().connect().await.context("indirect-context")?;
     Ok(Vc::cell(0))
 }
 
@@ -251,46 +265,70 @@ async fn test_indirect_panic_with_context() {
 }
 
 // ============================================================================
-// In-context wrapper functions (not turbo_tasks functions)
+// In-context wrapper operations
 // ============================================================================
 
 async fn direct_bail_in_context() -> Result<()> {
-    direct_bail().await.context("in-context")?;
+    direct_bail()
+        .read_strongly_consistent()
+        .await
+        .context("in-context")?;
     Ok(())
 }
 
 async fn direct_bail_with_context_in_context() -> Result<()> {
-    direct_bail_with_context().await.context("in-context")?;
+    direct_bail_with_context()
+        .read_strongly_consistent()
+        .await
+        .context("in-context")?;
     Ok(())
 }
 
 async fn direct_panic_in_context() -> Result<()> {
-    direct_panic().await.context("in-context")?;
+    direct_panic()
+        .read_strongly_consistent()
+        .await
+        .context("in-context")?;
     Ok(())
 }
 
 async fn direct_panic_with_context_in_context() -> Result<()> {
-    direct_panic_with_context().await.context("in-context")?;
+    direct_panic_with_context()
+        .read_strongly_consistent()
+        .await
+        .context("in-context")?;
     Ok(())
 }
 
 async fn indirect_bail_in_context() -> Result<()> {
-    indirect_bail().await.context("in-context")?;
+    indirect_bail()
+        .read_strongly_consistent()
+        .await
+        .context("in-context")?;
     Ok(())
 }
 
 async fn indirect_bail_with_context_in_context() -> Result<()> {
-    indirect_bail_with_context().await.context("in-context")?;
+    indirect_bail_with_context()
+        .read_strongly_consistent()
+        .await
+        .context("in-context")?;
     Ok(())
 }
 
 async fn indirect_panic_in_context() -> Result<()> {
-    indirect_panic().await.context("in-context")?;
+    indirect_panic()
+        .read_strongly_consistent()
+        .await
+        .context("in-context")?;
     Ok(())
 }
 
 async fn indirect_panic_with_context_in_context() -> Result<()> {
-    indirect_panic_with_context().await.context("in-context")?;
+    indirect_panic_with_context()
+        .read_strongly_consistent()
+        .await
+        .context("in-context")?;
     Ok(())
 }
 
@@ -301,7 +339,7 @@ async fn indirect_panic_with_context_in_context() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_bail_in_context() {
     test(async || {
-        assert_error(
+        assert_future_error(
             direct_bail_in_context(),
             indoc! {"
                 in-context
@@ -322,7 +360,7 @@ async fn test_direct_bail_in_context() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_bail_with_context_in_context() {
     test(async || {
-        assert_error(
+        assert_future_error(
             direct_bail_with_context_in_context(),
             indoc! {"
                 in-context
@@ -345,7 +383,7 @@ async fn test_direct_bail_with_context_in_context() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_panic_in_context() {
     test(async || {
-        assert_error(
+        assert_future_error(
             direct_panic_in_context(),
             indoc! {"
                 in-context
@@ -366,7 +404,7 @@ async fn test_direct_panic_in_context() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_direct_panic_with_context_in_context() {
     test(async || {
-        assert_error(
+        assert_future_error(
             direct_panic_with_context_in_context(),
             indoc! {"
                 in-context
@@ -387,7 +425,7 @@ async fn test_direct_panic_with_context_in_context() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_bail_in_context() {
     test(async || {
-        assert_error(
+        assert_future_error(
             indirect_bail_in_context(),
             indoc! {"
                 in-context
@@ -409,7 +447,7 @@ async fn test_indirect_bail_in_context() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_bail_with_context_in_context() {
     test(async || {
-        assert_error(
+        assert_future_error(
             indirect_bail_with_context_in_context(),
             indoc! {"
                 in-context
@@ -433,7 +471,7 @@ async fn test_indirect_bail_with_context_in_context() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_panic_in_context() {
     test(async || {
-        assert_error(
+        assert_future_error(
             indirect_panic_in_context(),
             indoc! {"
                 in-context
@@ -455,7 +493,7 @@ async fn test_indirect_panic_in_context() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_indirect_panic_with_context_in_context() {
     test(async || {
-        assert_error(
+        assert_future_error(
             indirect_panic_with_context_in_context(),
             indoc! {"
                 in-context

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_collection.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_collection.rs
@@ -8,23 +8,21 @@ mod util;
 use std::sync::Arc;
 
 use anyhow::Result;
-use turbo_tasks::{
-    ResolvedVc, TaskId, Vc, prevent_gc, unmark_top_level_task_may_leak_eventually_consistent_state,
-};
+use turbo_tasks::{ResolvedVc, TaskId, Vc, prevent_gc};
 
 use crate::{
     gc_fixture::{Selector, create_selector},
     util::create_tt,
 };
 
-/// The `TaskId` backing a resolved `Vc` (its `TaskOutput` node).
+/// The `TaskId` backing a `Vc`'s `TaskOutput` node.
 fn task_id_of<T>(vc: Vc<T>) -> TaskId {
     Vc::into_raw(vc)
         .try_get_task_id()
         .expect("a resolved Vc should be backed by a task")
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(root)]
 fn leaf(n: u32) -> Vc<u32> {
     Vc::cell(n)
 }
@@ -196,11 +194,10 @@ async fn dispose_root_task_releases_anchored_subgraph() {
         let tx = tx.lock().unwrap().take();
         Box::pin(async move {
             // The root body runs as a top-level task, as `subscribe`'s HMR handler does.
-            unmark_top_level_task_may_leak_eventually_consistent_state();
             let leaf_vc = leaf(88);
-            let value = *leaf_vc.await?;
+            let value = *leaf_vc.strongly_consistent().await?;
             if let Some(tx) = tx {
-                let _ = tx.send(task_id_of(leaf_vc.resolve().await?));
+                let _ = tx.send(task_id_of(leaf_vc));
             }
             anyhow::Ok(Vc::<u32>::cell(value))
         })

--- a/turbopack/crates/turbo-tasks-backend/tests/immutable.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/immutable.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
 use anyhow::Result;
-use turbo_tasks::{State, Vc, unmark_top_level_task_may_leak_eventually_consistent_state};
+use turbo_tasks::{ResolvedVc, State, Vc};
 use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
@@ -11,37 +11,46 @@ static REGISTRATION: Registration = register!();
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_hidden_mutate() {
     run_once(&REGISTRATION, async || {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-        let input = *create_input().to_resolved().await?;
+        #[turbo_tasks::function(operation, root)]
+        fn read_self_operation(input: ResolvedVc<Value>) -> Vc<u32> {
+            input.read_self()
+        }
+
+        #[turbo_tasks::function(operation, root)]
+        fn immutable_self_operation(input: ResolvedVc<Value>) -> Vc<u32> {
+            input.immutable_self_fn()
+        }
+
+        let input = create_input().resolve().strongly_consistent().await?;
         input.await?.state.set(1);
         let changing_value = compute(input);
-        assert_eq!(changing_value.await?.value, 1);
+        assert_eq!(changing_value.read_strongly_consistent().await?.value, 1);
 
-        let changing_value_resolved = *changing_value.to_resolved().await?;
+        let changing_value_resolved = changing_value.resolve().strongly_consistent().await?;
         let read_input = read_input(changing_value_resolved);
         let static_immutable = immutable_fn(changing_value_resolved);
-        let read_self = changing_value_resolved.read_self();
-        let static_immutable_self = changing_value_resolved.immutable_self_fn();
-        assert_eq!(*read_input.await?, 1);
-        assert_eq!(*static_immutable.await?, 42);
-        assert_eq!(*read_self.await?, 1);
-        assert_eq!(*static_immutable_self.await?, 42);
+        let read_self = read_self_operation(changing_value_resolved);
+        let static_immutable_self = immutable_self_operation(changing_value_resolved);
+        assert_eq!(*read_input.read_strongly_consistent().await?, 1);
+        assert_eq!(*static_immutable.read_strongly_consistent().await?, 42);
+        assert_eq!(*read_self.read_strongly_consistent().await?, 1);
+        assert_eq!(*static_immutable_self.read_strongly_consistent().await?, 42);
 
         println!("changing input");
         input.await?.state.set(10);
-        assert_eq!(changing_value.strongly_consistent().await?.value, 10);
-        assert_eq!(*read_input.strongly_consistent().await?, 10);
-        assert_eq!(*static_immutable.strongly_consistent().await?, 42);
-        assert_eq!(*read_self.strongly_consistent().await?, 10);
-        assert_eq!(*static_immutable_self.strongly_consistent().await?, 42);
+        assert_eq!(changing_value.read_strongly_consistent().await?.value, 10);
+        assert_eq!(*read_input.read_strongly_consistent().await?, 10);
+        assert_eq!(*static_immutable.read_strongly_consistent().await?, 42);
+        assert_eq!(*read_self.read_strongly_consistent().await?, 10);
+        assert_eq!(*static_immutable_self.read_strongly_consistent().await?, 42);
 
         println!("changing input");
         input.await?.state.set(5);
-        assert_eq!(changing_value.strongly_consistent().await?.value, 5);
-        assert_eq!(*read_input.strongly_consistent().await?, 5);
-        assert_eq!(*static_immutable.strongly_consistent().await?, 42);
-        assert_eq!(*read_self.strongly_consistent().await?, 5);
-        assert_eq!(*static_immutable_self.strongly_consistent().await?, 42);
+        assert_eq!(changing_value.read_strongly_consistent().await?.value, 5);
+        assert_eq!(*read_input.read_strongly_consistent().await?, 5);
+        assert_eq!(*static_immutable.read_strongly_consistent().await?, 42);
+        assert_eq!(*read_self.read_strongly_consistent().await?, 5);
+        assert_eq!(*static_immutable_self.read_strongly_consistent().await?, 42);
 
         anyhow::Ok(())
     })
@@ -59,7 +68,7 @@ struct Value {
     value: u32,
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation, root)]
 async fn create_input() -> Result<Vc<ChangingInput>> {
     println!("create_input()");
     Ok(ChangingInput {
@@ -68,23 +77,23 @@ async fn create_input() -> Result<Vc<ChangingInput>> {
     .cell())
 }
 
-#[turbo_tasks::function(root)]
-async fn compute(input: Vc<ChangingInput>) -> Result<Vc<Value>> {
+#[turbo_tasks::function(operation, root)]
+async fn compute(input: ResolvedVc<ChangingInput>) -> Result<Vc<Value>> {
     println!("compute()");
     let input = input.await?;
     let value = input.state.get();
     Ok(Value { value: *value }.cell())
 }
 
-#[turbo_tasks::function(root)]
-async fn read_input(input: Vc<Value>) -> Result<Vc<u32>> {
+#[turbo_tasks::function(operation, root)]
+async fn read_input(input: ResolvedVc<Value>) -> Result<Vc<u32>> {
     println!("read_input()");
     let value = input.await?;
     Ok(Vc::cell(value.value))
 }
 
-#[turbo_tasks::function(root)]
-fn immutable_fn(input: Vc<Value>) -> Vc<u32> {
+#[turbo_tasks::function(operation, root)]
+fn immutable_fn(input: ResolvedVc<Value>) -> Vc<u32> {
     let _ = input;
     println!("immutable_fn()");
     Vc::cell(42)

--- a/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/parent_count.rs
@@ -5,9 +5,7 @@
 mod util;
 
 use anyhow::Result;
-use turbo_tasks::{
-    ResolvedVc, State, TaskId, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
-};
+use turbo_tasks::{ResolvedVc, State, TaskId, Vc};
 
 use crate::util::create_tt;
 
@@ -62,8 +60,6 @@ async fn parent_count_tracks_connect_and_disconnect() {
     let tt2 = tt.clone();
 
     let result = turbo_tasks::run_once(tt.clone(), async move {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-
         let selector_op = create_selector(false);
         let selector_vc = selector_op.resolve().strongly_consistent().await?;
         let selector = selector_op.read_strongly_consistent().await?;
@@ -73,9 +69,9 @@ async fn parent_count_tracks_connect_and_disconnect() {
         assert_eq!(*output.read_strongly_consistent().await?, 11);
 
         // Resolve the branch task ids (calling the cached functions returns the same tasks).
-        let branch_a_id = task_id_of(branch_a().resolve().await?);
-        let leaf10_id = task_id_of(leaf(10).resolve().await?);
-        let branch_b_id = task_id_of(branch_b().resolve().await?);
+        let branch_a_id = task_id_of(branch_a());
+        let leaf10_id = task_id_of(leaf(10));
+        let branch_b_id = task_id_of(branch_b());
 
         assert_eq!(
             tt2.backend().parent_count_for_testing(branch_a_id),
@@ -148,8 +144,6 @@ async fn parent_count_not_double_counted_on_revalidation() {
     let tt2 = tt.clone();
 
     let result = turbo_tasks::run_once(tt.clone(), async move {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-
         let selector_op = create_selector(false);
         let selector_vc = selector_op.resolve().strongly_consistent().await?;
         let selector = selector_op.read_strongly_consistent().await?;
@@ -157,7 +151,7 @@ async fn parent_count_not_double_counted_on_revalidation() {
         let output = stable_child_parent(selector_vc);
         assert_eq!(*output.read_strongly_consistent().await?, 30);
 
-        let leaf30_id = task_id_of(leaf(30).resolve().await?);
+        let leaf30_id = task_id_of(leaf(30));
         assert_eq!(
             tt2.backend().parent_count_for_testing(leaf30_id),
             1,

--- a/turbopack/crates/turbo-tasks-backend/tests/recompute.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/recompute.rs
@@ -3,9 +3,7 @@
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
 use anyhow::Result;
-use turbo_tasks::{
-    ResolvedVc, State, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
-};
+use turbo_tasks::{ResolvedVc, State, Vc};
 use turbo_tasks_testing::{Registration, register, run, run_once};
 
 static REGISTRATION: Registration = register!();
@@ -13,38 +11,37 @@ static REGISTRATION: Registration = register!();
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recompute() {
     run_once(&REGISTRATION, async || {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
         let input = ChangingInput {
             state: State::new(1),
         }
-        .cell();
+        .resolved_cell();
         let input2 = ChangingInput {
             state: State::new(10),
         }
-        .cell();
+        .resolved_cell();
         let output = compute(input, input2);
-        let read = output.await?;
+        let read = output.read_strongly_consistent().await?;
         assert_eq!(read.state_value, 1);
         assert_eq!(read.state_value2, 10);
         let random_value = read.random_value;
 
         println!("changing input");
         input.await?.state.set(2);
-        let read = output.strongly_consistent().await?;
+        let read = output.read_strongly_consistent().await?;
         assert_eq!(read.state_value, 2);
         assert_ne!(read.random_value, random_value);
         let random_value = read.random_value;
 
         println!("changing input2");
         input2.await?.state.set(20);
-        let read = output.strongly_consistent().await?;
+        let read = output.read_strongly_consistent().await?;
         assert_eq!(read.state_value2, 20);
         assert_ne!(read.random_value, random_value);
         let random_value = read.random_value;
 
         println!("changing input");
         input.await?.state.set(5);
-        let read = output.strongly_consistent().await?;
+        let read = output.read_strongly_consistent().await?;
         assert_eq!(read.state_value, 5);
         assert_eq!(read.state_value2, 42);
         assert_ne!(read.random_value, random_value);
@@ -52,7 +49,7 @@ async fn recompute() {
 
         println!("changing input2");
         input2.await?.state.set(30);
-        let read = output.strongly_consistent().await?;
+        let read = output.read_strongly_consistent().await?;
         assert_eq!(read.random_value, random_value);
 
         anyhow::Ok(())
@@ -64,7 +61,6 @@ async fn recompute() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn immutable_analysis() {
     run_once(&REGISTRATION, async || {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
         let input = ChangingInput {
             state: State::new(1),
         }
@@ -105,7 +101,7 @@ struct VcHolder {
 impl VcHolder {
     #[turbo_tasks::function(root)]
     fn compute(&self) -> Vc<Output> {
-        compute(*self.vc, *self.vc)
+        compute(self.vc, self.vc).connect()
     }
 }
 
@@ -116,11 +112,14 @@ struct Output {
     random_value: u32,
 }
 
-#[turbo_tasks::function(root)]
-async fn compute(input: Vc<ChangingInput>, input2: Vc<ChangingInput>) -> Result<Vc<Output>> {
+#[turbo_tasks::function(operation, root)]
+async fn compute(
+    input: ResolvedVc<ChangingInput>,
+    input2: ResolvedVc<ChangingInput>,
+) -> Result<Vc<Output>> {
     let state_value = *input.await?.state.get();
     let state_value2 = if state_value < 5 {
-        *compute2(input2).await?
+        *compute2(*input2).await?
     } else {
         42
     };
@@ -150,15 +149,17 @@ async fn compute2(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recompute_dependency() {
     run(&REGISTRATION, async || {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-        let input = *get_dependency_input().to_resolved().await?;
+        let input = get_dependency_input()
+            .resolve()
+            .strongly_consistent()
+            .await?;
         // Reset state to 1 at the start of each iteration (important for multi-run tests)
         input.await?.state.set(1);
 
         // Initial execution - establishes dependency chain:
         // outer_compute -> inner_compute -> input.state
         let output = outer_compute(input);
-        let read = output.strongly_consistent().await?;
+        let read = output.read_strongly_consistent().await?;
         println!(
             "first read: value={}, inner_random={}, outer_random={}",
             read.value, read.inner_random, read.outer_random
@@ -172,7 +173,7 @@ async fn recompute_dependency() {
         println!("changing input");
         input.await?.state.set(2);
 
-        let read = output.strongly_consistent().await?;
+        let read = output.read_strongly_consistent().await?;
         println!(
             "second read: value={}, inner_random={}, outer_random={}",
             read.value, read.inner_random, read.outer_random
@@ -201,7 +202,7 @@ async fn recompute_dependency() {
     .unwrap();
 }
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation, root)]
 fn get_dependency_input() -> Vc<ChangingInput> {
     ChangingInput {
         state: State::new(1),
@@ -227,10 +228,10 @@ async fn inner_compute(input: Vc<ChangingInput>) -> Result<Vc<u32>> {
 }
 
 /// Outer task - depends on inner_compute
-#[turbo_tasks::function(root)]
-async fn outer_compute(input: Vc<ChangingInput>) -> Result<Vc<DependencyOutput>> {
+#[turbo_tasks::function(operation, root)]
+async fn outer_compute(input: ResolvedVc<ChangingInput>) -> Result<Vc<DependencyOutput>> {
     println!("outer_compute()");
-    let inner_result = *inner_compute(input).await?;
+    let inner_result = *inner_compute(*input).await?;
     let value = inner_result & 0xFFFF;
     let inner_random = inner_result >> 16;
     Ok(DependencyOutput {

--- a/turbopack/crates/turbo-tasks-backend/tests/recompute_collectibles.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/recompute_collectibles.rs
@@ -4,10 +4,7 @@
 
 use anyhow::{Result, bail};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{
-    CollectiblesSource, ResolvedVc, State, ValueToString, Vc, emit,
-    unmark_top_level_task_may_leak_eventually_consistent_state,
-};
+use turbo_tasks::{CollectiblesSource, ResolvedVc, State, ValueToString, Vc, emit};
 use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
@@ -15,26 +12,31 @@ static REGISTRATION: Registration = register!();
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn recompute() {
     run_once(&REGISTRATION, async || {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
-        let input = *ChangingInput::new(1).to_resolved().await?;
-        let input2 = *ChangingInput::new(2).to_resolved().await?;
+        let input = ChangingInput {
+            state: State::new(1),
+        }
+        .resolved_cell();
+        let input2 = ChangingInput {
+            state: State::new(1),
+        }
+        .resolved_cell();
         input.await?.state.set(1);
         input2.await?.state.set(1000);
         let output = compute(input, input2, 1);
-        let read = output.strongly_consistent().await?;
+        let read = output.read_strongly_consistent().await?;
         assert_eq!(read.value, 42);
         assert_eq!(read.collectible, "1");
 
         for i in 2..100 {
             input.await?.state.set(i);
-            let read = output.strongly_consistent().await?;
+            let read = output.read_strongly_consistent().await?;
             assert_eq!(read.value, 42);
             assert_eq!(read.collectible, i.to_string());
         }
 
         for i in 0..100 {
             input2.await?.state.set(i);
-            let read = output.strongly_consistent().await?;
+            let read = output.read_strongly_consistent().await?;
             assert_eq!(read.value, 42);
             assert_eq!(read.collectible, "99");
         }
@@ -47,18 +49,6 @@ async fn recompute() {
 #[turbo_tasks::value]
 struct ChangingInput {
     state: State<u32>,
-}
-
-#[turbo_tasks::value_impl]
-impl ChangingInput {
-    #[turbo_tasks::function]
-    fn new(key: u32) -> Vc<Self> {
-        let _ = key;
-        Self {
-            state: State::new(1),
-        }
-        .cell()
-    }
 }
 
 #[turbo_tasks::value]
@@ -103,7 +93,7 @@ async fn inner_compute2(input: Vc<ChangingInput>, innerness: u32) -> Result<Vc<u
     Ok(Vc::cell(42))
 }
 
-#[turbo_tasks::function(root)]
+#[turbo_tasks::function(operation, root)]
 async fn compute(
     input: ResolvedVc<ChangingInput>,
     input2: ResolvedVc<ChangingInput>,
@@ -111,7 +101,7 @@ async fn compute(
 ) -> Result<Vc<Output>> {
     println!("compute({innerness})");
     if innerness > 0 {
-        return Ok(compute(*input, *input2, innerness - 1));
+        return Ok(compute(input, input2, innerness - 1).connect());
     }
     let operation = inner_compute(input, input2);
     let value = *operation.connect().await?;

--- a/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell_mode.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trait_ref_cell_mode.rs
@@ -2,9 +2,7 @@
 #![feature(arbitrary_self_types_pointers)]
 
 use anyhow::Result;
-use turbo_tasks::{
-    State, TraitRef, Upcast, Vc, unmark_top_level_task_may_leak_eventually_consistent_state,
-};
+use turbo_tasks::{ResolvedVc, State, TraitRef, Upcast, Vc};
 use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
@@ -14,25 +12,35 @@ static REGISTRATION: Registration = register!();
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trait_ref_shared_cell_mode() {
     run_once(&REGISTRATION, async || {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
+        #[turbo_tasks::function(operation, root)]
+        fn operation(input: ResolvedVc<CellIdSelector>) -> Vc<Box<dyn ValueTrait>> {
+            shared_value_from_input(*input)
+        }
+
         let input = CellIdSelector {
             value: 42,
             cell_idx: State::new(0),
         }
-        .cell();
+        .resolved_cell();
 
         // create the task and compute it
-        let counter_value_vc = shared_value_from_input(input);
-        let trait_ref_a = counter_value_vc.into_trait_ref().await?;
+        let counter_value_op = operation(input);
+        let trait_ref_a = counter_value_op.read_trait_strongly_consistent().await?;
 
         // invalidate the task, and pick a different cell id for the next execution
         input.await?.cell_idx.set_unconditionally(1);
 
         // recompute the task
-        let trait_ref_b = counter_value_vc.into_trait_ref().await?;
+        let trait_ref_b = counter_value_op.read_trait_strongly_consistent().await?;
 
         for trait_ref in [&trait_ref_a, &trait_ref_b] {
-            assert_eq!(*TraitRef::cell(trait_ref.clone()).get_value().await?, 42);
+            assert_eq!(
+                *TraitRef::cell(trait_ref.clone())
+                    .get_value()
+                    .strongly_consistent()
+                    .await?,
+                42
+            );
         }
 
         // because we're using `cell = "compare"`, these trait refs must use the same
@@ -50,25 +58,35 @@ async fn test_trait_ref_shared_cell_mode() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trait_ref_new_cell_mode() {
     run_once(&REGISTRATION, async || {
-        unmark_top_level_task_may_leak_eventually_consistent_state();
+        #[turbo_tasks::function(operation, root)]
+        fn operation(input: ResolvedVc<CellIdSelector>) -> Vc<Box<dyn ValueTrait>> {
+            new_value_from_input(*input)
+        }
+
         let input = CellIdSelector {
             value: 42,
             cell_idx: State::new(0),
         }
-        .cell();
+        .resolved_cell();
 
         // create the task and compute it
-        let counter_value_vc = new_value_from_input(input);
-        let trait_ref_a = counter_value_vc.into_trait_ref().await?;
+        let counter_value_op = operation(input);
+        let trait_ref_a = counter_value_op.read_trait_strongly_consistent().await?;
 
         // invalidate the task, and pick a different cell id for the next execution
         input.await?.cell_idx.set_unconditionally(1);
 
         // recompute the task
-        let trait_ref_b = counter_value_vc.into_trait_ref().await?;
+        let trait_ref_b = counter_value_op.read_trait_strongly_consistent().await?;
 
         for trait_ref in [&trait_ref_a, &trait_ref_b] {
-            assert_eq!(*TraitRef::cell(trait_ref.clone()).get_value().await?, 42);
+            assert_eq!(
+                *TraitRef::cell(trait_ref.clone())
+                    .get_value()
+                    .strongly_consistent()
+                    .await?,
+                42
+            );
         }
 
         // because we're using `cell = "new"`, these trait refs must use different
@@ -83,7 +101,7 @@ async fn test_trait_ref_new_cell_mode() {
 
 #[turbo_tasks::value_trait]
 trait ValueTrait {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(root)]
     fn get_value(&self) -> Vc<usize>;
 }
 
@@ -95,7 +113,7 @@ struct NewValue(usize);
 
 #[turbo_tasks::value_impl]
 impl ValueTrait for SharedValue {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(root)]
     fn get_value(&self) -> Vc<usize> {
         Vc::cell(self.0)
     }
@@ -103,7 +121,7 @@ impl ValueTrait for SharedValue {
 
 #[turbo_tasks::value_impl]
 impl ValueTrait for NewValue {
-    #[turbo_tasks::function]
+    #[turbo_tasks::function(root)]
     fn get_value(&self) -> Vc<usize> {
         Vc::cell(self.0)
     }


### PR DESCRIPTION
### What?

Remove all 14 remaining non-API `unmark_top_level_task_may_leak_eventually_consistent_state()` calls from Turbopack tests across eight files. The manual mark/unmark consistency test remains unchanged because it intentionally covers this API.

### Why?

Top-level test reads should state their consistency boundary explicitly instead of globally permitting eventually consistent state. Removing the suppressions makes accidental eventual reads fail normally and keeps each test aligned with production consistency rules.

### How?

Use coarse operation roots for collectible and recomputation scenarios where the operation can settle, and narrower phase boundaries for tests that mutate dependencies. Preserve graph-sensitive behavior by extracting task IDs without resolving in parent-count tests and by strongly reading the existing leaf root without inserting wrapper parents in GC tests. Error tests use separate operation and plain-future helpers so their expected context stacks remain unchanged.

### Verification

- `cargo fmt --all -- --check`
- `timeout 300 cargo test -p turbo-tasks-backend --test parent_count --test trait_ref_cell_mode --test recompute_collectibles --test recompute --test collectibles --test errors --test immutable --test gc_collection` (36 passed)
- `git diff --check`

<!-- NEXT_JS_LLM -->

<!-- fleet 475180cd-06a7-4669-89b5-a2029a3a18c9 -->