### PR TITLE
[turbopack] Prototype standalone manifest chunks

### DIFF
--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -10,11 +10,11 @@ use turbo_tasks_hash::HashAlgorithm;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
-        AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkLoadRetry, ChunkType,
-        ChunkableModule, ChunkingConfig, ChunkingConfigs, ChunkingContext, ContentHashing,
-        CrossOrigin, EntryChunkGroupResult, EvaluatableAsset, EvaluatableAssets,
-        HmrChunkListSource, MinifyType, SourceMapSourceType, SourceMapsType, UnusedReferences,
-        UrlBehavior, WorkerConfigurationOptions,
+        AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkItemOrBatchWithAsyncModuleInfo,
+        ChunkItemWithAsyncModuleInfo, ChunkLoadRetry, ChunkType, ChunkableModule, ChunkingConfig,
+        ChunkingConfigs, ChunkingContext, ContentHashing, CrossOrigin, EntryChunkGroupResult,
+        EvaluatableAsset, EvaluatableAssets, HmrChunkListSource, MinifyType, SourceMapSourceType,
+        SourceMapsType, UnusedReferences, UrlBehavior, WorkerConfigurationOptions,
         availability_info::AvailabilityInfo,
         chunk_group::{MakeChunkGroupResult, make_chunk_group},
         chunk_id_strategy::ModuleIdStrategy,
@@ -1245,6 +1245,37 @@ impl ChunkingContext for BrowserChunkingContext {
             let module = AsyncLoaderModule::new(module, *chunking_context, availability_info);
             module.as_chunk_item(module_graph, *chunking_context)
         })
+    }
+
+    #[turbo_tasks::function]
+    async fn standalone_chunk_item(
+        self: Vc<Self>,
+        chunk_item: Vc<Box<dyn ChunkItem>>,
+    ) -> Result<Vc<Box<dyn OutputAsset>>> {
+        let chunk_item = chunk_item.to_resolved().await?;
+        let chunk_type = chunk_item
+            .into_trait_ref()
+            .await?
+            .ty()
+            .to_resolved()
+            .await?;
+        let chunk = chunk_type
+            .chunk(
+                Vc::upcast(self),
+                vec![ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(
+                    ChunkItemWithAsyncModuleInfo {
+                        chunk_item,
+                        chunk_type,
+                        module: None,
+                        async_info: None,
+                    },
+                )],
+                Vec::new(),
+                Vec::new(),
+            )
+            .to_resolved()
+            .await?;
+        Ok(*self.generate_chunk(chunk).await?)
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -478,6 +478,14 @@ pub trait ChunkingContext {
     fn async_loader_chunk_item_ident(&self, module: Vc<Box<dyn ChunkableModule>>)
     -> Vc<AssetIdent>;
 
+    /// Places a synthesized chunk item into a standalone output chunk without module graph
+    /// traversal.
+    #[turbo_tasks::function]
+    fn standalone_chunk_item(
+        self: Vc<Self>,
+        chunk_item: Vc<Box<dyn ChunkItem>>,
+    ) -> Vc<Box<dyn OutputAsset>>;
+
     #[turbo_tasks::function]
     fn chunk_group(
         self: Vc<Self>,

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -799,22 +799,6 @@ impl ModuleGraph {
         Ok(ReadRef::cell(graph))
     }
 
-    /// A graph containing nothing but `entry` and what it references, as an async chunk group
-    /// entry. Used to place modules that are synthesized during chunking and therefore are not
-    /// members of the graph they were synthesized from.
-    #[turbo_tasks::function]
-    pub fn isolated_async_entry(entry: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
-        Self::from_graphs(
-            vec![SingleModuleGraph::new_with_entry(
-                ChunkGroupEntry::Async(entry),
-                false,
-                false,
-            )],
-            None,
-        )
-        .connect()
-    }
-
     #[turbo_tasks::function(operation, root)]
     async fn from_graphs_inner(
         graphs: Vec<OperationVc<SingleModuleGraph>>,

--- a/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/manifest/chunk_asset.rs
@@ -95,14 +95,18 @@ impl ManifestAsyncModule {
                 .cell());
             }
         }
-        // The manifest module is synthesized while chunking, so it is not a member of
-        // `this.module_graph` and has to be placed in a graph of its own.
-        Ok(this.chunking_context.chunk_group_assets(
-            self.ident(),
-            ChunkGroup::Async(ResolvedVc::upcast(self)),
-            ModuleGraph::isolated_async_entry(*ResolvedVc::upcast(self)),
-            this.availability_info,
-        ))
+        let chunk_item = self.as_chunk_item(*this.module_graph, *this.chunking_context);
+        let chunk = this
+            .chunking_context
+            .standalone_chunk_item(chunk_item)
+            .to_resolved()
+            .await?;
+        Ok(OutputAssetsWithReferenced {
+            assets: ResolvedVc::cell(vec![chunk]),
+            referenced_assets: ResolvedVc::cell(vec![]),
+            references: ResolvedVc::cell(vec![]),
+        }
+        .cell())
     }
 
     /// Without a chunk list of its own, modules that are only reachable through this dynamic

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -9,10 +9,11 @@ use turbo_tasks_hash::HashAlgorithm;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
-        AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkType, ChunkableModule,
-        ChunkingConfig, ChunkingConfigs, ChunkingContext, ContentHashing, EntryChunkGroupResult,
-        EvaluatableAsset, MinifyType, SourceMapSourceType, SourceMapsType, UnusedReferences,
-        UrlBehavior, WorkerConfigurationOptions,
+        AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkItemOrBatchWithAsyncModuleInfo,
+        ChunkItemWithAsyncModuleInfo, ChunkType, ChunkableModule, ChunkingConfig, ChunkingConfigs,
+        ChunkingContext, ContentHashing, EntryChunkGroupResult, EvaluatableAsset, MinifyType,
+        SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
+        WorkerConfigurationOptions,
         availability_info::AvailabilityInfo,
         chunk_group::{MakeChunkGroupResult, make_chunk_group},
         chunk_id_strategy::ModuleIdStrategy,
@@ -737,6 +738,37 @@ impl ChunkingContext for NodeJsChunkingContext {
             let module = AsyncLoaderModule::new(module, *chunking_context, availability_info);
             module.as_chunk_item(module_graph, *chunking_context)
         })
