### PR TITLE
test: stabilize OpenTelemetry collector lifecycle

### DIFF
--- a/test/e2e/opentelemetry/instrumentation/collector.ts
+++ b/test/e2e/opentelemetry/instrumentation/collector.ts
@@ -3,6 +3,7 @@ import { SavedSpan } from './constants'
 
 export interface Collector {
   getSpans: () => SavedSpan[]
+  reset: () => void
   shutdown: () => Promise<void>
 }
 
@@ -56,6 +57,9 @@ export async function connectCollector({
   return {
     getSpans() {
       return spans
+    },
+    reset() {
+      spans.length = 0
     },
     shutdown() {
       return new Promise<void>((resolve, reject) =>

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -16,24 +16,39 @@ const ROUTE_PREPARATION_COLLECTOR_PORT = 9002
 const INSTRUMENTATION_STARTUP_COLLECTOR_PORT = 9003
 const APP_ROUTE_MODULE_LOADING_COLLECTOR_PORT = 9004
 
-function setup({ useDirectEntrypointHandler, useNodeMiddleware }) {
-  let collector: Collector
+type NextInstance = ReturnType<typeof nextTestSetup>['next']
 
-  function getCollector(): Collector {
+function setupCollector(next: NextInstance, port: number) {
+  let collector: Collector | undefined
+
+  // The app's span exporter remains active for the entire suite. Keep its
+  // endpoint available for the same lifetime and only reset collected state.
+  beforeAll(async () => {
+    collector = await connectCollector({ port })
+    await next.start()
+  })
+
+  beforeEach(() => {
+    collector?.reset()
+  })
+
+  afterAll(async () => {
+    await collector?.shutdown()
+  })
+
+  return function getCollector(): Collector {
+    if (!collector) {
+      throw new Error('OpenTelemetry collector is not connected')
+    }
     return collector
   }
+}
 
-  beforeEach(async () => {
-    collector = await connectCollector({ port: COLLECTOR_PORT })
-  })
-
-  afterEach(async () => {
-    await collector.shutdown()
-  })
-
-  let next = nextTestSetup({
+function setup({ useDirectEntrypointHandler, useNodeMiddleware }) {
+  const testSetup = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
+    skipStart: true,
     dependencies: require('./package.json').dependencies,
     ...(!useDirectEntrypointHandler
       ? {
@@ -65,7 +80,14 @@ function setup({ useDirectEntrypointHandler, useNodeMiddleware }) {
         }
       : undefined,
   })
-  return { next, getCollector }
+  return {
+    next: testSetup,
+    getCollector: testSetup.skipped
+      ? () => {
+          throw new Error('OpenTelemetry test setup was skipped')
+        }
+      : setupCollector(testSetup.next, COLLECTOR_PORT),
+  }
 }
 
 describe.each(
@@ -88,6 +110,32 @@ describe.each(
   if (skipped) {
     return
   }
+
+  let connectedCollector: Collector
+
+  async function expectAppRouteTrace(pathname: string) {
+    expect((await next.fetch(pathname)).status).toBe(200)
+    await expectTrace(getCollector(), [
+      {
+        name: 'GET /api/app/[param]/data',
+        attributes: {
+          'http.target': pathname,
+          'next.span_type': 'BaseServer.handleRequest',
+        },
+      },
+    ])
+  }
+
+  it('collects a trace before the per-test reset', async () => {
+    connectedCollector = getCollector()
+    await expectAppRouteTrace('/api/app/param/data')
+  })
+
+  it('keeps the collector connected across per-test resets', async () => {
+    expect(getCollector()).toBe(connectedCollector)
+    expect(getCollector().getSpans()).toEqual([])
+    await expectAppRouteTrace('/api/app/param/data')
+  })
 
   // Edge runtime is currently not implemented in custom-entrypoint-server.ts
   const itEdge = useDirectEntrypointHandler ? it.skip : it
@@ -1945,6 +1993,7 @@ describe.each(
     const { next, skipped } = nextTestSetup({
       files: __dirname,
       skipDeployment: true,
+      skipStart: true,
       dependencies: require('./package.json').dependencies,
       env: {
         TEST_OTEL_COLLECTOR_PORT: String(COLLECTOR_PORT),
@@ -1957,16 +2006,7 @@ describe.each(
       return
     }
 
-    let collector: Collector | undefined
-
-    beforeEach(async () => {
-      collector = await connectCollector({ port: COLLECTOR_PORT })
-    })
-
-    afterEach(async () => {
-      await collector?.shutdown()
-      collector = undefined
-    })
+    const getCollector = setupCollector(next, COLLECTOR_PORT)
 
     // Regression for https://github.com/vercel/otel/issues/107.
     it('all spans (including verbose) inherit traceId from incoming traceparent header', async () => {
@@ -1979,7 +2019,7 @@ describe.each(
 
       let spans: SavedSpan[] = []
       await retry(async () => {
-        const all = collector?.getSpans() ?? []
+        const all = getCollector().getSpans()
         const root = all.find(
           (s) =>
             s.attributes?.['next.span_type'] === 'BaseServer.handleRequest' &&
@@ -2012,6 +2052,7 @@ describe('opentelemetry with disabled fetch tracing', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
+    skipStart: true,
     dependencies: require('./package.json').dependencies,
     env: {
       NEXT_OTEL_FETCH_DISABLED: '1',
@@ -2023,20 +2064,7 @@ describe('opentelemetry with disabled fetch tracing', () => {
     return
   }
 
-  let collector: Collector
-
-  function getCollector(): Collector {
-    return collector
-  }
-
-  beforeEach(async () => {
-    collector = await connectCollector({ port: COLLECTOR_PORT })
-  })
-
-  afterEach(async () => {
-    await collector.shutdown()
-    await new Promise((r) => setTimeout(r, 1000))
-  })
+  const getCollector = setupCollector(next, COLLECTOR_PORT)
   ;(process.env.__NEXT_CACHE_COMPONENTS ? describe.skip : describe)(
     'root context',
     () => {
@@ -2094,6 +2122,7 @@ describe('opentelemetry with custom server', () => {
   const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
+    skipStart: true,
     dependencies: require('./package.json').dependencies,
     startCommand: 'pnpm start',
     packageJson: {
@@ -2113,19 +2142,7 @@ describe('opentelemetry with custom server', () => {
     return
   }
 
-  let collector: Collector
-
-  function getCollector(): Collector {
-    return collector
-  }
-
-  beforeEach(async () => {
-    collector = await connectCollector({ port: COLLECTOR_PORT })
-  })
-
-  afterEach(async () => {
-    await collector.shutdown()
-  })
+  const getCollector = setupCollector(next, COLLECTOR_PORT)
 
   it('should set attributes correctly on handleRequest span', async () => {
     await next.fetch('/app/param/rsc-fetch')
@@ -2272,6 +2289,7 @@ if (isNextStart) {
     const { next, skipped } = nextTestSetup({
       files: __dirname,
       skipDeployment: true,
+      skipStart: true,
       dependencies: require('./package.json').dependencies,
       startCommand: 'pnpm start-entrypoint',
       packageJson: {
@@ -2291,19 +2309,7 @@ if (isNextStart) {
       return
     }
 
-    let collector: Collector
-
-    function getCollector(): Collector {
-      return collector
-    }
-
-    beforeEach(async () => {
-      collector = await connectCollector({ port: COLLECTOR_PORT })
-    })
-
-    afterEach(async () => {
-      await collector.shutdown()
-    })
+    const getCollector = setupCollector(next, COLLECTOR_PORT)
 
     const directEntrypointCases = [
       { pathname: '/app/param/rsc-fetch', route: '/app/[param]/rsc-fetch' },
@@ -2327,7 +2333,7 @@ if (isNextStart) {
 
           await retry(
             async () => {
-              const spans = collector.getSpans()
+              const spans = getCollector().getSpans()
               const handleRequestSpan = spans.find((span) => {
                 if (
                   span.attributes?.['next.span_type'] !==


### PR DESCRIPTION
## What?

Stabilize the OpenTelemetry instrumentation e2e suite by keeping its local span collector available for each application's full lifetime. Reset collected span state between tests without closing the collector, and cover continuity across a test boundary.

## Why?

The suite kept Next.js and custom-server exporters alive across tests while closing and rebinding their collector port after every test. Exports during that gap failed with closed/reset/refused socket errors before trace assertions timed out or observed incomplete trees. Aligning the collector lifetime with the exporter removes that race instead of masking it with retries, longer timeouts, or weaker assertions.

## How?

- Start the collector before starting each managed application.
- Keep the listener bound until application teardown, while clearing only buffered spans in `beforeEach`.
- Replace per-test collector reconnects across the affected suites and remove the disabled-fetch suite's fixed teardown delay.
- Assert that one collector remains connected, resets its state, and receives a fresh trace across sequential tests.

## Verification

- Webpack dev / React 18.3.1: 5 consecutive focused runs, 54 tests passed per run
- Webpack start / React 18.3.1: 5 consecutive focused runs, 97 passed and 13 existing skips per run
- `pnpm test-types`
- Prettier and ESLint on the changed files

<!-- NEXT_JS_LLM -->

<!-- fleet c7f6c6e4-56b2-4648-bc2d-88b2f256bb7a -->