### PR TITLE
test: enable API body parser deployment coverage

### DIFF
--- a/.agents/skills/gate-tests/SKILL.md
+++ b/.agents/skills/gate-tests/SKILL.md
@@ -92,9 +92,11 @@ Every name in a pragma must be declared in `test/lib/gate/conditions.ts`
 (typos fail the suite at collection). Two tiers:
 
 - **static** — the run's shape: `dev`, `start`, `deploy`, `mode`, `turbopack`,
-  `rspack`, `webpack`, `bundler`, `react18`, `wasm`, `ci`, plus the
-  always-false `FIXME`/`TODO`. `prod` and `prefetching` are semantic aliases
-  for `!dev` — prefer the name that states _why_ the suite cannot run.
+  `rspack`, `webpack`, `bundler`, `react18`, `wasm`, `ci`; specialized CI
+  variants `adapter`, `standaloneOutput`, `turbopackDev`, and `turbopackBuild`;
+  plus the always-false `FIXME`/`TODO`.
+  `prod` and `prefetching` are semantic aliases for `!dev` — prefer the name
+  that states _why_ the suite cannot run.
 - **lazy** — a predicate over the fixture's _resolved_ `next.config`
   (`cacheComponents`, `ppr`, `useOffline`, `output`, …).
 

--- a/test/e2e/404-page-custom-error/404-page-custom-error.test.ts
+++ b/test/e2e/404-page-custom-error/404-page-custom-error.test.ts
@@ -1,48 +1,43 @@
 /* eslint-disable jest/no-standalone-expect */
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 
-const shouldSkip =
-  (isNextStart && !!process.env.TURBOPACK_DEV) ||
-  (isNextDev && !!process.env.TURBOPACK_BUILD)
+// TODO(deploy-test-completion): This likely inspects local build artifacts that
+// deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate !start || !turbopackDev
+// @force-gate !dev || !turbopackBuild
+describe('Default 404 Page with custom _error', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
 
-;(shouldSkip ? describe.skip : describe)(
-  'Default 404 Page with custom _error',
-  () => {
-    const { next } = nextTestSetup({
-      files: __dirname,
-      skipDeployment: true,
-    })
+  it('should respond to 404 correctly', async () => {
+    const res = await next.fetch('/404')
+    expect(res.status).toBe(404)
+    expect(await res.text()).toContain('This page could not be found')
+  })
 
-    it('should respond to 404 correctly', async () => {
-      const res = await next.fetch('/404')
-      expect(res.status).toBe(404)
-      expect(await res.text()).toContain('This page could not be found')
-    })
+  it('should render error correctly', async () => {
+    const text = await next.render('/err')
+    expect(text).toContain(isNextDev ? 'oops' : 'Internal Server Error')
+  })
 
-    it('should render error correctly', async () => {
-      const text = await next.render('/err')
-      expect(text).toContain(isNextDev ? 'oops' : 'Internal Server Error')
-    })
-
-    it('should render index page normal', async () => {
-      const html = await next.render('/')
-      expect(html).toContain('hello from index')
-    })
-    ;(isNextStart ? it : it.skip)(
-      'should set pages404 in routes-manifest correctly',
-      async () => {
-        const data = JSON.parse(
-          await next.readFile('.next/routes-manifest.json')
-        )
-        expect(data.pages404).toBe(true)
-      }
+  it('should render index page normal', async () => {
+    const html = await next.render('/')
+    expect(html).toContain('hello from index')
+  })
+  ;(isNextStart ? it : it.skip)(
+    'should set pages404 in routes-manifest correctly',
+    async () => {
+      const data = JSON.parse(await next.readFile('.next/routes-manifest.json'))
+      expect(data.pages404).toBe(true)
+    }
+  )
+  ;(isNextStart ? it : it.skip)('should have output 404.html', async () => {
+    const pagesManifest = await next.readJSON(
+      '.next/server/pages-manifest.json'
     )
-    ;(isNextStart ? it : it.skip)('should have output 404.html', async () => {
-      const pagesManifest = await next.readJSON(
-        '.next/server/pages-manifest.json'
-      )
-      const page = pagesManifest['/404']
-      expect(page.endsWith('.html')).toBe(true)
-    })
-  }
-)
+    const page = pagesManifest['/404']
+    expect(page.endsWith('.html')).toBe(true)
+  })
+})

