### PR TITLE
fix: drain build worker diagnostics before shutdown

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1068,6 +1068,7 @@ export default async function build(
 
   let loadedConfig: NextConfigComplete | undefined
   let staticWorker: StaticWorker
+  let buildFailed = false
 
   // Turbopack compile warnings are deferred until after static generation.
   let deferredTurbopackWarnings: string[] | undefined
@@ -4293,7 +4294,7 @@ export default async function build(
       // When output: export we want to end the worker later as it's still used for writeFullyStaticExport
       if (config.output !== 'export') {
         // ensure the worker is not left hanging
-        await staticWorker?.end()
+        staticWorker?.end()
         staticWorker = undefined! // Reset staticWorker to make sure it does not end in `finally`
       }
 
@@ -4528,7 +4529,7 @@ export default async function build(
       if (config.output === 'export') {
         // TODO: When writeFullyStaticExport doesn't fail when staticWorker is passed moved this after writeFullyStaticExport.
         // End the worker here when it's output: export.
-        await staticWorker.end()
+        staticWorker.end()
         staticWorker = undefined! // Reset staticWorker to make sure it does not end in `finally`
 
         await nextBuildSpan
@@ -4676,6 +4677,7 @@ export default async function build(
       }
     })
   } catch (e) {
+    buildFailed = true
     const telemetry: Telemetry | undefined = traceGlobals.get('telemetry')
     if (telemetry) {
       telemetry.record(
@@ -4690,7 +4692,11 @@ export default async function build(
   } finally {
     // @ts-expect-error Existence of staticWorker is checked here intentionally.
     if (staticWorker) {
-      await staticWorker.end()
+      if (buildFailed) {
+        await staticWorker.endGracefully()
+      } else {
+        staticWorker.end()
+      }
     }
     // Ensure we wait for lockfile patching if present
     await lockfilePatchPromise.cur

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4293,7 +4293,7 @@ export default async function build(
       // When output: export we want to end the worker later as it's still used for writeFullyStaticExport
       if (config.output !== 'export') {
         // ensure the worker is not left hanging
-        staticWorker?.end()
+        await staticWorker?.end()
         staticWorker = undefined! // Reset staticWorker to make sure it does not end in `finally`
       }
 
@@ -4528,7 +4528,7 @@ export default async function build(
       if (config.output === 'export') {
         // TODO: When writeFullyStaticExport doesn't fail when staticWorker is passed moved this after writeFullyStaticExport.
         // End the worker here when it's output: export.
-        staticWorker.end()
+        await staticWorker.end()
         staticWorker = undefined! // Reset staticWorker to make sure it does not end in `finally`
 
         await nextBuildSpan
@@ -4690,7 +4690,7 @@ export default async function build(
   } finally {
     // @ts-expect-error Existence of staticWorker is checked here intentionally.
     if (staticWorker) {
-      staticWorker.end()
+      await staticWorker.end()
     }
     // Ensure we wait for lockfile patching if present
     await lockfilePatchPromise.cur

--- a/packages/next/src/lib/worker.test.ts
+++ b/packages/next/src/lib/worker.test.ts
@@ -1,15 +1,26 @@
 import { PassThrough } from 'stream'
 
 let latestForkEnv: NodeJS.ProcessEnv | undefined
+let latestStdout: PassThrough | undefined
+let latestStderr: PassThrough | undefined
+let latestEnd: jest.Mock | undefined
+let latestKill: jest.Mock | undefined
 
 jest.mock('next/dist/compiled/jest-worker', () => {
   const WorkerMock = jest.fn().mockImplementation((_path, options) => {
     latestForkEnv = options?.forkOptions?.env
+    latestStdout = new PassThrough()
+    latestStderr = new PassThrough()
+    latestEnd = jest.fn().mockResolvedValue({ forceExited: false })
+    latestKill = jest.fn()
+
     return {
-      _workerPool: { _workers: [] },
-      getStdout: () => new PassThrough(),
-      getStderr: () => new PassThrough(),
-      end: jest.fn().mockResolvedValue(undefined),
+      _workerPool: {
+        _workers: [{ _child: { kill: latestKill, on: jest.fn() } }],
+      },
+      getStdout: () => latestStdout,
+      getStderr: () => latestStderr,
+      end: latestEnd,
       close: jest.fn(),
     }
   })
@@ -62,8 +73,14 @@ describe('lib/worker color propagation', () => {
       const restore = restoreDescriptors.pop()
       restore?.()
     }
+    latestStdout?.end()
+    latestStderr?.end()
     jest.resetModules()
     latestForkEnv = undefined
+    latestStdout = undefined
+    latestStderr = undefined
+    latestEnd = undefined
+    latestKill = undefined
   })
 
   it('enables FORCE_COLOR when the parent supports colors', () => {
@@ -123,5 +140,55 @@ describe('lib/worker color propagation', () => {
     worker.close()
 
     expect(latestForkEnv?.FORCE_COLOR).toBeUndefined()
+  })
+})
+
+describe('lib/worker shutdown', () => {
+  afterEach(() => {
+    latestStdout?.end()
+    latestStderr?.end()
+    jest.useRealTimers()
+    jest.resetModules()
+    latestForkEnv = undefined
+    latestStdout = undefined
+    latestStderr = undefined
+    latestEnd = undefined
+    latestKill = undefined
+  })
+
+  it('waits for stdout and stderr to drain without interrupting the worker', async () => {
+    const { Worker } = require('./worker') as typeof import('./worker')
+    const worker = new Worker(__filename, noopOptions)
+
+    let didEnd = false
+    const endPromise = worker.end().then((result) => {
+      didEnd = true
+      return result
+    })
+
+    await Promise.resolve()
+    expect(latestEnd).toHaveBeenCalledTimes(1)
+    expect(latestKill).not.toHaveBeenCalled()
+    expect(didEnd).toBe(false)
+
+    latestStdout!.end()
+    await Promise.resolve()
+    expect(didEnd).toBe(false)
+
+    latestStderr!.end()
+    await expect(endPromise).resolves.toEqual({ forceExited: false })
+  })
+
+  it('bounds the output drain wait', async () => {
+    jest.useFakeTimers()
+    const { Worker } = require('./worker') as typeof import('./worker')
+    const worker = new Worker(__filename, noopOptions)
+
+    const endPromise = worker.end()
+    await Promise.resolve()
+
+    jest.advanceTimersByTime(1000)
+    await expect(endPromise).resolves.toEqual({ forceExited: false })
+    expect(latestKill).toHaveBeenCalledWith('SIGINT')
   })
 })

--- a/packages/next/src/lib/worker.test.ts
+++ b/packages/next/src/lib/worker.test.ts
@@ -156,12 +156,20 @@ describe('lib/worker shutdown', () => {
     latestKill = undefined
   })
 
-  it('waits for stdout and stderr to drain without interrupting the worker', async () => {
+  it('retains interrupt-driven shutdown by default', async () => {
+    const { Worker } = require('./worker') as typeof import('./worker')
+    const worker = new Worker(__filename, noopOptions)
+
+    await expect(worker.end()).resolves.toEqual({ forceExited: false })
+    expect(latestKill).toHaveBeenCalledWith('SIGINT')
+  })
+
+  it('gracefully waits for stdout and stderr to drain', async () => {
     const { Worker } = require('./worker') as typeof import('./worker')
     const worker = new Worker(__filename, noopOptions)
 
     let didEnd = false
-    const endPromise = worker.end().then((result) => {
+    const endPromise = worker.endGracefully().then((result) => {
       didEnd = true
       return result
     })
@@ -179,16 +187,16 @@ describe('lib/worker shutdown', () => {
     await expect(endPromise).resolves.toEqual({ forceExited: false })
   })
 
-  it('bounds the output drain wait', async () => {
+  it('bounds the graceful output drain wait', async () => {
     jest.useFakeTimers()
     const { Worker } = require('./worker') as typeof import('./worker')
     const worker = new Worker(__filename, noopOptions)
 
-    const endPromise = worker.end()
+    const endPromise = worker.endGracefully()
     await Promise.resolve()
 
     jest.advanceTimersByTime(1000)
     await expect(endPromise).resolves.toEqual({ forceExited: false })
-    expect(latestKill).toHaveBeenCalledWith('SIGINT')
+    expect(latestKill).not.toHaveBeenCalled()
   })
 })

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -24,28 +24,23 @@ const cleanupWorkers = (worker: JestWorker) => {
 
 const WORKER_STDIO_DRAIN_TIMEOUT_MS = 1000
 
-const waitForStreamEnd = (
-  stream: NodeJS.ReadableStream,
-  signal: AbortSignal
-): Promise<boolean> => {
+const waitForStreamEnd = (stream: NodeJS.ReadableStream): Promise<void> => {
   const readable = stream as Readable
   if (readable.readableEnded || readable.destroyed) {
-    return Promise.resolve(true)
+    return Promise.resolve()
   }
 
   return new Promise((resolve) => {
-    const finish = (didDrain: boolean) => {
-      stream.off('end', onEnd)
-      stream.off('close', onEnd)
-      signal.removeEventListener('abort', onAbort)
-      resolve(didDrain)
+    const finish = () => {
+      clearTimeout(timeout)
+      stream.off('end', finish)
+      stream.off('close', finish)
+      resolve()
     }
-    const onEnd = () => finish(true)
-    const onAbort = () => finish(false)
+    const timeout = setTimeout(finish, WORKER_STDIO_DRAIN_TIMEOUT_MS)
 
-    stream.once('end', onEnd)
-    stream.once('close', onEnd)
-    signal.addEventListener('abort', onAbort, { once: true })
+    stream.once('end', finish)
+    stream.once('close', finish)
   })
 }
 
@@ -319,42 +314,31 @@ export class Worker {
     this._onActivityAbort = onActivityAbort
   }
 
-  async end(): ReturnType<JestWorker['end']> {
+  end(): ReturnType<JestWorker['end']> {
+    const worker = this._worker
+    if (!worker) {
+      throw new Error('Farm is ended, no more calls can be done to it')
+    }
+    cleanupWorkers(worker)
+    this._worker = undefined
+    return worker.end()
+  }
+
+  /**
+   * Shuts down without interrupting the worker so a failed build can preserve
+   * its trailing diagnostics. Successful builds use `end()` to retain their
+   * existing shutdown behavior.
+   */
+  async endGracefully(): ReturnType<JestWorker['end']> {
     const worker = this._worker
     if (!worker) {
       throw new Error('Farm is ended, no more calls can be done to it')
     }
 
-    // Worker method results and stdio use separate IPC channels. A method can
-    // resolve before its final output reaches the parent, so start observing
-    // both streams before asking jest-worker to shut down.
     const outputStreams = [worker.getStdout(), worker.getStderr()]
-    const drainController = new AbortController()
-    const outputEnded = Promise.all(
-      outputStreams.map((stream) =>
-        waitForStreamEnd(stream, drainController.signal)
-      )
-    )
-
     this._worker = undefined
-    let result: Awaited<ReturnType<JestWorker['end']>>
-    try {
-      result = await worker.end()
-    } catch (error) {
-      drainController.abort()
-      throw error
-    }
-
-    const drainTimeout = setTimeout(
-      () => drainController.abort(),
-      WORKER_STDIO_DRAIN_TIMEOUT_MS
-    )
-    const didDrain = await outputEnded
-    clearTimeout(drainTimeout)
-
-    if (didDrain.includes(false)) {
-      cleanupWorkers(worker)
-    }
+    const result = await worker.end()
+    await Promise.all(outputStreams.map(waitForStreamEnd))
     return result
   }
 

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from 'child_process'
 import { Worker as JestWorker } from 'next/dist/compiled/jest-worker'
-import { Transform } from 'stream'
+import { Transform, type Readable } from 'stream'
 import {
   formatDebugAddress,
   formatNodeOptions,
@@ -20,6 +20,33 @@ const cleanupWorkers = (worker: JestWorker) => {
   }[]) {
     curWorker._child?.kill('SIGINT')
   }
+}
+
+const WORKER_STDIO_DRAIN_TIMEOUT_MS = 1000
+
+const waitForStreamEnd = (
+  stream: NodeJS.ReadableStream,
+  signal: AbortSignal
+): Promise<boolean> => {
+  const readable = stream as Readable
+  if (readable.readableEnded || readable.destroyed) {
+    return Promise.resolve(true)
+  }
+
+  return new Promise((resolve) => {
+    const finish = (didDrain: boolean) => {
+      stream.off('end', onEnd)
+      stream.off('close', onEnd)
+      signal.removeEventListener('abort', onAbort)
+      resolve(didDrain)
+    }
+    const onEnd = () => finish(true)
+    const onAbort = () => finish(false)
+
+    stream.once('end', onEnd)
+    stream.once('close', onEnd)
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
 }
 
 export function getNextBuildDebuggerPortOffset(_: {
@@ -292,14 +319,43 @@ export class Worker {
     this._onActivityAbort = onActivityAbort
   }
 
-  end(): ReturnType<JestWorker['end']> {
+  async end(): ReturnType<JestWorker['end']> {
     const worker = this._worker
     if (!worker) {
       throw new Error('Farm is ended, no more calls can be done to it')
     }
-    cleanupWorkers(worker)
+
+    // Worker method results and stdio use separate IPC channels. A method can
+    // resolve before its final output reaches the parent, so start observing
+    // both streams before asking jest-worker to shut down.
+    const outputStreams = [worker.getStdout(), worker.getStderr()]
+    const drainController = new AbortController()
+    const outputEnded = Promise.all(
+      outputStreams.map((stream) =>
+        waitForStreamEnd(stream, drainController.signal)
+      )
+    )
+
     this._worker = undefined
-    return worker.end()
+    let result: Awaited<ReturnType<JestWorker['end']>>
+    try {
+      result = await worker.end()
+    } catch (error) {
+      drainController.abort()
+      throw error
+    }
+
+    const drainTimeout = setTimeout(
+      () => drainController.abort(),
+      WORKER_STDIO_DRAIN_TIMEOUT_MS
+    )
+    const didDrain = await outputEnded
+    clearTimeout(drainTimeout)
+
+    if (didDrain.includes(false)) {
+      cleanupWorkers(worker)
+    }
+    return result
   }
 
   /**

--- a/test/production/app-dir/sync-io-blocks-root/sync-io-blocks-root.test.ts
+++ b/test/production/app-dir/sync-io-blocks-root/sync-io-blocks-root.test.ts
@@ -1,8 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(lubieowoce): reenable when the cause of flakiness is found and fixed
-// (seems to have increased sharply around 2026-08-24/25)
-describe.skip('sync IO that blocks the root', () => {
+describe('sync IO that blocks the root', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipStart: true,


### PR DESCRIPTION
## Summary

The `sync-io-blocks-root` production suite was disabled after its `--debug-prerender` checks repeatedly missed route-specific sync-I/O diagnostics in webpack CI. Instrumentation confirmed that the render consistently tracks and throws the error, and the export worker consistently catches it. The diagnostic was lost afterward because the worker method result and worker stderr travel over independent channels: the result could reach the build first, triggering interrupt-driven teardown before the parent consumed trailing stderr.

This adds a bounded graceful shutdown path for build workers and uses it only when the build is already failing. Failed builds can therefore drain stdout and stderr before propagating their error, while successful builds retain the existing interrupt-driven lifecycle. Keeping successful teardown unchanged is important for behavior such as CPU profiling, where graceful shutdown would emit an additional static-worker profile.

The suite is re-enabled without changing its routes, build modes, or assertions. Focused unit coverage verifies the unchanged default shutdown, failed-build diagnostic draining, and the bounded fallback.

## Verification

- React 18.3.1 production webpack CI environment: 5 consecutive full-suite passes on retry 0 (40/40 route/build-mode cases)
- Default React production webpack CI environment: 8/8 route/build-mode cases on retry 0
- CPU profiling test in webpack, Turbopack, and experimental Turbopack modes (exact existing profile counts)
- `pnpm exec jest packages/next/src/lib/worker.test.ts --runInBand`
- `pnpm --filter=next types`
- `pnpm --filter=next build`
- `pnpm build-all`
- Focused Prettier and ESLint checks for all changed files

<!-- NEXT_JS_LLM -->


<!-- fleet 88f5c779-91ee-40e5-87a8-1026669e1d36 -->