### PR TITLE
fix: normalize line endings to CRLF when submitting `Form` with a string action

### DIFF
--- a/packages/next/src/client/form-shared.tsx
+++ b/packages/next/src/client/form-shared.tsx
@@ -80,12 +80,25 @@ export function createFormSubmitDestinationUrl(
   const formData = new FormData(formElement)
 
   for (let [name, value] of formData) {
+    // Native form submissions normalize line endings in entry names and values
+    // to CRLF before URL-encoding them. The `FormData` API does not do this,
+    // so we have to match it ourselves:
+    //
+    //  "Let name be entry's name, with every occurrence of U+000D (CR) not
+    //   followed by U+000A (LF), and every occurrence of U+000A (LF) not
+    //   preceded by U+000D (CR), replaced by a string consisting of U+000D
+    //   (CR) and U+000A (LF)."
+    //   https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#converting-an-entry-list-to-a-list-of-name-value-pairs
+    //
+    name = normalizeFormEntryNewlines(name)
+
     if (typeof value !== 'string') {
       // For file inputs, the native browser behavior is to use the filename as the value instead:
       //
       //   "If entry's value is a File object, then let value be entry's value's name. Otherwise, let value be entry's value."
       //   https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#converting-an-entry-list-to-a-list-of-name-value-pairs
       //
+      // (note that the File's name is used as-is, without newline normalization)
       if (process.env.NODE_ENV === 'development') {
         console.warn(
           `<Form> only supports file inputs if \`action\` is a function. File inputs cannot be used if \`action\` is a string, ` +
@@ -93,11 +106,23 @@ export function createFormSubmitDestinationUrl(
         )
       }
       value = value.name
+    } else {
+      // "Replace every occurrence of U+000D (CR) not followed by U+000A (LF),
+      //  and every occurrence of U+000A (LF) not preceded by U+000D (CR), in
+      //  value, by a string consisting of U+000D (CR) and U+000A (LF)."
+      value = normalizeFormEntryNewlines(value)
     }
 
     targetUrl.searchParams.append(name, value)
   }
   return targetUrl
+}
+
+function normalizeFormEntryNewlines(value: string): string {
+  // `CR LF` pairs are left as-is, while lone `CR`s and `LF`s are replaced with
+  // `CR LF`. (Matching `CR LF` first prevents the `LF` of a `CR LF` pair from
+  // being replaced on its own.)
+  return value.replace(/\r\n|\r|\n/g, '\r\n')
 }
 
 export function checkFormActionUrl(

--- a/test/e2e/next-form/default/app/forms/textarea/hydration-marker.tsx
+++ b/test/e2e/next-form/default/app/forms/textarea/hydration-marker.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import * as React from 'react'
+
+// Lets the test wait until the page has been hydrated, so that submitting
+// `#next-form` is guaranteed to go through `<Form>`'s submit handler (instead
+// of the browser's default form submission).
+export default function HydrationMarker() {
+  const [hydrated, setHydrated] = React.useState(false)
+  React.useEffect(() => setHydrated(true), [])
+  return hydrated ? <span id="hydrated">true</span> : null
+}

--- a/test/e2e/next-form/default/app/forms/textarea/page.tsx
+++ b/test/e2e/next-form/default/app/forms/textarea/page.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import Form from 'next/form'
+import HydrationMarker from './hydration-marker'
+
+export default function Page() {
+  return (
+    <>
+      <HydrationMarker />
+      <Form action="/search" id="next-form">
+        <textarea name="query" defaultValue={'line1\nline2'} />
+        <button type="submit">Submit</button>
+      </Form>
+      <form action="/search" id="native-form">
+        <textarea name="query" defaultValue={'line1\nline2'} />
+        <button type="submit">Submit</button>
+      </form>
+    </>
+  )
+}

--- a/test/e2e/next-form/default/pages/pages-dir/forms/textarea/index.tsx
+++ b/test/e2e/next-form/default/pages/pages-dir/forms/textarea/index.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+import Form from 'next/form'
+
+function HydrationMarker() {
+  // Lets the test wait until the page has been hydrated, so that submitting
+  // `#next-form` is guaranteed to go through `<Form>`'s submit handler
+  // (instead of the browser's default form submission).
+  const [hydrated, setHydrated] = React.useState(false)
+  React.useEffect(() => setHydrated(true), [])
+  return hydrated ? <span id="hydrated">true</span> : null
+}
+
+export default function Page() {
+  return (
+    <>
+      <HydrationMarker />
+      <Form action="/pages-dir/search" id="next-form">
+        <textarea name="query" defaultValue={'line1\nline2'} />
+        <button type="submit">Submit</button>
+      </Form>
+      <form action="/pages-dir/search" id="native-form">
+        <textarea name="query" defaultValue={'line1\nline2'} />
+        <button type="submit">Submit</button>
+      </form>
+    </>
+  )
+}

--- a/test/e2e/next-form/default/shared-tests.util.ts
+++ b/test/e2e/next-form/default/shared-tests.util.ts
@@ -285,6 +285,40 @@ export function runSharedTests(type: 'app' | 'pages') {
         ['file', 'hello.txt'],
       ])
     })
