### PR TITLE
fix(turbopack): add missing basePath to code-generated metadata icons

### DIFF
--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -200,6 +200,7 @@ impl AppPageLoaderTreeBuilder {
                     path.clone(),
                     name.into(),
                     app_page.clone(),
+                    self.base_path.clone(),
                 );
 
                 let module = self.base.process_source(source).to_resolved().await?;

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -28,6 +28,7 @@ async fn dynamic_image_metadata_with_generator_source(
     path: FileSystemPath,
     ty: RcStr,
     page: AppPage,
+    base_path: Option<RcStr>,
     exported_fields_excluding_default: String,
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
@@ -86,7 +87,7 @@ async fn dynamic_image_metadata_with_generator_source(
         "#,
         exported_fields_excluding_default = exported_fields_excluding_default,
         resource_path = StringifyJs(&format!("./{}", path.file_name())),
-        pathname_prefix = StringifyJs(&page.to_string()),
+        pathname_prefix = StringifyJs(&metadata_pathname_prefix(&base_path, &page)),
         page_segment = StringifyJs(stem),
         sizes = sizes,
         hash = StringifyJs(&hash),
@@ -105,6 +106,7 @@ async fn dynamic_image_metadata_without_generator_source(
     path: FileSystemPath,
     ty: RcStr,
     page: AppPage,
+    base_path: Option<RcStr>,
     exported_fields_excluding_default: String,
 ) -> Result<Vc<Box<dyn Source>>> {
     let stem = path.file_stem();
@@ -157,7 +159,7 @@ async fn dynamic_image_metadata_without_generator_source(
         "#,
         exported_fields_excluding_default = exported_fields_excluding_default,
         resource_path = StringifyJs(&format!("./{}", path.file_name())),
-        pathname_prefix = StringifyJs(&page.to_string()),
+        pathname_prefix = StringifyJs(&metadata_pathname_prefix(&base_path, &page)),
         page_segment = StringifyJs(stem),
         sizes = sizes,
         hash = StringifyJs(&hash),
@@ -172,12 +174,20 @@ async fn dynamic_image_metadata_without_generator_source(
     Ok(Vc::upcast(source))
 }
 
+fn metadata_pathname_prefix(base_path: &Option<RcStr>, page: &AppPage) -> String {
+    match base_path {
+        Some(base_path) if !base_path.is_empty() => format!("{base_path}{page}"),
+        _ => page.to_string(),
+    }
+}
+
 #[turbo_tasks::function]
 pub async fn dynamic_image_metadata_source(
     asset_context: Vc<Box<dyn AssetContext>>,
     path: FileSystemPath,
     ty: RcStr,
     page: AppPage,
+    base_path: Option<RcStr>,
 ) -> Result<Vc<Box<dyn Source>>> {
     let source = Vc::upcast(FileSource::new(path.clone()));
     let module = asset_context
@@ -201,6 +211,7 @@ pub async fn dynamic_image_metadata_source(
             path,
             ty,
             page,
+            base_path,
             exported_fields_excluding_default,
         )
         .await
@@ -209,6 +220,7 @@ pub async fn dynamic_image_metadata_source(
             path,
             ty,
             page,
+            base_path,
             exported_fields_excluding_default,
         )
         .await

--- a/test/e2e/app-dir/app-basepath/app/metadata/icon.tsx
+++ b/test/e2e/app-dir/app-basepath/app/metadata/icon.tsx
@@ -1,0 +1,25 @@
+import { ImageResponse } from 'next/og'
+
+export const contentType = 'image/png'
+export const size = { width: 64, height: 64 }
+
+export default function icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 32,
+          background: '#fff',
+          color: '#000',
+        }}
+      >
+        Icon
+      </div>
+    )
+  )
+}

--- a/test/e2e/app-dir/app-basepath/index.test.ts
+++ b/test/e2e/app-dir/app-basepath/index.test.ts
@@ -45,6 +45,12 @@ describe('app dir - basepath', () => {
     expect(manifestHref).toContain('/base/manifest.webmanifest')
   })
 
+  it('should prefix a code-generated icon with basePath', async () => {
+    const $ = await next.render$('/base/metadata')
+    const iconHref = $('link[rel="icon"]').attr('href')
+    expect(iconHref).toContain('/base/metadata/icon')
+  })
+
   it('should prefix redirect() with basePath', async () => {
     const browser = await next.browser('/base/redirect')
     await retry(async () => {


### PR DESCRIPTION
### What?
When `basePath` is configured, code-generated metadata icons (e.g. `icon.tsx`) built by Turbopack don't get `basePath` prefixed onto their URL. This doesn't happen with webpack — it applies `basePath` correctly there.

### Why?
`write_static_metadata_item` in `crates/next-core/src/app_page_loader_tree.rs` builds the prefix using `base_path`, but `dynamic_image_metadata_source` (`crates/next-core/src/next_app/metadata/image.rs`), which handles dynamic icon generation, was never passed `base_path`.

### How?
Made `dynamic_image_metadata_source` use `base_path`.
Also added a test case.

Fixes #87422