### PR TITLE
Fix canary package publication readiness races

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -155,8 +155,37 @@ jobs:
 
     secrets: inherit
 
+  wait-for-release-packages:
+    name: Wait for release packages
+    needs: ['changes']
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout release package metadata
+        if: ${{ needs.changes.outputs.is-release == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            lerna.json
+            packages/*/package.json
+            scripts/npm-release-readiness.js
+            scripts/wait-for-release-packages.js
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Wait for exact package versions
+        if: ${{ needs.changes.outputs.is-release == 'true' }}
+        env:
+          # The production publish waits up to ten minutes after publishing
+          # prerequisites. This outer gate also covers the preceding release build.
+          NPM_PUBLISH_READINESS_ATTEMPTS: 240
+        run: node scripts/wait-for-release-packages.js
+
   build-next:
     name: build-next
+    needs: ['wait-for-release-packages']
     permissions:
       contents: read
       id-token: write
@@ -1191,6 +1220,7 @@ jobs:
       - optimize-ci
       - changes
       - build-native
+      - wait-for-release-packages
       - build-next
       - fetch-test-timings
       - lint

--- a/scripts/npm-release-readiness.js
+++ b/scripts/npm-release-readiness.js
@@ -1,0 +1,274 @@
+// @ts-check
+
+const fs = require('fs/promises')
+const path = require('path')
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org'
+const DEFAULT_ATTEMPTS = 60
+const DEFAULT_DELAY_SECONDS = 10
+
+const EXACT_DEPENDENCY_FIELDS = ['dependencies', 'optionalDependencies']
+
+/**
+ * @param {string} value
+ * @param {number} fallback
+ */
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value, 10)
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+/**
+ * Find public workspace packages which must be registry-ready before another
+ * workspace package with the same exact version can be installed.
+ *
+ * @param {Array<{ dir: string, manifest: any }>} packages
+ * @param {string} version
+ */
+function findExactWorkspacePrerequisites(packages, version) {
+  const publicWorkspacePackages = new Map(
+    packages
+      .filter(({ manifest }) => !manifest.private && manifest.name)
+      .map((pkg) => [pkg.manifest.name, pkg])
+  )
+  const prerequisites = new Map()
+
+  for (const { manifest: consumer } of packages) {
+    if (consumer.private) continue
+
+    for (const field of EXACT_DEPENDENCY_FIELDS) {
+      for (const [dependencyName, dependencyVersion] of Object.entries(
+        consumer[field] || {}
+      )) {
+        const dependency = publicWorkspacePackages.get(dependencyName)
+        if (
+          dependency &&
+          dependencyVersion === version &&
+          dependency.manifest.version === version
+        ) {
+          prerequisites.set(dependencyName, dependency)
+        }
+      }
+    }
+  }
+
+  return [...prerequisites.values()].sort((a, b) =>
+    a.manifest.name.localeCompare(b.manifest.name)
+  )
+}
+
+/**
+ * Split prerequisites into dependency-first publication layers. This keeps the
+ * gate correct if a future exact-version prerequisite itself gains an exact
+ * workspace dependency.
+ *
+ * @param {Array<{ dir: string, manifest: any }>} packages
+ * @param {string} version
+ */
+function getExactWorkspacePublishLayers(packages, version) {
+  const prerequisites = findExactWorkspacePrerequisites(packages, version)
+  const remaining = new Map(
+    prerequisites.map((pkg) => [pkg.manifest.name, pkg])
+  )
+  const layers = []
+
+  while (remaining.size > 0) {
+    const layer = [...remaining.values()].filter(({ manifest }) =>
+      EXACT_DEPENDENCY_FIELDS.every((field) =>
+        Object.entries(manifest[field] || {}).every(
+          ([dependencyName, dependencyVersion]) =>
+            dependencyVersion !== version || !remaining.has(dependencyName)
+        )
+      )
+    )
+
+    if (layer.length === 0) {
+      throw new Error(
+        `Circular exact-version workspace dependencies among: ${[
+          ...remaining.keys(),
+        ].join(', ')}`
+      )
+    }
+
+    layer.sort((a, b) => a.manifest.name.localeCompare(b.manifest.name))
+    layers.push(layer)
+    for (const { manifest } of layer) remaining.delete(manifest.name)
+  }
+
+  return layers
+}
+
+/**
+ * @param {string} packagesDir
+ */
+async function readWorkspacePackages(packagesDir) {
+  const entries = await fs.readdir(packagesDir, { withFileTypes: true })
+  const packages = []
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+
+    const dir = path.join(packagesDir, entry.name)
+    try {
+      const manifest = JSON.parse(
+        await fs.readFile(path.join(dir, 'package.json'), 'utf8')
+      )
+      packages.push({ dir, manifest })
+    } catch (error) {
+      if (/** @type {NodeJS.ErrnoException} */ (error).code !== 'ENOENT') {
+        throw error
+      }
+    }
+  }
+
+  return packages
+}
+
+/**
+ * Poll npm's exact-version metadata endpoint. A dist-tag is insufficient here:
+ * dependents pin this exact version and npm can expose their metadata first.
+ *
+ * @param {string} name
+ * @param {string} version
+ * @param {{
+ *   attempts?: number,
+ *   delaySeconds?: number,
+ *   fetchImpl?: typeof fetch,
+ *   registry?: string,
+ *   sleep?: (milliseconds: number) => Promise<void>,
+ * }} [options]
+ */
+async function waitForExactPackageVersion(name, version, options = {}) {
+  const attempts =
+    options.attempts ??
+    positiveInteger(
+      process.env.NPM_PUBLISH_READINESS_ATTEMPTS || '',
+      DEFAULT_ATTEMPTS
+    )
+  const delaySeconds =
+    options.delaySeconds ??
+    positiveInteger(
+      process.env.NPM_PUBLISH_READINESS_DELAY_SECONDS || '',
+      DEFAULT_DELAY_SECONDS
+    )
+  const fetchImpl = options.fetchImpl || fetch
+  const sleep =
+    options.sleep ||
+    ((milliseconds) =>
+      new Promise((resolve) => setTimeout(resolve, milliseconds)))
+  const registry = (options.registry || DEFAULT_REGISTRY).replace(/\/$/, '')
+  const url = `${registry}/${encodeURIComponent(name)}/${encodeURIComponent(version)}`
+  let lastStatus = 'no response'
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const response = await fetchImpl(url, {
+        headers: { 'cache-control': 'no-cache' },
+      })
+      lastStatus = `${response.status} ${response.statusText}`.trim()
+      if (response.ok) {
+        console.log(`${name}@${version} is available from npm`)
+        return
+      }
+    } catch (error) {
+      lastStatus = error instanceof Error ? error.message : String(error)
+    }
+
+    if (attempt < attempts) {
+      console.log(
+        `${name}@${version} is not available from npm yet (${lastStatus}); retrying in ${delaySeconds}s (${attempt}/${attempts})`
+      )
+      await sleep(delaySeconds * 1000)
+    }
+  }
+
+  throw new Error(
+    `${name}@${version} was not available from npm after ${attempts} attempts (last result: ${lastStatus})`
+  )
+}
+
+/**
+ * @param {Array<{ manifest: { name: string } }>} packages
+ * @param {string} version
+ * @param {Parameters<typeof waitForExactPackageVersion>[2]} [options]
+ */
+async function waitForExactPackageVersions(packages, version, options) {
+  await Promise.all(
+    packages.map(({ manifest }) =>
+      waitForExactPackageVersion(manifest.name, version, options)
+    )
+  )
+}
+
+/**
+ * @param {{
+ *   packages: Array<{ dir: string, manifest: any }>,
+ *   version: string,
+ *   npmDistTag: string,
+ *   dryRun: boolean,
+ *   publish: (label: string, args: string[]) => Promise<unknown>,
+ *   waitForVersions?: typeof waitForExactPackageVersions,
+ * }} options
+ */
+async function publishWorkspacePackages(options) {
+  const {
+    packages,
+    version,
+    npmDistTag,
+    dryRun,
+    publish,
+    waitForVersions = waitForExactPackageVersions,
+  } = options
+  const publishLayers = getExactWorkspacePublishLayers(packages, version)
+  const prerequisites = publishLayers.flat()
+  const publishOptions = [
+    '--access',
+    'public',
+    '--no-git-checks',
+    '--ignore-scripts',
+    '--tag',
+    npmDistTag,
+    ...(dryRun ? ['--dry-run'] : []),
+  ]
+
+  for (const layer of publishLayers) {
+    await Promise.all(
+      layer.map(({ manifest }) =>
+        publish(manifest.name, [
+          '--filter',
+          manifest.name,
+          'publish',
+          ...publishOptions,
+        ])
+      )
+    )
+
+    if (!dryRun) {
+      await waitForVersions(layer, version)
+    }
+  }
+
+  await publish('workspace', [
+    '--filter',
+    './packages/**',
+    ...prerequisites.flatMap(({ manifest }) => [
+      '--filter',
+      `!${manifest.name}`,
+    ]),
+    'publish',
+    '--recursive',
+    ...publishOptions,
+    '--report-summary',
+  ])
+
+  return prerequisites
+}
+
+module.exports = {
+  findExactWorkspacePrerequisites,
+  getExactWorkspacePublishLayers,
+  publishWorkspacePackages,
+  readWorkspacePackages,
+  waitForExactPackageVersion,
+  waitForExactPackageVersions,
+}

