### PR TITLE
Added notice for root-params under Route Groups

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
+++ b/docs/01-app/03-api-reference/04-functions/next-root-params.mdx
@@ -48,6 +48,7 @@ Root parameters are the [dynamic segments](/docs/app/api-reference/file-conventi
 > - Root parameter names must be valid JavaScript function identifiers. Kebab-cased segment names (e.g. `[post-slug]`) are not supported and will cause an error at dev time or during build.
 > - `next/root-params` can be used in Server Components. It cannot be used in Client Components, Server Actions, or [Route Handlers](/docs/app/api-reference/file-conventions/route). Support for Route Handlers is planned for a future release.
 > - Types for the `next/root-params` exports are generated during `next dev`, `next build`, or [`next typegen`](/docs/app/api-reference/cli/next#next-typegen-options), the same as [`PageProps` and `LayoutProps`](/docs/app/api-reference/config/typescript#route-aware-type-helpers).
+> - Root parameters must not be under any [Route Group](/docs/app/api-reference/file-conventions/route-groups). Any Route Group that you have will not allow the compiler to generate and therefore export the params.
 
 ## Root parameters and `generateStaticParams`
 


### PR DESCRIPTION
Added a warning for root-params used inside Route Groups. When a root parameter exists within a Route Group, the compiler is unable to generate and export the corresponding parameters. As a result, the application cannot consume those parameters correctly and an unclear compiler error is displayed.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

We encourage you to use AI to assist you in researching, creating, and reviewing changes. However, you must review and deeply understand the contributions you are making. For this reason, **pull request descriptions from external contributors must be written by a human**.

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Signed commits

- This repository requires verified commit signatures on protected branches.
- If this pull request is blocked for unsigned commits, re-sign the commits and force-push the branch.
- A `Signed-off-by` line in the commit message is not enough.

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

Added note for root-params under Route Groups

### Why?

Any root-param that happens to be under any Route Group will not allow the compiler to generate and export the param

### How?

Adding a small notice under the root-params documentation about this case, so devs are reminded of this

Closes NEXT-
Fixes # 

-->