+
+    it('normalizes line endings in textarea values to CRLF, matching native form submissions', async () => {
+      // First, establish what a native form submits for a textarea whose value
+      // contains newlines: the browser's form submission algorithm normalizes
+      // line endings to CRLF before URL-encoding the value.
+      let session = await next.browser(pathPrefix + '/forms/textarea')
+      await session.elementByCss('#native-form [type="submit"]').click()
+
+      const nativeResult = await session
+        .waitForElementByCss('#search-results')
+        .text()
+      expect(nativeResult).toBe('query: "line1\\r\\nline2"')
+
+      // Then, verify that <Form> submits the same value. (Without the
+      // newline normalization, the hydrated <Form> would submit LF instead.)
+      session = await next.browser(pathPrefix + '/forms/textarea')
+      const navigationTracker = await trackMpaNavs(session)
+
+      // Wait for hydration so the submission is handled by <Form>'s submit
+      // handler, rather than the browser's default submit behavior.
+      await session.waitForElementByCss('#hydrated')
+
+      await session.elementByCss('#next-form [type="submit"]').click()
+
+      const nextFormResult = await session
+        .waitForElementByCss('#search-results')
+        .text()
+      expect(nextFormResult).toBe(nativeResult)
+
+      expect(await navigationTracker.didMpaNavigate()).toBe(false)
+
+      const url = new URL(await session.url())
+      expect(url.searchParams.get('query')).toBe('line1\r\nline2')
+    })
   })
 
   async function trackMpaNavs(session: Playwright) {


### PR DESCRIPTION
### What?

`<Form>` with a string `action` did not normalize line endings to CRLF when building the submission URL. After hydration, submitting a `<textarea>` with a value of `line1\nline2` produced `?query=line1%0Aline2`, where a native form would submit `?query=line1%0D%0Aline2`. The server-side `searchParams` therefore differed depending on whether the form was submitted before or after hydration, and also differed from an equivalent native `<form>` on the same page.

### Why?

Native HTML form submissions normalize line endings in entry names and values to CRLF before URL-encoding them, per the spec's algorithm for [converting an entry list to a list of name-value pairs](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#converting-an-entry-list-to-a-list-of-name-value-pairs):

> Let name be entry's name, with every occurrence of U+000D (CR) not followed by U+000A (LF), and every occurrence of U+000A (LF) not preceded by U+000D (CR), replaced by a string consisting of U+000D (CR) and U+000A (LF).

The docs for `<Form>` describe string actions as behaving like native GET forms, and the implementation already matches other parts of that same spec algorithm (using the file name for `File` entries, replacing the action URL's query string). However, the `FormData` API that `createFormSubmitDestinationUrl` uses to read the form entries does not perform this normalization, so it has to be applied manually.

Fixes #98405

### How?

- `createFormSubmitDestinationUrl` (shared by the App Router and Pages Router implementations of `<Form>`) now passes entry names and string values through a `normalizeFormEntryNewlines` helper that replaces lone `CR`s and `LF`s with `CRLF`, leaving `CR LF` pairs as-is. `File` names are still used as-is, matching the spec.
- Added an e2e test with fixtures for both routers. The fixture page contains a native `<form>` and a `<Form>` with the same multi-line `<textarea>`; the test first submits the native form to establish the expected (browser-normalized) value, then submits `<Form>` after waiting for hydration, and asserts that the server receives identical CRLF-normalized values via both paths.

### Bug fix checklist

- [x] Related issues linked using `fixes #number`
- [x] Tests added (e2e, dev + production, webpack + Turbopack)
- [ ] Errors have a helpful link attached (N/A: no new error messages)

<!-- NEXT_JS_LLM -->
