### PR TITLE
test: evaluate lazy force gates before deployment

### DIFF
--- a/test/e2e/app-dir/force-gate-deploy-build/app/layout.tsx
+++ b/test/e2e/app-dir/force-gate-deploy-build/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/force-gate-deploy-build/app/page.tsx
+++ b/test/e2e/app-dir/force-gate-deploy-build/app/page.tsx
@@ -1,0 +1,5 @@
+export const revalidate = 1
+
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/force-gate-deploy-build/force-gate-deploy-build.test.ts
+++ b/test/e2e/app-dir/force-gate-deploy-build/force-gate-deploy-build.test.ts
@@ -1,0 +1,15 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// Route-segment revalidate is incompatible with Cache Components.
+// The gate must prevent the build, not just skip the assertion afterward.
+// @force-gate !cacheComponents
+describe('force-gate-deploy-build', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('renders a page with route-segment revalidation', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+  })
+})

--- a/test/e2e/app-dir/force-gate-deploy-build/next.config.ts
+++ b/test/e2e/app-dir/force-gate-deploy-build/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {}
+
+export default nextConfig

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -18,6 +18,7 @@ import {
   hasLazyForceGate,
   findLazyForceSkip,
   ungatedHook,
+  type Gate,
 } from '../gate/runtime'
 
 export type { NextInstance }
