### PR TITLE
fix(next-rspack): stabilize rebuilds and React 18 builds

### DIFF
--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2331,6 +2331,9 @@ export default async function getBaseWebpackConfig(
   webpack5Config.module!.parser = {
     javascript: {
       url: 'relative',
+      // Rspack defaults missing imported exports to errors, unlike webpack.
+      // Preserve compatibility for imports removed by tree shaking.
+      ...(isRspack ? { importExportsPresence: 'warn' } : undefined),
     },
   }
   webpack5Config.module!.generator = {

--- a/packages/next/src/server/dev/middleware-webpack.ts
+++ b/packages/next/src/server/dev/middleware-webpack.ts
@@ -69,6 +69,18 @@ function getModuleById(
   id: string | undefined,
   compilation: webpack.Compilation
 ) {
+  // Rspack reuses its native Compilation allocation between rebuilds, so a
+  // Stats object retained from the previous build aliases the build in
+  // progress. Reading its module graph while Rspack has stolen the graph
+  // artifact aborts the process instead of throwing a JavaScript error. A
+  // failed compilation can likewise have no code generation results to read.
+  if (
+    process.env.NEXT_RSPACK &&
+    (compilation.compiler.watching?.running || compilation.errors.length > 0)
+  ) {
+    return undefined
+  }
+
   const { chunkGraph, modules } = compilation
 
   return [...modules].find((module) => chunkGraph.getModuleId(module) === id)

--- a/packages/next/src/server/lib/dedupe-fetch.ts
+++ b/packages/next/src/server/lib/dedupe-fetch.ts
@@ -5,6 +5,11 @@ import * as React from 'react'
 import { cloneResponse } from './clone-response'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
+// Keep this lookup dynamic. Rspack validates namespace-member exports before
+// tree shaking, so a React 18 Pages Router edge bundle that only re-exports
+// another `next/cache` API would otherwise fail on this unused React 19 API.
+const ReactCache = Reflect.get(React, 'cache') as typeof React.cache
+
 const simpleCacheKey = '["GET",[],null,"follow",null,null,null,null]' // generateCacheKey(new Request('https://blank'));
 
 // Headers that should not affect deduplication
@@ -42,7 +47,7 @@ type CacheEntry = [
 ]
 
 export function createDedupeFetch(originalFetch: typeof fetch) {
-  const getCacheEntries = React.cache(
+  const getCacheEntries = ReactCache(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars -- url is the cache key
     (url: string): CacheEntry[] => []
   )

--- a/packages/next/src/server/lib/dedupe-fetch.ts
+++ b/packages/next/src/server/lib/dedupe-fetch.ts
@@ -5,11 +5,6 @@ import * as React from 'react'
 import { cloneResponse } from './clone-response'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
-// Keep this lookup dynamic. Rspack validates namespace-member exports before
-// tree shaking, so a React 18 Pages Router edge bundle that only re-exports
-// another `next/cache` API would otherwise fail on this unused React 19 API.
-const ReactCache = Reflect.get(React, 'cache') as typeof React.cache
-
 const simpleCacheKey = '["GET",[],null,"follow",null,null,null,null]' // generateCacheKey(new Request('https://blank'));
 
 // Headers that should not affect deduplication
@@ -47,7 +42,7 @@ type CacheEntry = [
 ]
 
 export function createDedupeFetch(originalFetch: typeof fetch) {
-  const getCacheEntries = ReactCache(
+  const getCacheEntries = React.cache(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars -- url is the cache key
     (url: string): CacheEntry[] => []
   )

--- a/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
+++ b/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
@@ -64,6 +64,14 @@ describe('server-navigation-error', () => {
       `)
     })
 
+    it('keeps the dev server running after mapping middleware errors', async () => {
+      const browser = await next.browser('/middleware/redirect')
+      // Reloading asks the overlay to map the error while Rspack is rebuilding.
+      await browser.refresh()
+
+      expect((await next.fetch('/')).status).toBe(200)
+    })
+
     it('should error on navigation API not-found', async () => {
       const browser = await next.browser('/middleware/not-found')
 


### PR DESCRIPTION
### What?

Stabilize the Next.js–Rspack integration in the two shared failure paths recurring across the `v16.4.0-canary.11` through `.22` release runs:

- avoid reading Rspack compilation artifacts while a dev rebuild is running or after compilation has failed;
- allow React 18 Pages Router edge builds to tree-shake unused React 19-only cache code without Rspack rejecting the export first;
- cover the dev-server liveness behavior after middleware error frames are mapped.

### Why?

A cross-check of all 27 workflow attempts found 58 native Rspack panics—54 stolen `BuildModuleGraphArtifact`, two stolen `ModuleIdsArtifact`, and two missing code-generation entries. These were distinct from the npm package-availability failures and the connection-refused/uninitialized-instance errors that followed a compiler crash.

The dev panics happen because Rspack reuses its native compilation allocation during rebuilds. Next.js retains the previous `Stats.compilation` for source mapping, so an overlay or browser-log request can otherwise read an artifact currently owned by a compilation pass. Failed compilations can similarly expose no code-generation result. In both cases an unavailable source map should degrade to an unmapped frame, not terminate the dev server.

Separately, every release attempt contained the same React 18 production failure: `next/cache` pulls in `dedupe-fetch` for a Pages Router edge build, and Rspack validates the unused `React.cache` member before tree shaking. Keeping that lookup dynamic matches webpack's successful handling of the same supported React 18 build.

### How?

The source-map lookup now checks Rspack's watcher/compilation state before traversing the module graph. This keeps webpack behavior unchanged and prevents request-time code from racing Rspack's compilation lifecycle.

Rspack's parser configuration now treats missing imported exports as warnings, matching webpack's behavior while preserving Rspack's stricter handling for re-export conflicts. Shared runtime code remains unchanged, so webpack and Turbopack are unaffected.

The regression exercises real middleware error-overlay mapping and then verifies the dev server remains responsive. With the guard removed, the retained test deterministically panics on the stolen build-module-graph artifact.

### Verification

- `NEXT_TEST_REACT_VERSION=18.3.1 __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true NEXT_RSPACK=1 NEXT_TEST_USE_RSPACK=1 pnpm test-start-rspack test/e2e/app-dir/app-static/app-static-custom-handler.test.ts`
- `NEXT_TEST_REACT_VERSION=18.3.1 __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true TURBOPACK_DEV=1 NEXT_RSPACK=1 NEXT_TEST_USE_RSPACK=1 pnpm test-dev-rspack test/development/app-dir/server-navigation-error/server-navigation-error.test.ts`
- `NEXT_TEST_REACT_VERSION=18.3.1 __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true TURBOPACK_DEV=1 NEXT_RSPACK=1 NEXT_TEST_USE_RSPACK=1 pnpm test-dev-rspack test/development/acceptance-app/rsc-build-errors.test.ts test/development/pages-dir/client-navigation/rendering.test.ts`
- `NEXT_TEST_REACT_VERSION=18.3.1 __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true pnpm test-dev-webpack test/development/app-dir/server-navigation-error/server-navigation-error.test.ts`
- `pnpm --filter=next types`
- Prettier, ESLint, and `git diff --check`

Fixes #98213

<!-- NEXT_JS_LLM -->


<!-- fleet 23624db1-1ce6-4a34-abbd-c89a32592e4a -->