--- a/test/e2e/404-page-router/index.test.ts
+++ b/test/e2e/404-page-router/index.test.ts
@@ -49,6 +49,8 @@ describe('404-page-router', () => {
     (options) => {
       const isDev = (global as any).isNextDev
 
+      // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+      // It currently avoids creating five deployments rather than documenting an incompatibility.
       if ((global as any).isNextDeploy) {
         // TODO: investigate condensing these tests to avoid
         // 5 separate deploys for this one test

--- a/test/e2e/404-page-ssg/404-page-ssg.test.ts
+++ b/test/e2e/404-page-ssg/404-page-ssg.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup, isNextStart } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('404 Page Support SSG', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should respond to 404 correctly', async () => {
     const res = await next.fetch('/404')

--- a/test/e2e/404-page/404-page.test.ts
+++ b/test/e2e/404-page/404-page.test.ts
@@ -1,10 +1,12 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('404 Page Support', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   const gip404Err =
@@ -133,13 +135,15 @@ describe('404 Page Support', () => {
     })
   }
 })
-;(isNextStart ? describe : describe.skip)('404 Page build validation', () => {
-  const { next, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
+// @force-gate start
+describe('404 Page build validation', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const gip404Err =
     /`pages\/404` can not have getInitialProps\/getServerSideProps/

--- a/test/e2e/500-page/500-page-build.test.ts
+++ b/test/e2e/500-page/500-page-build.test.ts
@@ -1,15 +1,17 @@
-import { isNextDev, nextTestSetup } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
 // This test exercises `next build` outputs and `next start` behaviour, so it
 // is meaningless in dev mode where the dev server bypasses production build
 // artifacts (e.g. statically prerendered 500.html from getStaticProps).
-;(isNextDev ? describe.skip : describe)('500 Page build validation', () => {
-  const { next, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
+// @force-gate !dev
+describe('500 Page build validation', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const gip500Err =
     /`pages\/500` can not have getInitialProps\/getServerSideProps/

--- a/test/e2e/500-page/500-page.test.ts
+++ b/test/e2e/500-page/500-page.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('500 Page Support', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should use pages/500', async () => {
     const html = await next.render('/500')

--- a/test/e2e/api-body-parser/api-body-parser.test.ts
+++ b/test/e2e/api-body-parser/api-body-parser.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('API body parser', () => {
+  // Deploy mode exclusion: This suite controls a local server or proxy process.
+  // Uses a custom HTTP/proxy server in front of Next.js; not applicable in deploy mode.
+  // @force-gate !deploy
   describe('without custom server', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      // Uses a custom HTTP/proxy server in front of Next.js; not applicable in deploy mode.
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should parse JSON body', async () => {
       const res = await next.fetch('/api', {
@@ -22,8 +22,11 @@ describe('API body parser', () => {
     })
   })
 
+  // Deploy mode exclusion: This suite controls a local server or proxy process.
+  // Uses a custom HTTP/proxy server in front of Next.js; not applicable in deploy mode.
+  // @force-gate !deploy
   describe('with custom server (pre-parsed body)', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       startCommand: 'node server.js',
       serverReadyPattern: /- Local:/,
@@ -31,10 +34,7 @@ describe('API body parser', () => {
       dependencies: {
         express: '4',
       },
-      // Uses a custom HTTP/proxy server in front of Next.js; not applicable in deploy mode.
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should not throw if request body is already parsed in custom middleware', async () => {
       const res = await next.fetch('/api', {

--- a/test/e2e/api-body-parser/api-body-parser.test.ts
+++ b/test/e2e/api-body-parser/api-body-parser.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('API body parser', () => {
-  // Deploy mode exclusion: This suite controls a local server or proxy process.
-  // Uses a custom HTTP/proxy server in front of Next.js; not applicable in deploy mode.
-  // @force-gate !deploy
   describe('without custom server', () => {
     const { next } = nextTestSetup({
       files: __dirname,

--- a/test/e2e/api-catch-all/api-catch-all.test.ts
+++ b/test/e2e/api-catch-all/api-catch-all.test.ts
@@ -1,45 +1,43 @@
-import { nextTestSetup, isNextStart } from 'e2e-utils'
-;(process.env.TURBOPACK_DEV && isNextStart ? describe.skip : describe)(
-  'API routes',
-  () => {
-    const { next, skipped } = nextTestSetup({
-      files: __dirname,
-      // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-      skipDeployment: true,
+import { nextTestSetup } from 'e2e-utils'
+// TODO(deploy-test-completion): Assertions may differ from a local Next.js
+// server when deployed.
+// @force-gate !deploy
+// @force-gate !start || !turbopackDev
+describe('API routes', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should return data when catch-all', async () => {
+    const data = await next
+      .fetch('/api/users/1', {})
+      .then((res) => res.ok && res.json())
+
+    expect(data).toEqual({ slug: ['1'] })
+  })
+
+  it('should return redirect when catch-all with index and trailing slash', async () => {
+    const res = await next.fetch('/api/users/', {
+      redirect: 'manual',
     })
-    if (skipped) return
+    expect(res.status).toBe(308)
+    const text = await res.text()
+    expect(text).toEqual('/api/users')
+  })
 
-    it('should return data when catch-all', async () => {
-      const data = await next
-        .fetch('/api/users/1', {})
-        .then((res) => res.ok && res.json())
+  it('should return data when catch-all with index and trailing slash', async () => {
+    const data = await next
+      .fetch('/api/users/', {})
+      .then((res) => res.ok && res.json())
 
-      expect(data).toEqual({ slug: ['1'] })
-    })
+    expect(data).toEqual({})
+  })
 
-    it('should return redirect when catch-all with index and trailing slash', async () => {
-      const res = await next.fetch('/api/users/', {
-        redirect: 'manual',
-      })
-      expect(res.status).toBe(308)
-      const text = await res.text()
-      expect(text).toEqual('/api/users')
-    })
+  it('should return data when catch-all with index and no trailing slash', async () => {
+    const data = await next
+      .fetch('/api/users', {})
+      .then((res) => res.ok && res.json())
 
-    it('should return data when catch-all with index and trailing slash', async () => {
-      const data = await next
-        .fetch('/api/users/', {})
-        .then((res) => res.ok && res.json())
-
-      expect(data).toEqual({})
-    })
-
-    it('should return data when catch-all with index and no trailing slash', async () => {
-      const data = await next
-        .fetch('/api/users', {})
-        .then((res) => res.ok && res.json())
-
-      expect(data).toEqual({})
-    })
-  }
-)
+    expect(data).toEqual({})
+  })
+})

--- a/test/e2e/api-resolver-query-writeable/api-resolver-query-writeable.test.ts
+++ b/test/e2e/api-resolver-query-writeable/api-resolver-query-writeable.test.ts
@@ -1,9 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('api-resolver-query-writeable', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     startCommand: 'node server.js',
     serverReadyPattern: /Next mode: (production|development)/,
     dependencies: {
@@ -11,10 +13,6 @@ describe('api-resolver-query-writeable', () => {
       express: '5.1.0',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should allow req.query to be writable and reflect changes made in the API handler', async () => {
     const res = await next.fetch('/api?hello=yes', {

--- a/test/e2e/api-support/api-support.test.ts
+++ b/test/e2e/api-support/api-support.test.ts
@@ -7,18 +7,19 @@ import {
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import json from './big.json'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('API routes', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
       'http-proxy': 'latest',
       cors: 'latest',
       'node-fetch': '2.6.7',
     },
-    skipDeployment: true,
     disableAutoSkewProtection: true,
   })
-  if (skipped) return
 
   it('should not strip .json from API route', async () => {
     const res = await next.fetch('/api/hello.json')
@@ -594,8 +595,11 @@ describe('API routes', () => {
   }
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('API routes output export error', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
       'http-proxy': 'latest',
@@ -603,10 +607,8 @@ describe('API routes output export error', () => {
       'node-fetch': '2.6.7',
     },
     skipStart: true,
-    skipDeployment: true,
     disableAutoSkewProtection: true,
   })
-  if (skipped) return
 
   it('should show error with output export', async () => {
     if (isNextDev) return

--- a/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
+++ b/test/e2e/app-dir-export/test/dynamic-missing-gsp.test.ts
@@ -1,6 +1,8 @@
 import { isNextDev } from 'e2e-utils'
 import { runTests } from './utils'
 
+// These cases patch fixture files and manually run local builds.
+// @force-gate !deploy
 describe('app dir - with output export - dynamic missing gsp', () => {
   describe('should error when dynamic route is missing generateStaticParams', () => {
     runTests({

--- a/test/e2e/app-dir-export/test/dynamicapiroute.test.ts
+++ b/test/e2e/app-dir-export/test/dynamicapiroute.test.ts
@@ -1,5 +1,7 @@
 import { runTests } from './utils'
 
+// These cases patch fixture files and manually run local builds.
+// @force-gate !deploy
 describe('app dir - with output export - dynamic api route', () => {
   describe.each([
     {

--- a/test/e2e/app-dir-export/test/dynamicpage.test.ts
+++ b/test/e2e/app-dir-export/test/dynamicpage.test.ts
@@ -1,5 +1,7 @@
 import { runTests } from './utils'
 
+// These cases patch fixture files and manually run local builds.
+// @force-gate !deploy
 describe('app dir - with output export - dynamic api route', () => {
   describe.each([
     { dynamicPage: 'undefined' },

--- a/test/e2e/app-dir-export/test/trailing-slash.test.ts
+++ b/test/e2e/app-dir-export/test/trailing-slash.test.ts
@@ -1,5 +1,7 @@
 import { runTests } from './utils'
 
+// These cases patch fixture files and manually run local builds.
+// @force-gate !deploy
 describe('app dir - with output export - trailing slash', () => {
   describe.each([{ trailingSlash: false }, { trailingSlash: true }])(
     "should work in prod with trailingSlash '$trailingSlash'",

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -227,15 +227,11 @@ export function runTests({
     | 'set wrong param'
   expectedErrMsg?: string | RegExp
 }) {
-  let { next, skipped, isNextDev } = nextTestSetup({
+  let { next, isNextDev } = nextTestSetup({
     files: join(__dirname, '..'),
-    skipDeployment: true,
     skipStart: true,
     disableAutoSkewProtection: true,
   })
-  if (skipped) {
-    return
-  }
 
   beforeAll(async () => {
     if (trailingSlash !== undefined) {

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
@@ -2,20 +2,18 @@ import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir action allowed origins', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: join(__dirname, 'safe-origins'),
-    skipDeployment: true,
     dependencies: {
       'server-only': 'latest',
     },
     // An arbitrary & random port.
     forcedPort: 'random',
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should pass if localhost is set as a safe origin', async function () {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-disallowed-origins.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-disallowed-origins.test.ts
@@ -2,18 +2,16 @@ import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir action disallowed origins', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: join(__dirname, 'unsafe-origins'),
-    skipDeployment: true,
     dependencies: {
       'server-only': 'latest',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   // Origin should be localhost
   it('should error if x-forwarded-host does not match the origin', async function () {

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-opaque-origin.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-opaque-origin.test.ts
@@ -2,18 +2,16 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir action allowed from opaque origins', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: join(__dirname, 'opaque-origin'),
-    skipDeployment: true,
     env: {
       NEXT_TEST_ALLOW_OPAQUE_ORIGIN: '1',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should succeed on submission', async function () {
     const browser = await next.browser('/sandboxed')
@@ -28,18 +26,16 @@ describe('app-dir action allowed from opaque origins', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir action disallowed from opaque origins', () => {
-  const { isNextDev, next, skipped } = nextTestSetup({
+  const { isNextDev, next } = nextTestSetup({
     files: join(__dirname, 'opaque-origin'),
-    skipDeployment: true,
     env: {
       NEXT_TEST_ALLOW_OPAQUE_ORIGIN: '',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should fail on submission', async function () {
     const browser = await next.browser('/sandboxed')

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -18,8 +18,8 @@ describe('unrecognized server actions', () => {
     return next.cliOutput.slice(cliOutputPosition)
   }
 
-  // This is disabled when deployed because the 404 page will be served as a static route
-  // which will not support POST requests, and will return a 405 instead.
+  // Deploy mode exclusion: Deployed 404 pages are static routes, so POST
+  // requests return 405 instead of this suite's local 404 behavior.
   if (!isNextDeploy) {
     it('should 404 when POSTing a non-server-action request to a nonexistent page', async () => {
       const res = await next.fetch('/non-existent-route', {

--- a/test/e2e/app-dir/actions-unused-args/actions-unused-args.test.ts
+++ b/test/e2e/app-dir/actions-unused-args/actions-unused-args.test.ts
@@ -1,16 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from '../../../lib/next-test-utils'
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// No access to runtime logs when deployed.
+// @force-gate !deploy
 describe('actions-unused-args', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // No access to runtime logs when deployed.
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not call server actions with unused arguments', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/actions/app-action-export.test.ts
+++ b/test/e2e/app-dir/actions/app-action-export.test.ts
@@ -1,16 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir action handling - next export', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     dependencies: {
       nanoid: '4.0.1',
       'server-only': 'latest',
     },
   })
-  if (skipped) return
 
   if (!isNextStart) {
     it('skip test for development mode', () => {})

--- a/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
+++ b/test/e2e/app-dir/actions/app-action-size-limit-invalid.test.ts
@@ -9,7 +9,7 @@ const CONFIG_ERROR =
   'Server Actions Size Limit must be a valid number or filesize format larger than 1MB'
 
 describe('app-dir action size limit invalid config', () => {
-  const { next, isNextStart, isNextDeploy, skipped } = nextTestSetup({
+  const { next, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
     overrideFiles: process.env.TEST_NODE_MIDDLEWARE
       ? {
@@ -22,7 +22,6 @@ describe('app-dir action size limit invalid config', () => {
       'server-only': 'latest',
     },
   })
-  if (skipped) return
 
   const logs: string[] = []
 

--- a/test/e2e/app-dir/app-a11y/index.test.ts
+++ b/test/e2e/app-dir/app-a11y/index.test.ts
@@ -1,16 +1,14 @@
 import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app a11y features', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     packageJson: {},
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   describe('route announcer', () => {
     async function getAnnouncerContent(browser: Playwright) {

--- a/test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts
@@ -234,6 +234,8 @@ describe('app dir client cache semantics (experimental staleTimes)', () => {
       })
     })
 
+    // Deploy mode exclusion: This nested suite reads telemetry events from the
+    // local Next.js CLI output.
     if (!isNextDeploy) {
       describe('telemetry', () => {
         it('should send staleTimes feature usage event', async () => {
@@ -368,6 +370,8 @@ describe('app dir client cache semantics (experimental staleTimes)', () => {
       })
     })
 
+    // Deploy mode exclusion: This nested suite reads telemetry events from the
+    // local Next.js CLI output.
     if (!isNextDeploy) {
       describe('telemetry', () => {
         it('should send staleTimes feature usage event', async () => {

--- a/test/e2e/app-dir/app-client-cache/client-cache.original.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.original.test.ts
@@ -9,16 +9,16 @@ import {
 import path from 'path'
 
 // This preserves existing tests for the 30s/5min heuristic (previous router defaults)
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('app dir client cache semantics (30s/5min)', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'regular'),
     nextConfig: {
       experimental: { staleTimes: { dynamic: 30, static: 180 } },
     },
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   if (isNextDev) {
     // dev doesn't support prefetch={true}, so this just performs a basic test to make sure data is reused for 30s

--- a/test/e2e/app-dir/app-compilation/index.test.ts
+++ b/test/e2e/app-dir/app-compilation/index.test.ts
@@ -1,14 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox, retry } from 'next-test-utils'
 
+// Deploy mode exclusion: This suite only defines assertions for local dev or start modes.
+// This is skipped when deployed because there are no assertions outside of next start/next dev
+// @force-gate !deploy
 describe('app dir', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    // This is skipped when deployed because there are no assertions outside of next start/next dev
-    skipDeployment: true,
   })
 
-  if (skipped) return
+  if (isNextDeploy) {
+    it('is excluded from deploy testing by @force-gate', () => {})
+  }
 
   if (isNextStart) {
     describe('Loading', () => {

--- a/test/e2e/app-dir/app-config-crossorigin/index.test.ts
+++ b/test/e2e/app-dir/app-config-crossorigin/index.test.ts
@@ -4,15 +4,13 @@ import { isNextStart, nextTestSetup } from 'e2e-utils'
 const assetPrefix = 'https://example.vercel.sh'
 
 if (!isNextStart) {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('app dir - crossOrigin config', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('should render correctly with assetPrefix: "/"', async () => {
       const $ = await next.render$('/')
@@ -39,10 +37,11 @@ if (!isNextStart) {
   })
 } else {
   describe('app dir - unset crossOrigin config', () => {
+    // Deploy mode exclusion: This branch only runs in next start mode.
+    // @force-gate !deploy
     describe('default output', () => {
       const { next } = nextTestSetup({
         files: path.join(__dirname, 'default'),
-        skipDeployment: true,
       })
 
       function expectCrossOriginAttributesToBeOmitted(
@@ -66,6 +65,9 @@ if (!isNextStart) {
     })
 
     if (process.env.__NEXT_CACHE_COMPONENTS !== 'true') {
+      // Deploy mode exclusion: This test builds and starts the exported app
+      // through a local custom server.
+      // @force-gate !deploy
       describe('output: export', () => {
         const { next } = nextTestSetup({
           files: path.join(__dirname, 'default'),
@@ -73,7 +75,6 @@ if (!isNextStart) {
             NEXT_TEST_OUTPUT_EXPORT: '1',
           },
           skipStart: true,
-          skipDeployment: true,
           startCommand: 'node server.mjs',
           serverReadyPattern: /- Local:/,
         })

--- a/test/e2e/app-dir/app-custom-cache-handler-errors/app-custom-cache-handler-errors.test.ts
+++ b/test/e2e/app-dir/app-custom-cache-handler-errors/app-custom-cache-handler-errors.test.ts
@@ -2,16 +2,14 @@ import { nextTestSetup } from 'e2e-utils'
 import { hasErrorToast, retry, waitFor, waitForNoRedbox } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-custom-cache-handler-errors - get throws', () => {
-  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     env: { CACHE_HANDLER_THROW_ON: 'get' },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('surfaces the cache handler error', async () => {
     const outputIndex = next.cliOutput.length
@@ -96,16 +94,14 @@ describe('app-custom-cache-handler-errors - get throws', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-custom-cache-handler-errors - set throws', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     env: { CACHE_HANDLER_THROW_ON: 'set' },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('renders the page successfully', async () => {
     const outputIndex = next.cliOutput.length

--- a/test/e2e/app-dir/app-custom-cache-handler/index.test.ts
+++ b/test/e2e/app-dir/app-custom-cache-handler/index.test.ts
@@ -30,40 +30,39 @@ function runTests(
   })
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - custom-cache-handler - cjs', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     env: {
       CUSTOM_CACHE_HANDLER: 'cache-handler.js',
     },
   })
 
-  if (skipped) {
-    return
-  }
-
   runTests('cjs module exports', { next, isNextDev })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - custom-cache-handler - cjs-default-export', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     env: {
       CUSTOM_CACHE_HANDLER: 'cache-handler-cjs-default-export.js',
     },
   })
 
-  if (skipped) {
-    return
-  }
-
   runTests('cjs default export', { next, isNextDev })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - custom-cache-handler - esm', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: {
       app: new FileRef(__dirname + '/app'),
       'cache-handler-esm.js': new FileRef(__dirname + '/cache-handler-esm.js'),
@@ -72,7 +71,6 @@ describe('app-dir - custom-cache-handler - esm', () => {
         'export default '
       ),
     },
-    skipDeployment: true,
     packageJson: {
       type: 'module',
     },
@@ -81,29 +79,23 @@ describe('app-dir - custom-cache-handler - esm', () => {
     },
   })
 
-  if (skipped) {
-    return
-  }
-
   runTests('esm default export', { next, isNextDev })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - custom-cache-handler - esm import.meta.resolve', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: {
       app: new FileRef(__dirname + '/app'),
       'cache-handler-esm.js': new FileRef(__dirname + '/cache-handler-esm.js'),
       'next.config.js': importMetaResolveNextConfig,
     },
-    skipDeployment: true,
     packageJson: {
       type: 'module',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   runTests('esm default export', { next, isNextDev })
 })

--- a/test/e2e/app-dir/app-esm-js/standalone.test.ts
+++ b/test/e2e/app-dir/app-esm-js/standalone.test.ts
@@ -13,7 +13,7 @@ if (!(globalThis as any).isNextStart) {
   it('should skip for non-next start', () => {})
 } else {
   describe('output: standalone with ESM app dir', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: {
         app: new FileRef(path.join(__dirname, 'app')),
         pages: new FileRef(path.join(__dirname, 'pages')),
@@ -25,10 +25,6 @@ if (!(globalThis as any).isNextStart) {
       },
       skipStart: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     beforeAll(async () => {
       await next.start()

--- a/test/e2e/app-dir/app-external/app-external.test.ts
+++ b/test/e2e/app-dir/app-external/app-external.test.ts
@@ -15,8 +15,11 @@ async function resolveStreamResponse(response: any, onData?: any) {
   return result
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app dir - external dependency', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
       swr: '2.2.5',
@@ -32,12 +35,7 @@ describe('app dir - external dependency', () => {
     installCommand: 'pnpm i',
     startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
     buildCommand: 'pnpm build',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should be able to opt-out 3rd party packages being bundled in server components', async () => {
     await next.fetch('/react-server/optout').then(async (response) => {

--- a/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
+++ b/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
@@ -1,16 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-invalid-revalidate', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should error properly for invalid revalidate at layout', async () => {
     await next.stop().catch(() => {})

--- a/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
@@ -3,12 +3,14 @@ import { createRouterAct } from 'router-act'
 import { createTimeController } from './test-utils'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - prefetching (custom staleTime)', () => {
   const { next, isNextDev } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
     },
-    skipDeployment: true,
     nextConfig: {
       experimental: {
         staleTimes: {

--- a/test/e2e/app-dir/app-prefetch/prefetching.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.test.ts
@@ -393,7 +393,8 @@ describe('app dir - prefetching', () => {
     })
   })
 
-  // These tests are skipped when deployed as they rely on runtime logs
+  // Deploy mode exclusion: This nested suite asserts runtime logs from the
+  // local Next.js process.
   if (!isNextDeploy) {
     describe('dynamic rendering', () => {
       describe.each(['/force-dynamic', '/revalidate-0'])('%s', (basePath) => {

--- a/test/e2e/app-dir/app-rendering/rendering.test.ts
+++ b/test/e2e/app-dir/app-rendering/rendering.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir rendering', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should serve app/page.server.js at /', async () => {
     const html = await next.render('/')

--- a/test/e2e/app-dir/app-root-params-getters/generate-static-params-error.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/generate-static-params-error.test.ts
@@ -1,13 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-root-param-getters - generateStaticParams error', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'generate-static-params-error'),
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     try {

--- a/test/e2e/app-dir/app-root-params-getters/typecheck.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/typecheck.test.ts
@@ -8,17 +8,14 @@ import { retry } from 'next-test-utils'
 // Running `tsc --noEmit` verifies the generated root-params.d.ts is wired in
 // and produces the expected types.
 
+// This suite stops the local server and invokes `pnpm tsc` in its fixture.
+// @force-gate !deploy
 describe.each([{ fixture: 'simple' }, { fixture: 'multiple-roots' }])(
   'app-root-param-getters - typecheck ($fixture)',
   ({ fixture }) => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: join(__dirname, 'fixtures', fixture),
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('should pass typecheck with generated root-params types', async () => {
       await retry(async () => {

--- a/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
@@ -291,14 +291,13 @@ describe('app-root-param-getters - cache - at build', () => {
   }
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// In deploy mode, concurrent requests could hit different lambdas.
+// @force-gate !deploy
 describe('app-root-param-getters - cache dedup with root params', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'use-cache-dedup'),
-    // In deploy mode, concurrent requests could hit different lambdas.
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should dedupe same root params and isolate different root params', async () => {
     // Three concurrent requests: ca/en, ca/fr, ca/fr.

--- a/test/e2e/app-dir/app-routes/app-custom-route-base-path.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-route-base-path.test.ts
@@ -1,2 +1,4 @@
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 process.env.BASE_PATH = '/docs'
 require('./app-custom-routes.test')

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -689,7 +689,8 @@ describe('app-custom-routes', () => {
     })
   }
 
-  // This test is skipped in deploy mode because `next.cliOutput` will only contain build-time logs.
+  // Deploy mode exclusion: This nested suite asserts local CLI output that
+  // deployments do not expose.
   if (!isNextDeploy) {
     describe('no response returned', () => {
       it('should print an error when no response is returned', async () => {

--- a/test/e2e/app-dir/app-static/app-static-custom-handler.test.ts
+++ b/test/e2e/app-dir/app-static/app-static-custom-handler.test.ts
@@ -1,2 +1,4 @@
+// Deploy mode exclusion: This suite installs a process-local custom cache
+// handler, while a hosting platform supplies its own cache infrastructure.
 process.env.CUSTOM_CACHE_HANDLER = '1'
 require('./app-static.test')

--- a/test/e2e/app-dir/app-validation/validation.test.ts
+++ b/test/e2e/app-dir/app-validation/validation.test.ts
@@ -4,15 +4,13 @@ import {
   computeLegacyCacheBustingSearchParam,
 } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - validation', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should error when passing invalid router state tree', async () => {
     const stateTree1 = JSON.stringify(['', ''])

--- a/test/e2e/app-dir/app/standalone-gsp.test.ts
+++ b/test/e2e/app-dir/app/standalone-gsp.test.ts
@@ -13,7 +13,7 @@ if (!(globalThis as any).isNextStart) {
   it('should skip for non-next start', () => {})
 } else {
   describe('output: standalone with getStaticProps', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
       dependencies: {
@@ -21,10 +21,6 @@ if (!(globalThis as any).isNextStart) {
         nanoid: '4.0.1',
       },
     })
-
-    if (skipped) {
-      return
-    }
 
     beforeAll(async () => {
       await next.patchFile(

--- a/test/e2e/app-dir/app/standalone.test.ts
+++ b/test/e2e/app-dir/app/standalone.test.ts
@@ -13,17 +13,13 @@ if (!(globalThis as any).isNextStart) {
   it('should skip for non-next start', () => {})
 } else {
   describe('output: standalone with app dir', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
       dependencies: {
         nanoid: '4.0.1',
       },
     })
-
-    if (skipped) {
-      return
-    }
 
     beforeAll(async () => {
       await next.patchFile(

--- a/test/e2e/app-dir/async-component-preload/async-component-preload.test.ts
+++ b/test/e2e/app-dir/async-component-preload/async-component-preload.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('async-component-preload', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should handle redirect in an async page', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/back-button-download-bug/back-button-download-bug.test.ts
+++ b/test/e2e/app-dir/back-button-download-bug/back-button-download-bug.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 
 // TODO-APP: fix test as it's failing randomly
 describe.skip('app-dir back button download bug', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('app-dir back button download bug', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('should redirect route when clicking link', async () => {
       const browser = await next.browser('/')

--- a/test/e2e/app-dir/bun-externals/bun-externals.test.ts
+++ b/test/e2e/app-dir/bun-externals/bun-externals.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - bun externals', () => {
-  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should handle bun builtins as external modules', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/cache-components-console/cache-components.console.test.ts
+++ b/test/e2e/app-dir/cache-components-console/cache-components.console.test.ts
@@ -3,19 +3,18 @@ import { retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 // TODO(restart-on-cache-miss): cacheSignal timing changes break console log dimming/hiding tests
-describe.skip('cache-components - Console Dimming - Validation', () => {
-  const { next, skipped, isTurbopack } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate TODO
+describe('cache-components - Console Dimming - Validation', () => {
+  const { next, isTurbopack } = nextTestSetup({
     env: {
       FORCE_COLOR: '1',
     },
     files: __dirname + '/fixtures/default',
-    skipDeployment: true,
     skipStart: !isNextDev,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('dims console calls during prospective rendering', async () => {
     const path: string = '/console'
@@ -202,19 +201,17 @@ describe.skip('cache-components - Console Dimming - Validation', () => {
 
 // TODO(restart-on-cache-miss): cacheSignal timing changes break console log dimming/hiding tests
 describe.skip('cache-components - Logging after Abort', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('(default) With Dimming - Server', () => {
-    const { next, skipped, isTurbopack } = nextTestSetup({
+    const { next, isTurbopack } = nextTestSetup({
       env: {
         FORCE_COLOR: '1',
       },
       files: __dirname + '/fixtures/default',
-      skipDeployment: true,
       skipStart: !isNextDev,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('dims console calls after a prerender has aborted', async () => {
       const path: string = '/console-after-abort/server'
@@ -380,19 +377,17 @@ describe.skip('cache-components - Logging after Abort', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('(default) With Dimming - Client', () => {
-    const { next, skipped, isTurbopack } = nextTestSetup({
+    const { next, isTurbopack } = nextTestSetup({
       env: {
         FORCE_COLOR: '1',
       },
       files: __dirname + '/fixtures/default',
-      skipDeployment: true,
       skipStart: !isNextDev,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('dims console calls after a prerender has aborted', async () => {
       const path: string = '/console-after-abort/client'
@@ -549,19 +544,17 @@ describe.skip('cache-components - Logging after Abort', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('With Hiding - Server', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       env: {
         FORCE_COLOR: '1',
       },
       files: __dirname + '/fixtures/hide-logs-after-abort',
-      skipDeployment: true,
       skipStart: !isNextDev,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('hides console calls after a prerender has aborted', async () => {
       const path: string = '/console-after-abort/server'
@@ -650,19 +643,17 @@ describe.skip('cache-components - Logging after Abort', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('With Hiding - Client', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       env: {
         FORCE_COLOR: '1',
       },
       files: __dirname + '/fixtures/hide-logs-after-abort',
-      skipDeployment: true,
       skipStart: !isNextDev,
     })
-
-    if (skipped) {
-      return
-    }
 
     it('hides console calls after a prerender has aborted', async () => {
       const path: string = '/console-after-abort/client'

--- a/test/e2e/app-dir/cache-components-create-component-tree/cache-components-create-component-tree.test.ts
+++ b/test/e2e/app-dir/cache-components-create-component-tree/cache-components-create-component-tree.test.ts
@@ -1,11 +1,13 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('hello-world', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: !isNextDev,
-    skipDeployment: true,
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
+++ b/test/e2e/app-dir/cache-components-dynamic-imports/cache-components-dynamic-imports.test.ts
@@ -158,13 +158,13 @@ describe('async imports in cacheComponents', () => {
   })
 })
 
+// This block intentionally exercises a failed build, so there is no deployment to test.
+// @force-gate !deploy
 describe('async imports in cacheComponents - external packages', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: path.join(__dirname, 'external'),
-    skipDeployment: true,
     skipStart: true,
   })
-  if (skipped) return
 
   // This is currently expected to fail because we can only track `import()` in bundled code,
   // and packages marked as external aren't bundled.

--- a/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
@@ -1,16 +1,14 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { getPrerenderOutput } from './utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Cache Components Errors - Client Hook Abort Reasons', () => {
-  const { next, isTurbopack, isNextStart, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextStart } = nextTestSetup({
     files: __dirname + '/fixtures/client-hook-abort-reasons',
     skipStart: !isNextDev,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliOutputLength: number
 

--- a/test/e2e/app-dir/cache-components-errors/client.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/client.test.ts
@@ -1,16 +1,14 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { getPrerenderOutput } from './utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Cache Components Errors - Client Components', () => {
-  const { next, isTurbopack, isNextStart, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextStart } = nextTestSetup({
     files: __dirname + '/fixtures/client',
     skipStart: !isNextDev,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliOutputLength: number
 

--- a/test/e2e/app-dir/cache-components-errors/console-patch.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/console-patch.test.ts
@@ -2,19 +2,17 @@ import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { getPrerenderOutput } from './utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Cache Components Errors', () => {
-  const { next, isTurbopack, isNextStart, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextStart } = nextTestSetup({
     files: __dirname + '/fixtures/console-patch',
-    skipDeployment: true,
     skipStart: !isNextDev,
     env: {
       NODE_OPTIONS: '--require ./patch-console.js',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliOutputLength: number
 

--- a/test/e2e/app-dir/cache-components-errors/dev-cache-bypass.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/dev-cache-bypass.test.ts
@@ -1,13 +1,9 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 
 describe('Cache Components Errors', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname + '/fixtures/dev-cache-bypass',
   })
-
-  if (skipped) {
-    return
-  }
 
   describe('Warning for Bypassing Caches in Dev', () => {
     async function enableDraftMode() {

--- a/test/e2e/app-dir/cache-components-errors/error-attribution.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/error-attribution.util.ts
@@ -10,7 +10,7 @@ import type { CacheComponentsErrorsContext } from './shared.util'
 export function registerErrorAttributionTests(
   ctx: CacheComponentsErrorsContext
 ) {
-  const { next, isTurbopack, isDebugPrerender, prerender, skipped } = ctx
+  const { next, isTurbopack, isDebugPrerender, prerender } = ctx
 
   let cliOutputLength: number
   beforeEach(() => {
@@ -20,10 +20,6 @@ export function registerErrorAttributionTests(
   describe('Error Attribution with Sync IO', () => {
     describe('Guarded RSC with guarded Client sync IO', () => {
       const pathname = '/sync-attribution/guarded-async-guarded-clientsync'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('does not show a validation error in the dev overlay', async () => {
@@ -45,10 +41,6 @@ export function registerErrorAttributionTests(
 
     describe('Guarded RSC with unguarded Client sync IO', () => {
       const pathname = '/sync-attribution/guarded-async-unguarded-clientsync'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should show a collapsed redbox error', async () => {
@@ -193,10 +185,6 @@ export function registerErrorAttributionTests(
     describe('Unguarded RSC with guarded Client sync IO', () => {
       const pathname = '/sync-attribution/unguarded-async-guarded-clientsync'
 
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should show a collapsed redbox error', async () => {
           const browser = await next.browser(pathname)
@@ -327,10 +315,6 @@ export function registerErrorAttributionTests(
       const pathname =
         '/sync-attribution/unguarded-async-client-microtask-syncio'
 
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should show request data rather than attribute a microtask sync IO access', async () => {
           const browser = await next.browser(pathname)
@@ -368,10 +352,6 @@ export function registerErrorAttributionTests(
 
     describe('unguarded RSC with unguarded Client sync IO', () => {
       const pathname = '/sync-attribution/unguarded-async-unguarded-clientsync'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should show a collapsed redbox error', async () => {

--- a/test/e2e/app-dir/cache-components-errors/http-access-fallback-prerender.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/http-access-fallback-prerender.test.ts
@@ -2,16 +2,14 @@ import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { getPrerenderOutput } from './utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Cache Components HTTP Access Fallback Prerender', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname + '/fixtures/http-access-fallback-prerender',
     skipStart: !isNextDev,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliOutputLength: number
 

--- a/test/e2e/app-dir/cache-components-errors/module-scope.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/module-scope.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Lazy Module Init', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/lazy-module-init',
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     it('does not run in dev', () => {})

--- a/test/e2e/app-dir/cache-components-errors/prospective-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/prospective-errors.test.ts
@@ -2,17 +2,14 @@ import { nextTestSetup } from 'e2e-utils'
 
 const isTurbopack = !!process.env.IS_TURBOPACK_TEST
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// Accessing cliOutput is only available on the deployment
+// @force-gate !deploy
 describe(`Cache Components Prospective Render Errors - Debug Build`, () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/prospective-render-errors',
     env: { NEXT_DEBUG_BUILD: 'true' },
-    // Accessing cliOutput is only available on the deployment
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     // In next dev there really isn't a prospective render but we still assert we error on the first visit to each page
@@ -146,13 +143,9 @@ describe(`Cache Components Prospective Render Errors - Debug Build`, () => {
 })
 
 describe(`Cache Components Prospective Render Errors - Standard Build`, () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/prospective-render-errors',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     // In next dev there really isn't a prospective render but we still assert we error on the first visit to each page

--- a/test/e2e/app-dir/cache-components-errors/shared.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/shared.util.ts
@@ -8,9 +8,6 @@ export interface CacheComponentsErrorsContext {
   isNextStart: boolean
   isDebugPrerender: boolean
   prerender: (pathname: string) => Promise<void>
-  // Always false when sections run (the wrapper returns early when skipped);
-  // exposed because some sections carry redundant guards.
-  skipped: boolean
 }
 
 // This suite is far too slow to run as a single CI test file, so it's split
@@ -21,18 +18,14 @@ export interface CacheComponentsErrorsContext {
 export function runCacheComponentsErrorsTests(
   registerTests: (ctx: CacheComponentsErrorsContext) => void
 ) {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
+  // @force-gate !deploy
   describe('Cache Components Errors', () => {
-    const { next, isTurbopack, isNextStart, skipped, isRspack } = nextTestSetup(
-      {
-        files: __dirname + '/fixtures/default',
-        skipStart: !isNextDev,
-        skipDeployment: true,
-      }
-    )
-
-    if (skipped) {
-      return
-    }
+    const { next, isTurbopack, isNextStart, isRspack } = nextTestSetup({
+      files: __dirname + '/fixtures/default',
+      skipStart: !isNextDev,
+    })
 
     afterEach(async () => {
       if (isNextStart) {
@@ -99,7 +92,6 @@ export function runCacheComponentsErrorsTests(
         isNextStart,
         isDebugPrerender,
         prerender,
-        skipped,
       })
     })
   })

--- a/test/e2e/app-dir/cache-components-errors/sync-dynamic.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/sync-dynamic.util.ts
@@ -3,8 +3,7 @@ import { getPrerenderOutput } from './utils'
 import type { CacheComponentsErrorsContext } from './shared.util'
 
 export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
-  const { next, isTurbopack, isRspack, isDebugPrerender, prerender, skipped } =
-    ctx
+  const { next, isTurbopack, isRspack, isDebugPrerender, prerender } = ctx
 
   let cliOutputLength: number
   beforeEach(() => {
@@ -14,10 +13,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
   describe('Sync Dynamic Platform', () => {
     describe('With Fallback - Math.random()', () => {
       const pathname = '/sync-random-with-fallback'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should show a collapsed redbox error', async () => {
@@ -161,10 +156,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
 
     describe('Without Fallback - Math.random()', () => {
       const pathname = '/sync-random-without-fallback'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should show a collapsed redbox error', async () => {
@@ -314,10 +305,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
     describe('client searchParams', () => {
       const pathname = '/sync-client-search'
 
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should return `undefined` for `searchParams.foo`', async () => {
           const browser = await next.browser(`${pathname}?foo=test`)
@@ -351,10 +338,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
     describe('server searchParams', () => {
       const pathname = '/sync-server-search'
 
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should return `undefined` for `searchParams.foo`', async () => {
           const browser = await next.browser(`${pathname}?foo=test`)
@@ -387,10 +370,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
 
     describe('cookies', () => {
       const pathname = '/sync-cookies'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should show a redbox with a sync access error and a runtime error', async () => {
@@ -566,10 +545,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
     })
 
     describe('cookies at runtime', () => {
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should show a redbox with a sync access error and a runtime error', async () => {
           const browser = await next.browser('/sync-cookies-runtime')
@@ -666,10 +641,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
     describe('draftMode', () => {
       const pathname = '/sync-draft-mode'
 
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should return `undefined` for `draftMode().isEnabled`', async () => {
           const browser = await next.browser(`${pathname}`)
@@ -719,10 +690,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
 
     describe('headers', () => {
       const pathname = '/sync-headers'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should show a redbox with a sync access error and a runtime error', async () => {
@@ -898,10 +865,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
     })
 
     describe('headers at runtime', () => {
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should show a redbox with a sync access error and a runtime error', async () => {
           const browser = await next.browser('/sync-headers-runtime')
@@ -998,10 +961,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
     describe('client params', () => {
       const pathname = '/sync-client-params'
 
-      if (skipped) {
-        return
-      }
-
       if (isNextDev) {
         it('should return `undefined` for `params.slug`', async () => {
           const browser = await next.browser(`${pathname}/test`)
@@ -1032,10 +991,6 @@ export function registerSyncDynamicTests(ctx: CacheComponentsErrorsContext) {
 
     describe('server params', () => {
       const pathname = '/sync-server-params'
-
-      if (skipped) {
-        return
-      }
 
       if (isNextDev) {
         it('should return `undefined` for `params.slug`', async () => {

--- a/test/e2e/app-dir/cache-components-errors/unstable-deprecations.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/unstable-deprecations.test.ts
@@ -1,13 +1,9 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 
 describe('Cache Components Errors', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname + '/fixtures/unstable-deprecations',
   })
-
-  if (skipped) {
-    return
-  }
 
   describe('Deprecating `unstable` prefix for `cacheLife` and `cacheTag`', () => {
     it('warns if you use `cacheLife` through `unstable_cacheLife`', async () => {

--- a/test/e2e/app-dir/cache-components-prerender-matrix/cache-components-prerender-matrix.test.ts
+++ b/test/e2e/app-dir/cache-components-prerender-matrix/cache-components-prerender-matrix.test.ts
@@ -9,8 +9,6 @@ import { retry } from 'next-test-utils'
 // not implement it yet — its blocking entries still key and bake
 // never-prerenderable params — so deploy runs are limited to adapter
 // deployments until that ships (see vercel/vercel#17179).
-const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
-
 type NextInstance = ReturnType<typeof nextTestSetup>['next']
 
 // A first-principles test matrix for cache components prerendering.
@@ -67,7 +65,7 @@ type NextInstance = ReturnType<typeof nextTestSetup>['next']
 // allowQuery, keying and baking them on deployed infra. The fully-static
 // and dynamic matrices pass before and after those fixes and guard them
 // against over-correction. Deploy runs are adapter-only for now (see the
-// `skipDeployment` note above the `isAdapterTest` declaration).
+// `@force-gate !deploy || adapter` on the suite below).
 
 const PARAMS = ['lang', 'category', 'id'] as const
 type ParamName = (typeof PARAMS)[number]
@@ -449,10 +447,12 @@ function createDocumentFetcher(next: NextInstance) {
   }
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy || adapter
 describe('cache-components-prerender-matrix', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    skipDeployment: !isAdapterTest,
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/cache-components-request-apis/cache-components-request-apis.test.ts
+++ b/test/e2e/app-dir/cache-components-request-apis/cache-components-request-apis.test.ts
@@ -38,14 +38,10 @@ function createExpectError(cliOutput: string) {
 
 describe(`Request Promises`, () => {
   describe('On Prerender Completion', () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
+    const { next, isNextDev } = nextTestSetup({
       files: __dirname + '/fixtures/reject-hanging-promises-static',
       skipStart: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     if (isNextDev) {
       it('does not run in dev', () => {})
@@ -78,16 +74,14 @@ describe(`Request Promises`, () => {
       )
     })
   })
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('On Prerender Interruption', () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
+    const { next, isNextDev } = nextTestSetup({
       files: __dirname + '/fixtures/reject-hanging-promises-dynamic',
       skipStart: true,
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     if (isNextDev) {
       it('does not run in dev', () => {})

--- a/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
@@ -5,16 +5,14 @@ import {
   getRedboxSource,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components-route-handler-errors', () => {
-  const { next, skipped, isNextDev, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it("should error when route handlers use segment configs that aren't supported by cacheComponents", async () => {
     try {

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
@@ -23,30 +23,27 @@ function filterToErrorHeaders(output: string): string {
 
 // Only Turbopack runs the transform on the layout once in edge and non-edge contexts
 // so we only test this on Turbopack
-;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
-  'cache-components-edge-deduplication',
-  () => {
-    const { next, skipped, isNextDev } = nextTestSetup({
-      files: __dirname + '/fixtures/edge-deduplication',
-      skipStart: true,
-      skipDeployment: true,
-    })
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('cache-components-edge-deduplication', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname + '/fixtures/edge-deduplication',
+    skipStart: true,
+  })
 
-    if (skipped) {
-      return
+  it('should not duplicate errors when layout is compiled for both edge and non-edge contexts', async () => {
+    try {
+      await next.start()
+    } catch {
+      // we expect the build to fail
     }
 
-    it('should not duplicate errors when layout is compiled for both edge and non-edge contexts', async () => {
-      try {
-        await next.start()
-      } catch {
-        // we expect the build to fail
-      }
-
-      if (isNextDev) {
-        const browser = await next.browser('/edge-with-layout/edge')
-        waitForRedbox(browser)
-        await expect(browser).toDisplayRedbox(`
+    if (isNextDev) {
+      const browser = await next.browser('/edge-with-layout/edge')
+      waitForRedbox(browser)
+      await expect(browser).toDisplayRedbox(`
          {
            "description": "Route segment config "dynamic" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
            "environmentLabel": null,
@@ -59,34 +56,33 @@ function filterToErrorHeaders(output: string): string {
          }
         `)
 
-        // Count occurrences of the layout error at the specific location
-        // Filter out browser logs to avoid counting forwarded browser errors
-        const filteredOutput = filterToErrorHeaders(next.cliOutput)
-        const layoutErrorMatches = filteredOutput.match(
-          /\.\/app\/edge-with-layout\/layout\.tsx:1:14/g
-        )
-        // We don't show an error stack, just the individual error messages at each location
-        expect(layoutErrorMatches.length).toBe(1)
-      } else {
-        // Check that both the layout and edge page errors appear
-        expect(next.cliOutput).toContain('./app/edge-with-layout/layout.tsx')
-        expect(next.cliOutput).toContain('./app/edge-with-layout/edge/page.tsx')
-        expect(next.cliOutput).toContain(
-          '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
-        )
-        expect(next.cliOutput).toContain(
-          '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
-        )
-        // Count occurrences of the layout error at the specific location
-        const layoutErrorMatches = next.cliOutput.match(
-          /\.\/app\/layout\.tsx:1:14/g
-        )
+      // Count occurrences of the layout error at the specific location
+      // Filter out browser logs to avoid counting forwarded browser errors
+      const filteredOutput = filterToErrorHeaders(next.cliOutput)
+      const layoutErrorMatches = filteredOutput.match(
+        /\.\/app\/edge-with-layout\/layout\.tsx:1:14/g
+      )
+      // We don't show an error stack, just the individual error messages at each location
+      expect(layoutErrorMatches.length).toBe(1)
+    } else {
+      // Check that both the layout and edge page errors appear
+      expect(next.cliOutput).toContain('./app/edge-with-layout/layout.tsx')
+      expect(next.cliOutput).toContain('./app/edge-with-layout/edge/page.tsx')
+      expect(next.cliOutput).toContain(
+        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+      )
+      expect(next.cliOutput).toContain(
+        '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+      )
+      // Count occurrences of the layout error at the specific location
+      const layoutErrorMatches = next.cliOutput.match(
+        /\.\/app\/layout\.tsx:1:14/g
+      )
 
-        // The location appears once, in the formatted error message. The
-        // stack of the build error holds framework frames only, and none of
-        // them names the route.
-        expect(layoutErrorMatches.length).toBe(1)
-      }
-    })
-  }
-)
+      // The location appears once, in the formatted error message. The
+      // stack of the build error holds framework frames only, and none of
+      // them names the route.
+      expect(layoutErrorMatches.length).toBe(1)
+    }
+  })
+})

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
@@ -6,16 +6,14 @@ import {
   getRedboxSource,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('cache-components-segment-configs', () => {
-  const { next, skipped, isNextDev, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname + '/fixtures/default',
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it("it should error when using segment configs that aren't supported by cacheComponents", async () => {
     try {

--- a/test/e2e/app-dir/cache-components/cache-components.connection.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.connection.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should partially prerender pages that use connection', async () => {
     let $ = await next.render$('/connection/static-behavior/boundary', {})

--- a/test/e2e/app-dir/cache-components/cache-components.cookies.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.cookies.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should partially prerender pages that use cookies', async () => {
     let $ = await next.render$('/cookies/static-behavior', {})

--- a/test/e2e/app-dir/cache-components/cache-components.date.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.date.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import expect from 'expect'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have route specific errors', async () => {
     expect(next.cliOutput).not.toMatch('Error: Route "/')

--- a/test/e2e/app-dir/cache-components/cache-components.draft-mode.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.draft-mode.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliIndex = 0
   beforeEach(() => {

--- a/test/e2e/app-dir/cache-components/cache-components.headers.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.headers.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should partially prerender pages that use headers', async () => {
     let $ = await next.render$('/headers/static-behavior', {})

--- a/test/e2e/app-dir/cache-components/cache-components.node-crypto.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.node-crypto.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have route specific errors', async () => {
     expect(next.cliOutput).not.toMatch('Error: Route "/')

--- a/test/e2e/app-dir/cache-components/cache-components.params.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.params.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // cSpell:words lowcard highcard
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliIndex = 0
   beforeEach(() => {

--- a/test/e2e/app-dir/cache-components/cache-components.random.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.random.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have route specific errors', async () => {
     expect(next.cliOutput).not.toMatch('Error: Route "/')

--- a/test/e2e/app-dir/cache-components/cache-components.routes.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.routes.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let cliIndex = 0
   beforeEach(() => {

--- a/test/e2e/app-dir/cache-components/cache-components.search.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.search.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should partially prerender pages that await searchParams in a server component', async () => {
     let $ = await next.render$('/search/server/await?sentinel=hello')

--- a/test/e2e/app-dir/cache-components/cache-components.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.test.ts
@@ -5,15 +5,13 @@ import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/util
 import cheerio from 'cheerio'
 import { fetchViaHTTP, findPort } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have route specific errors', async () => {
     expect(next.cliOutput).not.toMatch('Error: Route "/')

--- a/test/e2e/app-dir/cache-components/cache-components.web-crypto.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.web-crypto.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('cache-components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have route specific errors', async () => {
     expect(next.cliOutput).not.toMatch('Error: Route "/')

--- a/test/e2e/app-dir/client-reference-chunking/client-reference-chunking.test.ts
+++ b/test/e2e/app-dir/client-reference-chunking/client-reference-chunking.test.ts
@@ -1,10 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 import { getClientReferenceManifest } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('client-reference-chunking', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('should use the same chunks for client references across routes', async () => {

--- a/test/e2e/app-dir/client-reference-side-effects/client-reference-side-effects.test.ts
+++ b/test/e2e/app-dir/client-reference-side-effects/client-reference-side-effects.test.ts
@@ -1,9 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('client-reference-side-effects', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('side effect behavior when only importing', async () => {

--- a/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
+++ b/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
@@ -1,18 +1,16 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('conflicting-page-segments', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     // we skip start & deploy because the build will fail and we won't be able to catch it
     // start is re-triggered but caught in the assertions below.
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw an error when a route groups causes a conflict with a parallel segment', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
+++ b/test/e2e/app-dir/create-root-layout/create-root-layout.test.ts
@@ -9,6 +9,7 @@ import stripAnsi from 'strip-ansi'
   () => {
     const isDev = (global as any).isNextDev
 
+    // Deploy mode exclusion: This suite creates and patches project files, which cannot be changed after deployment.
     if ((global as any).isNextDeploy) {
       it('should skip next deploy for now', () => {})
       return
@@ -224,40 +225,38 @@ import stripAnsi from 'strip-ansi'
     }
   }
 )
-;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
-  'app-dir missing root layout',
-  () => {
-    const { next, isNextDev, skipped } = nextTestSetup({
-      files: {
-        app: new FileRef(path.join(__dirname, 'app')),
-        'next.config.js': new FileRef(path.join(__dirname, 'next.config.js')),
-      },
-      skipDeployment: true,
-      skipStart: true,
-    })
+// Deploy mode exclusion: This suite intentionally fails a local build
+// and inspects its output and fixture files.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('app-dir missing root layout', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: {
+      app: new FileRef(path.join(__dirname, 'app')),
+      'next.config.js': new FileRef(path.join(__dirname, 'next.config.js')),
+    },
+    skipStart: true,
+  })
 
-    if (skipped) return
+  it('reports a compiler error without modifying the app', async () => {
+    if (isNextDev) {
+      await next.start()
 
-    it('reports a compiler error without modifying the app', async () => {
-      if (isNextDev) {
-        await next.start()
+      const response = await next.fetch('/route')
+      expect(response.status).toBe(500)
 
-        const response = await next.fetch('/route')
-        expect(response.status).toBe(500)
-
-        await retry(async () => {
-          expect(stripAnsi(next.cliOutput)).toContain(
-            "route/page.js doesn't have a root layout. To fix this error, make sure every page has a root layout."
-          )
-        })
-      } else {
-        await expect(next.start()).rejects.toThrow('next build failed')
+      await retry(async () => {
         expect(stripAnsi(next.cliOutput)).toContain(
           "route/page.js doesn't have a root layout. To fix this error, make sure every page has a root layout."
         )
-      }
+      })
+    } else {
+      await expect(next.start()).rejects.toThrow('next build failed')
+      expect(stripAnsi(next.cliOutput)).toContain(
+        "route/page.js doesn't have a root layout. To fix this error, make sure every page has a root layout."
+      )
+    }
 
-      expect(await next.hasFile('app/layout.js')).toBe(false)
-    })
-  }
-)
+    expect(await next.hasFile('app/layout.js')).toBe(false)
+  })
+})

--- a/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
+++ b/test/e2e/app-dir/custom-cache-control/custom-cache-control.test.ts
@@ -5,6 +5,8 @@ describe('custom-cache-control', () => {
     files: __dirname,
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // The hosting platform applies cache headers outside the Next.js server, so deploy mode needs separate expectations.
   if (isNextDeploy) {
     // customizing these headers won't apply on environments
     // where headers are applied outside of the Next.js server

--- a/test/e2e/app-dir/dedupe-rsc-error-log/dedupe-rsc-error-log.test.ts
+++ b/test/e2e/app-dir/dedupe-rsc-error-log/dedupe-rsc-error-log.test.ts
@@ -9,11 +9,12 @@ async function expectContainOnce(next: any, search: string) {
   })
 }
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// Runtime logs aren't available when deployed
+// @force-gate !deploy
 describe('dedupe-rsc-error-log', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // Runtime logs aren't available when deployed
-    skipDeployment: true,
   })
 
   it('should only log RSC error once for nodejs runtime', async () => {

--- a/test/e2e/app-dir/draft-mode-middleware/draft-mode-middleware.test.ts
+++ b/test/e2e/app-dir/draft-mode-middleware/draft-mode-middleware.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - draft-mode-middleware', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should be able to enable draft mode with middleware present', async () => {
     const browser = await next.browser(

--- a/test/e2e/app-dir/duplicate-layout-components/duplicate-layout-components.test.ts
+++ b/test/e2e/app-dir/duplicate-layout-components/duplicate-layout-components.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - duplicate layout components', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not duplicate layout elements when navigating to 404', async () => {
     const browser = await next.browser('/solutions/404')

--- a/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
+++ b/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 
 process.env.__TEST_SENTINEL = 'at buildtime'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('dynamic-data', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/main',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render the dynamic apis dynamically when used in a top-level scope', async () => {
     const $ = await next.render$(
@@ -154,15 +152,13 @@ describe('dynamic-data', () => {
 })
 
 describe('dynamic-data with dynamic = "error"', () => {
-  const { next, isNextDev, isNextDeploy, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname + '/fixtures/require-static',
     skipStart: true,
   })
 
-  if (skipped) {
-    return
-  }
-
+  // Deploy mode exclusion: This suite intentionally tests dev-server errors
+  // or a failed local build, so it cannot produce a deployment.
   if (isNextDeploy) {
     it.skip('should not run in next deploy.', () => {})
     return
@@ -281,17 +277,13 @@ describe('dynamic-data with dynamic = "error"', () => {
 })
 
 describe('dynamic-data inside cache scope', () => {
-  const { isTurbopack, next, isNextDev, isNextDeploy, skipped } = nextTestSetup(
-    {
-      files: __dirname + '/fixtures/cache-scoped',
-      skipStart: true,
-    }
-  )
+  const { isTurbopack, next, isNextDev, isNextDeploy } = nextTestSetup({
+    files: __dirname + '/fixtures/cache-scoped',
+    skipStart: true,
+  })
 
-  if (skipped) {
-    return
-  }
-
+  // Deploy mode exclusion: This suite intentionally tests dev-server errors
+  // or a failed local build, so it cannot produce a deployment.
   if (isNextDeploy) {
     it.skip('should not run in next deploy..', () => {})
     return

--- a/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
+++ b/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
@@ -1,18 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('dynamic-href', () => {
-  const {
-    isNextDev: isDev,
-    next,
-    skipped,
-  } = nextTestSetup({
+  const { isNextDev: isDev, next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isDev) {
     it('should error when using dynamic href.pathname in app dir', async () => {

--- a/test/e2e/app-dir/dynamic-import-tree-shaking/dynamic-import-tree-shaking.test.ts
+++ b/test/e2e/app-dir/dynamic-import-tree-shaking/dynamic-import-tree-shaking.test.ts
@@ -2,12 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import fs from 'fs'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('dynamic-import-tree-shaking', () => {
-  const { next, skipped, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   // Recursively read all .js files in a directory
   function getAllServerFiles(dir: string): string[] {

--- a/test/e2e/app-dir/dynamic-in-generate-params/index.test.ts
+++ b/test/e2e/app-dir/dynamic-in-generate-params/index.test.ts
@@ -11,10 +11,12 @@ function assertSitemapResponse(res: Response) {
   expect(res.headers.get('content-type')).toContain('application/xml')
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir - dynamic in generate params', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('should render sitemap with generateSitemaps in force-dynamic config dynamically', async () => {

--- a/test/e2e/app-dir/dynamic/dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic/dynamic.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('app dir - next/dynamic', () => {
-  const { next, isNextStart, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextStart, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should handle ssr: false in pages when appDir is enabled', async () => {
     const $ = await next.render$('/legacy/no-ssr')

--- a/test/e2e/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
+++ b/test/e2e/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('empty-generate-static-params', () => {
-  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   function errorBlock(cliOutput: string) {
     return cliOutput.slice(

--- a/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
+++ b/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
@@ -6,13 +6,14 @@ import {
   retry,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('app-dir - error-on-next-codemod-comment', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   if (isNextDev) {
     beforeAll(async () => {

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app-dir - errors', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   describe('error component', () => {
     it('should trigger error component when an error happens during rendering', async () => {

--- a/test/e2e/app-dir/explicit-parallel-route-children-viewport-known-limitation/explicit-parallel-route-children-viewport-known-limitation.test.ts
+++ b/test/e2e/app-dir/explicit-parallel-route-children-viewport-known-limitation/explicit-parallel-route-children-viewport-known-limitation.test.ts
@@ -3,21 +3,19 @@ import { createRouterAct } from 'router-act'
 
 const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
+// Deploy mode exclusion: A deployed fixture cannot be patched before
+// startup. The ordinary deploy run remains covered; Cache Components
+// behavior is exercised in the local dev and production test runs.
+// @force-gate !deploy || !cacheComponents
 describe('explicit parallel route children viewport limitation', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     // Cache Components requires this route to declare `instant = false`, but
     // that declaration is invalid when Cache Components is disabled. Delay
     // startup only in that mode so we can add the declaration to the isolated
     // fixture first.
     skipStart: isCacheComponentsEnabled,
-    // A deployed fixture cannot be patched before startup. The ordinary deploy
-    // run remains covered; Cache Components behavior is exercised in the local
-    // dev and production test runs.
-    skipDeployment: isCacheComponentsEnabled,
   })
-
-  if (skipped) return
 
   beforeAll(async () => {
     if (!isCacheComponentsEnabled) return

--- a/test/e2e/app-dir/forbidden/default/forbidden-default.test.ts
+++ b/test/e2e/app-dir/forbidden/default/forbidden-default.test.ts
@@ -5,15 +5,13 @@ import {
   getRedboxDescription,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - forbidden with default forbidden boundary', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // TODO: error forbidden usage in root layout
   it.skip('should error on client forbidden from root layout in browser', async () => {

--- a/test/e2e/app-dir/global-error/catch-all/index.test.ts
+++ b/test/e2e/app-dir/global-error/catch-all/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - global error - with catch-all route', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render catch-all route correctly', async () => {
     expect(await next.render('/en/foo')).toContain('catch-all page')

--- a/test/e2e/app-dir/global-error/layout-error/index.test.ts
+++ b/test/e2e/app-dir/global-error/layout-error/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - global error - layout error', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render global error for error in server components', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/i18n-hybrid/i18n-hybrid.test.ts
+++ b/test/e2e/app-dir/i18n-hybrid/i18n-hybrid.test.ts
@@ -48,6 +48,8 @@ const urls = [
   })),
 ]
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('i18n-hybrid', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/import-meta-glob-text-type/import-meta-glob-text-type.test.ts
+++ b/test/e2e/app-dir/import-meta-glob-text-type/import-meta-glob-text-type.test.ts
@@ -1,18 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // `turbopack.rules` is a Turbopack-only feature; skip under webpack
-const testFn =
-  process.env.IS_WEBPACK_TEST || process.env.NEXT_RSPACK
-    ? describe.skip
-    : describe
-
-testFn('turbopack `text` / `raw` module types', () => {
-  const { next, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): No deploy-specific incompatibility is
+// documented.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('turbopack `text` / `raw` module types', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should load matched files as strings through a `?raw` rule', async () => {
     const $ = await next.render$('/raw')

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -1323,6 +1323,9 @@ describe('instant-navigation-testing-api - partial prefetching (App Shells)', ()
 // lock) is a dev-time concern, so this suite uses a dedicated fixture and runs
 // in dev only; `next start`/deploy register a single placeholder so the build
 // is never attempted.
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('instant-navigation-testing-api - blocking routes (dev only)', () => {
   if (!isNextDev) {
     it('skips blocking route tests outside dev (route cannot be production-built)', () => {})
@@ -1331,7 +1334,6 @@ describe('instant-navigation-testing-api - blocking routes (dev only)', () => {
 
   const { next } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'blocking'),
-    skipDeployment: true,
   })
 
   // The cookie value must not commit while the instant lock is held; it only

--- a/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
+++ b/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
@@ -6,16 +6,14 @@ import {
   parseValidationMessages,
 } from 'e2e-utils/instant-validation'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant-validation-build', () => {
-  const { next, skipped, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
   if (!isNextStart) {
     it.skip('Build-time only test', () => {})
     return

--- a/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
+++ b/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
@@ -2,15 +2,16 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import type { ValidationEvent } from 'next/dist/server/app-render/dev-validation-events'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('instant validation causes', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
   if (!isNextDev) {
     it.skip('Only implemented in dev', () => {})
     return

--- a/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
+++ b/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
@@ -1,16 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app dir - instant-validation-client', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should error when a client component exports instant', async () => {
     const expectedErrMsg = `"instant" is a route segment config and can only be used when the segment is a Server Component module. Remove the "use client" directive`

--- a/test/e2e/app-dir/instant-validation-level-default/instant-validation-level-default.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-default/instant-validation-level-default.test.ts
@@ -11,16 +11,17 @@ import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 // For exhaustive coverage of explicit levels and per-segment overrides,
 // see the sibling `instant-validation-level-{warning,manual-warning,error,
 // manual-error}` fixtures.
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('instant validation - default level', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     it.skip('TODO: snapshot tests for webpack', () => {})

--- a/test/e2e/app-dir/instant-validation-level-error/instant-validation-level-error.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-error/instant-validation-level-error.test.ts
@@ -5,16 +5,17 @@ import {
 } from 'e2e-utils/instant-validation'
 import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant validation - level error', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     it.skip('TODO: snapshot tests for webpack', () => {})

--- a/test/e2e/app-dir/instant-validation-level-manual-error/instant-validation-level-manual-error.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/instant-validation-level-manual-error.test.ts
@@ -5,16 +5,17 @@ import {
 } from 'e2e-utils/instant-validation'
 import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant validation - level manual-error', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     it.skip('TODO: snapshot tests for webpack', () => {})

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/instant-validation-level-manual-warning.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/instant-validation-level-manual-warning.test.ts
@@ -7,16 +7,17 @@ import {
 import { getPrerenderOutput } from '../cache-components-errors/utils'
 import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant validation - level manual-warning', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     it.skip('TODO: snapshot tests for webpack', () => {})

--- a/test/e2e/app-dir/instant-validation-level-warning/instant-validation-level-warning.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-warning/instant-validation-level-warning.test.ts
@@ -5,16 +5,17 @@ import {
 } from 'e2e-utils/instant-validation'
 import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant validation - level warning', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     it.skip('TODO: snapshot tests for webpack', () => {})

--- a/test/e2e/app-dir/instant-validation-static-shells/instant-validation-static-shells.test.ts
+++ b/test/e2e/app-dir/instant-validation-static-shells/instant-validation-static-shells.test.ts
@@ -2,12 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitForNoErrorToast } from 'next-test-utils'
 import { join } from 'node:path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('instant validation - opting out of static shells', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'valid'),
-    skipDeployment: true,
   })
-  if (skipped) return
 
   // NOTE: if something's wrong in build, we'll fail before any tests run.
   // Visiting the pages is mostly just a sanity check.
@@ -30,13 +31,14 @@ describe('instant validation - opting out of static shells', () => {
 })
 
 describe('instant validation', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('requires a static shell if a below a static layout page is configured as blocking', () => {
-    const { next, skipped, isNextDev } = nextTestSetup({
+    const { next, isNextDev } = nextTestSetup({
       files: join(__dirname, 'fixtures', 'invalid-blocking-page-below-static'),
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     if (isNextDev) {
       beforeAll(() => next.start())

--- a/test/e2e/app-dir/instant-validation/harness.util.ts
+++ b/test/e2e/app-dir/instant-validation/harness.util.ts
@@ -43,17 +43,16 @@ export const NO_VALIDATION_ERRORS_WAIT: Parameters<
 export function runInstantValidationTests(
   registerTests: (ctx: InstantValidationCaseContext) => void
 ) {
+  // This suite controls the local build lifecycle directly, which deployment tests cannot reproduce.
+  // @force-gate !deploy
   describe('instant validation', () => {
-    const { next, skipped, isNextDev, isNextStart, isTurbopack } =
-      nextTestSetup({
-        files: __dirname,
-        skipStart: true, // for `prerender`
-        skipDeployment: true,
-        env: {
-          NEXT_TEST_LOG_VALIDATION: '1',
-        },
-      })
-    if (skipped) return
+    const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+      files: __dirname,
+      skipStart: true,
+      env: {
+        NEXT_TEST_LOG_VALIDATION: '1',
+      },
+    })
 
     if (isNextStart && !isTurbopack) {
       // TODO(instant-validation-build): snapshot tests for webpack

--- a/test/e2e/app-dir/instant-validation/parallel-slots.test.ts
+++ b/test/e2e/app-dir/instant-validation/parallel-slots.test.ts
@@ -7,16 +7,17 @@ import {
 } from 'e2e-utils/instant-validation'
 import { retry, waitForNoErrorToast } from '../../../lib/next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant validation - parallel slot configs', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     // TODO(instant-validation-build): snapshot tests for webpack

--- a/test/e2e/app-dir/instant-validation/server-errors.test.ts
+++ b/test/e2e/app-dir/instant-validation/server-errors.test.ts
@@ -6,16 +6,17 @@ import {
 import { retry, waitForRedbox } from '../../../lib/next-test-utils'
 import { createRedboxSnapshot } from '../../../lib/add-redbox-matchers'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('instant validation - server errors', () => {
-  const { next, skipped, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     env: {
       NEXT_TEST_LOG_VALIDATION: '1',
     },
   })
-  if (skipped) return
 
   if (isNextStart && !isTurbopack) {
     it.skip('TODO: snapshot tests for webpack', () => {})

--- a/test/e2e/app-dir/interception-routes-output-export/interception-routes-output-export.test.ts
+++ b/test/e2e/app-dir/interception-routes-output-export/interception-routes-output-export.test.ts
@@ -2,12 +2,13 @@ import type { ChildProcess } from 'child_process'
 import { isNextDev, isNextStart, nextTestSetup } from 'e2e-utils'
 import { findPort, killApp, retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('interception-routes-output-export', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
 
   it('should error when using interception routes with static export', async () => {

--- a/test/e2e/app-dir/io/io.test.ts
+++ b/test/e2e/app-dir/io/io.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('io with cache components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/cache-components',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should make content after io() dynamic during prerender', async () => {
     const $ = await next.render$('/io-boundary')
@@ -57,15 +55,13 @@ describe('io with cache components', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('io without cache components', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/default',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should be a no-op during prerender without cache components', async () => {
     const $ = await next.render$('/io-boundary')

--- a/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
+++ b/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
@@ -10,9 +10,11 @@ async function testDev(browser, errorRegex) {
 }
 
 describe('Error test if the loader file export a named function', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
   describe('in Development', () => {
     const { next, isNextDev } = nextTestSetup({
-      skipDeployment: true,
       files: __dirname,
     })
 
@@ -29,9 +31,11 @@ describe('Error test if the loader file export a named function', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
   describe('in Build and Start', () => {
     const { next, isNextStart } = nextTestSetup({
-      skipDeployment: true,
       skipStart: true,
       files: __dirname,
     })

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
 for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
+  // TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+  // It was excluded as a known deploy failure without a documented root cause.
   describe(`mdx ${type}`, () => {
     const { next } = nextTestSetup({
       files: __dirname,

--- a/test/e2e/app-dir/metadata-json-manifest/index.test.ts
+++ b/test/e2e/app-dir/metadata-json-manifest/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir metadata-json-manifest', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should support metadata.json manifest', async () => {
     const response = await next.fetch('/manifest.json')

--- a/test/e2e/app-dir/metadata-static-file-gsp/metadata-static-file-gsp.test.ts
+++ b/test/e2e/app-dir/metadata-static-file-gsp/metadata-static-file-gsp.test.ts
@@ -1,13 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('metadata-static-file-gsp', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should build and serve a static metadata file colocated with generateStaticParams', async () => {
     await next.render('/results/two')

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-dynamic-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-dynamic-route.test.ts
@@ -6,13 +6,9 @@ import {
 } from './utils'
 
 describe('metadata-files-static-output-dynamic-route', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have correct link tags for dynamic page with static placeholder', async () => {
     const browser = await next.browser('/dynamic/123')

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-group-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-group-route.test.ts
@@ -6,13 +6,9 @@ import {
 } from './utils'
 
 describe('metadata-files-static-output-group-route', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have correct link tags for group page', async () => {
     const browser = await next.browser('/group')

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-intercepting-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-intercepting-route.test.ts
@@ -28,13 +28,9 @@ describe('metadata-files-static-output-intercepting-route', () => {
     return
   }
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have correct link tags for intercepting page', async () => {
     const browser = await next.browser('/intercepting')

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-parallel-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-parallel-route.test.ts
@@ -28,13 +28,9 @@ describe('metadata-files-static-output-parallel-route', () => {
     return
   }
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have correct link tags for parallel slot page', async () => {
     const browser = await next.browser('/parallel')

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-root-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-root-route.test.ts
@@ -28,13 +28,9 @@ describe('metadata-files-static-output-root-route', () => {
     return
   }
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have correct link tags for root page', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-static-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-static-route.test.ts
@@ -28,13 +28,9 @@ describe('metadata-files-static-output-static-route', () => {
     return
   }
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have correct link tags for static page', async () => {
     const browser = await next.browser('/static')

--- a/test/e2e/app-dir/metadata-suspense/index.test.ts
+++ b/test/e2e/app-dir/metadata-suspense/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - metadata dynamic routes suspense', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render metadata in head when root layout is wrapped with Suspense for bot requests', async () => {
     const $ = await next.render$('/', undefined, {

--- a/test/e2e/app-dir/metadata-warnings/metadata-warnings-missing-metadatabase.test.ts
+++ b/test/e2e/app-dir/metadata-warnings/metadata-warnings-missing-metadatabase.test.ts
@@ -3,15 +3,13 @@ import { nextTestSetup } from 'e2e-utils'
 const METADATA_BASE_WARN_STRING =
   'metadataBase property in metadata export is not set for resolving social open graph or twitter images,'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app dir - metadata missing metadataBase', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // If it's start mode, we get the whole logs since they're from build process.
   // If it's development mode, we get the logs after request

--- a/test/e2e/app-dir/metadata-warnings/metadata-warnings-with-metadatabase.test.ts
+++ b/test/e2e/app-dir/metadata-warnings/metadata-warnings-with-metadatabase.test.ts
@@ -3,10 +3,12 @@ import { nextTestSetup } from 'e2e-utils'
 const METADATA_BASE_WARN_STRING =
   'metadataBase property in metadata export is not set for resolving social open graph or twitter images,'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app dir - metadata missing metadataBase', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     overrideFiles: {
       'app/layout.js': `
         export default function Layout({ children }) {
@@ -23,10 +25,6 @@ describe('app dir - metadata missing metadataBase', () => {
       `,
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   // If it's start mode, we get the whole logs since they're from build process.
   // If it's development mode, we get the logs after request

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -16,6 +16,8 @@ import path from 'path'
 // Turbopack: /favicon.ico?favicon.<hash>.ico
 const FAVICON_REGEX = /\/favicon.ico\?\w+/
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('app dir - metadata', () => {
   const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/missing-suspense-with-csr-bailout/missing-suspense-with-csr-bailout.test.ts
+++ b/test/e2e/app-dir/missing-suspense-with-csr-bailout/missing-suspense-with-csr-bailout.test.ts
@@ -1,16 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// Deploy mode exclusion: This suite mutates fixture files, which cannot be changed after deployment.
+// This test is skipped when deployed because it's not possible to rename files after deployment.
+// @force-gate !deploy
 describe('missing-suspense-with-csr-bailout', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    // This test is skipped when deployed because it's not possible to rename files after deployment.
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     it.skip('skip test for development mode', () => {})

--- a/test/e2e/app-dir/modularizeimports/modularizeimports.test.ts
+++ b/test/e2e/app-dir/modularizeimports/modularizeimports.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('modularizeImports', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
@@ -1,8 +1,11 @@
 import { join } from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('multiple-lockfiles - has-output-file-tracing-root', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
       // This will silence the multiple lockfiles warning.
@@ -22,15 +25,10 @@ describe('multiple-lockfiles - has-output-file-tracing-root', () => {
     },
     // So that ../package-lock.json doesn't leave the isolated testDir
     subDir: 'test',
-    skipDeployment: true,
     // The workspace file would suppress the warning itself, so the test
     // wouldn't be exercising `outputFileTracingRoot`.
     deleteWorkspaceFile: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have multiple lockfiles warnings', async () => {
     expect(next.cliOutput).not.toMatch(

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
@@ -1,8 +1,11 @@
 import { join } from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('multiple-lockfiles - has-turbo-root', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
       // This will silence the multiple lockfiles warning.
@@ -22,15 +25,10 @@ describe('multiple-lockfiles - has-turbo-root', () => {
     },
     // So that ../package-lock.json doesn't leave the isolated testDir
     subDir: 'test',
-    skipDeployment: true,
     // The workspace file would suppress the warning itself, so the test
     // wouldn't be exercising `turbopack.root`.
     deleteWorkspaceFile: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have multiple lockfiles warnings', async () => {
     expect(next.cliOutput).not.toMatch(

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
@@ -2,8 +2,11 @@ import { join } from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('multiple-lockfiles', () => {
-  const { next, skipped, isTurbopack } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
       // Write a package-lock.json file to the parent directory to simulate
@@ -21,15 +24,10 @@ describe('multiple-lockfiles', () => {
     },
     // So that ../package-lock.json doesn't leave the isolated testDir
     subDir: 'test',
-    skipDeployment: true,
     // The workspace file would be treated as the root and suppress the
     // warning.
     deleteWorkspaceFile: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should have multiple lockfiles warnings', async () => {
     await retry(async () => {

--- a/test/e2e/app-dir/next-condition/next-condition.test.ts
+++ b/test/e2e/app-dir/next-condition/next-condition.test.ts
@@ -1,7 +1,10 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Deploy tests are broken with `config.serverExternalPackages`
+// @force-gate !deploy
 describe('`next-js` Condition - Rendering', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname + '/fixtures/render',
     // copy shared packages over to the test folder. This will override the symlink that currently
     // exists in the fixture with relative paths
@@ -9,13 +12,7 @@ describe('`next-js` Condition - Rendering', () => {
       'sym-linked-packages': new FileRef(__dirname + '/packages'),
     },
     dependencies: require('./fixtures/render/package.json').dependencies,
-    // Deploy tests are broken with `config.serverExternalPackages`
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // TODO I should be able to access the complete config from a Next.js Server or Build
   // So I don't have to coordinate using process env variables
@@ -623,8 +620,11 @@ describe('`next-js` Condition - Rendering', () => {
   }
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Deploy tests are broken with `config.serverExternalPackages`
+// @force-gate !deploy
 describe('`next-js` Condition - middleware (legacy)', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname + '/fixtures/middleware',
     // copy shared packages over to the test folder. This will override the symlink that currently
     // exists in the fixture with relative paths
@@ -632,13 +632,7 @@ describe('`next-js` Condition - middleware (legacy)', () => {
       'sym-linked-packages': new FileRef(__dirname + '/packages'),
     },
     dependencies: require('./fixtures/middleware/package.json').dependencies,
-    // Deploy tests are broken with `config.serverExternalPackages`
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
   describe('With or Without Cache Components', () => {
@@ -668,8 +662,11 @@ describe('`next-js` Condition - middleware (legacy)', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Deploy tests are broken with `config.serverExternalPackages`
+// @force-gate !deploy
 describe('`next-js` Condition - proxy', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname + '/fixtures/proxy',
     // copy shared packages over to the test folder. This will override the symlink that currently
     // exists in the fixture with relative paths
@@ -677,13 +674,7 @@ describe('`next-js` Condition - proxy', () => {
       'sym-linked-packages': new FileRef(__dirname + '/packages'),
     },
     dependencies: require('./fixtures/proxy/package.json').dependencies,
-    // Deploy tests are broken with `config.serverExternalPackages`
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
   describe('With or Without Cache Components', () => {
@@ -713,8 +704,11 @@ describe('`next-js` Condition - proxy', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Deploy tests are broken with `config.serverExternalPackages`
+// @force-gate !deploy
 describe('`next-js` Condition - instrumentation', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname + '/fixtures/instrumentation',
     // copy shared packages over to the test folder. This will override the symlink that currently
     // exists in the fixture with relative paths
@@ -723,13 +717,7 @@ describe('`next-js` Condition - instrumentation', () => {
     },
     dependencies: require('./fixtures/instrumentation/package.json')
       .dependencies,
-    // Deploy tests are broken with `config.serverExternalPackages`
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // Recommended for tests that check HTML. Cheerio is a HTML parser that has a jQuery like API.
   describe('With or Without Cache Components', () => {

--- a/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-cjs.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-cjs.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-config-ts-type-error-cjs', () => {
   // TODO: Remove this once we bump minimum Node.js version to v22
   if (!(process.features as any).typescript) {
@@ -7,15 +10,10 @@ describe('next-config-ts-type-error-cjs', () => {
     return
   }
 
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw with type error on build (CJS)', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-esm.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-config-ts-type-error-esm', () => {
   // TODO: Remove this once we bump minimum Node.js version to v22
   if (!(process.features as any).typescript) {
@@ -7,18 +10,13 @@ describe('next-config-ts-type-error-esm', () => {
     return
   }
 
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     packageJson: {
       type: 'module',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw with type error on build (ESM)', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-cjs.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-cjs.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-config-ts-type-error-cjs', () => {
   // TODO: Remove this once we bump minimum Node.js version to v22
   if (!(process.features as any).typescript) {
@@ -7,15 +10,10 @@ describe('next-config-ts-type-error-cjs', () => {
     return
   }
 
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw with type error on build (CJS)', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-esm.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-config-ts-type-error-esm', () => {
   // TODO: Remove this once we bump minimum Node.js version to v22
   if (!(process.features as any).typescript) {
@@ -7,18 +10,13 @@ describe('next-config-ts-type-error-esm', () => {
     return
   }
 
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     packageJson: {
       type: 'module',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw with type error on build (ESM)', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-cjs.test.ts
+++ b/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-cjs.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-config-ts-type-error-cjs', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw with type error on build (CJS)', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-esm.test.ts
@@ -1,18 +1,16 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next-config-ts-type-error-esm', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     packageJson: {
       type: 'module',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should throw with type error on build (ESM)', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
+++ b/test/e2e/app-dir/non-root-project-monorepo/non-root-project-monorepo.test.ts
@@ -7,8 +7,11 @@ import {
 } from 'next-test-utils'
 import * as path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('non-root-project-monorepo', () => {
-  const { next, skipped, isTurbopack, isNextDev, isRspack } = nextTestSetup({
+  const { next, isTurbopack, isNextDev, isRspack } = nextTestSetup({
     files: {
       apps: new FileRef(path.resolve(__dirname, 'apps')),
       packages: new FileRef(path.resolve(__dirname, 'packages')),
@@ -24,12 +27,7 @@ describe('non-root-project-monorepo', () => {
     buildCommand: 'pnpm build',
     startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
     installCommand: 'pnpm i',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   describe('server relative import', () => {
     it('should resolve a `/`-rooted import from the project directory, not the workspace root', async () => {

--- a/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
+++ b/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
@@ -4,15 +4,13 @@ import {
   RSC_HEADER,
 } from 'next/dist/client/components/app-router-headers'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('non-rsc-router-prefetch', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   beforeAll(async () => {
     const res = await next.fetch('/')

--- a/test/e2e/app-dir/not-found-default/index.test.ts
+++ b/test/e2e/app-dir/not-found-default/index.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - not found with default 404 page', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should error on client notFound from root layout in browser', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/not-found-with-layout-and-group-not-found/index.test.ts
+++ b/test/e2e/app-dir/not-found-with-layout-and-group-not-found/index.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - not found with nested layouts and custom not-found', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render the custom not-found page when notFound() is thrown from a page within the group', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/not-found-with-nested-layouts/index.test.ts
+++ b/test/e2e/app-dir/not-found-with-nested-layouts/index.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - not found with nested layouts', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render the custom not-found page when notFound() is thrown from a page', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/not-found/basic/index.test.ts
+++ b/test/e2e/app-dir/not-found/basic/index.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('app dir - not-found - basic', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it("should propagate notFound errors past a segment's error boundary", async () => {
     let browser = await next.browser('/error-boundary')

--- a/test/e2e/app-dir/not-found/conflict-route/index.test.ts
+++ b/test/e2e/app-dir/not-found/conflict-route/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('app dir - not-found - conflict route', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   const runTests = () => {
     it('should use the not-found page for non-matching routes', async () => {

--- a/test/e2e/app-dir/not-found/default/default.test.ts
+++ b/test/e2e/app-dir/not-found/default/default.test.ts
@@ -2,10 +2,12 @@ import { nextTestSetup } from 'e2e-utils'
 
 const isPPREnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('app dir - not-found - default', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('should has noindex in the head html', async () => {

--- a/test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts
+++ b/test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - group routes with root not-found', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render default 404 with root layout for non-existent page', async () => {
     const browser = await next.browser('/non-existent')

--- a/test/e2e/app-dir/not-found/group-route/index.test.ts
+++ b/test/e2e/app-dir/not-found/group-route/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('app dir - not-found - group route', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   const runTests = () => {
     it('should use the not-found page under group routes', async () => {

--- a/test/e2e/app-dir/nx-handling/nx-handling.test.ts
+++ b/test/e2e/app-dir/nx-handling/nx-handling.test.ts
@@ -1,8 +1,10 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('nx-handling', () => {
   const { next } = nextTestSetup({
-    skipDeployment: true,
     files: __dirname,
     installCommand: 'npm i',
     buildCommand: 'npm run build',

--- a/test/e2e/app-dir/pages-router-app-not-found/pages-router-app-not-found.test.ts
+++ b/test/e2e/app-dir/pages-router-app-not-found/pages-router-app-not-found.test.ts
@@ -1,13 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
-const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
-
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The legacy builder incorrectly replaces this response with the Pages
+// Router error page. The adapter preserves the App Router not-found page.
+// @force-gate !deploy || adapter
 describe('pages-router-app-not-found', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // The legacy builder incorrectly replaces this response with the Pages
-    // Router error page. The adapter preserves the App Router not-found page.
-    skipDeployment: !isAdapterTest,
   })
 
   it('fully renders an app not-found selected by a pages route', async () => {

--- a/test/e2e/app-dir/parallel-routes-and-interception-nested-dynamic-routes/parallel-routes-and-interception-nested-dynamic-routes.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception-nested-dynamic-routes/parallel-routes-and-interception-nested-dynamic-routes.test.ts
@@ -1,11 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// TODO: re-enable when resolved related thread
+// https://vercel.slack.com/archives/C07UCHRBWGK/p1759165345308879
+// @force-gate !deploy
 describe('parallel-routes-and-interception-nested-dynamic-routes', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // TODO: re-enable when resolved related thread
-    // https://vercel.slack.com/archives/C07UCHRBWGK/p1759165345308879
-    skipDeployment: true,
   })
 
   it('should intercept the route for nested dynamic routes', async () => {

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -1056,11 +1056,12 @@ describe.each([true, false])(
   }
 )
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This is skipped when deployed as it appears to cause an issue when tracing Next.js files
+// TODO: Investigate why this causes an issue when deployed
+// @force-gate !deploy
 describe('parallel-routes-and-interception-conflicting-pages', () => {
-  const { next, skipped } = nextTestSetup({
-    // This is skipped when deployed as it appears to cause an issue when tracing Next.js files
-    // TODO: Investigate why this causes an issue when deployed
-    skipDeployment: true,
+  const { next } = nextTestSetup({
     files: {
       app: new FileRef(path.join(__dirname, 'app')),
       'app/parallel/nested-2/page.js': `
@@ -1071,8 +1072,6 @@ describe('parallel-routes-and-interception-conflicting-pages', () => {
     },
     nextConfig,
   })
-
-  if (skipped) return
 
   it('should gracefully handle when two page segments match the `children` parallel slot', async () => {
     const html = await next.render('/parallel/nested-2')

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
@@ -2,17 +2,14 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('parallel-routes-leaf-segments-build-error', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'build-error'),
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    it.skip('skip test', () => {})
-    return
-  }
 
   if (isNextDev) {
     beforeAll(() => next.start())

--- a/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
@@ -1,16 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// TODO: remove after deployment handling is updated
+// @force-gate !deploy
 describe('parallel-routes-and-interception', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // TODO: remove after deployment handling is updated
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // TODO: revisit the error for missing parallel routes slot
   it('should not render the @children slot when the @slot is not found', async () => {

--- a/test/e2e/app-dir/partial-fallback-root-blocking/partial-fallback-root-blocking.test.ts
+++ b/test/e2e/app-dir/partial-fallback-root-blocking/partial-fallback-root-blocking.test.ts
@@ -2,14 +2,13 @@ import cheerio from 'cheerio'
 import { nextTestSetup } from 'e2e-utils'
 import { splitResponseWithPPRSentinel } from 'e2e-utils/ppr'
 
-const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
-
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The latest changes to support this behavior on deployed infra are available in the adapter,
+// and are not being backported to the CLI
+// @force-gate !deploy || adapter
 describe('partial-fallback-root-blocking', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    // The latest changes to support this behavior on deployed infra are available in the adapter,
-    // and are not being backported to the CLI
-    skipDeployment: !isAdapterTest,
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
@@ -4,8 +4,6 @@ import { splitResponseWithPPRSentinel } from 'e2e-utils/ppr'
 import { retry, waitFor } from 'next-test-utils'
 import path from 'path'
 
-const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
-
 type NextInstance = ReturnType<typeof nextTestSetup>['next']
 
 function createSplitHTMLFetcher(next: NextInstance) {
@@ -32,14 +30,15 @@ function createSplitHTMLFetcher(next: NextInstance) {
   }
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The latest changes to support this behavior on deployed infra are available in the adapter,
+// and are not being backported to the CLI
+// @force-gate !deploy || adapter
 describe('partial-fallback-shell-upgrade', () => {
   const { next, isNextDev } = nextTestSetup({
     // Deployed shell upgrades require `partialFallback` metadata, which the
     // adapter only emits when Partial Prefetching is enabled in the fixture.
     files: path.join(__dirname, 'fixtures', 'default'),
-    // The latest changes to support this behavior on deployed infra are available in the adapter,
-    // and are not being backported to the CLI
-    skipDeployment: !isAdapterTest,
   })
 
   if (isNextDev) {
@@ -171,12 +170,13 @@ describe('partial-fallback-shell-upgrade', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The latest changes to support this behavior on deployed infra are available in the adapter,
+// and are not being backported to the CLI
+// @force-gate !deploy || adapter
 describe('partial-fallback-shell-upgrade - partialPrefetching disabled', () => {
   const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'partial-prefetching-disabled'),
-    // The latest changes to support this behavior on deployed infra are available in the adapter,
-    // and are not being backported to the CLI
-    skipDeployment: !isAdapterTest,
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/pnpm-workspace-root/pnpm-workspace-root.test.ts
+++ b/test/e2e/app-dir/pnpm-workspace-root/pnpm-workspace-root.test.ts
@@ -1,7 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('pnpm-workspace-root', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       'app/layout.tsx': `
         import { ReactNode } from 'react'
@@ -44,12 +47,7 @@ describe('pnpm-workspace-root', () => {
     },
     // So that parent files don't leave the isolated testDir
     subDir: 'test',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should detect root directory from pnpm-workspace.yaml and allow imports from outside app dir', async () => {
     // The app should start successfully when pnpm-workspace.yaml is present

--- a/test/e2e/app-dir/ppr-metadata-blocking/ppr-metadata-blocking-ppr-fallback.test.ts
+++ b/test/e2e/app-dir/ppr-metadata-blocking/ppr-metadata-blocking-ppr-fallback.test.ts
@@ -5,17 +5,17 @@ function countSubstring(str: string, substr: string): number {
 }
 
 // TODO(NAR-423): Migrate to Cache Components.
-describe.skip('ppr-metadata-blocking-ppr-fallback', () => {
-  const { next, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Need to skip deployment because the test uses the private env cannot be used in deployment
+// @force-gate !deploy
+// @force-gate TODO
+describe('ppr-metadata-blocking-ppr-fallback', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-    // Need to skip deployment because the test uses the private env cannot be used in deployment
-    skipDeployment: true,
     env: {
       __NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING: '1',
     },
   })
-
-  if (skipped) return
 
   it('should not include metadata in partial shell when page is fully dynamic', async () => {
     const $ = await next.render$('/fully-dynamic?__nextppronly=fallback')

--- a/test/e2e/app-dir/ppr-missing-root-params/ppr-missing-root-params.test.ts
+++ b/test/e2e/app-dir/ppr-missing-root-params/ppr-missing-root-params.test.ts
@@ -1,13 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('ppr-missing-root-params (single)', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures/single'),
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     try {
@@ -26,13 +27,14 @@ describe('ppr-missing-root-params (single)', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('ppr-missing-root-params (multiple)', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures/multiple'),
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     try {
@@ -51,13 +53,14 @@ describe('ppr-missing-root-params (multiple)', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('ppr-missing-root-params (nested)', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures/nested'),
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     try {

--- a/test/e2e/app-dir/ppr-navigations/avoid-popstate-flash/avoid-popstate-flash.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/avoid-popstate-flash/avoid-popstate-flash.test.ts
@@ -4,6 +4,7 @@ import { createTestDataServer } from 'test-data-service/writer'
 import { createTestLog } from 'test-log'
 
 describe('avoid-popstate-flash', () => {
+  // Deploy mode exclusion: This suite depends on a test-data service running on a local port.
   if ((global as any).isNextDev || (global as any).isNextDeploy) {
     // this is skipped in dev because PPR is not enabled in dev
     // and in deploy we can't rely on this test data service existing

--- a/test/e2e/app-dir/ppr-navigations/stale-prefetch-entry/stale-prefetch-entry.test.ts
+++ b/test/e2e/app-dir/ppr-navigations/stale-prefetch-entry/stale-prefetch-entry.test.ts
@@ -4,6 +4,7 @@ import { createTestDataServer } from 'test-data-service/writer'
 import { createTestLog } from 'test-log'
 
 describe('stale-prefetch-entry', () => {
+  // Deploy mode exclusion: This suite depends on a test-data service running on a local port.
   if ((global as any).isNextDev || (global as any).isNextDeploy) {
     // this is skipped in dev because PPR is not enabled in dev
     // and in deploy we can't rely on this test data service existing

--- a/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
+++ b/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
@@ -7,15 +7,16 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// the file-patching strategy we use for synchronizing the test doesn't work
+// on deployments
+// @force-gate !deploy
 describe('PPR - partial hydration', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    // the file-patching strategy we use for synchronizing the test doesn't work
-    // on deployments
-    skipDeployment: true,
   })
 
-  if (isNextDev || skipped) {
+  if (isNextDev) {
     it.skip('only testable in production (non-deployment)', () => {})
     return
   }

--- a/test/e2e/app-dir/ppr-unstable-cache/ppr-unstable-cache.test.ts
+++ b/test/e2e/app-dir/ppr-unstable-cache/ppr-unstable-cache.test.ts
@@ -3,6 +3,7 @@ import { findPort } from 'next-test-utils'
 import http from 'node:http'
 
 describe('ppr-unstable-cache', () => {
+  // Deploy mode exclusion: This suite starts a local HTTP data server on a dynamically allocated port.
   if (isNextDeploy) {
     it.skip('should not run in deploy mode', () => {})
     return

--- a/test/e2e/app-dir/proxy-missing-export/proxy-missing-export.test.ts
+++ b/test/e2e/app-dir/proxy-missing-export/proxy-missing-export.test.ts
@@ -15,16 +15,14 @@ To fix it:
 
 Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('proxy-missing-export', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should error when proxy file has invalid export named middleware', async () => {
     await writeFile(

--- a/test/e2e/app-dir/proxy-runtime/proxy-runtime.test.ts
+++ b/test/e2e/app-dir/proxy-runtime/proxy-runtime.test.ts
@@ -1,16 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('proxy-runtime', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should error when proxy file has runtime config export', async () => {
     let cliOutput: string

--- a/test/e2e/app-dir/refresh/refresh.test.ts
+++ b/test/e2e/app-dir/refresh/refresh.test.ts
@@ -1,14 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry, waitForRedbox, getRedboxDescription } from 'next-test-utils'
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// We do not have access to runtime logs when deployed
+// @force-gate !deploy
 describe('app-dir refresh', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    // We do not have access to runtime logs when deployed
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should refresh client cache when refresh() is called in a server action', async () => {
     const browser = await next.browser('/refresh')

--- a/test/e2e/app-dir/revalidate-dynamic/revalidate-dynamic.test.ts
+++ b/test/e2e/app-dir/revalidate-dynamic/revalidate-dynamic.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('app-dir revalidate-dynamic', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
+++ b/test/e2e/app-dir/rewrite-headers/rewrite-headers.test.ts
@@ -460,13 +460,13 @@ const cases: {
   },
 ]
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// TODO: re-enable once changes in infrastructure are merged
+// @force-gate !deploy
 describe('rewrite-headers', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // TODO: re-enable once changes in infrastructure are merged
-    skipDeployment: true,
   })
-  if (skipped) return
 
   describe.each(cases)(
     '$name ($pathname)',

--- a/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
+++ b/test/e2e/app-dir/rewrites-redirects/rewrites-redirects.test.ts
@@ -9,6 +9,8 @@ describe('redirects and rewrites', () => {
   })
 
   // TODO: investigate test failures on deploy
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // The source only records that these assertions fail after deployment; the root cause is unknown.
   if ((global as any).isNextDeploy) {
     it('should skip for deploy', () => {})
     return

--- a/test/e2e/app-dir/root-detection/git-repository-boundary.test.ts
+++ b/test/e2e/app-dir/root-detection/git-repository-boundary.test.ts
@@ -8,8 +8,11 @@ import { packageJson, packageLock } from './test-utils'
 //     ├── .git/
 //     ├── package-lock.json
 //     └── app/                 the Next.js app
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('root-detection - git repository boundary', () => {
-  const { next, skipped, isTurbopack } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
       // a `.git` directory makes the parent directory a repository root.
@@ -21,15 +24,10 @@ describe('root-detection - git repository boundary', () => {
     },
     // So that the files written above don't leave the isolated testDir
     subDir: 'repo/app',
-    skipDeployment: true,
     // The workspace file would stop the search before the Git boundary does,
     // so the test wouldn't be exercising the boundary.
     deleteWorkspaceFile: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not select a root above the repository', async () => {
     const repoDir = dirname(next.testDir)

--- a/test/e2e/app-dir/root-detection/git-worktree-boundary.test.ts
+++ b/test/e2e/app-dir/root-detection/git-worktree-boundary.test.ts
@@ -13,8 +13,11 @@ import {
 //     ├── .git                         a file pointing at the Git directory
 //     ├── package-lock.json
 //     └── app/                         the Next.js app
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('root-detection - git worktree boundary', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'app')),
       '../.git': 'gitdir: ../repo/.git/worktrees/worktree\n',
@@ -28,15 +31,10 @@ describe('root-detection - git worktree boundary', () => {
     },
     // So that the files written above don't leave the isolated testDir
     subDir: 'worktree/app',
-    skipDeployment: true,
     // The workspace file would stop the search before the worktree boundary
     // does, so the test wouldn't be exercising the boundary.
     deleteWorkspaceFile: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not select a root above the worktree', async () => {
     const worktreeDir = dirname(next.testDir)

--- a/test/e2e/app-dir/root-detection/home-directory-boundary.test.ts
+++ b/test/e2e/app-dir/root-detection/home-directory-boundary.test.ts
@@ -41,10 +41,13 @@ const cases: Array<{
   },
 ]
 
+// This suite changes HOME for a locally managed Next.js process and inspects
+// its CLI output.
+// @force-gate !deploy
 describe.each(cases)(
   'root-detection - home directory boundary ($name)',
   ({ getHome, getRoot, getRootLockFile }) => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: {
         app: new FileRef(join(__dirname, 'app')),
         '../package.json': packageJson('project'),
@@ -54,7 +57,6 @@ describe.each(cases)(
       },
       // So that the files written above don't leave the isolated testDir
       subDir: 'project/app',
-      skipDeployment: true,
       // The workspace file would stop the search before the home directory
       // boundary does, so the test wouldn't be exercising the boundary.
       deleteWorkspaceFile: true,
@@ -63,10 +65,6 @@ describe.each(cases)(
       buildCommand: `${nextBin} build`,
       startCommand: `${nextBin} ${isNextDev ? 'dev' : 'start'}`,
     })
-
-    if (skipped) {
-      return
-    }
 
     beforeAll(async () => {
       const home = getHome(next.testDir)

--- a/test/e2e/app-dir/root-detection/package-json-workspaces.test.ts
+++ b/test/e2e/app-dir/root-detection/package-json-workspaces.test.ts
@@ -15,8 +15,11 @@ import {
 // ├── package-lock.json
 // ├── shared/utils.ts        imported by the app
 // └── test/                  the Next.js app, with a lockfile of its own
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('root-detection - package.json workspaces', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       app: new FileRef(join(__dirname, 'workspace-app')),
       '../package.json': packageJson('workspace-root', {
@@ -28,15 +31,10 @@ describe('root-detection - package.json workspaces', () => {
     },
     // So that the files written above don't leave the isolated testDir
     subDir: 'test',
-    skipDeployment: true,
     // The workspace file would make the app directory a workspace root of its
     // own, so the test wouldn't be exercising the `workspaces` field.
     deleteWorkspaceFile: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should select the workspace root as the root', async () => {
     // the app imports a file from the workspace root, which is only reachable

--- a/test/e2e/app-dir/root-layout-render-once/index.test.ts
+++ b/test/e2e/app-dir/root-layout-render-once/index.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir root layout render once', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should only render root layout once', async () => {
     let $ = await next.render$('/render-once')

--- a/test/e2e/app-dir/root-layout/root-layout.test.ts
+++ b/test/e2e/app-dir/root-layout/root-layout.test.ts
@@ -1,19 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, check, getRedboxSource } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir root layout', () => {
-  const {
-    next,
-    isNextDev: isDev,
-    skipped,
-  } = nextTestSetup({
+  const { next, isNextDev: isDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isDev) {
     // TODO-APP: re-enable after reworking the error overlay.

--- a/test/e2e/app-dir/root-suspense-dynamic/root-suspense-dynamic.test.ts
+++ b/test/e2e/app-dir/root-suspense-dynamic/root-suspense-dynamic.test.ts
@@ -1,9 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Root Suspense Dynamic Rendering', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname + '/fixtures/default',
-    skipDeployment: true,
   })
 
   // TODO: remove when there is a test for isNextDev === false

--- a/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
+++ b/test/e2e/app-dir/rsc-basic/rsc-basic.test.ts
@@ -28,6 +28,8 @@ async function resolveStreamResponse(response: any, onData?: any) {
   return result
 }
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('app dir - rsc basics', () => {
   const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/rsc-webpack-loader/rsc-webpack-loader.test.ts
+++ b/test/e2e/app-dir/rsc-webpack-loader/rsc-webpack-loader.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // Skip as Turbopack doesn't support the `!=!` Webpack syntax
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'app dir - rsc webpack loader',
   () => {

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
@@ -7,6 +7,8 @@ import { isNextDeploy, isNextDev, nextTestSetup } from 'e2e-utils'
 import { createFakeCDN } from './server.mjs'
 
 describe('segment cache (CDN cache busting)', () => {
+  // Deploy mode exclusion: This suite runs Next.js behind an in-process fake
+  // CDN on local ports.
   if (isNextDev || isNextDeploy) {
     test('should not run during dev or deploy test runs', () => {})
     return

--- a/test/e2e/app-dir/segment-cache/prefetch-fallback-retry/prefetch-fallback-retry.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-fallback-retry/prefetch-fallback-retry.test.ts
@@ -7,6 +7,8 @@ describe('segment cache prefetch fallback retry', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
+  // Deploy mode exclusion: This suite requires direct observation and control
+  // of local ISR cache state and background regeneration.
   if (isNextDev || isNextDeploy) {
     // Prefetching is disabled in dev, and the recovery test relies on
     // observing ISR cache state and background regeneration, which aren't

--- a/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
+++ b/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
@@ -6,6 +6,8 @@ import { createTestLog } from 'test-log'
 import { findPort } from 'next-test-utils'
 
 describe('segment cache (revalidation)', () => {
+  // Deploy mode exclusion: This suite starts and mutates a process-local test
+  // data server.
   if (isNextDev || isNextDeploy) {
     test('disabled in development / deployment', () => {})
     return

--- a/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/runtime-prerender-cache-warming.test.ts
+++ b/test/e2e/app-dir/segment-cache/runtime-prerender-cache-warming/runtime-prerender-cache-warming.test.ts
@@ -4,12 +4,12 @@ import { createRouterAct } from 'router-act'
 
 import { UNEXPECTED_CACHE_MISS_MESSAGE } from 'next/src/server/use-cache/use-cache-errors'
 
+// Deploy mode exclusion: This suite asserts local server CLI output.
+// @force-gate !deploy
 describe('runtime prerender cache warming', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true, // reads CLI output
   })
-  if (skipped) return
 
   if (isNextDev) {
     it.skip('no prefetching in dev', () => {})

--- a/test/e2e/app-dir/segment-config-ts/segment-config-ts.test.ts
+++ b/test/e2e/app-dir/segment-config-ts/segment-config-ts.test.ts
@@ -1,9 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('TypeScript type expressions in route segment config', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   describe('app directory', () => {

--- a/test/e2e/app-dir/self-importing-package/self-importing-package.test.ts
+++ b/test/e2e/app-dir/self-importing-package/self-importing-package.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test is skipped when deployed because the local tarball appears corrupted
+// It also doesn't seem particularly useful to test when deployed
+// @force-gate !deploy
 describe('self-importing-package', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // This test is skipped when deployed because the local tarball appears corrupted
-    // It also doesn't seem particularly useful to test when deployed
-    skipDeployment: true,
     dependencies: {
       'internal-pkg': `file:${path.join(__dirname, 'internal-pkg.tar')}`,
     },

--- a/test/e2e/app-dir/server-components-externals/index.test.ts
+++ b/test/e2e/app-dir/server-components-externals/index.test.ts
@@ -1,14 +1,13 @@
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
+// Deploy mode exclusion: This suite manually changes the local `node_modules` tree.
+// This test is skipped when deployed because it relies on manually patched `node_modules`
+// @force-gate !deploy
 describe('app-dir - server components externals', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
-    // This test is skipped when deployed because it relies on manually patched `node_modules`
-    skipDeployment: true,
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
   })
-
-  if (skipped) return
 
   it('should have externals for those in config.serverExternalPackages', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/similar-pages-paths/similar-pages-paths.test.ts
+++ b/test/e2e/app-dir/similar-pages-paths/similar-pages-paths.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app-dir similar pages paths', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should not have conflicts for similar pattern page paths between app and pages', async () => {
     // pages/page and app/page

--- a/test/e2e/app-dir/static-shell-debugging/static-shell-debugging.test.ts
+++ b/test/e2e/app-dir/static-shell-debugging/static-shell-debugging.test.ts
@@ -1,18 +1,20 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // TODO(NAR-423): Migrate to Cache Components.
-describe.skip('static-shell-debugging', () => {
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test skips deployment because env vars that are doubled underscore prefixed
+// are not supported. This is also intended to be used in development.
+// @force-gate !deploy
+// @force-gate TODO
+describe('static-shell-debugging', () => {
   const cacheComponents = Boolean(process.env.__NEXT_CACHE_COMPONENTS)
   const context = {
     cacheComponents,
     debugging: cacheComponents,
   }
 
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    // This test skips deployment because env vars that are doubled underscore prefixed
-    // are not supported. This is also intended to be used in development.
-    skipDeployment: true,
     env: {
       __NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING: context.debugging
         ? '1'
@@ -22,8 +24,6 @@ describe.skip('static-shell-debugging', () => {
       cacheComponents: context.cacheComponents,
     },
   })
-
-  if (skipped) return
 
   if (context.debugging && context.cacheComponents) {
     it('should only render the static shell', async () => {

--- a/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
+++ b/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
@@ -1,14 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import * as cheerio from 'cheerio'
 
-const isAdapterTest = process.env.NEXT_ENABLE_ADAPTER === '1'
-
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The latest changes to support this behavior on deployed infra are available in the adapter,
+// and are not being backported to the CLI
+// @force-gate !deploy || adapter
 describe('sub-shell-generation', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    // The latest changes to support this behavior on deployed infra are available in the adapter,
-    // and are not being backported to the CLI
-    skipDeployment: !isAdapterTest,
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/syntax-highlighter-crash/syntax-highlighter-crash.test.ts
+++ b/test/e2e/app-dir/syntax-highlighter-crash/syntax-highlighter-crash.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('syntax-highlighter-crash', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/third-parties/basic.test.ts
+++ b/test/e2e/app-dir/third-parties/basic.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('@next/third-parties basic usage', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
+++ b/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
@@ -3,11 +3,13 @@ import { join } from 'path'
 import { existsSync } from 'fs'
 import { parseTraceFile } from '../../../lib/parse-trace-file'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('trace-build-file', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: !isNextDev,
-    skipDeployment: true,
     env: {
       // Enable persistent caching even when the git working directory is
       // dirty (e.g. when developing Next.js itself). Without this, the

--- a/test/e2e/app-dir/turbopack-loader-content-type/turbopack-loader-content-type.test.ts
+++ b/test/e2e/app-dir/turbopack-loader-content-type/turbopack-loader-content-type.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('turbopack-loader-content-type', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should apply loader based on contentType glob pattern', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
+++ b/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
@@ -5,16 +5,14 @@ import { getDistDir, retry } from 'next-test-utils'
 const strictRouteTypes =
   process.env.__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES === 'true'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('typed-routes-validator', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should generate route validation correctly', async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/typed-routes/typed-links.test.ts
+++ b/test/e2e/app-dir/typed-routes/typed-links.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('typed-links', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should generate types for next/link', async () => {
     await retry(async () => {

--- a/test/e2e/app-dir/typed-routes/typed-routes.test.ts
+++ b/test/e2e/app-dir/typed-routes/typed-routes.test.ts
@@ -12,15 +12,13 @@ type RewriteRoutes = "/api-legacy/[version]/[[...endpoint]]" | "/docs-old/[...pa
 type Routes = AppRoutes | PageRoutes | LayoutRoutes | RedirectRoutes | RewriteRoutes | AppRouteHandlerRoutes
 `
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('typed-routes', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should generate route types correctly', async () => {
     // Route type generation happens after the "Ready" log fires; give it time.

--- a/test/e2e/app-dir/typegen-bundler-env/typegen-bundler-env.test.ts
+++ b/test/e2e/app-dir/typegen-bundler-env/typegen-bundler-env.test.ts
@@ -11,16 +11,14 @@ const baseEnv = {
 
 // cssChunking: "graph", is Turbopack-only, so we use this as to verify whether
 // typegen is selecting the right bundler
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('typegen bundler env', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('defaults to Turbopack, accepting Turbopack-only config', async () => {
     const { code } = await runNextCommand(['typegen', next.testDir], {

--- a/test/e2e/app-dir/typegen-error-diagnostic/typegen-error-diagnostic.test.ts
+++ b/test/e2e/app-dir/typegen-error-diagnostic/typegen-error-diagnostic.test.ts
@@ -1,17 +1,15 @@
 import { nextTestSetup } from 'e2e-utils'
 import { runNextCommand } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('typegen error diagnostic', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     // We drive `next typegen` manually; no server needed.
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('fails loudly with an actionable message when route types cannot be generated', async () => {
     // `next typegen` runs with NODE_ENV=production, which makes the fixture's

--- a/test/e2e/app-dir/typeof-window/typeof-window.test.ts
+++ b/test/e2e/app-dir/typeof-window/typeof-window.test.ts
@@ -1,18 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test is skipped when deployed because the local tarball appears corrupted
+// It also doesn't seem particularly useful to test when deployed
+// @force-gate !deploy
 describe('typeof-window', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // This test is skipped when deployed because the local tarball appears corrupted
-    // It also doesn't seem particularly useful to test when deployed
-    skipDeployment: true,
     dependencies: {
       'my-differentiated-files': `file:${path.join(__dirname, 'my-differentiated-files.tar')}`,
     },
   })
-
-  if (skipped) return
 
   it('should work using cheerio', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/types/types.test.ts
+++ b/test/e2e/app-dir/types/types.test.ts
@@ -1,16 +1,14 @@
 import { execSync } from 'child_process'
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('app-dir types', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should check types', async () => {
     execSync('pnpm next typegen', { cwd: next.testDir, stdio: 'inherit' })

--- a/test/e2e/app-dir/unauthorized/default/unauthorized-default.test.ts
+++ b/test/e2e/app-dir/unauthorized/default/unauthorized-default.test.ts
@@ -5,15 +5,13 @@ import {
   getRedboxDescription,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('app dir - unauthorized with default unauthorized boundary', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   // TODO: error unauthorized usage in root layout
   it.skip('should error on client unauthorized from root layout in browser', async () => {

--- a/test/e2e/app-dir/undefined-default-export/undefined-default-export.test.ts
+++ b/test/e2e/app-dir/undefined-default-export/undefined-default-export.test.ts
@@ -1,11 +1,13 @@
 import path from 'path'
 import { isNextStart, nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Undefined default export', () => {
   const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname),
     skipStart: isNextStart,
-    skipDeployment: true,
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/upward-distdir/upward-distdir.test.ts
+++ b/test/e2e/app-dir/upward-distdir/upward-distdir.test.ts
@@ -1,8 +1,10 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely controls the local Next.js build or server lifecycle.
+// @force-gate !deploy
 describe('upward-distdir', () => {
   const { next } = nextTestSetup({
-    skipDeployment: true,
     files: __dirname,
     installCommand: 'pnpm install',
     buildCommand: 'pnpm next build apps/next-nx-test',

--- a/test/e2e/app-dir/use-cache-after-uncached-io/use-cache-after-uncached-io.test.ts
+++ b/test/e2e/app-dir/use-cache-after-uncached-io/use-cache-after-uncached-io.test.ts
@@ -4,10 +4,12 @@ import { createRouterAct } from '../../../lib/router-act'
 import { setTimeout } from 'timers/promises'
 import { retry } from '../../../lib/next-test-utils'
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// reads cli logs
+// @force-gate !deploy
 describe('use cache called after tasky uncached IO', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true, // reads cli logs
   })
 
   if (isNextStart) {

--- a/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
+++ b/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
@@ -7,16 +7,14 @@ import {
 } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-close-over-function', () => {
-  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     it('should show an error toast for client-side usage', async () => {

--- a/test/e2e/app-dir/use-cache-configured-timeout/use-cache-configured-timeout.test.ts
+++ b/test/e2e/app-dir/use-cache-configured-timeout/use-cache-configured-timeout.test.ts
@@ -8,16 +8,14 @@ function expectedTimeoutErrorMessage(route: string) {
   return `Route "${route}": ${timeoutErrorMessage}`
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-configured-timeout', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     describe('when a "use cache" fill is below the configured dev `useCacheTimeout`', () => {

--- a/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-custom-handler/use-cache-custom-handler.test.ts
@@ -3,14 +3,13 @@ import { retry } from 'next-test-utils'
 
 const isoDateRegExp = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Skip deployment so we can test the custom cache handlers log output
+// @force-gate !deploy
 describe('use-cache-custom-handler', () => {
-  const { next, skipped, isNextStart } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    // Skip deployment so we can test the custom cache handlers log output
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   let outputIndex: number
 

--- a/test/e2e/app-dir/use-cache-deadlock-probe/use-cache-deadlock-probe.test.ts
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/use-cache-deadlock-probe.test.ts
@@ -24,18 +24,17 @@ function expectedDeadlockMessage(route: string) {
 // than detected as a deadlock. Revisit by surfacing these deadlocks at build
 // time via `next build --debug-prerender`, then re-enable (and retarget) this
 // suite.
-describe.skip('use-cache-deadlock-probe', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate TODO
+describe('use-cache-deadlock-probe', () => {
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     // Probe behavior is dev-only; skip the production server start, but
     // let dev mode auto-start.
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (!isNextDev) {
     it('is a dev-only suite', () => {})

--- a/test/e2e/app-dir/use-cache-default-handler-expire-zero/use-cache-default-handler-expire-zero.test.ts
+++ b/test/e2e/app-dir/use-cache-default-handler-expire-zero/use-cache-default-handler-expire-zero.test.ts
@@ -1,19 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-default-handler-expire-zero', () => {
-  const { next, skipped, isNextStart } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
     // Enable the built-in default cache handler's debug logging so we can
     // assert on its `set()` decisions in the CLI output. That output is not
     // available on deploy, so skip the deploy variant.
     env: { NEXT_PRIVATE_DEBUG_CACHE: '1' },
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextStart) {
     it('does not save an expire:0 cache to the built-in default handler, but saves a short-lived one', async () => {

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -17,16 +17,14 @@ function expectedTimeoutErrorMessage(route: string) {
   return `Route "${route}": ${timeoutErrorMessage}`
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-hanging-inputs', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     // TODO(restart-on-cache-miss): reenable when fixed

--- a/test/e2e/app-dir/use-cache-hanging/use-cache-hanging.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging/use-cache-hanging.test.ts
@@ -9,16 +9,14 @@ function expectedTimeoutErrorMessage(route: string) {
   return `Route "${route}": ${timeoutErrorMessage}`
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-hanging', () => {
-  const { next, isNextDev, skipped, isTurbopack } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     describe('when a "use cache" fill hangs in the static stage', () => {

--- a/test/e2e/app-dir/use-cache-infinity-profile/use-cache-infinity-profile.test.ts
+++ b/test/e2e/app-dir/use-cache-infinity-profile/use-cache-infinity-profile.test.ts
@@ -3,11 +3,12 @@ import { nextTestSetup } from 'e2e-utils'
 const uuidRegExp =
   /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Deployment platforms provide their own cache handlers.
+// @force-gate !deploy
 describe('use-cache-infinity-profile', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    // Deployment platforms provide their own cache handlers.
-    skipDeployment: true,
   })
 
   it('caches forever with a configured profile using Infinity revalidate and expire', async () => {

--- a/test/e2e/app-dir/use-cache-og-image-top-level-await/use-cache-og-image-top-level-await.test.ts
+++ b/test/e2e/app-dir/use-cache-og-image-top-level-await/use-cache-og-image-top-level-await.test.ts
@@ -1,17 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The prerendered output can't be observed in a deployment, and without
+// it nothing distinguishes broken from fixed behavior.
+// @force-gate !deploy
 describe('use-cache-og-image-top-level-await', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    // The prerendered output can't be observed in a deployment, and without
-    // it nothing distinguishes broken from fixed behavior.
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextStart) {
     beforeAll(async () => {

--- a/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
+++ b/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
@@ -3,10 +3,12 @@ import { renderViaHTTP, startCleanStaticServer } from 'next-test-utils'
 import { join } from 'path'
 import { AddressInfo, Server } from 'net'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-output-export', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
 

--- a/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
+++ b/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
@@ -5,16 +5,14 @@ import stripAnsi from 'strip-ansi'
 const getExpectedErrorMessage = (route: string) =>
   `Route "${route}": \`searchParams\` can't be read inside \`"use cache"\`. Await it outside the cached function and pass what you need as an argument.\nLearn more: https://nextjs.org/docs/messages/next-request-in-use-cache`
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-search-params', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDev) {
     let route: string

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -2,16 +2,14 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitForRedbox } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('use-cache-segment-configs', () => {
-  const { next, skipped, isNextDev, isTurbopack, isRspack } = nextTestSetup({
+  const { next, isNextDev, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it("it should error when using segment configs that aren't supported by useCache", async () => {
     if (isNextDev) {

--- a/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
+++ b/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache-swr', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   let outputIndex: number
 

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -9,16 +9,14 @@ import {
 import stripAnsi from 'strip-ansi'
 import { createSandbox } from 'development-sandbox'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('use-cache-unknown-cache-kind', () => {
-  const { next, isNextStart, isTurbopack, isRspack, skipped } = nextTestSetup({
+  const { next, isNextStart, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextStart) {
     beforeAll(async () => {

--- a/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
+++ b/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
@@ -13,16 +13,14 @@ const nextConfigWithUseCache: NextConfig = {
   experimental: { useCache: true },
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('use-cache-without-experimental-flag', () => {
-  const { next, isNextStart, isTurbopack, skipped, isRspack } = nextTestSetup({
+  const { next, isNextStart, isTurbopack, isRspack } = nextTestSetup({
     files: __dirname,
     skipStart: process.env.NEXT_TEST_MODE !== 'dev',
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextStart) {
     it('should fail the build with an error', async () => {

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -19,17 +19,13 @@ const GENERIC_RSC_ERROR =
 
 const withCacheComponents = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('use-cache', () => {
-  const { next, isNextDev, isNextDeploy, isNextStart, skipped } = nextTestSetup(
-    {
-      files: __dirname,
-      skipDeployment: true,
-    }
-  )
-
-  if (skipped) {
-    return
-  }
+  const { next, isNextDev, isNextDeploy, isNextStart } = nextTestSetup({
+    files: __dirname,
+  })
 
   let cliOutputLength: number
 

--- a/test/e2e/app-dir/webpack-loader-conditions/webpack-loader-conditions.test.ts
+++ b/test/e2e/app-dir/webpack-loader-conditions/webpack-loader-conditions.test.ts
@@ -1,32 +1,30 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // Specifically tests turbopack.rules.*.foreign config
-;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
-  'webpack-loader-conditions',
-  () => {
-    const { next, skipped } = nextTestSetup({
-      files: __dirname,
-      skipDeployment: true,
-    })
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('webpack-loader-conditions', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
 
-    if (skipped) return
+  it('should render correctly on server site', async () => {
+    const res = await next.fetch('/')
+    const html = (await res.text()).replaceAll(/<!-- -->/g, '')
+    expect(html).toContain(`server: {&quot;default&quot;:true}`)
+    expect(html).toContain(`client: {&quot;default&quot;:true}`)
+    expect(html).toContain(`foreignClient: {}`)
+  })
 
-    it('should render correctly on server site', async () => {
-      const res = await next.fetch('/')
-      const html = (await res.text()).replaceAll(/<!-- -->/g, '')
-      expect(html).toContain(`server: {&quot;default&quot;:true}`)
-      expect(html).toContain(`client: {&quot;default&quot;:true}`)
-      expect(html).toContain(`foreignClient: {}`)
-    })
-
-    it('should render correctly on client side', async () => {
-      const browser = await next.browser('/')
-      const text = await browser.elementByCss('body').text()
-      expect(text).toContain(`server: ${JSON.stringify({ default: true })}`)
-      expect(text).toContain(`client: ${JSON.stringify({ browser: true })}`)
-      expect(text).toContain(
-        `foreignClient: ${JSON.stringify({ browser: true, foreign: true })}`
-      )
-    })
-  }
-)
+  it('should render correctly on client side', async () => {
+    const browser = await next.browser('/')
+    const text = await browser.elementByCss('body').text()
+    expect(text).toContain(`server: ${JSON.stringify({ default: true })}`)
+    expect(text).toContain(`client: ${JSON.stringify({ browser: true })}`)
+    expect(text).toContain(
+      `foreignClient: ${JSON.stringify({ browser: true, foreign: true })}`
+    )
+  })
+})

--- a/test/e2e/app-dir/webpack-loader-errors/webpack-loader-errors.test.ts
+++ b/test/e2e/app-dir/webpack-loader-errors/webpack-loader-errors.test.ts
@@ -2,13 +2,14 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry, waitForRedbox, getRedboxSource } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('webpack-loader-errors', () => {
-  const { next, isNextDev, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextDev, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-  if (skipped) return
 
   if (!isNextDev) {
     it('should skip in non-dev mode', () => {})

--- a/test/e2e/app-dir/webpack-loader-fs/webpack-loader-fs.test.ts
+++ b/test/e2e/app-dir/webpack-loader-fs/webpack-loader-fs.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('webpack-loader-fs', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should allow reading the input FS', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/webpack-loader-import-module/webpack-loader-import-module.test.ts
+++ b/test/e2e/app-dir/webpack-loader-import-module/webpack-loader-import-module.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('webpack-loader-import-module', () => {
-  const { next, skipped, isTurbopack } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should support this.importModule() in a webpack loader', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
+++ b/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('webpack-loader-module-type', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   // bytes type is Turbopack-only, webpack doesn't have a direct equivalent
   const itTurbopackOnly = isTurbopack ? it : it.skip

--- a/test/e2e/app-dir/webpack-loader-resolve/webpack-loader-resolve.test.ts
+++ b/test/e2e/app-dir/webpack-loader-resolve/webpack-loader-resolve.test.ts
@@ -1,15 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test is skipped because it's only expected to run in turbopack, which isn't enabled for builds
+// @force-gate !deploy
 describe('webpack-loader-resolve', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // This test is skipped because it's only expected to run in turbopack, which isn't enabled for builds
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should support resolving absolute path via loader getResolve', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
+++ b/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('webpack-loader-resource-query', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should pass query to loader', async () => {
     await next.render$('/')

--- a/test/e2e/app-dir/webpack-loader-ts-transform/webpack-loader-ts-transform.test.ts
+++ b/test/e2e/app-dir/webpack-loader-ts-transform/webpack-loader-ts-transform.test.ts
@@ -1,13 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test is skipped because it's only expected to run in turbopack, which isn't enabled for builds
+// @force-gate !deploy
 describe('webpack-loader-ts-transform', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // This test is skipped because it's only expected to run in turbopack, which isn't enabled for builds
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should accept Typescript returned from Webpack loaders', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-dir/with-babel/with-babel.test.ts
+++ b/test/e2e/app-dir/with-babel/with-babel.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('with babel', () => {
-  const { next, isNextStart, isTurbopack, skipped } = nextTestSetup({
+  const { next, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should support babel in app dir', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/app-document/client.test.ts
+++ b/test/e2e/app-document/client.test.ts
@@ -1,10 +1,12 @@
 import { retry } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('Document and App - Client side', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
   it('should share module state with pages', async () => {

--- a/test/e2e/basepath/basepath.test.ts
+++ b/test/e2e/basepath/basepath.test.ts
@@ -10,6 +10,8 @@ import {
   renderViaHTTP,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('basePath', () => {
   const basePath = '/docs'
 

--- a/test/e2e/build-indicator/test/index.test.ts
+++ b/test/e2e/build-indicator/test/index.test.ts
@@ -22,6 +22,7 @@ const installCheckVisible = (browser) => {
 
 describe('Build Activity Indicator', () => {
   // Use describe.skip so that this suite does not fail with "no tests" during deploy tests.
+  // Deploy mode exclusion: This nested suite intentionally fails a local build and asserts its CLI diagnostics.
   ;(isNextDeploy ? describe.skip : describe)('Invalid position config', () => {
     const { next } = nextTestSetup({
       files: join(__dirname, '..'),

--- a/test/e2e/cache-handlers-upstream-wiring/index.test.ts
+++ b/test/e2e/cache-handlers-upstream-wiring/index.test.ts
@@ -3,15 +3,13 @@ import { retry } from 'next-test-utils'
 import { join } from 'path'
 
 describe('cache-handlers-upstream-wiring', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('pages router non-edge', () => {
-    const { next, skipped, isNextDev } = nextTestSetup({
+    const { next, isNextDev } = nextTestSetup({
       files: join(__dirname, 'fixtures/pages-router-non-edge'),
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     let outputIndex = 0
 
@@ -51,15 +49,13 @@ describe('cache-handlers-upstream-wiring', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('cacheComponents enabled, non-edge app router', () => {
-    const { next, skipped, isNextDev } = nextTestSetup({
+    const { next, isNextDev } = nextTestSetup({
       files: join(__dirname, 'fixtures/non-edge-cache-components'),
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     let outputIndex = 0
 
@@ -98,16 +94,14 @@ describe('cache-handlers-upstream-wiring', () => {
       })
     })
   })
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   // @force-gate !cacheComponents
   describe('cacheComponents disabled, edge app router', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: join(__dirname, 'fixtures/edge-without-cache-components'),
-      skipDeployment: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     let outputIndex = 0
 

--- a/test/e2e/cancel-request/stream-cancel.test.ts
+++ b/test/e2e/cancel-request/stream-cancel.test.ts
@@ -2,6 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { sleep } from './sleep'
 import { get } from 'http'
 
+// Deploy mode exclusion: This suite aborts a raw client connection, but
+// a hosting proxy changes cancellation propagation before Next.js receives it.
 describe('streaming responses cancel inner stream after disconnect', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/catches-missing-getStaticProps/catches-missing-getStaticProps.test.ts
+++ b/test/e2e/catches-missing-getStaticProps/catches-missing-getStaticProps.test.ts
@@ -1,14 +1,15 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
-;((isNextDev && process.env.TURBOPACK_BUILD) ||
-  (isNextStart && process.env.TURBOPACK_DEV)
-  ? describe.skip
-  : describe)('Catches Missing getStaticProps', () => {
+// TODO(deploy-test-completion): This asserts local build/runtime output that
+// deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate !start || !turbopackDev
+// @force-gate !dev || !turbopackBuild
+describe('Catches Missing getStaticProps', () => {
   const errorRegex = /getStaticPaths was added without a getStaticProps in/
 
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: isNextStart,
-    skipDeployment: true,
   })
 
   if (isNextDev) {
@@ -16,9 +17,7 @@ import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
       const html = await next.render('/hello')
       expect(html).toMatch(errorRegex)
     })
-  }
-
-  if (isNextStart) {
+  } else {
     it('should catch it in server build mode', async () => {
       const { cliOutput } = await next.build()
       expect(cliOutput).toMatch(errorRegex)

--- a/test/e2e/cli/cli.test.ts
+++ b/test/e2e/cli/cli.test.ts
@@ -15,12 +15,14 @@ const reactDependencies = {
   'react-dom': '19.3.0-canary-fef12a01-20260413',
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('CLI Usage', () => {
   const { next, isNextStart } = nextTestSetup({
     files: join(__dirname, 'basic'),
     skipStart: true,
     dependencies: reactDependencies,
-    skipDeployment: true,
   })
 
   /**
@@ -1221,14 +1223,15 @@ Next.js Config:
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('CLI Usage: duplicate sass dependencies', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: join(__dirname, 'duplicate-sass'),
     skipStart: true,
     dependencies: reactDependencies,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   // The original integration test relied on pre-existing fake `sass` and
   // `node-sass` modules in `duplicate-sass/node_modules/`. In e2e mode the

--- a/test/e2e/client-404/client-404.test.ts
+++ b/test/e2e/client-404/client-404.test.ts
@@ -4,13 +4,13 @@ import {
   getClientBuildManifestLoaderChunkUrlPath,
 } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('Client 404', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     // pre-build the home page so that navigating to it from the

--- a/test/e2e/client-max-body-size/index.test.ts
+++ b/test/e2e/client-max-body-size/index.test.ts
@@ -2,14 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('client-max-body-size', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // Deployed environment has it's own configured limits.
+  // @force-gate !deploy
   describe('default 10MB limit', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      // Deployed environment has it's own configured limits.
-      skipDeployment: true,
     })
-
-    if (skipped) return
 
     it('should accept request body over 10MB but only buffer up to limit', async () => {
       const bodySize = 11 * 1024 * 1024 // 11MB
@@ -77,18 +76,18 @@ describe('client-max-body-size', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('custom limit with string format', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       nextConfig: {
         experimental: {
           proxyClientMaxBodySize: '5mb',
         },
       },
     })
-
-    if (skipped) return
 
     it('should accept request body over custom 5MB limit but only buffer up to limit', async () => {
       const bodySize = 6 * 1024 * 1024 // 6MB
@@ -136,18 +135,18 @@ describe('client-max-body-size', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('custom limit with number format', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       nextConfig: {
         experimental: {
           proxyClientMaxBodySize: 2 * 1024 * 1024, // 2MB in bytes
         },
       },
     })
-
-    if (skipped) return
 
     it('should accept request body over custom 2MB limit but only buffer up to limit', async () => {
       const bodySize = 3 * 1024 * 1024 // 3MB
@@ -195,18 +194,18 @@ describe('client-max-body-size', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('large custom limit', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       nextConfig: {
         experimental: {
           proxyClientMaxBodySize: '50mb',
         },
       },
     })
-
-    if (skipped) return
 
     it('should accept request body up to 50MB with custom limit', async () => {
       const bodySize = 20 * 1024 * 1024 // 20MB

--- a/test/e2e/config-schema-check/index.test.ts
+++ b/test/e2e/config-schema-check/index.test.ts
@@ -2,8 +2,11 @@ import stripAnsi from 'strip-ansi'
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next.config.js schema validating - defaultConfig', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       'pages/index.js': `
     export default function Page() {
@@ -16,12 +19,7 @@ describe('next.config.js schema validating - defaultConfig', () => {
     }
     `,
     },
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should validate against defaultConfig', async () => {
     const output = stripAnsi(next.cliOutput)
@@ -30,8 +28,11 @@ describe('next.config.js schema validating - defaultConfig', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('next.config.js schema validating - invalid config', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: {
       'pages/index.js': `
     export default function Page() {
@@ -44,12 +45,7 @@ describe('next.config.js schema validating - invalid config', () => {
     }
     `,
     },
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should warn the invalid next config', async () => {
     await check(() => {

--- a/test/e2e/conflicting-app-page-error/index.test.ts
+++ b/test/e2e/conflicting-app-page-error/index.test.ts
@@ -8,15 +8,17 @@ import {
 } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Conflict between app file and pages file', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
 
-  if (skipped) {
-    return
+  if (isNextDeploy) {
+    it('is excluded from deploy testing by @force-gate', () => {})
   }
 
   if (isNextStart) {

--- a/test/e2e/conflicting-public-file-page/conflicting-public-file-page.test.ts
+++ b/test/e2e/conflicting-public-file-page/conflicting-public-file-page.test.ts
@@ -1,12 +1,17 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Errors on conflict between public file and page file', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
+
+  if (isNextDeploy) {
+    it('is excluded from deploy testing by @force-gate', () => {})
+  }
 
   if (isNextDev) {
     it('should show conflict error during development', async () => {

--- a/test/e2e/custom-app-render/custom-app-render.test.ts
+++ b/test/e2e/custom-app-render/custom-app-render.test.ts
@@ -1,20 +1,18 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('custom-app-render', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     startCommand: 'node server.js',
     serverReadyPattern: /Next mode: (production|development)/,
     dependencies: {
       'get-port': '5.1.1',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it.each(['/', '/render'])('should render %s', async (page) => {
     const $ = await next.render$(page)

--- a/test/e2e/custom-cache-handler-image/custom-cache-handler-image.test.ts
+++ b/test/e2e/custom-cache-handler-image/custom-cache-handler-image.test.ts
@@ -1,19 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('custom-cache-handler-image', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     env: {
       // Set max cache entries to 2 to easily test eviction
       MAX_IMAGE_CACHE_ENTRIES: '2',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should use custom cache handler for image optimization', async () => {
     // First, render the page to get the image URLs

--- a/test/e2e/custom-error/custom-error.test.ts
+++ b/test/e2e/custom-error/custom-error.test.ts
@@ -4,15 +4,21 @@ import { retry } from 'next-test-utils'
 const customErrNo404Match =
   /You have added a custom \/_error page without a custom \/404 page/
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Custom _error', () => {
-  const { next, isNextDev, isNextStart } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
     dependencies: {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    skipDeployment: true,
   })
+
+  if (isNextDeploy) {
+    it('is excluded from deploy testing by @force-gate', () => {})
+  }
 
   if (isNextDev) {
     it('should not warn with /_error and /404 when rendering error first', async () => {

--- a/test/e2e/custom-routes-i18n-index-redirect/custom-routes-i18n-index-redirect.test.ts
+++ b/test/e2e/custom-routes-i18n-index-redirect/custom-routes-i18n-index-redirect.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('Custom routes i18n with index redirect', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should respond to default locale redirects correctly for index redirect', async () => {
     for (const [path, dest] of [

--- a/test/e2e/custom-routes-i18n/custom-routes-i18n.test.ts
+++ b/test/e2e/custom-routes-i18n/custom-routes-i18n.test.ts
@@ -3,13 +3,14 @@ import cheerio from 'cheerio'
 import { findPort, retry } from 'next-test-utils'
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('Custom routes i18n', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let server: http.Server
   let externalPort: number

--- a/test/e2e/custom-routes/custom-routes.test.ts
+++ b/test/e2e/custom-routes/custom-routes.test.ts
@@ -11,16 +11,17 @@ import {
   normalizeManifest,
   retry,
 } from 'next-test-utils'
-import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
+import { nextTestSetup, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Custom routes', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
     disableAutoSkewProtection: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let externalServerPort: number
   let externalServer: http.Server
@@ -3471,16 +3472,17 @@ describe('Custom routes', () => {
     })
   }
 })
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Custom routes no-op rewrite', () => {
-  const { next, isTurbopack, isNextStart, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextStart } = nextTestSetup({
     files: __dirname,
     skipStart: true,
     env: {
       ADD_NOOP_REWRITE: 'true',
     },
-    skipDeployment: true,
   })
-  if (skipped) return
   if (isTurbopack && isNextStart) {
     it('skipped - not supported in turbopack build mode', () => {})
     return
@@ -3528,14 +3530,15 @@ describe('Custom routes no-op rewrite', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Custom routes solo types', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
     disableAutoSkewProtection: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let externalServer: http.Server
   let externalServerPort: number
@@ -3651,13 +3654,15 @@ describe('Custom routes solo types', () => {
     }
   })
 })
-;(isNextStart ? describe : describe.skip)('Custom routes export', () => {
-  const { next, isNextDeploy } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate start
+describe('Custom routes export', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (isNextDeploy) return
 
   it('should not show warning for custom routes when not next export', async () => {
     await next.patchFile('next.config.js', (content) =>

--- a/test/e2e/data-fetching-errors/data-fetching-errors.test.ts
+++ b/test/e2e/data-fetching-errors/data-fetching-errors.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import {
   GSP_NO_RETURNED_VALUE,
@@ -6,12 +6,14 @@ import {
 } from '../../../packages/next/dist/lib/constants'
 
 describe('GS(S)P Page Errors', () => {
-  ;(isNextDev ? describe : describe.skip)('development mode', () => {
-    const { next, skipped } = nextTestSetup({
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
+  // @force-gate dev
+  describe('development mode', () => {
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should show error for getStaticProps as component member', async () => {
       const outputIndex = next.cliOutput.length
@@ -103,13 +105,15 @@ describe('GS(S)P Page Errors', () => {
       )
     })
   })
-  ;(isNextStart ? describe : describe.skip)('production mode', () => {
-    const { next, skipped } = nextTestSetup({
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
+  // @force-gate start
+  describe('production mode', () => {
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should show build error for getStaticProps as component member', async () => {
       await next.patchFile(

--- a/test/e2e/deferred-entries/deferred-entries.test.ts
+++ b/test/e2e/deferred-entries/deferred-entries.test.ts
@@ -110,15 +110,15 @@ async function waitForCallbackTimestampToStabilize(
   )
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('deferred-entries', () => {
-  const { next, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
     dependencies: {},
   })
-
-  if (skipped) return
 
   beforeAll(async () => {
     // Clear log files before starting

--- a/test/e2e/disable-js/disable-js.test.ts
+++ b/test/e2e/disable-js/disable-js.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('disabled runtime JS', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should render the page', async () => {
     const html = await next.render('/')

--- a/test/e2e/dist-dir/dist-dir.test.ts
+++ b/test/e2e/dist-dir/dist-dir.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { BUILD_ID_FILE, BUILD_MANIFEST } from 'next/constants'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('distDir', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should render the page', async () => {
     const html = await next.render('/')
@@ -27,13 +28,14 @@ describe('distDir', () => {
 })
 
 if (isNextStart) {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('distDir config validation', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       skipStart: true,
-      skipDeployment: true,
     })
-    if (skipped) return
 
     it('should throw error with invalid distDir', async () => {
       const origConfig = await next.readFile('next.config.js')

--- a/test/e2e/draft-mode/draft-mode.test.ts
+++ b/test/e2e/draft-mode/draft-mode.test.ts
@@ -12,12 +12,17 @@ function getData(html: string) {
   }
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Test Draft Mode', () => {
-  const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
+  const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
+
+  if (isNextDeploy) {
+    it('is excluded from deploy testing by @force-gate', () => {})
+  }
 
   if (isNextDev) {
     it('should start development application', async () => {

--- a/test/e2e/dynamic-optional-routing/dynamic-optional-routing.test.ts
+++ b/test/e2e/dynamic-optional-routing/dynamic-optional-routing.test.ts
@@ -2,12 +2,13 @@ import cheerio from 'cheerio'
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Dynamic Optional Routing', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should render catch-all top-level route with multiple segments', async () => {
     const html = await next.render('/hello/world')
@@ -216,13 +217,14 @@ describe('Dynamic Optional Routing', () => {
   }
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('Dynamic Optional Routing - build validation', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const DUMMY_PAGE = 'export default () => null'
 

--- a/test/e2e/dynamic-routing/dynamic-routing.test.ts
+++ b/test/e2e/dynamic-routing/dynamic-routing.test.ts
@@ -1,16 +1,16 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { runTests } from './shared'
 
+// Deploy mode exclusion: The assertions exercise behavior specific to the local Next.js server.
+// Some assertions (`should not decode slashes`, `should serve file with
+// plus from public/static folder`) depend on local Next.js URL handling
+// and don't apply to Vercel's deploy infrastructure.
+// @force-gate !deploy
 describe('Dynamic Routing', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
-    // Some assertions (`should not decode slashes`, `should serve file with
-    // plus from public/static folder`) depend on local Next.js URL handling
-    // and don't apply to Vercel's deploy infrastructure.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   runTests({ next, isNextDev, isTurbopack, middlewareEnabled: false })
 })

--- a/test/e2e/env-config/env-config.test.ts
+++ b/test/e2e/env-config/env-config.test.ts
@@ -2,16 +2,17 @@ import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('env-config', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     env: {
       PROCESS_ENV_KEY: 'processenvironment',
       ENV_FILE_PROCESS_ENV: 'env-cli',
     },
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const getEnvFromHtml = async (path: string) => {
     const html = await next.render(path)

--- a/test/e2e/externals-pages-bundle/externals-pages-bundle.test.ts
+++ b/test/e2e/externals-pages-bundle/externals-pages-bundle.test.ts
@@ -2,13 +2,14 @@ import fs from 'fs/promises'
 import { join } from 'path'
 import { nextTestSetup, isNextStart, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('externals-pages-bundle', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   describe('bundle pages externals with config.bundlePagesRouterDependencies', () => {
     if (!isNextStart) {

--- a/test/e2e/fallback-false-rewrite/fallback-false-rewrite.test.ts
+++ b/test/e2e/fallback-false-rewrite/fallback-false-rewrite.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('fallback: false rewrite', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should rewrite correctly for path at same level as fallback: false SSR', async () => {
     const res = await next.fetch('/hello', { redirect: 'manual' })

--- a/test/e2e/fetch-polyfill/fetch-polyfill.test.ts
+++ b/test/e2e/fetch-polyfill/fetch-polyfill.test.ts
@@ -3,21 +3,21 @@ import cheerio from 'cheerio'
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { findPort } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('Fetch polyfill', () => {
   let apiServerPort: number
   let apiServer: http.Server
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
     dependencies: {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   beforeAll(async () => {
     apiServerPort = await findPort()

--- a/test/e2e/filesystem-cache/build-cache-default.test.ts
+++ b/test/e2e/filesystem-cache/build-cache-default.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup, isNextStart } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import fs from 'fs/promises'
 import path from 'path'
 
@@ -9,109 +9,106 @@ import path from 'path'
 // This is a Turbopack + build (start) mode test. It runs `next build` with
 // controlled local and CI environments and checks whether anything is written
 // to `.next/cache/turbopack`.
-;(process.env.IS_TURBOPACK_TEST && isNextStart ? describe : describe.skip)(
-  'filesystem-cache build default',
-  () => {
-    const { next, skipped } = nextTestSetup({
-      files: __dirname,
-      skipStart: true,
-      skipDeployment: true,
-    })
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
+// @force-gate turbopack
+// @force-gate start
+describe('filesystem-cache build default', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
 
-    if (skipped) {
-      return
-    }
+  // Simulate a non-CI (local) environment by clearing the common CI signals.
+  const NON_CI_ENV = {
+    CI: '',
+    CONTINUOUS_INTEGRATION: '',
+    BUILD_NUMBER: '',
+    RUN_ID: '',
+    GITHUB_ACTIONS: '',
+    NOW_BUILDER: '',
+    // Persist even a tiny snapshot so the assertion doesn't depend on the
+    // minimum-compilation-time threshold.
+    TURBO_ENGINE_IGNORE_DIRTY: '1',
+    TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS: '0',
+  }
 
-    // Simulate a non-CI (local) environment by clearing the common CI signals.
-    const NON_CI_ENV = {
-      CI: '',
-      CONTINUOUS_INTEGRATION: '',
-      BUILD_NUMBER: '',
-      RUN_ID: '',
-      GITHUB_ACTIONS: '',
-      NOW_BUILDER: '',
-      // Persist even a tiny snapshot so the assertion doesn't depend on the
-      // minimum-compilation-time threshold.
-      TURBO_ENGINE_IGNORE_DIRTY: '1',
-      TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS: '0',
-    }
+  function cachePath() {
+    return path.join(next.testDir, '.next', 'cache', 'turbopack')
+  }
 
-    function cachePath() {
-      return path.join(next.testDir, '.next', 'cache', 'turbopack')
-    }
-
-    async function getCacheSize(): Promise<number> {
-      let entries
-      try {
-        entries = await fs.readdir(cachePath(), {
-          recursive: true,
-          withFileTypes: true,
-        })
-      } catch {
-        // Directory doesn't exist -> nothing was cached.
-        return 0
-      }
-      let totalSize = 0
-      for (const entry of entries) {
-        if (entry.isFile()) {
-          const filePath = path.join(entry.parentPath ?? entry.path, entry.name)
-          totalSize += (await fs.stat(filePath)).size
-        }
-      }
-      return totalSize
-    }
-
-    async function cleanBuildOutput() {
-      await fs.rm(path.join(next.testDir, '.next'), {
+  async function getCacheSize(): Promise<number> {
+    let entries
+    try {
+      entries = await fs.readdir(cachePath(), {
         recursive: true,
-        force: true,
+        withFileTypes: true,
       })
+    } catch {
+      // Directory doesn't exist -> nothing was cached.
+      return 0
     }
-
-    // The shared fixture's next.config.js sets the flag explicitly from
-    // `ENABLE_CACHING`; overwrite it so we exercise the *default* instead.
-    async function setConfig(experimental: Record<string, unknown> = {}) {
-      await next.patchFile(
-        'next.config.js',
-        `module.exports = ${JSON.stringify({ experimental }, null, 2)}`
-      )
+    let totalSize = 0
+    for (const entry of entries) {
+      if (entry.isFile()) {
+        const filePath = path.join(entry.parentPath ?? entry.path, entry.name)
+        totalSize += (await fs.stat(filePath)).size
+      }
     }
+    return totalSize
+  }
 
-    afterEach(async () => {
-      await setConfig()
-    })
-
-    it('writes the cache by default (no config, local environment)', async () => {
-      await cleanBuildOutput()
-      await setConfig()
-
-      const { exitCode } = await next.build({ env: NON_CI_ENV })
-      expect(exitCode).toBe(0)
-
-      expect(await getCacheSize()).toBeGreaterThan(0)
-    })
-
-    it('writes nothing when turbopackFileSystemCacheForBuild is false', async () => {
-      await cleanBuildOutput()
-      await setConfig({ turbopackFileSystemCacheForBuild: false })
-
-      const { exitCode } = await next.build({ env: NON_CI_ENV })
-      expect(exitCode).toBe(0)
-
-      expect(await getCacheSize()).toBe(0)
-    })
-
-    it('writes the cache by default in CI', async () => {
-      await cleanBuildOutput()
-      await setConfig()
-
-      const { exitCode } = await next.build({
-        // Force a generic CI environment.
-        env: { ...NON_CI_ENV, CI: '1' },
-      })
-      expect(exitCode).toBe(0)
-
-      expect(await getCacheSize()).toBeGreaterThan(0)
+  async function cleanBuildOutput() {
+    await fs.rm(path.join(next.testDir, '.next'), {
+      recursive: true,
+      force: true,
     })
   }
-)
+
+  // The shared fixture's next.config.js sets the flag explicitly from
+  // `ENABLE_CACHING`; overwrite it so we exercise the *default* instead.
+  async function setConfig(experimental: Record<string, unknown> = {}) {
+    await next.patchFile(
+      'next.config.js',
+      `module.exports = ${JSON.stringify({ experimental }, null, 2)}`
+    )
+  }
+
+  afterEach(async () => {
+    await setConfig()
+  })
+
+  it('writes the cache by default (no config, local environment)', async () => {
+    await cleanBuildOutput()
+    await setConfig()
+
+    const { exitCode } = await next.build({ env: NON_CI_ENV })
+    expect(exitCode).toBe(0)
+
+    expect(await getCacheSize()).toBeGreaterThan(0)
+  })
+
+  it('writes nothing when turbopackFileSystemCacheForBuild is false', async () => {
+    await cleanBuildOutput()
+    await setConfig({ turbopackFileSystemCacheForBuild: false })
+
+    const { exitCode } = await next.build({ env: NON_CI_ENV })
+    expect(exitCode).toBe(0)
+
+    expect(await getCacheSize()).toBe(0)
+  })
+
+  it('writes the cache by default in CI', async () => {
+    await cleanBuildOutput()
+    await setConfig()
+
+    const { exitCode } = await next.build({
+      // Force a generic CI environment.
+      env: { ...NON_CI_ENV, CI: '1' },
+    })
+    expect(exitCode).toBe(0)
+
+    expect(await getCacheSize()).toBeGreaterThan(0)
+  })
+})

--- a/test/e2e/filesystem-cache/evict-after-snapshot.test.ts
+++ b/test/e2e/filesystem-cache/evict-after-snapshot.test.ts
@@ -1,9 +1,13 @@
-import { nextTestSetup, isNextDev } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 import { retry, waitFor } from 'next-test-utils'
 
 // Eviction requires the dev server (HMR) and persistent caching (Turbopack).
 // Skip entirely in prod/start mode.
-;(isNextDev ? describe : describe.skip)('evict-after-snapshot', () => {
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
+// @force-gate dev
+describe('evict-after-snapshot', () => {
   const envVars = [
     'ENABLE_CACHING=1',
     'TURBO_ENGINE_IGNORE_DIRTY=1',
@@ -14,9 +18,8 @@ import { retry, waitFor } from 'next-test-utils'
     'ENABLE_EVICTION=1',
   ].join(' ')
 
-  const { skipped, next } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     packageJson: {
       scripts: {
         dev: `${envVars} next dev`,
@@ -25,10 +28,6 @@ import { retry, waitFor } from 'next-test-utils'
     installCommand: 'npm i',
     startCommand: 'npm run dev',
   })
-
-  if (skipped) {
-    return
-  }
 
   async function waitForSnapshotAndEviction() {
     // The idle timeout is 1s, give extra time for snapshot + eviction to complete

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -28,6 +28,9 @@ async function getDirectorySize(dirPath: string): Promise<number> {
 }
 
 for (const cacheEnabled of [false, true]) {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely mutates files in the isolated local fixture after setup.
+  // @force-gate !deploy
   describe(`filesystem-caching with cache ${cacheEnabled ? 'enabled' : 'disabled'}`, () => {
     beforeAll(() => {
       process.env.NEXT_PUBLIC_ENV_VAR = 'hello world'
@@ -47,9 +50,8 @@ for (const cacheEnabled of [false, true]) {
       `TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS=0`,
     ].join(' ')
 
-    const { skipped, next, isTurbopack } = nextTestSetup({
+    const { next, isTurbopack } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       packageJson: {
         packageManager: 'npm@10.9.2',
         scripts: {
@@ -64,10 +66,6 @@ for (const cacheEnabled of [false, true]) {
       buildCommand: `npm run build`,
       startCommand: isNextDev ? 'npm run dev' : 'npm run start',
     })
-
-    if (skipped) {
-      return
-    }
 
     beforeAll(() => {
       // We can skip the dev watch delay since this is not an HMR test

--- a/test/e2e/filesystem-cache/warm-restart-task-stats.test.ts
+++ b/test/e2e/filesystem-cache/warm-restart-task-stats.test.ts
@@ -25,103 +25,100 @@ type TaskStats = Record<string, TaskFunctionStatistics>
 
 const STATS_RELATIVE_PATH = '.next/warm-restart-task-stats.json'
 
-;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
-  'warm-restart task statistics',
-  () => {
-    const env = [
-      'ENABLE_CACHING=1',
-      'TURBO_ENGINE_IGNORE_DIRTY=1',
-      'TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS=1000',
-      // Persist even tiny snapshots so the test doesn't depend on the
-      // minimum-compilation-time threshold.
-      'TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS=0',
-      `NEXT_TURBOPACK_TASK_STATISTICS=${STATS_RELATIVE_PATH}`,
-      // The task-statistics file is written by an `on_exit` handler in the
-      // napi binding. In dev that handler only runs if the child process
-      // gets a chance to clean up (i.e. SIGTERM, not SIGKILL). The parent
-      // `next dev` process gives the child 100ms by default before
-      // escalating to SIGKILL — bump that so the on-exit handler can flush.
-      'NEXT_EXIT_TIMEOUT_MS=30000',
-    ].join(' ')
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('warm-restart task statistics', () => {
+  const env = [
+    'ENABLE_CACHING=1',
+    'TURBO_ENGINE_IGNORE_DIRTY=1',
+    'TURBO_ENGINE_SNAPSHOT_IDLE_TIMEOUT_MILLIS=1000',
+    // Persist even tiny snapshots so the test doesn't depend on the
+    // minimum-compilation-time threshold.
+    'TURBO_ENGINE_SNAPSHOT_MIN_ACTIVE_TIME_MILLIS=0',
+    `NEXT_TURBOPACK_TASK_STATISTICS=${STATS_RELATIVE_PATH}`,
+    // The task-statistics file is written by an `on_exit` handler in the
+    // napi binding. In dev that handler only runs if the child process
+    // gets a chance to clean up (i.e. SIGTERM, not SIGKILL). The parent
+    // `next dev` process gives the child 100ms by default before
+    // escalating to SIGKILL — bump that so the on-exit handler can flush.
+    'NEXT_EXIT_TIMEOUT_MS=30000',
+  ].join(' ')
 
-    const { skipped, next } = nextTestSetup({
-      files: __dirname,
-      skipDeployment: true,
-      packageJson: {
-        packageManager: 'npm@10.9.2',
-        scripts: {
-          build: `${env} next build`,
-          dev: `${env} next dev`,
-          start: 'next start',
-        },
+  const { next } = nextTestSetup({
+    files: __dirname,
+    packageJson: {
+      packageManager: 'npm@10.9.2',
+      scripts: {
+        build: `${env} next build`,
+        dev: `${env} next dev`,
+        start: 'next start',
       },
-      installCommand: 'npm i',
-      buildCommand: 'npm run build',
-      startCommand: isNextDev ? 'npm run dev' : 'npm run start',
-    })
+    },
+    installCommand: 'npm i',
+    buildCommand: 'npm run build',
+    startCommand: isNextDev ? 'npm run dev' : 'npm run start',
+  })
 
-    if (skipped) {
-      return
-    }
+  beforeAll(() => {
+    // No file edits in this test — skip HMR debounce.
+    ;(next as any).handleDevWatchDelayBeforeChange = () => {}
+    ;(next as any).handleDevWatchDelayAfterChange = () => {}
+  })
 
-    beforeAll(() => {
-      // No file edits in this test — skip HMR debounce.
-      ;(next as any).handleDevWatchDelayBeforeChange = () => {}
-      ;(next as any).handleDevWatchDelayAfterChange = () => {}
-    })
-
-    async function stop() {
-      if (isNextDev) {
-        // Persistent cache snapshot is on a 1s idle timer; give it room.
-        await waitFor(3000)
-        // SIGTERM (not the harness default SIGKILL) so the dev server gets
-        // to run its cleanup, which is what flushes the task-stats file.
-        await next.stop('SIGTERM')
-      } else {
-        await next.stop()
-      }
-    }
-
-    async function readMissedTaskNames(): Promise<string[]> {
-      const absPath = path.join(next.testDir, STATS_RELATIVE_PATH)
-      const raw = await fs.readFile(absPath, 'utf8')
-      const stats = JSON.parse(raw) as TaskStats
-      const misses: string[] = []
-      for (const [name, s] of Object.entries(stats)) {
-        if (s.cache_miss > 0) misses.push(name)
-      }
-      // Turbopack sorts on the Rust side, but sort again here to be robust
-      // against the JSON parser's object iteration order.
-      misses.sort()
-      return misses
-    }
-
+  async function stop() {
     if (isNextDev) {
-      it('snapshot of tasks with cache misses on warm dev restart', async () => {
-        // Cycle 1: the harness already auto-started; perform a request so the
-        // SSR/Node chunk work runs and gets persisted on shutdown.
-        async function runDevCycle() {
-          const browser = await next.browser('/')
-          // Wait for actual rendered content before declaring "ready".
-          await browser.elementByCss('p')
-          // Settle: the dev server keeps doing background work after first
-          // paint (HMR socket handshake, tail compilation). A fixed sleep
-          // is the least-bad option here since next.js doesn't expose
-          // turbopack's internal idle signal. If this proves flaky in CI,
-          // raise the value.
-          await waitFor(2000)
-          await browser.close()
-        }
-        await runDevCycle()
-        await stop()
+      // Persistent cache snapshot is on a 1s idle timer; give it room.
+      await waitFor(3000)
+      // SIGTERM (not the harness default SIGKILL) so the dev server gets
+      // to run its cleanup, which is what flushes the task-stats file.
+      await next.stop('SIGTERM')
+    } else {
+      await next.stop()
+    }
+  }
 
-        // Cycle 2: warm.
-        await next.start()
-        await runDevCycle()
-        await stop()
+  async function readMissedTaskNames(): Promise<string[]> {
+    const absPath = path.join(next.testDir, STATS_RELATIVE_PATH)
+    const raw = await fs.readFile(absPath, 'utf8')
+    const stats = JSON.parse(raw) as TaskStats
+    const misses: string[] = []
+    for (const [name, s] of Object.entries(stats)) {
+      if (s.cache_miss > 0) misses.push(name)
+    }
+    // Turbopack sorts on the Rust side, but sort again here to be robust
+    // against the JSON parser's object iteration order.
+    misses.sort()
+    return misses
+  }
 
-        const missed = await readMissedTaskNames()
-        expect(missed).toMatchInlineSnapshot(`
+  if (isNextDev) {
+    it('snapshot of tasks with cache misses on warm dev restart', async () => {
+      // Cycle 1: the harness already auto-started; perform a request so the
+      // SSR/Node chunk work runs and gets persisted on shutdown.
+      async function runDevCycle() {
+        const browser = await next.browser('/')
+        // Wait for actual rendered content before declaring "ready".
+        await browser.elementByCss('p')
+        // Settle: the dev server keeps doing background work after first
+        // paint (HMR socket handshake, tail compilation). A fixed sleep
+        // is the least-bad option here since next.js doesn't expose
+        // turbopack's internal idle signal. If this proves flaky in CI,
+        // raise the value.
+        await waitFor(2000)
+        await browser.close()
+      }
+      await runDevCycle()
+      await stop()
+
+      // Cycle 2: warm.
+      await next.start()
+      await runDevCycle()
+      await stop()
+
+      const missed = await readMissedTaskNames()
+      expect(missed).toMatchInlineSnapshot(`
          [
            "<turbopack_browser::ecmascript::list::content::EcmascriptDevChunkListContent as dyn turbopack_core::version::VersionedContent>::update",
            "next_api::project::Project::hmr_update",
@@ -131,22 +128,21 @@ const STATS_RELATIVE_PATH = '.next/warm-restart-task-stats.json'
            "turbopack_core::version::VersionState::get",
          ]
         `)
-      }, 180_000)
-    } else {
-      it('snapshot of tasks with cache misses on warm build', async () => {
-        // In start mode the harness auto-runs `next build` then `next start`.
-        // The build is cycle 1. We stop the server (we don't care about it)
-        // and run a second build manually for the warm measurement.
-        await stop()
+    }, 180_000)
+  } else {
+    it('snapshot of tasks with cache misses on warm build', async () => {
+      // In start mode the harness auto-runs `next build` then `next start`.
+      // The build is cycle 1. We stop the server (we don't care about it)
+      // and run a second build manually for the warm measurement.
+      await stop()
 
-        const result = await (next as any).build()
-        if (result.exitCode !== 0) {
-          throw new Error(`next build exited with ${result.exitCode}`)
-        }
+      const result = await (next as any).build()
+      if (result.exitCode !== 0) {
+        throw new Error(`next build exited with ${result.exitCode}`)
+      }
 
-        const missed = await readMissedTaskNames()
-        expect(missed).toMatchInlineSnapshot(`[]`)
-      }, 240_000)
-    }
+      const missed = await readMissedTaskNames()
+      expect(missed).toMatchInlineSnapshot(`[]`)
+    }, 240_000)
   }
-)
+})

--- a/test/e2e/getserversideprops-preview/getserversideprops-preview.test.ts
+++ b/test/e2e/getserversideprops-preview/getserversideprops-preview.test.ts
@@ -15,13 +15,13 @@ function getData(html: string) {
   }
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('ServerSide Props Preview Mode', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   if (isNextStart) {
     it('should compile successfully', async () => {

--- a/test/e2e/gip-identifier/gip-identifier.test.ts
+++ b/test/e2e/gip-identifier/gip-identifier.test.ts
@@ -2,12 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('gip identifiers', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const getNextData = async () => {
     const html = await next.render('/')

--- a/test/e2e/gssp-redirect-base-path/gssp-redirect-base-path.test.ts
+++ b/test/e2e/gssp-redirect-base-path/gssp-redirect-base-path.test.ts
@@ -3,16 +3,17 @@ import { retry } from 'next-test-utils'
 
 const basePath = '/docs'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('GS(S)P Redirect with basePath', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
       react: '19.3.0-canary-da9325b5-20260417',
       'react-dom': '19.3.0-canary-da9325b5-20260417',
     },
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should apply temporary redirect when visited directly for GSSP page', async () => {
     const res = await next.fetch(`${basePath}/gssp-blog/redirect-1`, {

--- a/test/e2e/gssp-redirect/gssp-redirect.test.ts
+++ b/test/e2e/gssp-redirect/gssp-redirect.test.ts
@@ -1,16 +1,17 @@
 import { nextTestSetup, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('GS(S)P Redirect Support', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should apply temporary redirect when visited directly for GSSP page', async () => {
     const res = await next.fetch('/gssp-blog/redirect-1', {

--- a/test/e2e/i18n-data-fetching-redirect/redirect-from-context.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/redirect-from-context.test.ts
@@ -2,13 +2,10 @@ import { join } from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// The source only records that these assertions fail after deployment; the root cause is unknown.
+// @force-gate !deploy
 describe('i18n-data-fetching-redirect', () => {
-  // TODO: investigate tests failures on deploy
-  if ((global as any).isNextDeploy) {
-    it('should skip temporarily', () => {})
-    return
-  }
-
   const { next } = nextTestSetup({
     files: {
       pages: new FileRef(join(__dirname, 'app/pages')),

--- a/test/e2e/i18n-data-fetching-redirect/redirect.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/redirect.test.ts
@@ -4,6 +4,8 @@ import { check } from 'next-test-utils'
 
 describe('i18n-data-fetching-redirect', () => {
   // TODO: investigate tests failures on deploy
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // The source only records that these assertions fail after deployment; the root cause is unknown.
   if ((global as any).isNextDeploy) {
     it('should skip temporarily', () => {})
     return

--- a/test/e2e/i18n-data-route/i18n-data-route.test.ts
+++ b/test/e2e/i18n-data-route/i18n-data-route.test.ts
@@ -12,19 +12,18 @@ function checkDataRoute(data: any, page: string) {
   expect(data.pageProps).toHaveProperty('page', page)
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test skips deployment because env vars that are doubled underscore prefixed
+// are not supported.
+// @force-gate !deploy
 describe('i18n-data-route', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // This test skips deployment because env vars that are doubled underscore prefixed
-    // are not supported.
-    skipDeployment: true,
     env: {
       // Disable internal header stripping so we can test the invoke output.
       __NEXT_NO_STRIP_INTERNAL_HEADERS: '1',
     },
   })
-
-  if (skipped) return
 
   describe('with locale prefix', () => {
     describe.each(i18n.locales)('/%s', (locale) => {

--- a/test/e2e/i18n-disallow-multiple-locales/i18n-disallow-multiple-locales.test.ts
+++ b/test/e2e/i18n-disallow-multiple-locales/i18n-disallow-multiple-locales.test.ts
@@ -13,16 +13,13 @@ async function verify(res, locale) {
   expect($('#router-locale').text()).toBe(locale)
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// TODO: re-enable after this behavior is corrected
+// @force-gate !deploy
 describe('i18n-disallow-multiple-locales', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // TODO: re-enable after this behavior is corrected
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should verify the default locale works', async () => {
     const res = await next.fetch('/', { redirect: 'manual' })

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
@@ -5,15 +5,13 @@ import fs from 'fs-extra'
 
 const locales = ['', '/en', '/sv', '/nl']
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely reads files from the isolated local fixture.
+// @force-gate !deploy
 describe('i18n-ignore-rewrite-source-locale with basepath', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   test.each(locales)(
     'get public file by skipping locale in rewrite, locale: %s',

--- a/test/e2e/i18n-support-base-path/i18n-support-base-path.test.ts
+++ b/test/e2e/i18n-support-base-path/i18n-support-base-path.test.ts
@@ -7,13 +7,14 @@ import { nextTestSetup, isNextDev, type NextInstance } from 'e2e-utils'
 
 type BrowserOptions = Parameters<NextInstance['browser']>[1]
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('i18n Support basePath', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const ctx: Record<string, any> = {
     basePath: '/docs',

--- a/test/e2e/i18n-support-custom-error/i18n-support-custom-error.test.ts
+++ b/test/e2e/i18n-support-custom-error/i18n-support-custom-error.test.ts
@@ -1,13 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('Custom routes i18n custom error', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const locales = ['en', 'fr', 'de', 'it']
 

--- a/test/e2e/i18n-support/i18n-support.test.ts
+++ b/test/e2e/i18n-support/i18n-support.test.ts
@@ -9,13 +9,14 @@ import assert from 'assert'
 
 type BrowserOptions = Parameters<NextInstance['browser']>[1]
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely expects a local build failure instead of a successful deployment.
+// @force-gate !deploy
 describe('i18n Support', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const ctx: Record<string, any> = {
     basePath: '',

--- a/test/e2e/import-meta-env/import-meta-env.test.ts
+++ b/test/e2e/import-meta-env/import-meta-env.test.ts
@@ -1,17 +1,13 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 
-const testFn =
-  process.env.IS_WEBPACK_TEST || process.env.NEXT_RSPACK
-    ? describe.skip
-    : describe
-
-testFn('import.meta.env', () => {
-  const { next, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): No deploy-specific incompatibility is
+// documented.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('import.meta.env', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('exposes built-in environment values on the server and client', async () => {
     const browser = await next.browser('/docs')

--- a/test/e2e/import-meta-glob/import-meta-glob.test.ts
+++ b/test/e2e/import-meta-glob/import-meta-glob.test.ts
@@ -1,18 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // import.meta.glob is a Turbopack-only feature; skip under webpack
-const testFn =
-  process.env.IS_WEBPACK_TEST || process.env.NEXT_RSPACK
-    ? describe.skip
-    : describe
-
-testFn('import-meta-glob', () => {
-  const { next, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): No deploy-specific incompatibility is
+// documented.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('import-meta-glob', () => {
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('should resolve lazy glob modules', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/index-index/index-index.test.ts
+++ b/test/e2e/index-index/index-index.test.ts
@@ -2,15 +2,15 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel's deploy infrastructure normalizes nested `/index/index/index`
+// paths differently from Next.js's local server, so the routing
+// assertions here are local-only.
+// @force-gate !deploy
 describe('nested index.js', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
-    // Vercel's deploy infrastructure normalizes nested `/index/index/index`
-    // paths differently from Next.js's local server, so the routing
-    // assertions here are local-only.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should ssr page /', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/invalid-custom-routes/invalid-custom-routes.test.ts
+++ b/test/e2e/invalid-custom-routes/invalid-custom-routes.test.ts
@@ -1,13 +1,14 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Errors on invalid custom routes', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   const writeConfig = async (routes: any, type = 'redirects') => {
     await next.patchFile(

--- a/test/e2e/invalid-multi-match/invalid-multi-match.test.ts
+++ b/test/e2e/invalid-multi-match/invalid-multi-match.test.ts
@@ -1,18 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// Deploy mode exclusion: This suite asserts local CLI or runtime logs that deployments do not expose.
+// The test asserts on `next.cliOutput`, expecting the local
+// `next build` failure message ("To use a multi-match in the
+// destination..."). In deploy mode `next.cliOutput` contains the
+// Vercel deploy log, which doesn't surface the same Next.js build
+// error string at the top level, so the assertions don't apply.
+// @force-gate !deploy
 describe('Custom routes invalid multi-match', () => {
-  const { next, isNextDeploy, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     disableAutoSkewProtection: true,
-    // The test asserts on `next.cliOutput`, expecting the local
-    // `next build` failure message ("To use a multi-match in the
-    // destination..."). In deploy mode `next.cliOutput` contains the
-    // Vercel deploy log, which doesn't surface the same Next.js build
-    // error string at the top level, so the assertions don't apply.
-    skipDeployment: true,
   })
-  if (skipped) return
-  if (isNextDeploy) return
 
   it('should show error for invalid multi-match', async () => {
     await next.render('/random')

--- a/test/e2e/jsconfig-baseurl/jsconfig-baseurl.test.ts
+++ b/test/e2e/jsconfig-baseurl/jsconfig-baseurl.test.ts
@@ -2,12 +2,13 @@ import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('jsconfig.json baseurl', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   describe('default behavior', () => {
     it('should render the page', async () => {

--- a/test/e2e/jsconfig-paths/jsconfig-paths.test.ts
+++ b/test/e2e/jsconfig-paths/jsconfig-paths.test.ts
@@ -2,13 +2,13 @@ import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('jsconfig paths', () => {
-  const { next, isNextDeploy, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
-  if (isNextDeploy) return
 
   it('should alias components', async () => {
     const $ = await next.render$('/basic-alias')
@@ -96,13 +96,14 @@ describe('jsconfig paths', () => {
   }
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('jsconfig paths without baseurl', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let originalJsconfigContent: string
 

--- a/test/e2e/legacy-link-behavior/index.test.ts
+++ b/test/e2e/legacy-link-behavior/index.test.ts
@@ -5,15 +5,13 @@ import {
   type ErrorSnapshot,
 } from '../../lib/add-redbox-matchers'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('Link with legacyBehavior', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return it('should skip', () => {})
-  }
 
   describe('if the child is an <a> tag', () => {
     it('forwards the href attribute', async () => {

--- a/test/e2e/legacy-link-behavior/validations.console.test.ts
+++ b/test/e2e/legacy-link-behavior/validations.console.test.ts
@@ -4,12 +4,13 @@ import { getDeterministicOutput } from '../app-dir/cache-components-errors/utils
 
 const partialPrefetching = !!process.env.__NEXT_PARTIAL_PREFETCHING
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Validations for <Link legacyBehavior>', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
   let previousOutputIndex = 0
 
   beforeEach(() => {

--- a/test/e2e/manual-client-base-path/index.test.ts
+++ b/test/e2e/manual-client-base-path/index.test.ts
@@ -6,6 +6,7 @@ import assert from 'assert'
 import { check, renderViaHTTP, waitFor } from 'next-test-utils'
 
 describe('manual-client-base-path', () => {
+  // Deploy mode exclusion: This suite runs an in-test HTTP proxy in front of the local Next.js server.
   if ((global as any).isNextDeploy) {
     it('should skip deploy', () => {})
     return

--- a/test/e2e/multi-zone/multi-zone.test.ts
+++ b/test/e2e/multi-zone/multi-zone.test.ts
@@ -2,10 +2,12 @@ import { nextTestSetup } from 'e2e-utils'
 import { check, waitFor } from 'next-test-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely mutates files in the isolated local fixture after setup.
+// @force-gate !deploy
 describe('multi-zone', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'app'),
-    skipDeployment: true,
     buildCommand: 'pnpm build',
     startCommand: (global as any).isNextDev ? 'pnpm dev' : 'pnpm start',
     serverReadyPattern: /Next mode: (production|development)/,
@@ -19,10 +21,6 @@ describe('multi-zone', () => {
     },
     dependencies: require('./app/package.json').dependencies,
   })
-
-  if (skipped) {
-    return
-  }
 
   it.each([
     { pathname: '/', content: ['hello from host app'] },

--- a/test/e2e/new-link-behavior/material-ui.test.ts
+++ b/test/e2e/new-link-behavior/material-ui.test.ts
@@ -3,6 +3,8 @@ import path from 'path'
 
 const appDir = path.join(__dirname, 'material-ui')
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('New Link Behavior with material-ui', () => {
   const { next } = nextTestSetup({
     files: {

--- a/test/e2e/new-link-behavior/stitches.test.ts
+++ b/test/e2e/new-link-behavior/stitches.test.ts
@@ -3,6 +3,8 @@ import path from 'path'
 
 const appDir = path.join(__dirname, 'stitches')
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('New Link Behavior with stitches', () => {
   const { next } = nextTestSetup({
     files: {

--- a/test/e2e/next-analyze/next-analyze.test.ts
+++ b/test/e2e/next-analyze/next-analyze.test.ts
@@ -4,6 +4,9 @@ import path from 'node:path'
 import type { ChildProcess } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely inspects local build artifacts that deploy tests do not expose.
+// @force-gate !deploy
 describe('next experimental-analyze', () => {
   if (!shouldUseTurbopack()) {
     // Test suites require at least one test
@@ -11,17 +14,10 @@ describe('next experimental-analyze', () => {
     return
   }
 
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    // Test suites require at least one test
-    it('is skipped', () => {})
-    return
-  }
 
   it('runs successfully without errors', async () => {
     let serveProcess: ChildProcess | undefined

--- a/test/e2e/next-link-errors/next-link-errors.test.ts
+++ b/test/e2e/next-link-errors/next-link-errors.test.ts
@@ -1,12 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('next-link', () => {
-  const { skipped, next, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   it('errors on invalid href', async () => {
     const browser = await next.browser('/invalid-href')

--- a/test/e2e/next-phase/index.test.ts
+++ b/test/e2e/next-phase/index.test.ts
@@ -1,10 +1,11 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This test is skipped when deployed because it asserts against runtime
+// logs that cannot be queried in a deployed environment.
+// @force-gate !deploy
 describe('next-phase', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
-    // This test is skipped when deployed because it asserts against runtime
-    // logs that cannot be queried in a deployed environment.
-    skipDeployment: true,
+  const { next, isNextDev } = nextTestSetup({
     files: {
       'app/layout.js': `export default function Layout({ children }) {
         return <html><body>{children}</body></html>
@@ -19,8 +20,6 @@ describe('next-phase', () => {
       `,
     },
   })
-
-  if (skipped) return
 
   it('should render page with next phase correctly', async () => {
     await next.fetch('/')

--- a/test/e2e/next-script/index.test.ts
+++ b/test/e2e/next-script/index.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('beforeInteractive in document Head', () => {
   const { next } = nextTestSetup({
     files: {

--- a/test/e2e/next-test/next-test.test.ts
+++ b/test/e2e/next-test/next-test.test.ts
@@ -25,18 +25,18 @@ function createTemporaryFixture(fixtureName: string) {
   return dir
 }
 
-describe.skip('next test', () => {
-  const { next: basicExample, skipped } = nextTestSetup({
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// This doesn't need to be deployed as it's using `experimental-test` mode
+// @force-gate !deploy
+// @force-gate TODO
+describe('next test', () => {
+  const { next: basicExample } = nextTestSetup({
     files: new FileRef(join(__dirname, 'basic-example')),
     dependencies: {
       '@playwright/test': '1.43.1',
     },
     skipStart: true,
-    // This doesn't need to be deployed as it's using `experimental-test` mode
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   afterAll(async () => {
     await basicExample.destroy()

--- a/test/e2e/nullish-config/nullish-config.test.ts
+++ b/test/e2e/nullish-config/nullish-config.test.ts
@@ -1,12 +1,13 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('Nullish configs in next.config.js', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   afterEach(async () => {
     await next.stop().catch(() => {})

--- a/test/e2e/og-api/index.test.ts
+++ b/test/e2e/og-api/index.test.ts
@@ -4,13 +4,13 @@ import { randomUUID } from 'crypto'
 import fs from 'fs-extra'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy || !standaloneOutput
 describe('og-api', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: new FileRef(join(__dirname, 'app')),
-    skipDeployment: process.env.TEST_OUTPUT_STANDALONE === 'true',
   })
-
-  if (skipped) return
 
   it('should respond from index', async () => {
     const html = await renderViaHTTP(next.url, '/')

--- a/test/e2e/pages-performance-mark/index.test.ts
+++ b/test/e2e/pages-performance-mark/index.test.ts
@@ -2,15 +2,13 @@ import { nextTestSetup } from 'e2e-utils'
 
 // This test case doesn't indicate rendering duplicate head in _document is valid,
 // but it's a way to reproduce the performance mark crashing.
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('pages performance mark', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should render the page correctly without crashing with performance mark', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/persistent-caching-migration/persistent-caching-migration.test.ts
+++ b/test/e2e/persistent-caching-migration/persistent-caching-migration.test.ts
@@ -18,8 +18,11 @@ const CASES = [
 
 describe('persistent-caching-migration', () => {
   for (const [option, error] of CASES) {
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely expects a local build failure instead of a successful deployment.
+    // @force-gate !deploy
     describe(option, () => {
-      const { skipped, next, isTurbopack, isNextStart } = nextTestSetup({
+      const { next, isTurbopack, isNextStart } = nextTestSetup({
         files: {
           'next.config.js': `module.exports = {
   experimental: {
@@ -27,13 +30,8 @@ describe('persistent-caching-migration', () => {
   },
 }`,
         },
-        skipDeployment: true,
         skipStart: true,
       })
-
-      if (skipped) {
-        return
-      }
 
       if (!isTurbopack) {
         it.skip('only for turbopack', () => {})

--- a/test/e2e/prerender-fallback-encoding/prerender-fallback-encoding.test.ts
+++ b/test/e2e/prerender-fallback-encoding/prerender-fallback-encoding.test.ts
@@ -3,11 +3,12 @@ import { retry } from 'next-test-utils'
 import fs from 'fs'
 import { join } from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// @force-gate !deploy
 describe('Fallback path encoding', () => {
   const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,
-    // Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-    skipDeployment: true,
   })
 
   const urlPaths = [

--- a/test/e2e/react-compiler/react-compiler.test.ts
+++ b/test/e2e/react-compiler/react-compiler.test.ts
@@ -16,6 +16,8 @@ function normalizeCodeLocInfo(str) {
   )
 }
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe.each(['default', 'babelrc', 'rust'] as const)(
   'react-compiler %s',
   (variant) => {

--- a/test/e2e/react-current-version/react-current-version.test.ts
+++ b/test/e2e/react-current-version/react-current-version.test.ts
@@ -36,15 +36,13 @@ export const config = {
 
 describe('react-current-version', () => {
   describe('React 18 deprecation warning', () => {
-    const { next, isNextDeploy, skipped } = nextTestSetup({
+    const { next, isNextDeploy } = nextTestSetup({
       files: join(__dirname, 'app'),
       skipStart: true,
     })
 
-    if (skipped) {
-      return
-    }
-
+    // Deploy mode exclusion: This block asserts local build and server CLI
+    // output, which is produced before a deployment is available.
     if (isNextDeploy) {
       it('should skip in deploy mode', () => {})
       return

--- a/test/e2e/react-dnd-compile/react-dnd-compile.test.ts
+++ b/test/e2e/react-dnd-compile/react-dnd-compile.test.ts
@@ -1,5 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('react-dnd-compile', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/relay-graphql-swc-multi-project/relay-graphql-swc-multi-project.test.ts
+++ b/test/e2e/relay-graphql-swc-multi-project/relay-graphql-swc-multi-project.test.ts
@@ -18,6 +18,9 @@ function relayCompilerValidate(next: NextInstance) {
 }
 
 describe('Relay Compiler Transform - Multi Project Config', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+  // @force-gate !deploy
   describe('project-a', () => {
     const { next } = nextTestSetup({
       files: __dirname,
@@ -44,8 +47,6 @@ describe('Relay Compiler Transform - Multi Project Config', () => {
       startCommand: isNextDev
         ? 'pnpm run dev-project-a'
         : 'pnpm run start-project-a',
-      // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-      skipDeployment: true,
     })
 
     relayCompilerValidate(next)
@@ -57,6 +58,9 @@ describe('Relay Compiler Transform - Multi Project Config', () => {
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+  // @force-gate !deploy
   describe('project-b', () => {
     const { next } = nextTestSetup({
       files: __dirname,
@@ -78,8 +82,6 @@ describe('Relay Compiler Transform - Multi Project Config', () => {
       startCommand: isNextDev
         ? 'pnpm run dev-project-b'
         : 'pnpm run start-project-b',
-      // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-      skipDeployment: true,
     })
 
     relayCompilerValidate(next)

--- a/test/e2e/repeated-slashes/repeated-slashes.test.ts
+++ b/test/e2e/repeated-slashes/repeated-slashes.test.ts
@@ -7,7 +7,7 @@ import {
   fetchViaHTTP,
   retry,
 } from 'next-test-utils'
-import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
+import { nextTestSetup, isNextDev } from 'e2e-utils'
 
 function runTests({
   next,
@@ -418,22 +418,25 @@ function runTests({
 
 describe('404 handling', () => {
   describe('custom _error', () => {
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
+    // @force-gate !deploy
     describe('server mode', () => {
-      const { next, isNextDeploy } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: path.join(__dirname, 'app'),
-        skipDeployment: true,
       })
-      if (isNextDeploy) return
 
       runTests({ next, isDev: isNextDev, isPages404: false })
     })
-    ;(isNextStart ? describe : describe.skip)('export mode', () => {
-      const { next, skipped } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
+    // @force-gate !deploy
+    // @force-gate start
+    describe('export mode', () => {
+      const { next } = nextTestSetup({
         files: path.join(__dirname, 'app'),
         skipStart: true,
-        skipDeployment: true,
       })
-      if (skipped) return
 
       let staticServer: any
       let staticPort: number
@@ -471,13 +474,14 @@ describe('404 handling', () => {
   })
 
   describe('pages/404', () => {
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
+    // @force-gate !deploy
     describe('server mode', () => {
-      const { next, skipped } = nextTestSetup({
+      const { next } = nextTestSetup({
         files: path.join(__dirname, 'app'),
         skipStart: true,
-        skipDeployment: true,
       })
-      if (skipped) return
 
       beforeAll(async () => {
         await next.deleteFile('pages/_error.js')
@@ -501,13 +505,15 @@ describe('404 handling', () => {
 
       runTests({ next, isDev: isNextDev, isPages404: true })
     })
-    ;(isNextStart ? describe : describe.skip)('pages/404 export mode', () => {
-      const { next, skipped } = nextTestSetup({
+    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+    // It likely mutates files in the isolated local fixture after setup.
+    // @force-gate !deploy
+    // @force-gate start
+    describe('pages/404 export mode', () => {
+      const { next } = nextTestSetup({
         files: path.join(__dirname, 'app'),
         skipStart: true,
-        skipDeployment: true,
       })
-      if (skipped) return
 
       let staticServer: any
       let staticPort: number

--- a/test/e2e/rewrite-request-smuggling/rewrite-request-smuggling.test.ts
+++ b/test/e2e/rewrite-request-smuggling/rewrite-request-smuggling.test.ts
@@ -4,6 +4,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { findPort, retry } from 'next-test-utils'
 
 describe('rewrite-request-smuggling', () => {
+  // Deploy mode exclusion: This suite opens raw TCP connections to a local backend server.
   if ((global as any).isNextDeploy) {
     it('should skip deploy', () => {})
     return

--- a/test/e2e/rewrite-with-browser-history/rewrite-with-browser-history.test.ts
+++ b/test/e2e/rewrite-with-browser-history/rewrite-with-browser-history.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('rewrites persist with browser history actions', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -7,8 +10,6 @@ describe('rewrites persist with browser history actions', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
 
   it('back-button should go back to rewritten path successfully', async () => {

--- a/test/e2e/rewrites-hostname/rewrites-hostname.test.ts
+++ b/test/e2e/rewrites-hostname/rewrites-hostname.test.ts
@@ -2,16 +2,14 @@ import { nextTestSetup } from 'e2e-utils'
 import { findPort } from 'next-test-utils'
 import createTargetServer from './target-server'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely depends on a local server, proxy, process, or dynamically allocated port.
+// @force-gate !deploy
 describe('rewrites hostname', () => {
-  const { skipped, next } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   let targetPort: number | null = null
   let closeTargetServer: (() => Promise<void>) | null = null

--- a/test/e2e/route-index/route-index.test.ts
+++ b/test/e2e/route-index/route-index.test.ts
@@ -1,11 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Pages-router `/index` route resolution differs in Vercel's deploy
+// infrastructure; these assertions are local-only.
+// @force-gate !deploy
 describe('Route index handling', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // Pages-router `/index` route resolution differs in Vercel's deploy
-    // infrastructure; these assertions are local-only.
-    skipDeployment: true,
   })
 
   it('should handle / correctly', async () => {

--- a/test/e2e/route-indexes/route-indexes.test.ts
+++ b/test/e2e/route-indexes/route-indexes.test.ts
@@ -1,11 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Pages-router `/index` route resolution differs in Vercel's deploy
+// infrastructure; these assertions are local-only.
+// @force-gate !deploy
 describe('Route indexes handling', () => {
   const { next } = nextTestSetup({
     files: __dirname,
-    // Pages-router `/index` route resolution differs in Vercel's deploy
-    // infrastructure; these assertions are local-only.
-    skipDeployment: true,
   })
 
   it('should handle / correctly', async () => {

--- a/test/e2e/router-hash-navigation/router-hash-navigation.test.ts
+++ b/test/e2e/router-hash-navigation/router-hash-navigation.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('router hash navigation', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -7,8 +10,6 @@ describe('router hash navigation', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
 
   it('scrolls to top when href="/" and url already contains a hash', async () => {

--- a/test/e2e/scroll-back-restoration/scroll-back-restoration.test.ts
+++ b/test/e2e/scroll-back-restoration/scroll-back-restoration.test.ts
@@ -1,6 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('Scroll Back Restoration Support', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -8,8 +11,6 @@ describe('Scroll Back Restoration Support', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
 
   it('should restore the scroll position on navigating back', async () => {

--- a/test/e2e/skip-trailing-slash-redirect/index.test.ts
+++ b/test/e2e/skip-trailing-slash-redirect/index.test.ts
@@ -11,6 +11,8 @@ import {
 import { join } from 'path'
 import cheerio from 'cheerio'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('skip-trailing-slash-redirect', () => {
   const { next } = nextTestSetup({
     files: new FileRef(join(__dirname, 'app')),

--- a/test/e2e/ssg-dynamic-routes-404-page/ssg-dynamic-routes-404-page.test.ts
+++ b/test/e2e/ssg-dynamic-routes-404-page/ssg-dynamic-routes-404-page.test.ts
@@ -1,5 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// @force-gate !deploy
 describe('ssg-dynamic-routes-404-page', () => {
   const { next } = nextTestSetup({
     files: __dirname,
@@ -7,8 +10,6 @@ describe('ssg-dynamic-routes-404-page', () => {
       react: '19.3.0-canary-fef12a01-20260413',
       'react-dom': '19.3.0-canary-fef12a01-20260413',
     },
-    // Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
-    skipDeployment: true,
   })
 
   it('should respond to a not existing page with 404', async () => {

--- a/test/e2e/swc-plugins-env/index.test.ts
+++ b/test/e2e/swc-plugins-env/index.test.ts
@@ -1,11 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('swc-plugins-env', () => {
-  const { next, skipped, isNextDev } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should pass correct environment to swc plugins', async () => {
     const $ = await next.render$('/')

--- a/test/e2e/swc-plugins/index.test.ts
+++ b/test/e2e/swc-plugins/index.test.ts
@@ -1,15 +1,16 @@
-import { nextTestSetup, isNextDev } from 'e2e-utils'
+import { nextTestSetup } from 'e2e-utils'
 
 describe('swcPlugins', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
   describe('supports swcPlugins', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       dependencies: {
         '@swc/plugin-react-remove-properties': '13.0.0',
       },
     })
-    if (skipped) return
 
     it('basic case', async () => {
       const html = await next.render('/')
@@ -17,15 +18,17 @@ describe('swcPlugins', () => {
       expect(html).not.toContain('data-custom-attribute')
     })
   })
-  ;(isNextDev ? describe : describe.skip)('incompatible plugin version', () => {
-    const { next, skipped, isTurbopack } = nextTestSetup({
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
+  // @force-gate dev
+  describe('incompatible plugin version', () => {
+    const { next, isTurbopack } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       dependencies: {
         '@swc/plugin-react-remove-properties': '7.0.2',
       },
     })
-    if (skipped) return
 
     it('shows a redbox in dev', async () => {
       const browser = await next.browser('/')
@@ -55,10 +58,13 @@ describe('swcPlugins', () => {
       }
     })
   })
-  ;(isNextDev ? describe : describe.skip)('invalid plugin name', () => {
-    const { next, skipped, isTurbopack } = nextTestSetup({
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely expects a local build failure instead of a successful deployment.
+  // @force-gate !deploy
+  // @force-gate dev
+  describe('invalid plugin name', () => {
+    const { next, isTurbopack } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       overrideFiles: {
         'next.config.js': `
 module.exports = {
@@ -68,9 +74,7 @@ module.exports = {
 }`,
       },
     })
-    if (skipped) return
 
-    // eslint-disable-next-line jest/no-identical-title
     it('shows a redbox in dev', async () => {
       const browser = await next.browser('/')
 

--- a/test/e2e/swc-warnings/index.test.ts
+++ b/test/e2e/swc-warnings/index.test.ts
@@ -2,6 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { renderViaHTTP } from 'next-test-utils'
 
 // Tests Babel, not needed for Turbopack
+// Deploy mode exclusion: This suite asserts warning output from the local
+// Next.js CLI, which is not available from a deployed runtime.
 ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
   'swc warnings by default',
   () => {

--- a/test/e2e/switchable-runtime/index.test.ts
+++ b/test/e2e/switchable-runtime/index.test.ts
@@ -31,6 +31,8 @@ async function testRoute(appPort, url, { isStatic, isEdge }) {
 describe('Switchable runtime', () => {
   let context
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // Prerenders used by this suite are not currently handled by deploy mode.
   if ((global as any).isNextDeploy) {
     // TODO-APP: re-enable after Prerenders are handled on deploy
     it('should skip for deploy temporarily', () => {})

--- a/test/e2e/third-parties/index.test.ts
+++ b/test/e2e/third-parties/index.test.ts
@@ -1,6 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 
+// TODO(deploy-test-completion): Remove this suite from the deploy manifest.
+// It was excluded as a known deploy failure without a documented root cause.
 describe('@next/third-parties basic usage', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/trailing-slashes-rewrite/trailing-slashes-rewrite.test.ts
+++ b/test/e2e/trailing-slashes-rewrite/trailing-slashes-rewrite.test.ts
@@ -2,15 +2,15 @@ import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { findPort, initNextServerScript, killApp } from 'next-test-utils'
 
+// Deploy mode exclusion: This suite controls a local server or proxy process.
+// Spawns a custom proxy server in front of `next.start()`; deploy mode
+// doesn't run a local server.
+// @force-gate !deploy
 describe('Trailing Slash Rewrite Proxying', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    // Spawns a custom proxy server in front of `next.start()`; deploy mode
-    // doesn't run a local server.
-    skipDeployment: true,
   })
-  if (skipped) return
 
   let proxyServer: any
 

--- a/test/e2e/trailingslash-with-rewrite/index.test.ts
+++ b/test/e2e/trailingslash-with-rewrite/index.test.ts
@@ -3,6 +3,8 @@ import { FileRef, nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('trailingSlash:true with rewrites and getStaticProps', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
   if ((global as any).isNextDeploy) {
     it('should skip for deploy mode for now', () => {})
     return

--- a/test/e2e/transpile-packages-typescript-foreign/index.test.ts
+++ b/test/e2e/transpile-packages-typescript-foreign/index.test.ts
@@ -1,19 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('transpile-packages-typescript-foreign', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('without transpilePackages', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       skipStart: true,
       dependencies: {
         pkg: `file:./pkg`,
       },
     })
-
-    if (skipped) {
-      return
-    }
 
     it('should fail', async () => {
       try {
@@ -38,10 +36,12 @@ Module parse failed: Unexpected token`)
     })
   })
 
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // @force-gate !deploy
   describe('with transpilePackages', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
-      skipDeployment: true,
       dependencies: {
         pkg: `file:./pkg`,
       },
@@ -49,10 +49,6 @@ Module parse failed: Unexpected token`)
         transpilePackages: ['pkg'],
       },
     })
-
-    if (skipped) {
-      return
-    }
 
     it('should work', async () => {
       const $ = await next.render$('/')

--- a/test/e2e/transpile-packages/index.test.ts
+++ b/test/e2e/transpile-packages/index.test.ts
@@ -2,6 +2,8 @@ import path from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('transpile packages', () => {
+  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+  // No deploy-specific incompatibility is documented.
   if ((global as any).isNextDeploy) {
     it('should skip for deploy mode for now', () => {})
     return

--- a/test/e2e/tsconfig-module-preserve/index.test.ts
+++ b/test/e2e/tsconfig-module-preserve/index.test.ts
@@ -5,8 +5,11 @@ import stripAnsi from 'strip-ansi'
 const strictRouteTypes =
   process.env.__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES === 'true'
 
+// Deploy mode exclusion: This suite reads local build artifacts that deployments do not expose.
+// This test is skipped because it relies on `next.readFile`
+// @force-gate !deploy
 describe('tsconfig module: preserve', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       'tsconfig.json': JSON.stringify({
         compilerOptions: { module: 'preserve' },
@@ -17,14 +20,10 @@ describe('tsconfig module: preserve', () => {
         } 
       `,
     },
-    // This test is skipped because it relies on `next.readFile`
-    skipDeployment: true,
     dependencies: {
       typescript: '5.4.4',
     },
   })
-
-  if (skipped) return
 
   it('allows you to skip moduleResolution, esModuleInterop and resolveJsonModule when using "module: preserve"', async () => {
     let output = ''

--- a/test/e2e/tsconfig-path/index.test.ts
+++ b/test/e2e/tsconfig-path/index.test.ts
@@ -1,16 +1,12 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
 describe('specified tsconfig', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: new FileRef(__dirname),
     dependencies: {
       typescript: '5.4.4',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('app router: allows a user-specific tsconfig via the next config', async () => {
     const html = await next.render('/')

--- a/test/e2e/turbopack-emit-collect/index.test.ts
+++ b/test/e2e/turbopack-emit-collect/index.test.ts
@@ -2,15 +2,15 @@ import { nextTestSetup } from 'e2e-utils'
 
 // Only implemented in Webpack
 // Fixture uses force-dynamic which doesn't work with cache components enabled
-;(process.env.IS_TURBOPACK_TEST && !process.env.__NEXT_CACHE_COMPONENTS
-  ? describe
-  : describe.skip)('turbopack-emit-collect', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+// Deploy mode exclusion: This suite restarts the local server to inspect
+// process-global module state.
+// @force-gate !deploy
+// @force-gate turbopack
+// @force-gate !cacheComponents
+describe('turbopack-emit-collect', () => {
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   function formatId(id: string) {
     return id.slice(id.lastIndexOf('/src/') + 5).replace(' (ecmascript)', '')

--- a/test/e2e/turbopack-import-with-type/index.test.ts
+++ b/test/e2e/turbopack-import-with-type/index.test.ts
@@ -5,54 +5,50 @@ const jsContent = `export const nope = 'nope'
 throw new Error('please dont execute me')
 `
 
-;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
-  'turbopack-import-with-type',
-  () => {
-    const { next, skipped } = nextTestSetup({
-      files: __dirname,
-      skipDeployment: true,
-    })
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
+// @force-gate turbopack
+describe('turbopack-import-with-type', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
 
-    if (skipped) {
-      return
-    }
-
-    // Testing this together on one route ensures we also avoid weird duplicate module ident things
-    it('supports import with type: text, type: bytes, and type: json', async () => {
-      const response = JSON.parse(await next.render('/api'))
-      expect(response).toEqual({
-        text: {
-          typeofString: true,
-          length: 12,
-          content: 'hello world\n',
-        },
-        jsAsText: {
-          typeofString: true,
-          content: jsContent,
-        },
-        bytes: {
-          instanceofUint8Array: true,
-          length: 18,
-          content: 'this is some data\n',
-        },
-        jsAsBytes: {
-          instanceofUint8Array: true,
-          content: jsContent,
-        },
-        configuredAsJsAsBytes: {
-          instanceofUint8Array: true,
-          content:
-            "throw new Error('this file is configured as ecmascript but imported as bytes')\n",
-        },
-        json: {
-          typeofObject: true,
-          content: { hello: 'world' },
-        },
-        jsonAsText: {
-          typeofString: true,
-          content: '{ "hello": "world" }\n',
-        },
-      })
+  // Testing this together on one route ensures we also avoid weird duplicate module ident things
+  it('supports import with type: text, type: bytes, and type: json', async () => {
+    const response = JSON.parse(await next.render('/api'))
+    expect(response).toEqual({
+      text: {
+        typeofString: true,
+        length: 12,
+        content: 'hello world\n',
+      },
+      jsAsText: {
+        typeofString: true,
+        content: jsContent,
+      },
+      bytes: {
+        instanceofUint8Array: true,
+        length: 18,
+        content: 'this is some data\n',
+      },
+      jsAsBytes: {
+        instanceofUint8Array: true,
+        content: jsContent,
+      },
+      configuredAsJsAsBytes: {
+        instanceofUint8Array: true,
+        content:
+          "throw new Error('this file is configured as ecmascript but imported as bytes')\n",
+      },
+      json: {
+        typeofObject: true,
+        content: { hello: 'world' },
+      },
+      jsonAsText: {
+        typeofString: true,
+        content: '{ "hello": "world" }\n',
+      },
     })
-  }
-)
+  })
+})

--- a/test/e2e/turbopack-loader-config/index.test.ts
+++ b/test/e2e/turbopack-loader-config/index.test.ts
@@ -1,16 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('turbopack-loader-config', () => {
-  const { next, isTurbopack, isNextDev, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     // we can't set `nextConfig` inline because it contains regexes that fail to serialize, it needs
     // to be set in a separate module (`next.config.ts`)
   })
-
-  if (skipped) {
-    return
-  }
 
   if (!isTurbopack) {
     it('should only run the test in turbopack', () => {})

--- a/test/e2e/turbopack-trace-server-query/turbopack-trace-server.test.ts
+++ b/test/e2e/turbopack-trace-server-query/turbopack-trace-server.test.ts
@@ -111,19 +111,21 @@ function runQueryTraceCli(
 
 // ─── test suite ──────────────────────────────────────────────────────────────
 
+// Deploy mode exclusion: The trace server requires local trace files and
+// child processes.
+// @force-gate !deploy
 describe('turbopack-trace-server', () => {
+  // Deploy mode exclusion: This suite reads a local trace file and spawns
+  // local MCP and CLI processes.
   if (isNextDeploy) {
     it('skipped for deploy mode', () => {})
     return
   }
 
-  const { next, isTurbopack, isNextDev, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: __dirname,
     env: { NEXT_TURBOPACK_TRACING: '1' },
-    skipDeployment: true,
   })
-
-  if (skipped) return
 
   // Error-path test: does not need turbopack or a running trace server.
   it('CLI: should show an error when the trace server is not running', async () => {

--- a/test/e2e/twoslash/standalone.test.ts
+++ b/test/e2e/twoslash/standalone.test.ts
@@ -13,7 +13,7 @@ if (!(globalThis as any).isNextStart) {
   it('should skip for non-next start', () => {})
 } else {
   describe('output: standalone with twoslash', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next } = nextTestSetup({
       files: __dirname,
       dependencies: {
         twoslash: '0.3.4',
@@ -22,10 +22,6 @@ if (!(globalThis as any).isNextStart) {
       },
       skipStart: true,
     })
-
-    if (skipped) {
-      return
-    }
 
     let server: any
     let appPort: number

--- a/test/e2e/typescript-custom-tsconfig/test/index.test.ts
+++ b/test/e2e/typescript-custom-tsconfig/test/index.test.ts
@@ -4,16 +4,12 @@ import { join } from 'path'
 import { nextTestSetup, FileRef } from 'e2e-utils'
 
 describe('Custom TypeScript Config', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: new FileRef(join(__dirname, '..')),
     dependencies: {
       typescript: '5.4.4',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   it('app router: allows a user-specific tsconfig via the next config', async () => {
     const html = await next.render('/')

--- a/test/e2e/typescript-version-no-warning/typescript-version-no-warning.test.ts
+++ b/test/e2e/typescript-version-no-warning/typescript-version-no-warning.test.ts
@@ -1,15 +1,13 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('typescript-version-no-warning', () => {
-  const { next, isNextDeploy, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDeploy, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDeploy || isNextDev) {
     it('should skip', () => {})

--- a/test/e2e/typescript-version-warning/typescript-version-warning.test.ts
+++ b/test/e2e/typescript-version-warning/typescript-version-warning.test.ts
@@ -1,18 +1,16 @@
 import { nextTestSetup } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('typescript-version-warning', () => {
-  const { next, isNextDeploy, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDeploy, isNextDev } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeployment: true,
     dependencies: {
       typescript: '4.0.6',
     },
   })
-
-  if (skipped) {
-    return
-  }
 
   if (isNextDeploy || isNextDev) {
     it('should skip', () => {})

--- a/test/e2e/typescript-workspaces-paths/packages/www/test/index.test.ts
+++ b/test/e2e/typescript-workspaces-paths/packages/www/test/index.test.ts
@@ -4,6 +4,9 @@ import { join } from 'path'
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { readFileSync, writeFileSync } from 'fs'
 
+// This suite mutates the workspace config and runs custom local build/start
+// commands.
+// @force-gate !deploy
 describe('TypeScript Features', () => {
   describe.each([
     { label: '', testBaseUrl: true },
@@ -46,8 +49,7 @@ describe('TypeScript Features', () => {
       }
     })
 
-    const { next, skipped } = nextTestSetup({
-      skipDeployment: true,
+    const { next } = nextTestSetup({
       dependencies: testBaseUrl
         ? {
             typescript: '5.9.3',
@@ -58,8 +60,6 @@ describe('TypeScript Features', () => {
       startCommand:
         'pnpm next ' + (isNextDev ? 'dev' : 'start') + ' packages/www',
     })
-    if (skipped) return
-
     it('should alias components', async () => {
       const $ = await next.render$('/basic-alias')
       expect($('body').text()).toMatch(/World/)

--- a/test/e2e/typescript/typescript.test.ts
+++ b/test/e2e/typescript/typescript.test.ts
@@ -1,14 +1,15 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('TypeScript Features', () => {
-  const { next, isTurbopack, skipped } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     dependencies: {
       sass: 'latest',
     },
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('should render the page', async () => {
     const $ = await next.render$('/hello')
@@ -98,30 +99,30 @@ export default function EvilPage(): JSX.Element {
     })
   }
 })
-;(isNextStart ? describe : describe.skip)(
-  'TypeScript production compilation',
-  () => {
-    const { next, skipped } = nextTestSetup({
-      files: __dirname,
-      skipStart: true,
-      dependencies: {
-        sass: 'latest',
-      },
-      skipDeployment: true,
-    })
-    if (skipped) return
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate start
+describe('TypeScript production compilation', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    dependencies: {
+      sass: 'latest',
+    },
+  })
 
-    it('should build the app', async () => {
-      const { cliOutput, exitCode } = await next.build()
-      expect(cliOutput).toMatch(/Compiled successfully/)
-      expect(exitCode).toBe(0)
-    })
+  it('should build the app', async () => {
+    const { cliOutput, exitCode } = await next.build()
+    expect(cliOutput).toMatch(/Compiled successfully/)
+    expect(exitCode).toBe(0)
+  })
 
-    it('should build the app with functions in next.config.js', async () => {
-      const originalConfig = await next.readFile('next.config.js')
-      await next.patchFile(
-        'next.config.js',
-        `
+  it('should build the app with functions in next.config.js', async () => {
+    const originalConfig = await next.readFile('next.config.js')
+    await next.patchFile(
+      'next.config.js',
+      `
     module.exports = {
       webpack(config) { return config },
       onDemandEntries: {
@@ -130,45 +131,44 @@ export default function EvilPage(): JSX.Element {
       },
     }
     `
-      )
+    )
 
+    try {
+      const { cliOutput, exitCode } = await next.build()
+      expect(cliOutput).toMatch(/Compiled successfully/)
+      expect(exitCode).toBe(0)
+    } finally {
+      await next.patchFile('next.config.js', originalConfig)
+    }
+  })
+
+  describe('should compile with different types', () => {
+    it('should compile async getInitialProps for _error', async () => {
+      const errorPage = await next.readFile('pages/_error.tsx')
+      await next.patchFile(
+        'pages/_error.tsx',
+        errorPage.replace('static ', 'static async ')
+      )
       try {
-        const { cliOutput, exitCode } = await next.build()
+        const { cliOutput } = await next.build()
         expect(cliOutput).toMatch(/Compiled successfully/)
-        expect(exitCode).toBe(0)
       } finally {
-        await next.patchFile('next.config.js', originalConfig)
+        await next.patchFile('pages/_error.tsx', errorPage)
       }
     })
 
-    describe('should compile with different types', () => {
-      it('should compile async getInitialProps for _error', async () => {
-        const errorPage = await next.readFile('pages/_error.tsx')
-        await next.patchFile(
-          'pages/_error.tsx',
-          errorPage.replace('static ', 'static async ')
-        )
-        try {
-          const { cliOutput } = await next.build()
-          expect(cliOutput).toMatch(/Compiled successfully/)
-        } finally {
-          await next.patchFile('pages/_error.tsx', errorPage)
-        }
-      })
-
-      it('should compile sync getStaticPaths & getStaticProps', async () => {
-        const page = await next.readFile('pages/ssg/[slug].tsx')
-        await next.patchFile(
-          'pages/ssg/[slug].tsx',
-          page.replace(/async \(/g, '(')
-        )
-        try {
-          const { cliOutput } = await next.build()
-          expect(cliOutput).toMatch(/Compiled successfully/)
-        } finally {
-          await next.patchFile('pages/ssg/[slug].tsx', page)
-        }
-      })
+    it('should compile sync getStaticPaths & getStaticProps', async () => {
+      const page = await next.readFile('pages/ssg/[slug].tsx')
+      await next.patchFile(
+        'pages/ssg/[slug].tsx',
+        page.replace(/async \(/g, '(')
+      )
+      try {
+        const { cliOutput } = await next.build()
+        expect(cliOutput).toMatch(/Compiled successfully/)
+      } finally {
+        await next.patchFile('pages/ssg/[slug].tsx', page)
+      }
     })
-  }
-)
+  })
+})

--- a/test/e2e/undefined-webpack-config/undefined-webpack-config.test.ts
+++ b/test/e2e/undefined-webpack-config/undefined-webpack-config.test.ts
@@ -5,29 +5,28 @@ const expectedErr =
   /Webpack config is undefined. You may have forgot to return properly from within the "webpack" method of your next.config.js/
 
 // Webpack-specific test, not needed for Turbopack
-;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-  'undefined webpack config error',
-  () => {
-    const { next, isNextDev, isNextStart, skipped } = nextTestSetup({
-      files: __dirname,
-      skipStart: true,
-      skipDeployment: true,
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
+// @force-gate !turbopack
+describe('undefined webpack config error', () => {
+  const { next, isNextDev, isNextStart } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+  ;(isNextStart ? describe : describe.skip)('production mode', () => {
+    it.skip('should show in production mode', async () => {
+      const { cliOutput } = await next.build()
+      expect(cliOutput).toMatch(expectedErr)
     })
-    if (skipped) return
-    ;(isNextStart ? describe : describe.skip)('production mode', () => {
-      it.skip('should show in production mode', async () => {
-        const { cliOutput } = await next.build()
-        expect(cliOutput).toMatch(expectedErr)
+  })
+  ;(isNextDev ? it : it.skip)(
+    'should show error in development mode',
+    async () => {
+      await next.start()
+      await retry(async () => {
+        expect(next.cliOutput).toMatch(expectedErr)
       })
-    })
-    ;(isNextDev ? it : it.skip)(
-      'should show error in development mode',
-      async () => {
-        await next.start()
-        await retry(async () => {
-          expect(next.cliOutput).toMatch(expectedErr)
-        })
-      }
-    )
-  }
-)
+    }
+  )
+})

--- a/test/e2e/url-imports/url-imports.test.ts
+++ b/test/e2e/url-imports/url-imports.test.ts
@@ -8,93 +8,88 @@ import { FileRef, nextTestSetup, isNextDev } from 'e2e-utils'
 import { join } from 'path'
 
 // experimental.urlImports is not implemented in Turbopack
-;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-  `Handle url imports`,
-  () => {
-    let staticServer
-    let staticServerPort
-    beforeAll(async () => {
-      staticServerPort = 12345
-      staticServer = await startStaticServer(
-        join(__dirname, 'source'),
-        undefined,
-        staticServerPort
-      )
-    })
-    afterAll(async () => {
-      await stopApp(staticServer)
-    })
-
-    const { next, skipped } = nextTestSetup({
-      files: isNextDev
-        ? {
-            // exclude next.lock here, should be generated automatically in dev
-            'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
-            pages: new FileRef(join(__dirname, 'pages')),
-            public: new FileRef(join(__dirname, 'public')),
-          }
-        : __dirname,
-      // The staticServer above doesn't work when deployed
-      skipDeployment: true,
-    })
-
-    if (skipped) {
-      return
-    }
-
-    const expectedServer =
-      /Hello <!-- -->42<!-- -->\+<!-- -->42<!-- -->\+<!-- -->\/_next\/static\/(immutable\/)?media\/vercel\.[0-9a-z_-]+\.png<!-- -->\+<!-- -->\/_next\/static\/(immutable\/)?media\/vercel\.[0-9a-z_-]+\.png/
-    const expectedClient = new RegExp(
-      expectedServer.source.replace(/<!-- -->/g, '')
+// Deploy mode exclusion: This suite controls a local server or proxy process.
+// The staticServer above doesn't work when deployed
+// @force-gate !deploy
+// @force-gate !turbopack
+describe(`Handle url imports`, () => {
+  let staticServer
+  let staticServerPort
+  beforeAll(async () => {
+    staticServerPort = 12345
+    staticServer = await startStaticServer(
+      join(__dirname, 'source'),
+      undefined,
+      staticServerPort
     )
+  })
+  afterAll(async () => {
+    await stopApp(staticServer)
+  })
 
-    for (const page of ['/static', '/ssr', '/ssg']) {
-      it(`should render the ${page} page`, async () => {
-        const html = await next.render(page)
-        expect(html).toMatch(expectedServer)
-      })
+  const { next } = nextTestSetup({
+    files: isNextDev
+      ? {
+          // exclude next.lock here, should be generated automatically in dev
+          'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
+          pages: new FileRef(join(__dirname, 'pages')),
+          public: new FileRef(join(__dirname, 'public')),
+        }
+      : __dirname,
+  })
 
-      it(`should client-render the ${page} page`, async () => {
-        const browser = await next.browser(page)
-        await retry(async () =>
-          expect(await getBrowserBodyText(browser)).toMatch(expectedClient)
-        )
-      })
-    }
+  const expectedServer =
+    /Hello <!-- -->42<!-- -->\+<!-- -->42<!-- -->\+<!-- -->\/_next\/static\/(immutable\/)?media\/vercel\.[0-9a-z_-]+\.png<!-- -->\+<!-- -->\/_next\/static\/(immutable\/)?media\/vercel\.[0-9a-z_-]+\.png/
+  const expectedClient = new RegExp(
+    expectedServer.source.replace(/<!-- -->/g, '')
+  )
 
-    it(`should render a static url image import`, async () => {
-      const browser = await next.browser('/image')
-      await browser.waitForElementByCss('#static-image')
-      await retry(async () =>
-        expect(
-          await browser.elementByCss('#static-image').getAttribute('src')
-        ).toMatch(
-          /^\/_next\/image\?url=%2F_next%2Fstatic%2F(immutable%2F)?media%2Fvercel\.[0-9a-z_-]+\.png&/
-        )
-      )
+  for (const page of ['/static', '/ssr', '/ssg']) {
+    it(`should render the ${page} page`, async () => {
+      const html = await next.render(page)
+      expect(html).toMatch(expectedServer)
     })
 
-    it(`should allow url import in css`, async () => {
-      const browser = await next.browser('/css')
-
-      await browser.waitForElementByCss('#static-css')
+    it(`should client-render the ${page} page`, async () => {
+      const browser = await next.browser(page)
       await retry(async () =>
-        expect(
-          await browser
-            .elementByCss('#static-css')
-            .getComputedCss('background-image')
-        ).toMatch(
-          /^url\("http(s)?:\/\/.+\/_next\/static\/(immutable\/)?media\/vercel\.[0-9a-z_-]+\.png(?:\?.*)?"\)$/
-        )
+        expect(await getBrowserBodyText(browser)).toMatch(expectedClient)
       )
-    })
-
-    it('should respond on value api', async () => {
-      const data = await next
-        .fetch('/api/value')
-        .then((res) => res.ok && res.json())
-
-      expect(data).toEqual({ value: 42 })
     })
   }
-)
+
+  it(`should render a static url image import`, async () => {
+    const browser = await next.browser('/image')
+    await browser.waitForElementByCss('#static-image')
+    await retry(async () =>
+      expect(
+        await browser.elementByCss('#static-image').getAttribute('src')
+      ).toMatch(
+        /^\/_next\/image\?url=%2F_next%2Fstatic%2F(immutable%2F)?media%2Fvercel\.[0-9a-z_-]+\.png&/
+      )
+    )
+  })
+
+  it(`should allow url import in css`, async () => {
+    const browser = await next.browser('/css')
+
+    await browser.waitForElementByCss('#static-css')
+    await retry(async () =>
+      expect(
+        await browser
+          .elementByCss('#static-css')
+          .getComputedCss('background-image')
+      ).toMatch(
+        /^url\("http(s)?:\/\/.+\/_next\/static\/(immutable\/)?media\/vercel\.[0-9a-z_-]+\.png(?:\?.*)?"\)$/
+      )
+    )
+  })
+
+  it('should respond on value api', async () => {
+    const data = await next
+      .fetch('/api/value')
+      .then((res) => res.ok && res.json())
+
+    expect(data).toEqual({ value: 42 })
+  })
+})

--- a/test/e2e/url/url.test.ts
+++ b/test/e2e/url/url.test.ts
@@ -10,20 +10,18 @@ import { isNextDev, isNextStart, nextTestSetup } from 'e2e-utils'
 // Webpack has
 // - a bug where App Router API routes (and Metadata) return client assets for `new URL`s.
 // - a bug where Edge Page routes return client assets for `new URL`s.
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe(`Handle new URL asset references`, () => {
-  const { next, skipped, isTurbopack } = nextTestSetup({
+  const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     env: {
       // rely on skew protection when deployed
       NEXT_DEPLOYMENT_ID: isNextStart ? 'test-deployment-id' : undefined,
       __NEXT_SUPPORTS_IMMUTABLE_ASSETS: isNextStart ? '1' : undefined,
     },
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   const serverFileRegex = expect.stringMatching(
     /file:.*\/.next(\/dev)?\/server\/.*\/vercel.HASH.png$/

--- a/test/e2e/vary-header/test/index.test.ts
+++ b/test/e2e/vary-header/test/index.test.ts
@@ -2,10 +2,12 @@ import { nextTestSetup } from 'e2e-utils'
 import { expectVaryHeaderToContain } from 'next-test-utils'
 import path from 'path'
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// No deploy-specific incompatibility is documented.
+// @force-gate !deploy
 describe('Vary Header Tests', () => {
   const { next } = nextTestSetup({
     files: path.join(__dirname, '../app'),
-    skipDeployment: true,
   })
 
   it('should preserve custom vary header in API routes', async () => {

--- a/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
+++ b/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
@@ -75,13 +75,14 @@ function extractErrorBlock(output: string, errorTitle: string): string {
   return block.trimEnd()
 }
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('webpack-loader-parse-error (development)', () => {
-  const { next, isTurbopack, isNextDev, skipped } = nextTestSetup({
+  const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
-  if (skipped) return
 
   if (!isNextDev) {
     it('skipped in production mode', () => {})
@@ -198,10 +199,12 @@ describe('webpack-loader-parse-error (development)', () => {
   })
 })
 
+// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// @force-gate !deploy
 describe('webpack-loader-parse-error (production)', () => {
   const { next, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
     skipStart: true,
   })
 

--- a/test/lib/gate/README.md
+++ b/test/lib/gate/README.md
@@ -85,7 +85,9 @@ There are two tiers:
 - **static** — the run's own shape (`dev`, `start`, `deploy`, `mode`,
   `turbopack`, `rspack`, `webpack`, `bundler`, `react18`, `wasm`, `ci`),
   semantic aliases for `!dev` that state the reason rather than the mode
-  (`prod`, `prefetching`), plus `FIXME` / `TODO`, which are always false.
+  (`prod`, `prefetching`), specialized CI variants (`adapter`,
+  `standaloneOutput`, `turbopackDev`, `turbopackBuild`), plus `FIXME` / `TODO`,
+  which are always false.
 - **lazy** — a predicate over the fixture's *resolved* `next.config`
   (`cacheComponents`, `ppr`, `prefetchInlining`, `output`, …), read the first
   time a gate asks for it.
@@ -190,9 +192,11 @@ var is not what the fixture actually resolved.
 ## How it works
 
 1. `pragma-transform.js` rewrites the pragma into
-   `_test_gate([{force,source}], 'it')(...)`. It is a line-oriented regex, not an
-   AST transform, so **only the `it(` line changes** and every other line keeps
-   its byte offsets — `toMatchInlineSnapshot()` is written back by line/column.
+   `_test_gate([{force,source}], 'it')(...)`. `describe.each` uses the analogous
+   `_test_gate_describe_each([{force,source}], table)(...)` helper. It is a
+   line-oriented regex, not an AST transform, so **only the call line changes**
+   and every other line keeps its byte offsets — `toMatchInlineSnapshot()` is
+   written back by line/column.
 2. `jest-transformer.js` chains that rewrite in front of the SWC transformer
    `next/jest` configures. `jest.config.js` wires it up with
    `withGateTransformer()`.

--- a/test/lib/gate/conditions.ts
+++ b/test/lib/gate/conditions.ts
@@ -134,6 +134,21 @@ export const conditions: Record<string, Condition> = {
   ci: staticCondition('running in CI (`NEXT_TEST_CI`)', () =>
     Boolean(process.env.NEXT_TEST_CI)
   ),
+  adapter: staticCondition('running the adapter test variant', () =>
+    Boolean(process.env.NEXT_ENABLE_ADAPTER === '1')
+  ),
+  standaloneOutput: staticCondition(
+    'running the standalone-output test variant (`TEST_OUTPUT_STANDALONE`)',
+    () => process.env.TEST_OUTPUT_STANDALONE === 'true'
+  ),
+  turbopackDev: staticCondition(
+    'the test run uses the Turbopack development build (`TURBOPACK_DEV`)',
+    () => Boolean(process.env.TURBOPACK_DEV)
+  ),
+  turbopackBuild: staticCondition(
+    'the test run uses the Turbopack production build (`TURBOPACK_BUILD`)',
+    () => Boolean(process.env.TURBOPACK_BUILD)
+  ),
 
   // Always false, so `// @gate FIXME` marks a test as a known failure without
   // inventing a condition for it. Mirrors the same convention in React's

--- a/test/lib/gate/pragma-transform.js
+++ b/test/lib/gate/pragma-transform.js
@@ -28,13 +28,14 @@
 
 /**
  * A pragma block is one or more consecutive `// @gate` lines *immediately*
- * followed by an `it` / `test` / `fit` / `describe` call. Anything else (a
- * pragma in a JSDoc block, a pragma with a blank line under it, a pragma over
- * `it.each`) is not matched, and is reported as an error by `rewrite()` rather
- * than silently ignored.
+ * followed by an `it` / `test` / `fit` / `describe` call. `describe.each` has
+ * a dedicated runtime helper because its table is bound before the suite name.
+ * Anything else (a pragma in a JSDoc block, a pragma with a blank line under
+ * it, a pragma over `it.each`) is not matched, and is reported as an error by
+ * `rewrite()` rather than silently ignored.
  */
 const PRAGMA_BLOCK =
-  /((?:^[ \t]*\/\/[ \t]*@(?:force-)?gate\b[^\n]*\n)+)([ \t]*)(it|test|fit|describe)((?:\.only)?)([ \t]*\()/gm
+  /((?:^[ \t]*\/\/[ \t]*@(?:force-)?gate\b[^\n]*\n)+)([ \t]*)(?:(it|test|fit|describe)((?:\.only)?)([ \t]*\()|(describe)\.each[ \t]*\()/gm
 
 /** Matches a single pragma line and captures `force` + the condition source. */
 const PRAGMA_LINE = /^[ \t]*\/\/[ \t]*@(force-)?gate\b[ \t]*([^\n]*)$/
@@ -108,9 +109,19 @@ function rewrite(src, filename) {
      * @param {string} callee
      * @param {string} only
      * @param {string} openParen
+     * @param {string | undefined} describeEach
      * @param {number} offset
      */
-    (_all, pragmaLines, indent, callee, only, openParen, offset) => {
+    (
+      _all,
+      pragmaLines,
+      indent,
+      callee,
+      only,
+      openParen,
+      describeEach,
+      offset
+    ) => {
       const firstLine = getLineNumber(lineStarts, offset)
       const gates = []
       const lines = pragmaLines.split('\n')
@@ -133,14 +144,17 @@ function rewrite(src, filename) {
         gates.push({ force: Boolean(match[1]), source })
       }
 
-      return (
-        pragmaLines +
-        indent +
-        `_test_gate(${JSON.stringify(gates)},${JSON.stringify(
-          callee + only
-        )})` +
-        openParen
-      )
+      if (describeEach) {
+        return (
+          pragmaLines +
+          indent +
+          `_test_gate_describe_each(${JSON.stringify(gates)},`
+        )
+      }
+
+      return `${pragmaLines}${indent}_test_gate(${JSON.stringify(
+        gates
+      )},${JSON.stringify(callee + only)})${openParen}`
     }
   )
 
@@ -181,9 +195,10 @@ function assertNoInertPragmas(src, consumed, filename) {
         `effect.\n\n` +
         `  ${lines[i].trim()}\n\n` +
         `A pragma must sit on the line(s) immediately above an ` +
-        `\`it(\`, \`test(\`, \`fit(\`, \`describe(\`, \`it.only(\`, ` +
-        `\`test.only(\` or \`describe.only(\` call — with no blank line in ` +
-        `between. \`it.each\` and \`it.failing\` are not supported. If this ` +
+        `\`it(\`, \`test(\`, \`fit(\`, \`describe(\`, \`describe.each(\`, ` +
+        `\`it.only(\`, \`test.only(\` or \`describe.only(\` call — with no ` +
+        `blank line in between. \`it.each\` and \`it.failing\` are not ` +
+        `supported. If this ` +
         `comment is prose rather than a pragma, reword it so it does not ` +
         `start with \`@gate\`.`
     )

--- a/test/lib/gate/runtime.ts
+++ b/test/lib/gate/runtime.ts
@@ -431,6 +431,35 @@ export function _test_gate(pragmas: GatePragma[], kind: string) {
   // Parsing and validation happen while the test file is being collected, so a
   // typo'd condition fails the whole suite instead of one test.
   const allGates = pragmas.map(parseGate)
+  return createGatedTest(
+    allGates,
+    kind,
+    () => resolveTestFn(kind),
+    () => resolveSkipFn(kind)
+  )
+}
+
+/** `describe.each(table)` binds the table before receiving the suite call. */
+export function _test_gate_describe_each(
+  pragmas: GatePragma[],
+  table: readonly unknown[]
+) {
+  const g = global as any
+  const allGates = pragmas.map(parseGate)
+  return createGatedTest(
+    allGates,
+    'describe.each',
+    () => g.describe.each(table),
+    () => g.describe.skip.each(table)
+  )
+}
+
+function createGatedTest(
+  allGates: Gate[],
+  kind: string,
+  getTestFn: () => TestFn,
+  getSkipFn: () => TestFn
+) {
   // A static `@force-gate` is decided at collection time (a real Jest skip).
   // Everything else — `@gate`, and *lazy* `@force-gate` — is resolved at
   // runtime, so it inherits down into the tests via the describe stack.
@@ -441,7 +470,6 @@ export function _test_gate(pragmas: GatePragma[], kind: string) {
     (gate) => !gate.force || gate.needsResolvedConfig
   )
   const isDescribe = kind.startsWith('describe')
-  const testFn = resolveTestFn(kind)
 
   return function gated(name: string, callback: Function, timeout?: number) {
     // A false static `@force-gate` is a real Jest skip, decided right here.
@@ -449,21 +477,18 @@ export function _test_gate(pragmas: GatePragma[], kind: string) {
       (gate) => !evaluate(gate.node, (condition) => readCondition(condition))
     )
     if (forcedOff) {
-      return resolveSkipFn(kind)(
-        name,
-        callback as jest.ProvidesCallback,
-        timeout
-      )
+      return getSkipFn()(name, callback as jest.ProvidesCallback, timeout)
     }
 
+    const testFn = getTestFn()
     if (isDescribe) {
       // Register the `describe` normally, but make its runtime gates (including
       // a lazy `@force-gate`) visible while its body is collected so nested
       // tests inherit them and `nextTestSetup` can gate the build.
-      return testFn(name, function (this: unknown) {
+      return testFn(name, function (this: unknown, ...args: unknown[]) {
         describeGateStack.push(...runtimeGates)
         try {
-          return callback.call(this)
+          return callback.apply(this, args)
         } finally {
           describeGateStack.length -= runtimeGates.length
         }
@@ -614,6 +639,7 @@ function wrapHookGlobals(): void {
 /** Called from `test/jest-setup-after-env.ts`. */
 export function installGate(): void {
   ;(global as any)._test_gate = _test_gate
+  ;(global as any)._test_gate_describe_each = _test_gate_describe_each
   wrapTestGlobals()
   wrapHookGlobals()
 }

--- a/test/unit/gate/pragma-transform.test.ts
+++ b/test/unit/gate/pragma-transform.test.ts
@@ -89,6 +89,27 @@ describe('@gate pragma transform', () => {
     )
   })
 
+  it('supports describe.each without changing the table or line count', () => {
+    const input = src(
+      '// @force-gate !deploy',
+      'describe.each([',
+      "  { name: 'one' },",
+      "  { name: 'two' },",
+      '])("suite: $name", ({ name }) => {})'
+    )
+    const out = rewrite(input, 'x.ts')
+    expect(out.split('\n')).toHaveLength(input.split('\n').length)
+    expect(out).toBe(
+      src(
+        '// @force-gate !deploy',
+        `_test_gate_describe_each([{"force":true,"source":"!deploy"}],[`,
+        "  { name: 'one' },",
+        "  { name: 'two' },",
+        '])("suite: $name", ({ name }) => {})'
+      )
+    )
+  })
+
   it('keeps the condition source verbatim, including quotes', () => {
     const out = rewrite(
       src("// @gate mode === 'start' && !turbopack", "it('a', () => {})"),

--- a/test/unit/gate/runtime.test.ts
+++ b/test/unit/gate/runtime.test.ts
@@ -1,7 +1,12 @@
 // Imported through the same specifier tests use, so this also covers the
 // re-export from next-test-utils.
 import { gate } from 'next-test-utils'
-import { __testing, _test_gate, expectTestToFail } from '../../lib/gate/runtime'
+import {
+  __testing,
+  _test_gate,
+  _test_gate_describe_each,
+  expectTestToFail,
+} from '../../lib/gate/runtime'
 import {
   clearGateTestContext,
   setGateTestContext,
@@ -32,17 +37,21 @@ const runGated = (sources: string[], body: () => unknown) => {
 }
 
 type FakeTestFn = jest.Mock & {
-  skip: jest.Mock
+  skip: jest.Mock & { each: jest.Mock }
   only: jest.Mock & { failing: jest.Mock }
   failing: jest.Mock
+  each: jest.Mock
 }
 
-const makeFakeTestFn = (): FakeTestFn =>
-  Object.assign(jest.fn(), {
-    skip: jest.fn(),
+const makeFakeTestFn = (): FakeTestFn => {
+  const skip = Object.assign(jest.fn(), { each: jest.fn(() => jest.fn()) })
+  return Object.assign(jest.fn(), {
+    skip,
     only: Object.assign(jest.fn(), { failing: jest.fn() }),
     failing: jest.fn(),
+    each: jest.fn(() => jest.fn()),
   }) as FakeTestFn
+}
 
 /**
  * Swaps `global.it` / `global.test` / `global.describe` for spies while `fn`
@@ -290,6 +299,45 @@ describe('@gate runtime', () => {
         undefined
       )
       expect(fakes.describe).not.toHaveBeenCalled()
+    })
+
+    it('skips every row of describe.each with describe.skip.each', () => {
+      const table = [{ name: 'one' }, { name: 'two' }]
+      const fakes = withFakeTestGlobals(() => {
+        _test_gate_describe_each([{ force: true, source: 'dev' }], table)(
+          'suite: $name',
+          () => {}
+        )
+      })
+      expect(fakes.describe.skip.each).toHaveBeenCalledWith(table)
+      expect(fakes.describe.each).not.toHaveBeenCalled()
+    })
+
+    it('registers describe.each normally when a force-gate holds', () => {
+      const table = [{ name: 'one' }]
+      const fakes = withFakeTestGlobals(() => {
+        _test_gate_describe_each([{ force: true, source: '!dev' }], table)(
+          'suite: $name',
+          () => {}
+        )
+      })
+      expect(fakes.describe.each).toHaveBeenCalledWith(table)
+      expect(fakes.describe.skip.each).not.toHaveBeenCalled()
+    })
+
+    it('forwards describe.each row arguments to the suite callback', () => {
+      const table = [{ name: 'one' }]
+      const callback = jest.fn()
+      const fakes = withFakeTestGlobals(() => {
+        _test_gate_describe_each([{ force: true, source: '!dev' }], table)(
+          'suite: $name',
+          callback
+        )
+      })
+      const boundDescribe = fakes.describe.each.mock.results[0].value
+      const registeredCallback = boundDescribe.mock.calls[0][1]
+      registeredCallback(table[0])
+      expect(callback).toHaveBeenCalledWith(table[0])
     })
 
     it('leaves a `@gate` on the same test in charge when it holds', async () => {


### PR DESCRIPTION
## Summary

Enable deployment coverage for the API body parser's “without custom server” suite. It uses a standard Next.js API route and only checks a JSON POST response, so the custom-server deployment exclusion does not apply. Keep the sibling custom-server suite excluded.

Based on #98157.

## Verification

- Prettier and ESLint passed, including the pre-commit checks.
- Deployment tests have not been run; deployment validation is pending.

<!-- NEXT_JS_LLM -->
