### PR TITLE
Turbopack: fix output tracing include glob traversal

### DIFF
--- a/crates/next-api/src/nft.rs
+++ b/crates/next-api/src/nft.rs
@@ -181,18 +181,30 @@ pub async fn trace_endpoint(
 /// a directory (including a directory symlink) matched by the user pattern without making the
 /// original pattern an unanchored partial match.
 fn include_glob_pattern(globs: &[&str]) -> RcStr {
-    let mut alternatives = Vec::with_capacity(globs.len() * 2);
-    for glob in globs {
-        alternatives.push((*glob).to_owned());
+    if globs.contains(&"**") {
+        return rcstr!("**");
+    }
+    if let [glob] = globs
+        && glob.ends_with("/**")
+    {
+        return RcStr::from(*glob);
+    }
+
+    let mut pattern = String::new();
+    pattern.push('{');
+    for (index, glob) in globs.iter().enumerate() {
+        if index > 0 {
+            pattern.push(',');
+        }
+        pattern.push_str(glob);
         if *glob != "**" && !glob.ends_with("/**") {
-            alternatives.push(format!("{glob}/**"));
+            pattern.push(',');
+            pattern.push_str(glob);
+            pattern.push_str("/**");
         }
     }
-    if alternatives.len() == 1 {
-        alternatives.pop().unwrap().into()
-    } else {
-        format!("{{{}}}", alternatives.join(",")).into()
-    }
+    pattern.push('}');
+    pattern.into()
 }
 
 /// Apply outputFileTracingIncludes patterns to find additional files
@@ -642,13 +654,16 @@ mod include_glob_tests {
 
     #[test]
     fn include_glob_supports_braces_and_multiple_patterns() {
-        let glob = glob(&["assets/{one,two}", "config/*.json"]);
+        let combined = glob(&["assets/{one,two}", "config/*.json"]);
 
-        assert!(glob.matches("assets/one"));
-        assert!(glob.matches("assets/two/nested.txt"));
-        assert!(glob.matches("config/runtime.json"));
-        assert!(!glob.matches("config/nested/runtime.json"));
-        assert!(!glob.matches("assets/three"));
+        assert!(combined.matches("assets/one"));
+        assert!(combined.matches("assets/two/nested.txt"));
+        assert!(combined.matches("config/runtime.json"));
+        assert!(!combined.matches("config/nested/runtime.json"));
+        assert!(!combined.matches("assets/three"));
+
+        let match_all = glob(&["config/*.json", "**"]);
+        assert!(match_all.matches("any/deeply/nested/file"));
     }
 }
 
@@ -675,17 +690,8 @@ mod tests {
             .root()
             .owned()
             .await?;
-        let includes = get_glob_includes(
-            root,
-            Glob::new(
-                rcstr!("**"),
-                GlobOptions {
-                    contains: true,
-                    ..Default::default()
-                },
-            ),
-        )
-        .await?;
+        let includes =
+            get_glob_includes(root, Glob::new(rcstr!("**"), GlobOptions::default())).await?;
 
         assert_eq!(
             includes

--- a/crates/next-api/src/nft.rs
+++ b/crates/next-api/src/nft.rs
@@ -184,12 +184,6 @@ fn include_glob_pattern(globs: &[&str]) -> RcStr {
     if globs.contains(&"**") {
         return rcstr!("**");
     }
-    if let [glob] = globs
-        && glob.ends_with("/**")
-    {
-        return RcStr::from(*glob);
-    }
-
     let mut pattern = String::new();
     pattern.push('{');
     for (index, glob) in globs.iter().enumerate() {
@@ -197,7 +191,9 @@ fn include_glob_pattern(globs: &[&str]) -> RcStr {
             pattern.push(',');
         }
         pattern.push_str(glob);
-        if *glob != "**" && !glob.ends_with("/**") {
+        // A recursive suffix must remain at the end of its alternative. Appending another suffix
+        // would produce e.g. `assets/**/**`, which is invalid in the glob parser.
+        if !glob.ends_with("/**") {
             pattern.push(',');
             pattern.push_str(glob);
             pattern.push_str("/**");
@@ -639,8 +635,10 @@ mod include_glob_tests {
             let expanded = glob(&[pattern]);
 
             for path in [
+                "assets",
                 "assets/file.txt",
                 "assets/directory/nested.txt",
+                "assets/directory/deeply/nested.txt",
                 "other/assets/file.txt",
             ] {
                 assert_eq!(
@@ -661,6 +659,10 @@ mod include_glob_tests {
         assert!(combined.matches("config/runtime.json"));
         assert!(!combined.matches("config/nested/runtime.json"));
         assert!(!combined.matches("assets/three"));
+
+        let recursive = glob(&["assets/**", "config/*.json"]);
+        assert!(recursive.matches("assets/any/deeply/nested/file"));
+        assert!(recursive.matches("config/runtime.json"));
 
         let match_all = glob(&["config/*.json", "**"]);
         assert!(match_all.matches("any/deeply/nested/file"));

--- a/crates/next-api/src/nft.rs
+++ b/crates/next-api/src/nft.rs
@@ -155,13 +155,7 @@ pub async fn trace_endpoint(
             let includes = combined_includes_by_root
                 .into_iter()
                 .map(|(root, globs)| {
-                    let glob = Glob::new(
-                        format!("{{{}}}", globs.join(",")).into(),
-                        GlobOptions {
-                            contains: true,
-                            ..Default::default()
-                        },
-                    );
+                    let glob = Glob::new(include_glob_pattern(&globs), GlobOptions::default());
                     get_glob_includes(root, glob)
                 })
                 .try_join()
@@ -181,6 +175,24 @@ pub async fn trace_endpoint(
     }
     .instrument(span)
     .await
+}
+
+/// Build root-relative include alternatives. The recursive alternative preserves the contents of
+/// a directory (including a directory symlink) matched by the user pattern without making the
+/// original pattern an unanchored partial match.
+fn include_glob_pattern(globs: &[&str]) -> RcStr {
+    let mut alternatives = Vec::with_capacity(globs.len() * 2);
+    for glob in globs {
+        alternatives.push((*glob).to_owned());
+        if *glob != "**" && !glob.ends_with("/**") {
+            alternatives.push(format!("{glob}/**"));
+        }
+    }
+    if alternatives.len() == 1 {
+        alternatives.pop().unwrap().into()
+    } else {
+        format!("{{{}}}", alternatives.join(",")).into()
+    }
 }
 
 /// Apply outputFileTracingIncludes patterns to find additional files
@@ -571,6 +583,72 @@ impl Issue for ForbiddenTracedFileIssue {
             StyledString::Text(rcstr!("- remove them.")),
         ];
         Ok(Some(StyledString::Stack(stack)))
+    }
+}
+
+#[cfg(test)]
+mod include_glob_tests {
+    use turbo_rcstr::RcStr;
+    use turbo_tasks_fs::glob::{Glob, GlobOptions};
+
+    use super::include_glob_pattern;
+
+    fn glob(patterns: &[&str]) -> Glob {
+        Glob::parse(include_glob_pattern(patterns), GlobOptions::default()).unwrap()
+    }
+
+    fn plain_glob(pattern: &str) -> Glob {
+        Glob::parse(RcStr::from(pattern), GlobOptions::default()).unwrap()
+    }
+
+    #[test]
+    fn include_glob_is_root_relative() {
+        let glob = glob(&["node_modules/pkg/file.wasm"]);
+
+        assert!(glob.matches("node_modules/pkg/file.wasm"));
+        assert!(!glob.matches("nested/node_modules/pkg/file.wasm"));
+        assert!(glob.can_match_in_directory("node_modules/pkg"));
+        assert!(!glob.can_match_in_directory("node_modules/other"));
+    }
+
+    #[test]
+    fn include_glob_recurses_below_matched_directories() {
+        let glob = glob(&["assets/*"]);
+
+        assert!(glob.matches("assets/file.txt"));
+        assert!(glob.matches("assets/directory/nested.txt"));
+        assert!(!glob.matches("other/assets/file.txt"));
+    }
+
+    #[test]
+    fn include_glob_preserves_recursive_patterns() {
+        for pattern in ["assets/**/*", "assets/**", "**"] {
+            let original = plain_glob(pattern);
+            let expanded = glob(&[pattern]);
+
+            for path in [
+                "assets/file.txt",
+                "assets/directory/nested.txt",
+                "other/assets/file.txt",
+            ] {
+                assert_eq!(
+                    original.matches(path),
+                    expanded.matches(path),
+                    "pattern {pattern:?}, path {path:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn include_glob_supports_braces_and_multiple_patterns() {
+        let glob = glob(&["assets/{one,two}", "config/*.json"]);
+
+        assert!(glob.matches("assets/one"));
+        assert!(glob.matches("assets/two/nested.txt"));
+        assert!(glob.matches("config/runtime.json"));
+        assert!(!glob.matches("config/nested/runtime.json"));
+        assert!(!glob.matches("assets/three"));
     }
 }
 

--- a/test/production/app-dir/output-file-tracing-includes-read-glob/app/app/layout.tsx
+++ b/test/production/app-dir/output-file-tracing-includes-read-glob/app/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/output-file-tracing-includes-read-glob/app/app/page.tsx
+++ b/test/production/app-dir/output-file-tracing-includes-read-glob/app/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/output-file-tracing-includes-read-glob/app/include-me/file.txt
+++ b/test/production/app-dir/output-file-tracing-includes-read-glob/app/include-me/file.txt
@@ -1,0 +1,1 @@
+include me

--- a/test/production/app-dir/output-file-tracing-includes-read-glob/app/nested/include-me/file.txt
+++ b/test/production/app-dir/output-file-tracing-includes-read-glob/app/nested/include-me/file.txt
@@ -1,0 +1,1 @@
+do not include me

--- a/test/production/app-dir/output-file-tracing-includes-read-glob/app/next.config.ts
+++ b/test/production/app-dir/output-file-tracing-includes-read-glob/app/next.config.ts
@@ -1,10 +1,16 @@
+import path from 'path'
 import type { NextConfig } from 'next'
+
+const wasmPath = path
+  .relative(
+    __dirname,
+    require.resolve('lightningcss-wasm/lightningcss_node.wasm')
+  )
+  .replaceAll(path.sep, '/')
 
 const nextConfig: NextConfig = {
   outputFileTracingIncludes: {
-    '/*': [
-      '../node_modules/.pnpm/lightningcss-wasm@1.28.2_patch_hash=d2d6e72f68b8ae36c669d00a13784346180c35c614b37a4412d651117c518ecf/node_modules/lightningcss-wasm/lightningcss_node.wasm',
-    ],
+    '/*': [wasmPath],
   },
 }
 

--- a/test/production/app-dir/output-file-tracing-includes-read-glob/app/next.config.ts
+++ b/test/production/app-dir/output-file-tracing-includes-read-glob/app/next.config.ts
@@ -10,7 +10,7 @@ const wasmPath = path
 
 const nextConfig: NextConfig = {
   outputFileTracingIncludes: {
-    '/*': [wasmPath],
+    '/*': [wasmPath, 'include-me/file.txt'],
   },
 }
 

--- a/test/production/app-dir/output-file-tracing-includes-read-glob/app/next.config.ts
+++ b/test/production/app-dir/output-file-tracing-includes-read-glob/app/next.config.ts
@@ -1,0 +1,11 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  outputFileTracingIncludes: {
+    '/*': [
+      '../node_modules/.pnpm/lightningcss-wasm@1.28.2_patch_hash=d2d6e72f68b8ae36c669d00a13784346180c35c614b37a4412d651117c518ecf/node_modules/lightningcss-wasm/lightningcss_node.wasm',
+    ],
+  },
+}
+
+export default nextConfig

--- a/test/production/app-dir/output-file-tracing-includes-read-glob/output-file-tracing-includes-read-glob.test.ts
+++ b/test/production/app-dir/output-file-tracing-includes-read-glob/output-file-tracing-includes-read-glob.test.ts
@@ -1,0 +1,31 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { nextTestSetup } from 'e2e-utils'
+
+const wasmPath =
+  'node_modules/.pnpm/lightningcss-wasm@1.28.2_patch_hash=d2d6e72f68b8ae36c669d00a13784346180c35c614b37a4412d651117c518ecf/node_modules/lightningcss-wasm/lightningcss_node.wasm'
+
+describe('outputFileTracingIncludes read glob', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+  if (skipped) return
+
+  it('traces a file from the monorepo node_modules directory', async () => {
+    const target = path.join(next.testDir, wasmPath)
+    await fs.mkdir(path.dirname(target), { recursive: true })
+    await fs.writeFile(target, 'wasm')
+
+    const { exitCode } = await next.runCommand(['build'], {
+      cwd: path.join(next.testDir, 'app'),
+    })
+    expect(exitCode).toBe(0)
+
+    const trace = JSON.parse(
+      await next.readFile('app/.next/server/app/page.js.nft.json')
+    )
+    expect(trace.files).toContain(`../../../../${wasmPath}`)
+  })
+})

--- a/test/production/app-dir/output-file-tracing-includes-read-glob/output-file-tracing-includes-read-glob.test.ts
+++ b/test/production/app-dir/output-file-tracing-includes-read-glob/output-file-tracing-includes-read-glob.test.ts
@@ -1,31 +1,35 @@
-import { promises as fs } from 'fs'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
-
-const wasmPath =
-  'node_modules/.pnpm/lightningcss-wasm@1.28.2_patch_hash=d2d6e72f68b8ae36c669d00a13784346180c35c614b37a4412d651117c518ecf/node_modules/lightningcss-wasm/lightningcss_node.wasm'
 
 describe('outputFileTracingIncludes read glob', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
+    dependencies: {
+      'lightningcss-wasm': '1.28.2',
+    },
     skipStart: true,
     skipDeployment: true,
   })
   if (skipped) return
 
   it('traces a file from the monorepo node_modules directory', async () => {
-    const target = path.join(next.testDir, wasmPath)
-    await fs.mkdir(path.dirname(target), { recursive: true })
-    await fs.writeFile(target, 'wasm')
+    const wasmPath = require.resolve(
+      'lightningcss-wasm/lightningcss_node.wasm',
+      { paths: [next.testDir] }
+    )
 
     const { exitCode } = await next.runCommand(['build'], {
       cwd: path.join(next.testDir, 'app'),
     })
     expect(exitCode).toBe(0)
 
+    const traceDirectory = path.join(next.testDir, 'app/.next/server/app')
+    const expectedTracePath = path
+      .relative(traceDirectory, wasmPath)
+      .replaceAll(path.sep, '/')
     const trace = JSON.parse(
       await next.readFile('app/.next/server/app/page.js.nft.json')
     )
-    expect(trace.files).toContain(`../../../../${wasmPath}`)
+    expect(trace.files).toContain(expectedTracePath)
   })
 })

--- a/test/production/app-dir/output-file-tracing-includes-read-glob/output-file-tracing-includes-read-glob.test.ts
+++ b/test/production/app-dir/output-file-tracing-includes-read-glob/output-file-tracing-includes-read-glob.test.ts
@@ -24,12 +24,18 @@ describe('outputFileTracingIncludes read glob', () => {
     expect(exitCode).toBe(0)
 
     const traceDirectory = path.join(next.testDir, 'app/.next/server/app')
-    const expectedTracePath = path
-      .relative(traceDirectory, wasmPath)
-      .replaceAll(path.sep, '/')
+    const toTracePath = (filePath: string) =>
+      path.relative(traceDirectory, filePath).replaceAll(path.sep, '/')
     const trace = JSON.parse(
       await next.readFile('app/.next/server/app/page.js.nft.json')
     )
-    expect(trace.files).toContain(expectedTracePath)
+
+    expect(trace.files).toContain(toTracePath(wasmPath))
+    expect(trace.files).toContain(
+      toTracePath(path.join(next.testDir, 'app/include-me/file.txt'))
+    )
+    expect(trace.files).not.toContain(
+      toTracePath(path.join(next.testDir, 'app/nested/include-me/file.txt'))
+    )
   })
 })

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -373,4 +373,34 @@ mod tests {
 
         assert!(!glob.matches(path));
     }
+
+    #[test]
+    fn literal_glob_directory_pruning() {
+        let pattern = rcstr!(
+            "node_modules/.pnpm/lightningcss-wasm@1.28.2/node_modules/lightningcss-wasm/\
+             lightningcss_node.wasm"
+        );
+        let anchored = Glob::parse(pattern.clone(), GlobOptions::default()).unwrap();
+        let contains = Glob::parse(
+            pattern,
+            GlobOptions {
+                contains: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert!(anchored.can_match_in_directory("node_modules"));
+        assert!(anchored.can_match_in_directory("node_modules/.pnpm"));
+        assert!(!anchored.can_match_in_directory("node_modules/next"));
+
+        // Before the first literal segment appears, the directory regex incorrectly prunes a
+        // directory that could contain a deeper match such as `packages/app/node_modules/...`.
+        assert!(!contains.can_match_in_directory("packages"));
+
+        // Once the unanchored directory regex finds its first literal segment, its optional
+        // suffix means every descendant can contain a match that restarts later in the path.
+        assert!(contains.can_match_in_directory("node_modules/next"));
+        assert!(contains.can_match_in_directory("node_modules/next/dist/server"));
+    }
 }

--- a/turbopack/crates/turbo-tasks-fs/src/glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/glob.rs
@@ -77,7 +77,10 @@ pub struct GlobOptions {
     /// Allows glob to match any part of the given string(s).
     /// NOTE: this means that a pattern like `node_modules/package_name` with `contains:true` will
     /// match `foo_node_modules/package_name_bar` If you want to match a _directory_ named
-    /// `node_modules/package_name` you should use `**/node_modules/package_name/**`
+    /// `node_modules/package_name` you should use `**/node_modules/package_name/**`.
+    ///
+    /// A partial match cannot safely determine whether a directory might contain a match, so this
+    /// option cannot be used with [`Glob::can_match_in_directory`].
     pub contains: bool,
     /// Whether matching should ignore ASCII case differences.
     pub case_insensitive: bool,
@@ -92,6 +95,10 @@ impl Glob {
     // Returns true if the glob might match a filename underneath this `path` where the
     // path represents a directory.
     pub fn can_match_in_directory(&self, path: &str) -> bool {
+        assert!(
+            !self.opts.contains,
+            "Glob::can_match_in_directory cannot be used when GlobOptions::contains is true"
+        );
         debug_assert!(
             !path.ends_with('/'),
             "Path should be a directory name and not end with /"
@@ -380,9 +387,20 @@ mod tests {
             "node_modules/.pnpm/lightningcss-wasm@1.28.2/node_modules/lightningcss-wasm/\
              lightningcss_node.wasm"
         );
-        let anchored = Glob::parse(pattern.clone(), GlobOptions::default()).unwrap();
-        let contains = Glob::parse(
-            pattern,
+        let anchored = Glob::parse(pattern, GlobOptions::default()).unwrap();
+
+        assert!(anchored.can_match_in_directory("node_modules"));
+        assert!(anchored.can_match_in_directory("node_modules/.pnpm"));
+        assert!(!anchored.can_match_in_directory("node_modules/next"));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Glob::can_match_in_directory cannot be used when GlobOptions::contains is true"
+    )]
+    fn contains_glob_cannot_match_in_directory() {
+        let glob = Glob::parse(
+            rcstr!("node_modules/package_name"),
             GlobOptions {
                 contains: true,
                 ..Default::default()
@@ -390,17 +408,6 @@ mod tests {
         )
         .unwrap();
 
-        assert!(anchored.can_match_in_directory("node_modules"));
-        assert!(anchored.can_match_in_directory("node_modules/.pnpm"));
-        assert!(!anchored.can_match_in_directory("node_modules/next"));
-
-        // Before the first literal segment appears, the directory regex incorrectly prunes a
-        // directory that could contain a deeper match such as `packages/app/node_modules/...`.
-        assert!(!contains.can_match_in_directory("packages"));
-
-        // Once the unanchored directory regex finds its first literal segment, its optional
-        // suffix means every descendant can contain a match that restarts later in the path.
-        assert!(contains.can_match_in_directory("node_modules/next"));
-        assert!(contains.can_match_in_directory("node_modules/next/dist/server"));
+        glob.can_match_in_directory("node_modules");
     }
 }


### PR DESCRIPTION
### What?

Make Turbopack's `outputFileTracingIncludes` file patterns root-relative and targeted during output tracing. Reject unanchored partial globs when code attempts directory-prefix matching. Add production coverage using a real pnpm-installed WASM package, plus unit coverage for anchored directory pruning and include-pattern expansion.

### Why?

Turbopack previously treated include file patterns as unanchored partial matches. The directory-prefix matcher could therefore accept every descendant after matching the first literal segment: an exact WASM include under `node_modules/.pnpm` caused 2,093 `read_glob_inner` executions instead of traversing only its 5 directory prefixes.

Unanchored patterns also cannot soundly answer whether a directory may contain a future match, so allowing `contains: true` with directory-prefix matching risks both over-traversal and missed files. Include behavior also differed from webpack and the documented project-root-relative semantics.

### How?

Build anchored alternatives for each include pattern: one for the direct match and one for descendants of a matched directory. Anchoring lets `read_glob` prune unrelated directories, while the recursive alternative preserves existing behavior for matched directories and directory symlinks, including their resolved target contents.

`can_match_in_directory` now fails immediately for `contains: true`, while direct partial matching remains supported. Route-key and exclusion matching continue to use direct partial matches and are unchanged.

The production fixture resolves `lightningcss-wasm/lightningcss_node.wasm` from a real `lightningcss-wasm@1.28.2` dependency, avoiding assumptions about pnpm's store naming or patch hashes.

### Verification

- `CARGO_INCREMENTAL=0 pnpm build-all`
- `cargo fmt -p turbo-tasks-fs -p next-api -- --check`
- `cargo test -p turbo-tasks-fs glob` (84 passed)
- `cargo test -p next-api` (17 passed)
- `pnpm test-start-turbo test/production/app-dir/output-file-tracing-includes-read-glob/output-file-tracing-includes-read-glob.test.ts test/production/build-trace-extra-entries-turbo/build-trace-extra-entries-turbo.test.ts test/production/build-trace-extra-entries-monorepo/build-trace-extra-entries-monorepo.test.ts` (3 passed)
- `pnpm test-start-webpack test/production/app-dir/output-file-tracing-includes-read-glob/output-file-tracing-includes-read-glob.test.ts`
- The shared fixture asserts that both bundlers include a root-relative exact match and exclude a nested file with the same suffix
- Measured the exact reproduction at 5 include-specific `read_glob_inner` executions, down from 2,093

<!-- NEXT_JS_LLM -->


<!-- fleet b3cefb44-e1ce-4bd6-83a9-da2f22848cad -->