### PR TITLE
test: stabilize deferred entries HMR assertions

### DIFF
--- a/test/e2e/deferred-entries/deferred-entries.test.ts
+++ b/test/e2e/deferred-entries/deferred-entries.test.ts
@@ -6,6 +6,10 @@ import { Response } from 'node-fetch'
 
 const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
+// Webpack's HMR cycle waits for all compilers, which can exceed retry's
+// default duration under load.
+const HMR_RETRY_DURATION = 10_000
+
 interface LogEntry {
   timestamp: number
   entry: string
@@ -523,14 +527,14 @@ describe('deferred-entries', () => {
         expect(newTimestamp).not.toBeNull()
         // The callback should have been called again with a newer timestamp
         expect(newTimestamp).toBeGreaterThan(initialTimestamp!)
-      })
+      }, HMR_RETRY_DURATION)
 
       // Verify the home page was updated
       await retry(async () => {
         const homeRes = await next.fetch('/')
         expect(homeRes.status).toBe(200)
         expect(await homeRes.text()).toContain('Home Page Updated')
-      })
+      }, HMR_RETRY_DURATION)
     })
 
     it('should update deferred rendered timestamp during HMR when non-deferred entry changes', async () => {
@@ -567,7 +571,7 @@ describe('deferred-entries', () => {
         expect(updatedCallbackTimestamp).toBeGreaterThan(
           initialCallbackTimestamp!
         )
-      })
+      }, HMR_RETRY_DURATION)
 
       // Deferred page should now render the new callback-written timestamp.
       await retry(async () => {
@@ -588,7 +592,7 @@ describe('deferred-entries', () => {
         expect(updatedRenderedTimestamp).toBeGreaterThan(
           initialRenderedTimestamp!
         )
-      })
+      }, HMR_RETRY_DURATION)
     })
 
     it('should handle successive non-deferred edits without callback looping', async () => {
@@ -640,7 +644,7 @@ describe('deferred-entries', () => {
           expect(callbackAfterEdit).toBeGreaterThan(
             previousCallbackTimestampForIteration
           )
-        })
+        }, HMR_RETRY_DURATION)
 
         let renderedAfterEdit: number | null = null
         await retry(async () => {
@@ -660,7 +664,7 @@ describe('deferred-entries', () => {
           expect(renderedAfterEdit).toBeGreaterThan(
             previousRenderedTimestampForIteration
           )
-        })
+        }, HMR_RETRY_DURATION)
 
         // No runaway callback loop: timestamp should settle when idle.
         const stabilizedTimestamp =


### PR DESCRIPTION
### What?

Stabilize the deferred-entries development-mode HMR assertions by giving condition-based callback, rendered-output, and page-content polling an HMR-appropriate retry budget.

### Why?

Canary CI repeatedly observed the previous callback timestamp after a non-deferred edit. The logs show webpack detecting and compiling the edit, while its multi-compiler HMR cycle—including the edge compiler—finishes after the generic three-second retry window. The deferred callback is scheduled after that cycle, so these failures reflect the harness timing out before valid product behavior rather than a deferred-entries product defect.

### How?

Use a shared ten-second retry duration only for the six HMR-observable polls in the existing dev-only tests. The checks still wait on real callback timestamps, rendered values, and updated page content. Existing ordering and callback-stability assertions remain unchanged, so missing callbacks, stale rendering, and callback loops continue to fail.

### Verification

- `pnpm test-dev-webpack test/e2e/deferred-entries/deferred-entries.test.ts` (3 consecutive runs, 23/23 each, with CI environment mirrored)
- `pnpm test-dev-turbo test/e2e/deferred-entries/deferred-entries.test.ts` (23/23)
- `pnpm prettier --with-node-modules --ignore-path .prettierignore --write test/e2e/deferred-entries/deferred-entries.test.ts`
- `npx eslint --config eslint.config.mjs --fix test/e2e/deferred-entries/deferred-entries.test.ts`

<!-- NEXT_JS_LLM -->


<!-- fleet 3cae6bf2-a515-4375-8814-03055b906f2a -->