--- a/scripts/publish-release.js
+++ b/scripts/publish-release.js
@@ -10,6 +10,10 @@ const {
   getGitHubToken,
   getGitHubTokenMissingMessage,
 } = require('./release-github-auth')
+const {
+  publishWorkspacePackages,
+  readWorkspacePackages,
+} = require('./npm-release-readiness')
 
 const cwd = process.cwd()
 const dryRun = process.argv.includes('--dry-run')
@@ -248,14 +252,14 @@ const publishRetryDelaySeconds = 15
       '-1',
       '--json',
     ])
-    const workspacePackages = JSON.parse(pnpmListJson.stdout)
+    const workspacePackageList = JSON.parse(pnpmListJson.stdout)
     const publishedPackageNames = new Set(
-      workspacePackages
+      workspacePackageList
         .filter((workspacePackage) => !workspacePackage.private)
         .map((workspacePackage) => workspacePackage.name)
     )
 
-    for (const workspacePackage of workspacePackages) {
+    for (const workspacePackage of workspacePackageList) {
       if (workspacePackage.private) {
         continue
       }
@@ -282,20 +286,21 @@ const publishRetryDelaySeconds = 15
     }
   }
 
-  await publish('workspace', [
-    '--filter',
-    './packages/**',
-    'publish',
-    '--recursive',
-    '--access',
-    'public',
-    '--no-git-checks',
-    '--ignore-scripts',
-    '--report-summary',
-    '--tag',
+  const workspacePackages = await readWorkspacePackages(
+    path.join(cwd, 'packages')
+  )
+
+  // pnpm's recursive publish can finish publishing a dependent before npm's
+  // registry serves the exact workspace package it requires. Publish those
+  // prerequisites separately, then wait for exact-version metadata before
+  // exposing dependent package metadata.
+  await publishWorkspacePackages({
+    packages: workspacePackages,
+    version,
     npmDistTag,
-    ...(dryRun ? ['--dry-run'] : []),
-  ])
+    dryRun,
+    publish,
+  })
 
   if (dryRun) {
     console.log('Dry run: skipping GitHub release un-draft')

--- a/scripts/wait-for-release-packages.js
+++ b/scripts/wait-for-release-packages.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// @ts-check
+
+const fs = require('fs/promises')
+const path = require('path')
+const {
+  findExactWorkspacePrerequisites,
+  readWorkspacePackages,
+  waitForExactPackageVersions,
+} = require('./npm-release-readiness')
+
+async function main() {
+  const cwd = process.cwd()
+  const { version } = JSON.parse(
+    await fs.readFile(path.join(cwd, 'lerna.json'), 'utf8')
+  )
+
+  if (typeof version !== 'string' || version.length === 0) {
+    throw new Error(`Invalid version in lerna.json: ${version}`)
+  }
+
+  const packages = await readWorkspacePackages(path.join(cwd, 'packages'))
+  const prerequisites = findExactWorkspacePrerequisites(packages, version)
+
+  if (prerequisites.length === 0) {
+    console.log(`No exact ${version} workspace prerequisites need an npm gate`)
+    return
+  }
+
+  console.log(
+    `Waiting for exact npm release prerequisites: ${prerequisites
+      .map(({ manifest }) => `${manifest.name}@${version}`)
+      .join(', ')}`
+  )
+  await waitForExactPackageVersions(prerequisites, version)
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+}
+
+module.exports = { main }

--- a/test/unit/publish-release-readiness.test.ts
+++ b/test/unit/publish-release-readiness.test.ts
@@ -1,0 +1,184 @@
+const {
+  findExactWorkspacePrerequisites,
+  getExactWorkspacePublishLayers,
+  publishWorkspacePackages,
+  waitForExactPackageVersion,
+} = require('../../scripts/npm-release-readiness')
+
+const version = '16.4.0-canary.22'
+
+function packageFixture(
+  name: string,
+  dependencies: Record<string, string> = {},
+  extra: Record<string, unknown> = {}
+) {
+  return {
+    dir: `packages/${name}`,
+    manifest: { name, version, dependencies, ...extra },
+  }
+}
+
+describe('npm release readiness', () => {
+  const packages = [
+    packageFixture('@next/env'),
+    packageFixture('next', { '@next/env': version }),
+    packageFixture('@next/eslint-plugin-next'),
+    packageFixture('eslint-config-next', {
+      '@next/eslint-plugin-next': version,
+    }),
+    packageFixture('@next/ranged-consumer', { '@next/env': `^${version}` }),
+    packageFixture('@next/workspace-consumer', { '@next/env': 'workspace:*' }),
+    packageFixture('@next/private-prerequisite', {}, { private: true }),
+    packageFixture(
+      '@next/private-consumer',
+      { '@next/private-prerequisite': version },
+      { private: true }
+    ),
+  ]
+
+  it('finds public exact-version workspace prerequisites', () => {
+    expect(
+      findExactWorkspacePrerequisites(packages, version).map(
+        ({ manifest }: any) => manifest.name
+      )
+    ).toEqual(['@next/env', '@next/eslint-plugin-next'])
+  })
+
+  it('orders chained prerequisites in dependency-first layers', () => {
+    const chainedPackages = [
+      packageFixture('@next/leaf'),
+      packageFixture('@next/middle', { '@next/leaf': version }),
+      packageFixture('@next/consumer', { '@next/middle': version }),
+    ]
+
+    expect(
+      getExactWorkspacePublishLayers(chainedPackages, version).map(
+        (layer: any[]) => layer.map(({ manifest }) => manifest.name)
+      )
+    ).toEqual([['@next/leaf'], ['@next/middle']])
+  })
+
+  it('waits for exact companions before publishing their dependents', async () => {
+    const events: string[] = []
+
+    await publishWorkspacePackages({
+      packages,
+      version,
+      npmDistTag: 'canary',
+      dryRun: false,
+      publish: async (label: string, args: string[]) => {
+        events.push(`publish:${label}`)
+        if (label === 'workspace') {
+          expect(args).toEqual(
+            expect.arrayContaining([
+              '!@next/env',
+              '!@next/eslint-plugin-next',
+              '--recursive',
+              '--report-summary',
+            ])
+          )
+        }
+      },
+      waitForVersions: async (prerequisites: any[]) => {
+        events.push(
+          `ready:${prerequisites
+            .map(({ manifest }) => manifest.name)
+            .join(',')}`
+        )
+      },
+    })
+
+    expect(events.slice(0, 2).sort()).toEqual([
+      'publish:@next/env',
+      'publish:@next/eslint-plugin-next',
+    ])
+    expect(events[2]).toBe('ready:@next/env,@next/eslint-plugin-next')
+    expect(events[3]).toBe('publish:workspace')
+  })
+
+  it('polls the exact encoded package version until it is ready', async () => {
+    const urls: string[] = []
+    const statuses = [404, 404, 200]
+    const sleep = jest.fn(async () => {})
+
+    await waitForExactPackageVersion('@next/env', version, {
+      attempts: 3,
+      delaySeconds: 1,
+      sleep,
+      fetchImpl: async (url: string) => {
+        urls.push(url)
+        const status = statuses.shift()!
+        return {
+          ok: status === 200,
+          status,
+          statusText: status === 200 ? 'OK' : 'Not Found',
+        }
+      },
+    })
+
+    expect(urls).toEqual(
+      Array(3).fill(
+        `https://registry.npmjs.org/%40next%2Fenv/${encodeURIComponent(version)}`
+      )
+    )
+    expect(sleep).toHaveBeenCalledTimes(2)
+  })
+
+  it('fails closed when an exact companion never becomes ready', async () => {
+    await expect(
+      waitForExactPackageVersion('@next/eslint-plugin-next', version, {
+        attempts: 2,
+        delaySeconds: 1,
+        sleep: async () => {},
+        fetchImpl: async () => ({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        }),
+      })
+    ).rejects.toThrow(
+      '@next/eslint-plugin-next@16.4.0-canary.22 was not available from npm after 2 attempts'
+    )
+  })
+
+  it('does not publish dependents when readiness fails', async () => {
+    const published: string[] = []
+
+    await expect(
+      publishWorkspacePackages({
+        packages,
+        version,
+        npmDistTag: 'canary',
+        dryRun: false,
+        publish: async (label: string) => {
+          published.push(label)
+        },
+        waitForVersions: async () => {
+          throw new Error('exact version unavailable')
+        },
+      })
+    ).rejects.toThrow('exact version unavailable')
+
+    expect(published).not.toContain('workspace')
+  })
+
+  it('does not perform registry readiness checks during a dry run', async () => {
+    const events: string[] = []
+    const waitForVersions = jest.fn(async () => {})
+
+    await publishWorkspacePackages({
+      packages,
+      version,
+      npmDistTag: 'canary',
+      dryRun: true,
+      publish: async (label: string, args: string[]) => {
+        events.push(label)
+        expect(args).toContain('--dry-run')
+      },
+      waitForVersions,
+    })
+
+    expect(waitForVersions).not.toHaveBeenCalled()
+    expect(events).toContain('workspace')
+  })
+})


### PR DESCRIPTION
### What?

Make canary npm publication and release CI wait for exact-version workspace companion packages before exposing or testing dependent packages.

### Why?

Recent canary releases repeatedly made a consumer available before npm served its exact companion version. This caused installs of `next` to fail on a missing `@next/env`, and installs of `eslint-config-next` to fail on a missing `@next/eslint-plugin-next`. Release test jobs also started concurrently with the production build, so they could attempt those installs before publication began.

### How?

The release publisher now discovers exact-version dependencies between public workspace packages, publishes prerequisites in dependency-first layers, and polls npm's exact package/version metadata endpoint before publishing the remaining packages. The polling is bounded and fails closed, while preserving the existing publish retry and dry-run behavior.

Release-commit CI uses the same discovery and readiness logic in a lightweight gate before the shared build/test dependency. Non-release commits take a no-op path, and native builds remain parallel. Focused tests cover both affected dependency pairs, delayed registry propagation, dependency chains, terminal failure, and dry-run behavior.

### Verification

- `pnpm testonly test/unit/publish-release-readiness.test.ts --runInBand`
- `pnpm typescript`
- `./scripts/publish-release.js --dry-run`
- Live exact-version npm readiness smoke test for `16.4.0-canary.22`
- Prettier, ESLint, and `git diff --check`

<!-- NEXT_JS_LLM -->

<!-- fleet 75f49110-fa39-41b2-9da0-6e8c662a05d0 -->