### PR TITLE
Size dev heap from cgroup limit

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -8,6 +8,7 @@ import {
   getNodeDebugType,
   getParsedDebugAddress,
   getMaxOldSpaceSize,
+  getProcessMemoryLimit,
   printAndExit,
   formatNodeOptions,
   formatDebugAddress,
@@ -355,9 +356,9 @@ const nextDev = async (
 
       let maxOldSpaceSize: string | number | undefined = getMaxOldSpaceSize()
       if (!maxOldSpaceSize && !process.env.NEXT_DISABLE_MEM_OVERRIDE) {
-        const totalMem = os.totalmem()
-        const totalMemInMB = Math.floor(totalMem / 1024 / 1024)
-        maxOldSpaceSize = Math.floor(totalMemInMB * 0.5).toString()
+        const memoryLimit = getProcessMemoryLimit()
+        const memoryLimitInMB = Math.floor(memoryLimit / 1024 / 1024)
+        maxOldSpaceSize = Math.floor(memoryLimitInMB * 0.5).toString()
 
         nodeOptions['max-old-space-size'] = maxOldSpaceSize
 

--- a/packages/next/src/server/lib/utils.test.ts
+++ b/packages/next/src/server/lib/utils.test.ts
@@ -5,6 +5,7 @@ import {
   tokenizeArgs,
   getParsedNodeOptions,
   getMemoryRestartStats,
+  getProcessMemoryLimit,
 } from './utils'
 
 const originalNodeOptions = process.env.NODE_OPTIONS
@@ -191,5 +192,56 @@ describe('getFormattedNodeOptionsWithoutInspect', () => {
     const result = getFormattedNodeOptionsWithoutInspect()
 
     expect(result).toBe('--other --inspect-port=0.0.0.0:1234 --additional')
+  })
+})
+
+describe('getProcessMemoryLimit', () => {
+  const HOST_TOTAL = 32 * 1024 * 1024 * 1024
+
+  it('returns the cgroup limit when it is below the host total', () => {
+    const containerLimit = 2 * 1024 * 1024 * 1024
+
+    expect(
+      getProcessMemoryLimit(
+        () => containerLimit,
+        () => HOST_TOTAL
+      )
+    ).toBe(containerLimit)
+  })
+
+  it('falls back to the host total when there is no constraint', () => {
+    expect(
+      getProcessMemoryLimit(
+        () => 0,
+        () => HOST_TOTAL
+      )
+    ).toBe(HOST_TOTAL)
+  })
+
+  it('falls back to the host total when cgroup v2 reports an unlimited sentinel', () => {
+    expect(
+      getProcessMemoryLimit(
+        () => Number.MAX_SAFE_INTEGER,
+        () => HOST_TOTAL
+      )
+    ).toBe(HOST_TOTAL)
+  })
+
+  it('falls back to the host total when the constraint matches it', () => {
+    expect(
+      getProcessMemoryLimit(
+        () => HOST_TOTAL,
+        () => HOST_TOTAL
+      )
+    ).toBe(HOST_TOTAL)
+  })
+
+  it('falls back to the host total when process.constrainedMemory is unavailable', () => {
+    expect(
+      getProcessMemoryLimit(
+        () => undefined,
+        () => HOST_TOTAL
+      )
+    ).toBe(HOST_TOTAL)
   })
 })

--- a/packages/next/src/server/lib/utils.ts
+++ b/packages/next/src/server/lib/utils.ts
@@ -1,3 +1,4 @@
+import os from 'node:os'
 import { parseArgs } from 'node:util'
 import { InvalidArgumentError } from 'next/dist/compiled/commander'
 
@@ -344,4 +345,28 @@ export function getMaxOldSpaceSize() {
   if (!size || typeof size !== 'string') return
 
   return parseInt(size, 10)
+}
+
+/**
+ * Get the amount of memory this process is allowed to use, in bytes.
+ *
+ * @returns The cgroup memory limit when there is one, otherwise the host total.
+ */
+export function getProcessMemoryLimit(
+  constrainedMemory: () => number | undefined = () =>
+    process.constrainedMemory?.(),
+  totalMemory: () => number = () => os.totalmem()
+): number {
+  const total = totalMemory()
+  const constrained = constrainedMemory()
+
+  if (
+    typeof constrained === 'number' &&
+    constrained > 0 &&
+    constrained < total
+  ) {
+    return constrained
+  }
+
+  return total
 }


### PR DESCRIPTION
### What?

Fix `next dev` overriding Node.js's container-aware V8 heap limit with a value derived from the host's `os.totalmem()`.

### Why?

next dev uses host memory instead of the container limit, preventing devMemoryThresholdRestart from triggering.

### How?

Respect the memory constraint detected by Node.js when determining the V8 heap size, rather than blindly deriving the override from `os.totalmem()`.

Fixes #98381 