### PR TITLE
Skip bundler config validation in next/jest and under test

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -12,6 +12,7 @@ import {
   PHASE_PRODUCTION_BUILD,
   PHASE_PRODUCTION_SERVER,
   PHASE_INFO,
+  PHASE_TEST,
   type PHASE_TYPE,
 } from '../shared/lib/constants'
 import {
@@ -554,7 +555,11 @@ function assignDefaultsAndValidate(
   // Turbopack-only; strict mode and `false` (single-chunk-per-module) are webpack-only.
   // Only validate during build/dev — `next start` doesn't pick a bundler and would otherwise
   // see `process.env.TURBOPACK` unset and reject a valid `cssChunking: "graph"` config.
-  if (phase !== PHASE_PRODUCTION_SERVER && phase !== PHASE_INFO) {
+  if (
+    phase !== PHASE_PRODUCTION_SERVER &&
+    phase !== PHASE_INFO &&
+    phase !== PHASE_TEST
+  ) {
     if (result.experimental.durableUseCacheEntries && !process.env.TURBOPACK) {
       throw new Error(
         `\`experimental.durableUseCacheEntries: true\` is only supported with Turbopack. ` +

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { join } from 'path'
-import { PHASE_DEVELOPMENT_SERVER } from 'next/constants'
+import { PHASE_DEVELOPMENT_SERVER, PHASE_TEST } from 'next/constants'
 
 const pathToConfig = join(__dirname, '_resolvedata', 'without-function')
 const pathToConfigFn = join(__dirname, '_resolvedata', 'with-function')
@@ -106,6 +106,21 @@ describe('config', () => {
       }
     )
     expect(disabledConfig.experimental.devMemoryThresholdRestart).toBe(false)
+  })
+
+  it('Should allow bundler-specific options during the test phase', async () => {
+    const config = await loadConfig(PHASE_TEST, '<rootDir>-test-phase', {
+      customConfig: {
+        reactCompiler: true,
+        experimental: {
+          cssChunking: 'graph',
+          turbopackRustReactCompiler: true,
+        },
+      },
+    })
+
+    expect(config.experimental.cssChunking).toBe('graph')
+    expect(config.experimental.turbopackRustReactCompiler).toBe(true)
   })
 
   it('Should allow setting objects which do not have defaults', async () => {


### PR DESCRIPTION
## Summary

Skip active-bundler config validation when `next/jest` loads `next.config.*` under `PHASE_TEST`. Jest uses the Next.js SWC transformer without running Turbopack or webpack, so bundler-specific options should remain available without requiring phase-dependent user config.

Add regression coverage for `experimental.turbopackRustReactCompiler` and `experimental.cssChunking: 'graph'` in the test phase.

## Verification

- `pnpm test-unit test/unit/isolated/config.test.ts -t "Should allow bundler-specific options during the test phase"`

<!-- NEXT_JS_LLM -->