+    }
+
+    #[turbo_tasks::function]
+    async fn standalone_chunk_item(
+        self: Vc<Self>,
+        chunk_item: Vc<Box<dyn ChunkItem>>,
+    ) -> Result<Vc<Box<dyn OutputAsset>>> {
+        let chunk_item = chunk_item.to_resolved().await?;
+        let chunk_type = chunk_item
+            .into_trait_ref()
+            .await?
+            .ty()
+            .to_resolved()
+            .await?;
+        let chunk = chunk_type
+            .chunk(
+                Vc::upcast(self),
+                vec![ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(
+                    ChunkItemWithAsyncModuleInfo {
+                        chunk_item,
+                        chunk_type,
+                        module: None,
+                        async_info: None,
+                    },
+                )],
+                Vec::new(),
+                Vec::new(),
+            )
+            .to_resolved()
+            .await?;
+        Ok(*self.generate_chunk(chunk).await?)
     }
 
     #[turbo_tasks::function]


### PR DESCRIPTION
## Summary

Prototype direct placement of the synthesized manifest chunk item instead of constructing an isolated one-entry module graph and running normal chunk-group traversal. This is intended to show one interpretation of synthesizing the manifest during chunking, similar to regular async loaders.

The new `standalone_chunk_item` operation creates a one-item chunk directly in the browser and Node.js chunking contexts.

## Verification

- `cargo check -p turbopack-browser -p turbopack-nodejs -p turbopack-ecmascript`
- Not run: lazy dynamic imports integration suite (prototype has not been rebuilt through the Next.js native binding)

<!-- NEXT_JS_LLM -->