### PR TITLE
Stabilize scope_unbounded panic test

### DIFF
--- a/turbopack/crates/turbo-tasks/src/scope_unbounded.rs
+++ b/turbopack/crates/turbo-tasks/src/scope_unbounded.rs
@@ -667,19 +667,26 @@ mod tests {
     /// A panic in a `run` invocation propagates after all in-flight work is joined, and aborts the
     /// scope: the queued-but-unstarted items are abandoned rather than run.
     ///
-    /// The first item panics, so with a large seed set almost nothing else should be dispatched.
-    /// Items already picked up by another drainer still complete, so the bound is "far fewer than
-    /// seeded" rather than exactly one.
+    /// Use a growing cascade and panic after enough work has run to guarantee that work remains
+    /// queued. A fixed seed set can drain completely before its first item panics, making it unable
+    /// to distinguish a missed abort from valid scheduling.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_unbounded_panic_propagates_and_abandons_queue() {
-        const ITEMS: usize = 10_000;
+        const MAX_ID: usize = 1 << 14;
         let processed = Arc::new(AtomicUsize::new(0));
         let processed_clone = processed.clone();
         let result = catch_unwind(AssertUnwindSafe(|| {
-            scope_unbounded(0..ITEMS, move |_spawner, item| {
-                processed_clone.fetch_add(1, Ordering::SeqCst);
-                if item == 0 {
+            scope_unbounded(std::iter::once(1usize), move |spawner, id| {
+                let n = processed_clone.fetch_add(1, Ordering::SeqCst);
+                if n == 100 {
                     panic!("Intentional panic");
+                }
+                let (left, right) = (id * 2, id * 2 + 1);
+                if left <= MAX_ID {
+                    spawner.spawn(left);
+                }
+                if right <= MAX_ID {
+                    spawner.spawn(right);
                 }
                 ControlFlow::Continue(())
             });
@@ -689,8 +696,8 @@ mod tests {
         assert_eq!(err.downcast_ref::<&str>(), Some(&"Intentional panic"));
         let count = processed.load(Ordering::SeqCst);
         assert!(
-            count < ITEMS,
-            "a panic must abandon the queue, but all {ITEMS} items ran"
+            count < MAX_ID,
+            "a panic must cut the cascade short, but {count} items ran"
         );
     }
 


### PR DESCRIPTION
### What?

Make `test_unbounded_panic_propagates_and_abandons_queue` deterministically exercise panic-driven queue abandonment.

### Why?

The test failed in two consecutive canary `test-cargo-unit` attempts after all 10,000 fixed seed items ran before the panic's abort was recorded. That outcome is legal scheduling: a fixed seed queue can drain before its designated panicking item executes, so the assertion did not prove that abort handling was broken.

### How?

The test now grows a bounded work cascade and panics after a fixed amount of processing. Since each completed item adds more work, queued items are guaranteed to exist when the panic occurs. The test therefore continues to verify panic propagation and queue abandonment without relying on worker timing. Production `scope_unbounded` behavior is unchanged.

### Verification

- Changed panic test passed 100 consecutive runs with `release-with-assertions`
- `cargo nextest run -p turbo-tasks -E 'test(~scope_unbounded::tests::)' --cargo-profile release-with-assertions` (17 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- NEXT_JS_LLM -->


<!-- fleet ae1d9ec9-156e-4b53-80c0-f24bf0b22f13 -->