### PR TITLE
Handle all Turbopack HMR subscription updates

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1063,11 +1063,9 @@ export async function createHotReloaderTurbopack(
     const subscription = project!.clientHmrEvents(id)
     state.subscriptions.set(id, subscription)
 
-    // The subscription will always emit once, which is the initial
-    // computation. This is not a change, so swallow it.
+    // Baseline capture and subscription setup are not atomic, so the first
+    // emission can be a real update and must go through the normal handler.
     try {
-      await subscription.next()
-
       for await (const data of subscription) {
         processIssues(state.clientIssues, key, data, false, true)
         if (data.type !== 'issues') {

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1064,9 +1064,16 @@ export async function createHotReloaderTurbopack(
     state.subscriptions.set(id, subscription)
 
     // Baseline capture and subscription setup are not atomic, so the first
-    // emission can be a real update and must go through the normal handler.
+    // emission can be a real update. Skip only an issues-only baseline.
+    let isInitial = true
     try {
       for await (const data of subscription) {
+        if (isInitial) {
+          isInitial = false
+          if (data.type === 'issues') {
+            continue
+          }
+        }
         processIssues(state.clientIssues, key, data, false, true)
         if (data.type !== 'issues') {
           sendTurbopackMessage(data as TurbopackUpdate)

--- a/test/development/app-dir/hmr-dynamic-component/hmr-dynamic-component.test.ts
+++ b/test/development/app-dir/hmr-dynamic-component/hmr-dynamic-component.test.ts
@@ -1,9 +1,11 @@
+import { mkdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+import type * as Playwright from 'playwright'
 
 describe('hmr-dynamic-component', () => {
-  const { next } = nextTestSetup({
+  const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: __dirname,
     patchFileDelay: 500,
   })
@@ -138,4 +140,111 @@ describe('hmr-dynamic-component', () => {
       await next.patchFile(cssPath, originalCss)
     }
   })
+  if (isTurbopack && isNextDev) {
+    it('should not lose an edit while establishing the client HMR subscription', async () => {
+      const componentPath = join('app', 'components', 'dynamic.tsx')
+      const absoluteComponentPath = join(next.testDir, componentPath)
+      const originalContent = await next.readFile(componentPath)
+      const graphDirectory = join(
+        next.testDir,
+        'app',
+        'components',
+        'hmr-subscription-race'
+      )
+      const moduleCount = 800
+
+      mkdirSync(graphDirectory, { recursive: true })
+      for (let index = 0; index < moduleCount; index++) {
+        writeFileSync(
+          join(graphDirectory, `module-${index}.ts`),
+          `export default ${index}\n`
+        )
+      }
+
+      const createComponent = (label: string) => `
+'use client'
+
+import styles from './dynamic.module.css'
+${Array.from(
+  { length: moduleCount },
+  (_, index) =>
+    `import value${index} from './hmr-subscription-race/module-${index}'`
+).join('\n')}
+
+const values = [${Array.from(
+        { length: moduleCount },
+        (_, index) => `value${index}`
+      ).join(', ')}]
+
+export default function Dynamic() {
+  return (
+    <div id="dynamic-component" className={styles.dynamic}>
+      HMR subscription ${label} {values.length}
+    </div>
+  )
+}
+`
+
+      try {
+        await next.patchFile(componentPath, createComponent('before'))
+
+        const subscriptionPaths = new Set<string>()
+        let editTriggered = false
+        let pageLoads = 0
+
+        const browser = await next.browser('/', {
+          beforePageLoad(page: Playwright.Page) {
+            page.on('load', () => {
+              pageLoads++
+            })
+            page.on('websocket', (ws) => {
+              if (!ws.url().includes('/_next/hmr')) {
+                return
+              }
+              ws.on('framesent', (frame) => {
+                const payload =
+                  typeof frame.payload === 'string'
+                    ? frame.payload
+                    : frame.payload.toString('utf8')
+                try {
+                  const message = JSON.parse(payload)
+                  if (
+                    message?.type === 'turbopack-subscribe' &&
+                    typeof message?.path === 'string' &&
+                    message.path.endsWith('.js')
+                  ) {
+                    subscriptionPaths.add(message.path)
+                    if (subscriptionPaths.size === 2 && !editTriggered) {
+                      editTriggered = true
+                      writeFileSync(
+                        absoluteComponentPath,
+                        createComponent('after')
+                      )
+                    }
+                  }
+                } catch {
+                  // Non-JSON frames are unrelated to Turbopack subscriptions.
+                }
+              })
+            })
+          },
+        })
+
+        await retry(async () => {
+          expect(editTriggered).toBe(true)
+          const div = await browser.elementByCss('#dynamic-component')
+          expect(await div.text()).toContain(
+            `HMR subscription after ${moduleCount}`
+          )
+        }, 10000)
+
+        // The edit must arrive through HMR, not a recovery reload.
+        expect(pageLoads).toBe(1)
+      } finally {
+        await next.patchFile(componentPath, originalContent)
+      }
+    })
+  } else {
+    it.skip('subscription race is Turbopack development-mode only', () => {})
+  }
 })


### PR DESCRIPTION
### What?

Prevent a real client HMR update from being discarded when it arrives as the first subscription emission, without retaining stale issues from the initialization baseline.

### Why?

Capturing the chunk baseline and installing the update subscription are separate asynchronous operations. A change between them turns the first emission into a real update. At the same time, the ordinary first issues-only emission represents baseline state rather than a change; storing it can resurface stale build errors after route cleanup.

### How?

Keep one subscription-processing loop with per-subscription initialization state. Skip only an issues-only first emission, while a first partial or restart update and every later emission continue through the normal issue and browser-update paths. This preserves the baseline/update distinction without duplicating the update handler.

### Verification

- `hmr-deleted-page`: 10/10 normal Turbopack development trials
- `hmr-deleted-page`: experimental Turbopack run passed 2/2
- `hmr-dynamic-component`: copied subscription-race suite passed 5/5
- Independently forced baseline-gap suite passed 5/5
- `pnpm --filter=next build`
- Prettier and ESLint on the changed source

<!-- NEXT_JS_LLM -->

<!-- fleet 3820fb8a-c662-4c74-8316-e2d7cd42bfbd -->