### PR TITLE
Enable React browser bailout by default

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -2290,7 +2290,7 @@ export const defaultConfig = Object.freeze({
     clientParamParsingOrigins: undefined,
     cachedNavigations: false,
     dynamicOnHover: false,
-    reactBrowserBailout: false,
+    reactBrowserBailout: true,
     useOffline: false,
     varyParams: true,
     optimisticRouting: true,


### PR DESCRIPTION
Enable React browser bailouts by default without requiring applications to opt in.
