### PR TITLE
test: stabilize error recovery snapshot timing

### DIFF
--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -739,6 +739,7 @@ describe('pages/ error recovery', () => {
       `
     )
     // TODO: this acts weird without above step
+    // Leave enough time to snapshot the first error before the interval repeats.
     await session.patch(
       'index.js',
       outdent`
@@ -747,13 +748,12 @@ describe('pages/ error recovery', () => {
         setInterval(() => {
           i++
           throw Error('no ' + i)
-        }, 1000)
+        }, 3000)
         export default function FunctionNamed() {
           return <div />
         }
       `
     )
-    await new Promise((resolve) => setTimeout(resolve, 1000))
 
     if (isRspack) {
       await expect(browser).toDisplayRedbox(`
@@ -794,7 +794,7 @@ describe('pages/ error recovery', () => {
         setInterval(() => {
           i++
           throw Error('no ' + i)
-        }, 1000)
+        }, 3000)
         export default function FunctionNamed() {`
     )
 
@@ -826,7 +826,7 @@ describe('pages/ error recovery', () => {
                │    ,-[7:1]
                │  4 |   i++
                │  5 |   throw Error('no ' + i)
-               │  6 | }, 1000)
+               │  6 | }, 3000)
                │  7 | export default function FunctionNamed() {
                │    \`----
                │
@@ -850,7 +850,7 @@ describe('pages/ error recovery', () => {
           ,-[7:1]
         4 |   i++
         5 |   throw Error('no ' + i)
-        6 | }, 1000)
+        6 | }, 3000)
         7 | export default function FunctionNamed() {
           \`----
        Caused by:
@@ -864,7 +864,7 @@ describe('pages/ error recovery', () => {
     }
 
     // Test that runtime error does not take over:
-    await new Promise((resolve) => setTimeout(resolve, 2000))
+    await new Promise((resolve) => setTimeout(resolve, 3500))
 
     if (isTurbopack) {
       // TODO: Remove this branching once import traces are implemented in Turbopack
@@ -891,7 +891,7 @@ describe('pages/ error recovery', () => {
                │    ,-[7:1]
                │  4 |   i++
                │  5 |   throw Error('no ' + i)
-               │  6 | }, 1000)
+               │  6 | }, 3000)
                │  7 | export default function FunctionNamed() {
                │    \`----
                │
@@ -915,7 +915,7 @@ describe('pages/ error recovery', () => {
           ,-[7:1]
         4 |   i++
         5 |   throw Error('no ' + i)
-        6 | }, 1000)
+        6 | }, 3000)
         7 | export default function FunctionNamed() {
           \`----
        Caused by:


### PR DESCRIPTION
### What?

Stabilizes the pages-router `syntax > runtime error` acceptance test without weakening its redbox assertions.

### Why?

The fixture emitted runtime errors every second and waited exactly one second before capturing the first redbox. On slower release runners, a second error could arrive while the asynchronous snapshot was being collected, changing the expected single error into an array and causing repeated retries.

The broader canary assertion cluster has several independent signatures; this PR intentionally addresses only the timing race with a reproducible, test-local cause.

### How?

The redbox matcher now performs the initial wait itself, while the fixture uses a longer interval to leave a stable capture window. The later wait remains long enough for another runtime error to occur, preserving the test’s core assertion that a subsequent runtime error does not replace the syntax/build error.

### Verification

- `pnpm build-all`
- `HEADLESS=true NEXT_TELEMETRY_DISABLED=1 NEXT_TEST_CI=true pnpm test-dev-webpack test/development/acceptance/error-recovery.test.ts` (6 tests and 10 snapshots passed)
- Prettier and ESLint on the changed file

<!-- NEXT_JS_LLM -->

<!-- fleet ee9dd3ec-a271-4d0d-8165-d7872e226a6a -->