@@ -268,7 +269,8 @@ const setupTracing = () => {
  * `nextTestSetup` directly instead of `createNext`.
  */
 async function createNext(
-  opts: NextInstanceOpts & { skipStart?: boolean; patchFileDelay?: number }
+  opts: NextInstanceOpts & { skipStart?: boolean; patchFileDelay?: number },
+  describeGates: Gate[] = []
 ): Promise<NextInstance> {
   try {
     if (nextInstance) {
@@ -312,7 +314,25 @@ async function createNext(
         clearFixture()
       })
 
-      await nextInstance.setup(rootSpan)
+      if (
+        nextInstance instanceof NextDeployInstance &&
+        hasLazyForceGate(describeGates)
+      ) {
+        const instance = nextInstance
+        await instance.setup(rootSpan, async () => {
+          // Deploy builds during setup, even with skipStart. Resolve the
+          // prepared fixture's config before attempting that remote build.
+          const config = await instance.getResolvedConfig()
+          const forceSkip = findLazyForceSkip(describeGates, config)
+          if (!forceSkip) return false
+          require('console').warn(
+            `  ⚠ suite deployment skipped by \`@force-gate ${forceSkip.source}\``
+          )
+          return true
+        })
+      } else {
+        await nextInstance.setup(rootSpan)
+      }
 
       // Lazy `// @gate` conditions read this fixture's resolved next.config.
       // Registering the instance (not a snapshot) before `start()` keeps
@@ -374,10 +394,10 @@ export function nextTestSetup(
   // gates the *build*, not just the test bodies: some fixtures can't build
   // under the condition at all. Snapshot the describe's gates now, while the
   // describe body is still being collected — the stack is empty by `beforeAll`.
-  // Suites that manage their own build (`skipStart`) are left untouched.
+  // Local suites that manage their own build (`skipStart`) are left untouched.
   const describeGates = getActiveDescribeGates()
-  // Deploy's "build" is a remote deployment we can't gate this way, and suites
-  // that pass `skipStart` build manually — leave both to their own handling.
+  // Deploy checks its gates inside setup, before the remote build. Local
+  // suites that pass `skipStart` still manage their own build.
   const buildForceGated =
     !options.skipStart && !isNextDeploy && hasLazyForceGate(describeGates)
 
@@ -388,7 +408,7 @@ export function nextTestSetup(
     beforeAll(
       ungatedHook(async () => {
         if (!buildForceGated) {
-          next = await createNext(options)
+          next = await createNext(options, describeGates)
           return
         }
         // Try to decide the force-gate against the *source* fixture first,

--- a/test/lib/gate/README.md
+++ b/test/lib/gate/README.md
@@ -73,8 +73,16 @@ output, the fixture can't build under the condition.
 
 Both forms work on `it`, `test`, `fit`, `describe`, and their `.only` variants.
 A gate on a `describe` applies to every test inside it. Several pragmas may stack
-on one call. (Build-skipping applies only to suites where `nextTestSetup` owns
-the build — not `skipStart` suites — and to `start`/`dev`, not deploy.)
+on one call. In `start`/`dev`, build-skipping applies only to suites where
+`nextTestSetup` owns the build, not local `skipStart` suites. In deploy mode,
+the gate is checked after preparing the fixture files but before deployment,
+including for `skipStart` suites (deployment happens during setup).
+
+Deploy gates use the prepared fixture's locally resolved production config,
+including configuration overrides and the fixture environment. This uses the
+same local approximation as other lazy deploy gates; configuration depending
+on remote-only state cannot be reproduced locally. If config resolution fails,
+the suite fails: an unknown gate condition is never treated as an exclusion.
 
 ## Conditions
 

--- a/test/lib/gate/runtime.ts
+++ b/test/lib/gate/runtime.ts
@@ -86,6 +86,10 @@ const gatedBodies = new WeakSet<Function>()
  */
 const ungatedHooks = new WeakSet<Function>()
 
+// User afterAll hooks may run after nextTestSetup has destroyed the fixture.
+// Retain a skipped describe's decision so those hooks stay skipped as well.
+const forceSkippedGates = new WeakSet<Gate>()
+
 /**
  * Marks a hook callback as harness-internal so `wrapHookGlobals` leaves it
  * alone. Suite code never needs this.
@@ -321,6 +325,7 @@ function wrapGatedHook(
 ): () => Promise<unknown> {
   return async function gatedHook(this: unknown): Promise<unknown> {
     if (!hasFixture()) {
+      if (gates.some((gate) => forceSkippedGates.has(gate))) return
       // The condition cannot be resolved here: either this hook runs before
       // `nextTestSetup`'s own `beforeAll` registered the fixture, or it is an
       // `afterAll` running after the fixture was cleared. Run as if ungated.
@@ -486,7 +491,9 @@ function createGatedTest(
       // a lazy `@force-gate`) visible while its body is collected so nested
       // tests inherit them and `nextTestSetup` can gate the build.
       return testFn(name, function (this: unknown, ...args: unknown[]) {
-        describeGateStack.push(...runtimeGates)
+        // Each concrete describe (including each row of describe.each) owns
+        // its skip decision; it must not leak to another fixture's hooks.
+        describeGateStack.push(...runtimeGates.map((gate) => ({ ...gate })))
         try {
           return callback.apply(this, args)
         } finally {
@@ -536,12 +543,12 @@ export function findLazyForceSkip(
   config: ResolvedNextConfig
 ): GatePragma | null {
   for (const gate of gates) {
-    if (
-      gate.force &&
-      gate.needsResolvedConfig &&
-      !evaluate(gate.node, (name) => readCondition(name, config))
-    ) {
-      return gate
+    if (gate.force && gate.needsResolvedConfig) {
+      if (!evaluate(gate.node, (name) => readCondition(name, config))) {
+        forceSkippedGates.add(gate)
+        return gate
+      }
+      forceSkippedGates.delete(gate)
     }
   }
   return null

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -20,6 +20,7 @@ export class NextDeployInstance extends NextInstance {
   private _supportsImmutableAssets: boolean = false
   private _writtenHostsLine: string | null = null
   private _restoreDnsLookup: (() => void) | null = null
+  private deploymentSkipped = false
 
   constructor(opts: NextInstanceOpts) {
     super(opts)
@@ -252,9 +253,19 @@ export class NextDeployInstance extends NextInstance {
     return output
   }
 
-  public async setup(parentSpan: Span) {
+  public async setup(
+    parentSpan: Span,
+    shouldSkipDeployment?: () => Promise<boolean>
+  ) {
     super.setup(parentSpan)
     await super.createTestDir({ parentSpan, skipInstall: true })
+
+    // The fixture now includes nextConfig, overrideFiles, and PatchedFileRef
+    // changes. A lazy suite gate can be decided before any deployment work.
+    if (shouldSkipDeployment && (await shouldSkipDeployment())) {
+      this.deploymentSkipped = true
+      return
+    }
 
     await this.writeMirrorNpmrcIfNecessary()
 
@@ -929,7 +940,7 @@ export class NextDeployInstance extends NextInstance {
     // Run custom cleanup script if provided
     const customCleanupScriptPath =
       process.env.NEXT_TEST_CLEANUP_SCRIPT_PATH?.trim()
-    if (customCleanupScriptPath) {
+    if (customCleanupScriptPath && !this.deploymentSkipped) {
       await this.cleanupUsingCustomScript().catch((err) => {
         require('console').error(
           'Error running custom cleanup script, continuing with destroy:',

--- a/test/unit/gate-deploy/fixtures/next.config.js
+++ b/test/unit/gate-deploy/fixtures/next.config.js
@@ -1,0 +1,1 @@
+module.exports = { cacheComponents: false }

--- a/test/unit/gate-deploy/gate-deploy.test.ts
+++ b/test/unit/gate-deploy/gate-deploy.test.ts
@@ -1,0 +1,259 @@
+import execa from 'execa'
+import fs from 'fs-extra'
+import path from 'path'
+import { _test_gate, installGate } from '../../lib/gate/runtime'
+import { hasFixture } from '../../lib/gate/state'
+
+// Exercise real deploy setup and config resolution, but never contact a
+// deployment provider or run any user-supplied deployment/cleanup script.
+jest.mock('execa', () => jest.fn())
+
+const originalMode = process.env.NEXT_TEST_MODE
+process.env.NEXT_TEST_MODE = 'deploy'
+const {
+  nextTestSetup,
+  FileRef,
+  PatchedFileRef,
+}: typeof import('../../lib/e2e-utils') = require('../../lib/e2e-utils')
+if (originalMode === undefined) delete process.env.NEXT_TEST_MODE
+else process.env.NEXT_TEST_MODE = originalMode
+
+const fixture = path.join(__dirname, 'fixtures')
+type SetupOptions = Parameters<typeof nextTestSetup>[0]
+type Hook = () => Promise<unknown>
+const hookNames = ['beforeAll', 'beforeEach', 'afterEach', 'afterAll'] as const
+
+/** Collect the real harness hooks and gate wrappers without nesting Jest tests. */
+function collectSuite(
+  options: SetupOptions,
+  gatedDescribe = _test_gate(
+    [{ force: true, source: '!deploy || !cacheComponents' }],
+    'describe'
+  )
+) {
+  const hooks = Object.fromEntries(
+    hookNames.map((name) => [name, []])
+  ) as Record<(typeof hookNames)[number], Hook[]>
+  const bodies: Hook[] = []
+  const userHooks = Object.fromEntries(
+    hookNames.map((name) => [name, jest.fn()])
+  ) as Record<(typeof hookNames)[number], jest.Mock>
+  const body = jest.fn()
+  let next: ReturnType<typeof nextTestSetup>['next']
+  const originals = {
+    describe: global.describe,
+    it: global.it,
+    test: global.test,
+    ...Object.fromEntries(hookNames.map((name) => [name, global[name]])),
+  }
+  Object.assign(global, {
+    describe: (_name: string, callback: () => void) => callback(),
+    it: (_name: string, callback: Hook) => bodies.push(callback),
+    test: (_name: string, callback: Hook) => bodies.push(callback),
+    ...Object.fromEntries(
+      hookNames.map((name) => [
+        name,
+        (callback: Hook) => hooks[name].push(callback),
+      ])
+    ),
+  })
+  try {
+    installGate()
+    gatedDescribe('fixture', () => {
+      next = nextTestSetup(options).next
+      for (const name of hookNames) global[name](userHooks[name])
+      it('body', body)
+    })
+  } finally {
+    Object.assign(global, originals)
+  }
+  return {
+    hooks,
+    userHooks,
+    body,
+    bodies,
+    get next() {
+      return next!
+    },
+  }
+}
+
+async function runSuite(suite: ReturnType<typeof collectSuite>) {
+  try {
+    for (const hook of suite.hooks.beforeAll) await hook()
+    for (const body of suite.bodies) {
+      for (const hook of suite.hooks.beforeEach) await hook()
+      await body()
+      for (const hook of suite.hooks.afterEach) await hook()
+    }
+  } finally {
+    for (const hook of suite.hooks.afterAll) await hook()
+  }
+}
+
+describe('lazy deployment force-gates', () => {
+  let resolveConfig: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.replaceProperty(process, 'env', {
+      ...process.env,
+      NEXT_TEST_MODE: 'deploy',
+      NEXT_TEST_DEPLOY_URL: '',
+      NEXT_TEST_DEPLOY_SCRIPT_PATH: 'mock-deploy',
+      NEXT_TEST_DEPLOY_LOGS_SCRIPT_PATH: 'mock-logs',
+      NEXT_TEST_CLEANUP_SCRIPT_PATH: '',
+      NEXT_TEST_PROXY_ADDRESS: '',
+      NEXT_TEST_SKIP_CLEANUP: '',
+      __NEXT_CACHE_COMPONENTS: '',
+      __NEXT_EXPERIMENTAL_CACHED_NAVIGATIONS: '',
+    })
+    jest.spyOn(require('console'), 'log').mockImplementation(() => {})
+    jest.spyOn(require('console'), 'warn').mockImplementation(() => {})
+    jest.spyOn(require('console'), 'error').mockImplementation(() => {})
+    const { NextInstance } = require('../../lib/next-modes/base')
+    resolveConfig = jest.spyOn(NextInstance.prototype, 'getResolvedConfig')
+    jest.mocked(execa).mockImplementation((command) => {
+      if (command === 'mock-deploy') {
+        return Promise.resolve({
+          exitCode: 0,
+          stdout: 'https://fixture.test',
+          stderr: '',
+        }) as unknown as ReturnType<typeof execa>
+      }
+      if (command === 'mock-logs') {
+        return Promise.resolve({
+          exitCode: 0,
+          stdout:
+            'BUILD_ID: build\nDEPLOYMENT_ID: deployment\nNEXT_SUPPORTS_IMMUTABLE_ASSETS: 0\n',
+          stderr: '',
+        }) as unknown as ReturnType<typeof execa>
+      }
+      throw new Error(`Unexpected subprocess: ${command}`)
+    })
+  })
+
+  afterEach(() => {
+    try {
+      if (hasFixture()) throw new Error('Suite leaked its registered fixture')
+    } finally {
+      jest.restoreAllMocks()
+      jest.mocked(execa).mockReset()
+    }
+  })
+
+  it.each([false, true])(
+    'skips deployment and all user hooks with skipStart=%s',
+    async (skipStart) => {
+      process.env.NEXT_TEST_CLEANUP_SCRIPT_PATH =
+        'must-not-clean-up-a-deployment'
+      const suite = collectSuite({
+        files: fixture,
+        overrideFiles: {
+          'next.config.js': new PatchedFileRef(
+            path.join(fixture, 'next.config.js'),
+            (content) => content.replace('false', 'true')
+          ),
+        },
+        skipStart,
+      })
+      await runSuite(suite)
+      expect(execa).not.toHaveBeenCalled()
+      expect(suite.body).not.toHaveBeenCalled()
+      for (const hook of Object.values(suite.userHooks)) {
+        expect(hook).not.toHaveBeenCalled()
+      }
+      expect(await fs.pathExists(suite.next.testDir)).toBe(false)
+      expect(require('console').warn).toHaveBeenCalledWith(
+        expect.stringContaining('suite deployment skipped')
+      )
+    }
+  )
+
+  it('uses nextConfig and the fixture environment before deployment', async () => {
+    const suite = collectSuite({
+      files: {},
+      nextConfig: {},
+      env: { __NEXT_CACHE_COMPONENTS: 'true' },
+    })
+    await runSuite(suite)
+    expect(execa).not.toHaveBeenCalled()
+    expect(suite.body).not.toHaveBeenCalled()
+  })
+
+  it('honors an explicit config override of the Cache Components shard', async () => {
+    process.env.__NEXT_CACHE_COMPONENTS = 'true'
+    const suite = collectSuite({ files: new FileRef(fixture) })
+    await runSuite(suite)
+    expect(execa).toHaveBeenCalledWith('mock-deploy', [], expect.any(Object))
+    expect(suite.body).toHaveBeenCalledTimes(1)
+    for (const hook of Object.values(suite.userHooks)) {
+      expect(hook).toHaveBeenCalledTimes(1)
+    }
+  })
+
+  it('skips a deployment that would fail when the lazy force-gate excludes it', async () => {
+    jest
+      .mocked(execa)
+      .mockRejectedValueOnce(
+        new Error('fixture build failed before lazy force-gate evaluation')
+      )
+    const suite = collectSuite({
+      files: {},
+      nextConfig: { cacheComponents: true },
+    })
+
+    await runSuite(suite)
+
+    expect(execa).not.toHaveBeenCalled()
+    expect(suite.body).not.toHaveBeenCalled()
+  })
+
+  it('does not suppress a deployment failure when the gate allows it', async () => {
+    jest.mocked(execa).mockRejectedValueOnce(new Error('fixture build failed'))
+    const suite = collectSuite({ files: fixture })
+    await expect(runSuite(suite)).rejects.toThrow('fixture build failed')
+    expect(execa).toHaveBeenCalledTimes(1)
+    expect(suite.body).not.toHaveBeenCalled()
+  })
+
+  it('fails when configuration cannot be resolved', async () => {
+    const suite = collectSuite({
+      files: fixture,
+      overrideFiles: { 'next.config.js': 'throw new Error("broken config")' },
+    })
+    await expect(runSuite(suite)).rejects.toThrow('broken config')
+    expect(execa).not.toHaveBeenCalled()
+    expect(require('console').warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('suite deployment skipped')
+    )
+  })
+
+  it('does not resolve config for suites without a lazy force-gate', async () => {
+    const suite = collectSuite({ files: fixture }, _test_gate([], 'describe'))
+    await runSuite(suite)
+    expect(resolveConfig).not.toHaveBeenCalled()
+    expect(suite.body).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps skip decisions scoped to each describe using the same gate', async () => {
+    const gatedDescribe = _test_gate(
+      [{ force: true, source: '!deploy || !cacheComponents' }],
+      'describe'
+    )
+    const excluded = collectSuite(
+      { files: {}, nextConfig: { cacheComponents: true } },
+      gatedDescribe
+    )
+    const sibling = collectSuite({ files: fixture }, gatedDescribe)
+    await runSuite(excluded)
+    await runSuite(sibling)
+    expect(excluded.body).not.toHaveBeenCalled()
+    for (const hook of Object.values(excluded.userHooks)) {
+      expect(hook).not.toHaveBeenCalled()
+    }
+    expect(sibling.body).toHaveBeenCalledTimes(1)
+    for (const hook of Object.values(sibling.userHooks)) {
+      expect(hook).toHaveBeenCalledTimes(1)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Evaluate lazy suite force-gates after preparing the deployment fixture, before attempting its remote build. This also covers `skipStart` suites, whose deployment still happens during setup. The decision uses the existing resolved-config conditions, including fixture configuration overrides, without introducing another Cache Components flag.

Keep excluded suites' user hooks skipped through teardown, scope that decision to each concrete describe, and clean up local files without invoking deployment cleanup for a deployment that never ran. Config-resolution errors and allowed deployment failures remain failures.

## Concrete reproduction

The first commit adds a [normal e2e test with a literal pragma](https://github.com/vercel/next.js/blob/60e78a19c3d3ef6ca2cbb2c4a3c438d4fa631312/test/e2e/app-dir/force-gate-deploy-build/force-gate-deploy-build.test.ts):

```ts
// @force-gate !cacheComponents
describe('force-gate-deploy-build', () => {
  const { next } = nextTestSetup({ files: __dirname })

  it('renders a page with route-segment revalidation', async () => {
    const $ = await next.render$('/')
    expect($('p').text()).toBe('hello world')
  })
})
```

Its page exports `revalidate = 1`, which is incompatible with Cache Components. Before the fix, deploy setup attempts to build the fixture before evaluating the excluding gate, so the suite fails with:

```text
Route segment config "revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.
```

After the fix, the same test reports `suite deployment skipped by @force-gate !cacheComponents`, without starting the deployment build. Without Cache Components, the page builds and the render assertion passes.

## Test-first commits

1. [Test-only reproduction](https://github.com/vercel/next.js/commit/60e78a19c3d3ef6ca2cbb2c4a3c438d4fa631312) adds the literal-pragma e2e fixture and nine lower-level deployment regression cases directly on the canary base, without the implementation. The e2e reproduction and six of the nine lower-level cases fail before the fix.
2. The implementation commit makes those same tests pass without changing their files. The implementation itself is unchanged from the previous version of this PR.

This remains the base for the deploy-test migration stack, starting with #98155. Existing deploy exclusions are unchanged; enabling those suites is a separate pass.

## Verification

- The e2e render assertion passes in production/webpack mode without Cache Components.
- In deploy mode on axis A, the literal-pragma e2e suite fails before the fix with the real compiler error above. For local verification, a custom deployment script runs a real local `next build`; it cannot deploy or return a deployment URL.
- With the fix, the identical e2e suite is gated successfully and the local build script is never invoked.
- All nine lower-level deployment regression cases pass with the fix, as do the other 77 focused gate tests. Those lower-level tests mock deployment and cleanup subprocesses while using real fixture preparation and config resolution.
- `pnpm typescript --skipLibCheck`, Prettier, and ESLint pass.
- No real deployments were attempted.

<!-- NEXT_JS_LLM -->
