### PR TITLE
Failing test

### DIFF
--- a/test/e2e/app-dir/cache-components/app/server-action-uncontrolled-form/data.ts
+++ b/test/e2e/app-dir/cache-components/app/server-action-uncontrolled-form/data.ts
@@ -1,0 +1,12 @@
+import { io } from 'next/cache'
+
+const post = { title: 'Post 1 v1' }
+
+export async function getPost() {
+  await io()
+  return post
+}
+
+export function updatePost(title: string) {
+  post.title = title
+}

--- a/test/e2e/app-dir/cache-components/app/server-action-uncontrolled-form/edit/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/server-action-uncontrolled-form/edit/page.tsx
@@ -1,0 +1,33 @@
+import { refresh } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { Suspense } from 'react'
+import { getPost, updatePost } from '../data'
+
+export default function Page() {
+  return (
+    <Suspense fallback="Loading...">
+      <EditPost />
+    </Suspense>
+  )
+}
+
+async function EditPost() {
+  const post = await getPost()
+
+  async function savePost(formData: FormData) {
+    'use server'
+
+    updatePost(String(formData.get('title')))
+    refresh()
+    redirect('/server-action-uncontrolled-form')
+  }
+
+  return (
+    <form action={savePost}>
+      <input data-testid="title-input" name="title" defaultValue={post.title} />
+      <button data-testid="save-post" type="submit">
+        Save
+      </button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/cache-components/app/server-action-uncontrolled-form/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/server-action-uncontrolled-form/page.tsx
@@ -1,0 +1,40 @@
+import { refresh } from 'next/cache'
+import Link from 'next/link'
+import { Suspense } from 'react'
+import { getPost, updatePost } from './data'
+
+export default function Page() {
+  return (
+    <Suspense fallback="Loading...">
+      <Post />
+    </Suspense>
+  )
+}
+
+async function Post() {
+  const post = await getPost()
+
+  async function savePost(formData: FormData) {
+    'use server'
+
+    updatePost(String(formData.get('title')))
+    refresh()
+  }
+
+  return (
+    <>
+      <h1 data-testid="post-title">{post.title}</h1>
+      <Link href="/server-action-uncontrolled-form/edit">Edit post</Link>
+      <form action={savePost}>
+        <input
+          data-testid="inline-title-input"
+          name="title"
+          defaultValue={post.title}
+        />
+        <button data-testid="save-inline-post" type="submit">
+          Save
+        </button>
+      </form>
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components/cache-components.server-action.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.server-action.test.ts
@@ -44,4 +44,69 @@ describe('cache-components', () => {
       expect($('#page').text()).toBe('at buildtime')
     }
   })
+
+  it('uses fresh server data for an uncontrolled input without an action redirect', async () => {
+    const browser = await next.browser('/server-action-uncontrolled-form')
+    const initialTitle = await browser
+      .elementByCss('[data-testid="post-title"]')
+      .text()
+
+    expect(
+      await browser
+        .elementByCss('[data-testid="inline-title-input"]')
+        .getValue()
+    ).toBe(initialTitle)
+    await browser
+      .locator('[data-testid="inline-title-input"]')
+      .fill('Post 1 inline')
+    await browser.locator('[data-testid="save-inline-post"]').click()
+
+    await retry(async () => {
+      expect(new URL(await browser.url()).pathname).toBe(
+        '/server-action-uncontrolled-form'
+      )
+      expect(
+        await browser.elementByCss('[data-testid="post-title"]').text()
+      ).toBe('Post 1 inline')
+      const input = browser.locator('[data-testid="inline-title-input"]')
+      expect(await input.getAttribute('value')).toBe('Post 1 inline')
+      expect(await input.inputValue()).toBe('Post 1 inline')
+    })
+  })
+
+  it('uses fresh server data for an uncontrolled input after an action redirect', async () => {
+    const browser = await next.browser('/server-action-uncontrolled-form')
+
+    await browser
+      .locator('a[href="/server-action-uncontrolled-form/edit"]')
+      .click()
+
+    expect(
+      await browser.elementByCss('[data-testid="title-input"]').getValue()
+    ).not.toBe('Post 1 v2')
+    await browser.locator('[data-testid="title-input"]').fill('Post 1 v2')
+    await browser.locator('[data-testid="save-post"]').click()
+
+    await retry(async () => {
+      expect(new URL(await browser.url()).pathname).toBe(
+        '/server-action-uncontrolled-form'
+      )
+      expect(
+        await browser.elementByCss('[data-testid="post-title"]').text()
+      ).toBe('Post 1 v2')
+    })
+
+    await browser
+      .locator('a[href="/server-action-uncontrolled-form/edit"]')
+      .click()
+
+    await retry(async () => {
+      expect(new URL(await browser.url()).pathname).toBe(
+        '/server-action-uncontrolled-form/edit'
+      )
+      expect(
+        await browser.elementByCss('[data-testid="title-input"]').getValue()
+      ).toBe('Post 1 v2')
+    })
+  })
 })


### PR DESCRIPTION
Adds a failing test for an uncontrolled input showing stale state after a server action + redirect.

The first test passes, showing an uncontrolled input on the same page correctly reflects new data after a refresh().