### PR TITLE
Fix Pages Router hydration snapshots for ssr:false dynamic components

### DIFF
--- a/packages/next/src/shared/lib/loadable.shared-runtime.tsx
+++ b/packages/next/src/shared/lib/loadable.shared-runtime.tsx
@@ -58,6 +58,16 @@ function load(loader: any) {
 }
 
 function createLoadableComponent(loadFn: any, options: any) {
+  // Match the loading state rendered by dynamic() when SSR is disabled.
+  // Keep this snapshot stable while hydration may suspend and retry.
+  const serverSnapshot = {
+    loading: true,
+    loaded: null,
+    error: null,
+    pastDelay: false,
+    timedOut: false,
+  }
+
   let opts = Object.assign(
     {
       loader: null,
@@ -125,7 +135,7 @@ function createLoadableComponent(loadFn: any, options: any) {
     const state = (React as any).useSyncExternalStore(
       subscription.subscribe,
       subscription.getCurrentValue,
-      subscription.getCurrentValue
+      opts.ssr === false ? () => serverSnapshot : subscription.getCurrentValue
     )
 
     React.useImperativeHandle(

--- a/test/e2e/next-dynamic/components/hydration-header.js
+++ b/test/e2e/next-dynamic/components/hydration-header.js
@@ -1,0 +1,11 @@
+import { useState } from 'react'
+
+export default function Header() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <button id="dynamic-header" onClick={() => setCount(count + 1)}>
+      Header: {count}
+    </button>
+  )
+}

--- a/test/e2e/next-dynamic/next-dynamic.test.ts
+++ b/test/e2e/next-dynamic/next-dynamic.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 describe('next/dynamic', () => {
   const { next } = nextTestSetup({ files: __dirname })
@@ -24,4 +25,65 @@ describe('next/dynamic', () => {
       'https://nextjs.org/docs/messages/invalid-dynamic-suspense'
     )
   })
+
+  it.each(['retry', 'retry-no-boundary', 'plain', 'ssr-retry'])(
+    'preserves server content when a dynamic import resolves during hydration (%s)',
+    async (mode) => {
+      const errors: string[] = []
+      const browser = await next.browser(`/hydration?mode=${mode}`, {
+        // The test releases the suspended render after the import resolves.
+        waitHydration: false,
+        beforePageLoad(page) {
+          page.on('pageerror', (error) => errors.push(error.message))
+        },
+      })
+
+      await retry(async () => {
+        expect(
+          await browser.eval('window.dynamicHydration.originalRoom !== null')
+        ).toBe(true)
+        expect(await browser.eval('window.dynamicHydration.loaded')).toBe(true)
+        if (mode !== 'plain') {
+          expect(await browser.eval('window.dynamicHydration.suspended')).toBe(
+            true
+          )
+        }
+      })
+
+      if (mode !== 'plain') {
+        await browser.eval('window.dynamicHydration.release()')
+      }
+
+      await retry(async () => {
+        expect(await browser.elementByCss('#dynamic-header').text()).toBe(
+          'Header: 0'
+        )
+      })
+
+      // Working buttons alone would also pass after React discards the SSR DOM.
+      expect(
+        await browser.eval(
+          'window.dynamicHydration.originalRoom === document.getElementById("hydration-room")'
+        )
+      ).toBe(true)
+      expect(errors).toEqual([])
+
+      await browser.elementByCss('#dynamic-header').click()
+      await browser.elementByCss('#hydration-room').click()
+      await retry(async () => {
+        expect(await browser.elementByCss('#dynamic-header').text()).toBe(
+          'Header: 1'
+        )
+        expect(await browser.elementByCss('#hydration-room').text()).toBe(
+          'Room: 1'
+        )
+      })
+      expect(
+        await browser.eval(
+          'window.dynamicHydration.originalRoom === document.getElementById("hydration-room")'
+        )
+      ).toBe(true)
+      expect(errors).toEqual([])
+    }
+  )
 })

--- a/test/e2e/next-dynamic/pages/hydration.js
+++ b/test/e2e/next-dynamic/pages/hydration.js
@@ -1,0 +1,79 @@
+import dynamic from 'next/dynamic'
+import { Suspense, useState } from 'react'
+
+const hydration =
+  typeof window === 'undefined'
+    ? null
+    : (window.dynamicHydration = {
+        originalRoom: document.getElementById('hydration-room'),
+        loaded: false,
+        suspended: false,
+        released: false,
+      })
+
+const gate = new Promise((resolve) => {
+  if (hydration) {
+    hydration.release = () => {
+      hydration.released = true
+      resolve()
+    }
+  }
+})
+
+function Loading({ isLoading, pastDelay, timedOut, error }) {
+  return (
+    <p id="dynamic-loading">
+      {JSON.stringify({ isLoading, pastDelay, timedOut, error })}
+    </p>
+  )
+}
+
+const ClientHeader = dynamic(
+  () =>
+    import('../components/hydration-header').then((mod) => {
+      if (hydration) hydration.loaded = true
+      return mod
+    }),
+  { ssr: false, loading: Loading }
+)
+
+const ServerHeader = dynamic(
+  () =>
+    import('../components/hydration-header').then((mod) => {
+      if (hydration) hydration.loaded = true
+      return mod
+    }),
+  { ssr: true, loading: Loading }
+)
+
+function Gate() {
+  if (hydration && !hydration.released) {
+    hydration.suspended = true
+    throw gate
+  }
+  return null
+}
+
+export default function Hydration({ mode }) {
+  const [count, setCount] = useState(0)
+  const Header = mode === 'ssr-retry' ? ServerHeader : ClientHeader
+  const content = (
+    <div>
+      <Header />
+      {mode !== 'plain' && <Gate />}
+      <button id="hydration-room" onClick={() => setCount(count + 1)}>
+        Room: {count}
+      </button>
+    </div>
+  )
+
+  return mode === 'retry-no-boundary' ? (
+    content
+  ) : (
+    <Suspense fallback={<p>Waiting</p>}>{content}</Suspense>
+  )
+}
+
+export function getServerSideProps({ query }) {
+  return { props: { mode: query.mode || 'retry' } }
+}


### PR DESCRIPTION
Fixes #98394.

When an `ssr: false` dynamic import finishes while Pages Router hydration is suspended, a retry reads the loaded component through `getServerSnapshot`. That no longer matches the loading output rendered on the server, so React discards the affected SSR content and recovers with client rendering.

This keeps a stable loading snapshot for hydration of `ssr: false` components. Normal client updates still read the live subscription, and SSR-enabled dynamic components keep their existing snapshot/preloading behavior.

The regression fixture suspends a sibling, waits for the import to finish, then explicitly releases hydration. It checks original DOM identity and working buttons, with and without an explicit Suspense boundary, plus no-suspension and SSR-enabled controls.

Validation:
- Canary `16.4.0-canary.22`, production Webpack, React/ReactDOM 18.3.1 and 19.0.0: the unchanged public reproduction mismatches before the loader-only patch and retains SSR nodes afterward; controls pass in both variants.
- The exact added test bodies were run against real browser builds using a small Playwright adapter: both retry cases fail on the DOM-identity assertion before the patch; all four cases pass afterward.
- Changed files pass the repository's `eslint.config.mjs`, Prettier, and `git diff --check`.

The full Next.js build/test harness, Turbopack, and deployment tests have not been run locally. Leaving this as a draft for those checks and maintainer review.
