### PR TITLE
Serialize turbo-tasks trybuild tests

### DIFF
--- a/turbopack/crates/turbo-tasks-macros-tests/tests/trybuild.rs
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/trybuild.rs
@@ -8,37 +8,19 @@ fn unset_rustc_wrapper() {
     unsafe { std::env::remove_var("RUSTC_WRAPPER") };
 }
 
+// Trybuild uses one generated Cargo project per package. Keep every case in one test so nextest
+// cannot run separate processes that overwrite that project's manifest while another case uses it.
 #[test]
-fn derive_operation_value() {
+fn trybuild() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive_operation_value/pass_*.rs");
     t.compile_fail("tests/derive_operation_value/fail_*.rs");
-}
-
-#[test]
-fn derive_non_local_value() {
-    let t = trybuild::TestCases::new();
     t.pass("tests/derive_non_local_value/pass_*.rs");
     t.compile_fail("tests/derive_non_local_value/fail_*.rs");
-}
-
-#[test]
-fn function() {
-    let t = trybuild::TestCases::new();
     t.pass("tests/function/pass_*.rs");
     t.compile_fail("tests/function/fail_*.rs");
-}
-
-#[test]
-fn value() {
-    let t = trybuild::TestCases::new();
     t.pass("tests/value/pass_*.rs");
     t.compile_fail("tests/value/fail_*.rs");
-}
-
-#[test]
-fn value_trait() {
-    let t = trybuild::TestCases::new();
     t.pass("tests/value_trait/pass_*.rs");
     t.compile_fail("tests/value_trait/fail_*.rs");
 }


### PR DESCRIPTION
### What?

Run all `turbo-tasks-macros-tests` trybuild fixture groups through one test process and one generated Cargo project lifecycle.

### Why?

Trybuild uses one generated Cargo project per package. Cargo-nextest previously launched the five test groups as separate processes, allowing them to overwrite that project's manifest while another group was compiling. On canary this surfaced as diagnostics from the wrong fixture, missing `trybuild00N` bin targets, and compile-fail cases incorrectly succeeding.

The tracked stderr snapshots are correct; the instability is in concurrent harness execution rather than compiler output or the SWC version.

### How?

A single `TestCases` instance now queues every existing pass and compile-fail glob. This preserves per-fixture diagnostics and coverage while preventing cross-process manifest collisions. A comment documents the shared-project invariant so the groups are not split into concurrent tests again.

### Verification

- `cargo nextest run -p turbo-tasks-macros-tests --cargo-profile release-with-assertions --no-fail-fast`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- NEXT_JS_LLM -->


<!-- fleet ae1d9ec9-156e-4b53-80c0-f24bf0b22f13 -->