### PR TITLE
Add a fast-path to 'get_relative_path_to' for a potential common case when 'from' is empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10321,6 +10321,7 @@ name = "turbo-unix-path"
 version = "0.0.1"
 dependencies = [
  "rstest",
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -351,13 +351,17 @@ pub async fn resolve_babel_plugin_react_compiler(
         return Ok(None);
     };
 
-    Ok(Some(
-        // the relative path should only ever fail to resolve when the `fs` is different, which
-        // should only happen due to eventual consistency.
-        project_path
-            .get_relative_path_to(&source.ident().await?.path.parent())
-            .context("failed to resolve relative path for react compiler plugin")?,
-    ))
+    // The relative path should only ever fail to resolve when the `fs` is different, which should
+    // only happen due to eventual consistency.
+    let plugin_path = project_path
+        .get_relative_path_to(&source.ident().await?.path.parent())
+        .context("failed to resolve relative path for react compiler plugin")?;
+
+    Ok(Some(if plugin_path.starts_with("../") {
+        plugin_path
+    } else {
+        RcStr::from(format!("./{plugin_path}"))
+    }))
 }
 
 #[turbo_tasks::value]

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2582,14 +2582,10 @@ async fn project_trace_source_operation(
         if let Some(source_file) = original_file.strip_prefix(&project_root_uri) {
             // Client code uses file://
             (
-                RcStr::from(
-                    get_relative_path_to(
-                        &current_directory_path,
-                        &decode_uri_fragment(&original_file)?,
-                    )
-                    // TODO(sokra) remove this to include a ./ here to make it a relative path
-                    .trim_start_matches("./"),
-                ),
+                RcStr::from(get_relative_path_to(
+                    &current_directory_path,
+                    &decode_uri_fragment(&original_file)?,
+                )),
                 Some(decode_uri_fragment(source_file)?),
             )
         } else if let Some(source_file) = original_file.strip_prefix(&*SOURCE_MAP_PREFIX_PROJECT) {
@@ -2597,14 +2593,10 @@ async fn project_trace_source_operation(
             // TODO should this also be file://?
             let source_file = decode_uri_fragment(source_file)?;
             (
-                RcStr::from(
-                    get_relative_path_to(
-                        &current_directory_path,
-                        &format!("{}{}", decode_uri_fragment(&project_root_uri)?, source_file),
-                    )
-                    // TODO(sokra) remove this to include a ./ here to make it a relative path
-                    .trim_start_matches("./"),
-                ),
+                RcStr::from(get_relative_path_to(
+                    &current_directory_path,
+                    &format!("{}{}", decode_uri_fragment(&project_root_uri)?, source_file),
+                )),
                 Some(source_file),
             )
         } else if let Some(source_file) = original_file.strip_prefix(&*SOURCE_MAP_PREFIX) {

--- a/crates/next-taskless/src/lib.rs
+++ b/crates/next-taskless/src/lib.rs
@@ -114,17 +114,14 @@ fn expand_next_js_template_inner<'a>(
 
         let relative = get_relative_path_to(&next_package_dir_parent_path, &imported_path);
 
-        if !relative.starts_with("./next/") {
+        if !relative.starts_with("next/") {
             bail!(
-                "Invariant: Expected relative import to start with \"./next/\", found \
-                 {relative:?}. Path computed from {next_package_dir_parent_path:?} to \
-                 {imported_path:?}.",
+                "Invariant: Expected relative import to start with \"next/\", found {relative:?}. \
+                 Path computed from {next_package_dir_parent_path:?} to {imported_path:?}.",
             )
         }
 
-        let relative = relative
-            .strip_prefix("./")
-            .context("should be able to strip the prefix")?;
+        let relative = relative.as_ref();
 
         Ok(if caps.get(1).is_some() {
             format!("from {}", serde_json::to_string(relative).unwrap())

--- a/test/production/next-server-nft/next-server-nft.test.ts
+++ b/test/production/next-server-nft/next-server-nft.test.ts
@@ -444,8 +444,8 @@ async function readNormalizedNFT(next, name) {
 
         expect(nonNodeModulesFiles).toMatchInlineSnapshot(`
                 [
-                  "./page/react-loadable-manifest.json",
-                  "./page_client-reference-manifest.js",
+                  "page/react-loadable-manifest.json",
+                  "page_client-reference-manifest.js",
                 ]
               `)
       })
@@ -564,8 +564,8 @@ async function readNormalizedNFT(next, name) {
 
         expect(nonNodeModulesFiles).toMatchInlineSnapshot(`
          [
-           "./page/react-loadable-manifest.json",
-           "./page_client-reference-manifest.js",
+           "page/react-loadable-manifest.json",
+           "page_client-reference-manifest.js",
          ]
         `)
       })

--- a/turbopack/crates/turbo-tasks-fs/src/path.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/path.rs
@@ -1,6 +1,6 @@
 //! [`FileSystemPath`] and the path-resolution operations built on top of it.
 
-use std::{error::Error, fmt, path::MAIN_SEPARATOR};
+use std::{borrow::Cow, error::Error, fmt, path::MAIN_SEPARATOR};
 
 use anyhow::{Result, bail};
 use auto_hash_map::{AutoMap, AutoSet};
@@ -104,7 +104,11 @@ impl FileSystemPath {
             return None;
         }
 
-        Some(get_relative_path_to(&self.path, &other.path).into())
+        Some(match get_relative_path_to(&self.path, &other.path) {
+            Cow::Borrowed(path) if std::ptr::eq(path, other.path.as_str()) => other.path.clone(),
+            Cow::Borrowed(path) => path.into(),
+            Cow::Owned(path) => path.into(),
+        })
     }
 
     /// Returns the final component of the FileSystemPath, or an empty string
@@ -763,22 +767,6 @@ mod tests {
 
     use super::*;
     use crate::VirtualFileSystem;
-
-    #[test]
-    fn test_get_relative_path_to() {
-        assert_eq!(get_relative_path_to("a/b/c", "a/b/c").as_str(), ".");
-        assert_eq!(get_relative_path_to("a/c/d", "a/b/c").as_str(), "../../b/c");
-        assert_eq!(get_relative_path_to("", "a/b/c").as_str(), "./a/b/c");
-        assert_eq!(get_relative_path_to("a/b/c", "").as_str(), "../../..");
-        assert_eq!(
-            get_relative_path_to("a/b/c", "c/b/a").as_str(),
-            "../../../c/b/a"
-        );
-        assert_eq!(
-            get_relative_path_to("file:///a/b/c", "file:///c/b/a").as_str(),
-            "../../../c/b/a"
-        );
-    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn with_extension() {

--- a/turbopack/crates/turbo-unix-path/Cargo.toml
+++ b/turbopack/crates/turbo-unix-path/Cargo.toml
@@ -12,6 +12,7 @@ bench = false
 workspace = true
 
 [dependencies]
+smallvec = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/turbopack/crates/turbo-unix-path/src/lib.rs
+++ b/turbopack/crates/turbo-unix-path/src/lib.rs
@@ -2,6 +2,8 @@
 
 use std::borrow::Cow;
 
+use smallvec::SmallVec;
+
 /// Converts system paths into Unix paths. This is a noop on Unix systems, and replaces backslash
 /// directory separators with forward slashes on Windows.
 #[inline]
@@ -62,7 +64,7 @@ pub fn join_path(fs_path: &str, join: &str) -> Option<String> {
 ///
 /// Returns None if the path would need to start with ".." to be equal.
 pub fn normalize_path(str: &str) -> Option<String> {
-    let mut segments = Vec::new();
+    let mut segments = SmallVec::<[&str; 8]>::new();
     for segment in str.split('/') {
         match segment {
             "." | "" => {}
@@ -83,7 +85,8 @@ pub fn normalize_path(str: &str) -> Option<String> {
 /// A request might only start with a single "." segment and no ".." segments, or any positive
 /// number of ".." segments but no "." segment.
 pub fn normalize_request(str: &str) -> String {
-    let mut segments = vec!["."];
+    let mut segments = SmallVec::<[&str; 8]>::new();
+    segments.push(".");
     // Keeps track of our directory depth so that we can pop directories when encountering a "..".
     // If this is positive, then we're inside a directory and we can pop that. If it's 0, then we
     // can't pop the directory and we must keep the ".." in our segments. This is not the same as
@@ -116,11 +119,16 @@ pub fn normalize_request(str: &str) -> String {
     segments.join("/")
 }
 
-pub fn get_relative_path_to(from: &str, target: &str) -> String {
+/// Returns `"."` by reference when the paths are identical, or `target` by reference when `from`
+/// is empty.
+pub fn get_relative_path_to<'a>(from: &str, target: &'a str) -> Cow<'a, str> {
+    if from.is_empty() && !target.is_empty() {
+        return Cow::Borrowed(target);
+    }
+
     fn split(s: &str) -> impl Iterator<Item = &str> {
-        let empty = s.is_empty();
         let mut iterator = s.split('/');
-        if empty {
+        if s.is_empty() {
             iterator.next();
         }
         iterator
@@ -131,13 +139,11 @@ pub fn get_relative_path_to(from: &str, target: &str) -> String {
     while from_segments.peek() == target_segments.peek() {
         from_segments.next();
         if target_segments.next().is_none() {
-            return ".".to_string();
+            return Cow::Borrowed(".");
         }
     }
-    let mut result = Vec::new();
-    if from_segments.peek().is_none() {
-        result.push(".");
-    } else {
+    let mut result = SmallVec::<[&str; 8]>::new();
+    if from_segments.peek().is_some() {
         while from_segments.next().is_some() {
             result.push("..");
         }
@@ -145,7 +151,7 @@ pub fn get_relative_path_to(from: &str, target: &str) -> String {
     for segment in target_segments {
         result.push(segment);
     }
-    result.join("/")
+    Cow::Owned(result.join("/"))
 }
 
 pub fn get_parent_path(path: &str) -> &str {
@@ -183,5 +189,25 @@ mod tests {
     #[case("a/../../file.js")]
     fn test_normalize_path_invalid(#[case] path: &str) {
         assert_eq!(None, normalize_path(path));
+    }
+
+    #[rstest]
+    #[case("a/b/c", "a/b/c", ".", true)]
+    #[case("a/c/d", "a/b/c", "../../b/c", false)]
+    #[case("", "a/b/c", "a/b/c", true)]
+    #[case("", "", ".", true)]
+    #[case("a/b", "a/b/c", "c", false)]
+    #[case("a/b/c", "", "../../..", false)]
+    #[case("a/b/c", "c/b/a", "../../../c/b/a", false)]
+    #[case("file:///a/b/c", "file:///c/b/a", "../../../c/b/a", false)]
+    fn test_get_relative_path_to(
+        #[case] from: &str,
+        #[case] target: &str,
+        #[case] expected: &str,
+        #[case] borrowed: bool,
+    ) {
+        let relative = get_relative_path_to(from, target);
+        assert_eq!(relative, expected);
+        assert_eq!(matches!(relative, Cow::Borrowed(_)), borrowed);
     }
 }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -3149,7 +3149,14 @@ async fn resolved(
         path.parent(),
         options,
         options_value,
-        |package_path| package_path.get_relative_path_to(&path_ref),
+        |package_path| {
+            let path = package_path.get_relative_path_to(&path_ref)?;
+            Some(if path.starts_with("../") {
+                path
+            } else {
+                RcStr::from(format!("./{path}"))
+            })
+        },
         query.clone(),
         fragment.clone(),
     )

--- a/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
@@ -477,6 +477,11 @@ impl ImportMetaGlobMap {
                              matched file"
                         );
                     };
+                    let origin_relative = if origin_relative.starts_with("../") {
+                        origin_relative
+                    } else {
+                        RcStr::from(format!("./{origin_relative}"))
+                    };
 
                     // Append query string if specified (e.g., `?raw`).
                     let request_str: RcStr = if let Some(q) = query {

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -69,7 +69,7 @@ impl DirList {
     }
 
     #[turbo_tasks::function]
-    pub(crate) async fn read_internal(
+    async fn read_internal(
         root: FileSystemPath,
         dir: FileSystemPath,
         recursive: bool,
@@ -90,10 +90,12 @@ impl DirList {
         for (_, entry) in entries.iter().flat_map(|m| m.iter()) {
             match entry {
                 DirectoryEntry::File(path) => {
-                    if let Some(relative_path) = root_val.get_relative_path_to(path)
-                        && regex.is_match(&relative_path)
-                    {
-                        list.insert(relative_path, DirListEntry::File(path.clone()));
+                    if let Some(relative_path) = root_val.get_relative_path_to(path) {
+                        // Webpack always chacks the RegExp against a path prefixed with `./`
+                        let relative_path = RcStr::from(format!("./{relative_path}"));
+                        if regex.is_match(&relative_path) {
+                            list.insert(relative_path, DirListEntry::File(path.clone()));
+                        }
                     }
                 }
                 DirectoryEntry::Directory(path) if recursive => {
@@ -195,6 +197,11 @@ impl RequireContextMap {
         for (context_relative, path) in list {
             let Some(origin_relative) = origin_path.get_relative_path_to(path) else {
                 bail!("invariant error: this was already checked in `list_dir`");
+            };
+            let origin_relative = if origin_relative.starts_with("../") {
+                origin_relative
+            } else {
+                RcStr::from(format!("./{origin_relative}"))
             };
 
             let request = Request::parse(origin_relative.clone().into())

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 
 use anyhow::Result;
 use indoc::writedoc;
+use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc, turbobail};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
@@ -84,6 +85,11 @@ impl EcmascriptBuildNodeEntryChunk {
                      chunk ({runtime_path})",
                 );
             };
+        let runtime_request = if runtime_relative_path.starts_with("../") {
+            runtime_relative_path
+        } else {
+            RcStr::from(format!("./{runtime_relative_path}"))
+        };
         let chunk_public_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path
         } else {
@@ -97,7 +103,7 @@ impl EcmascriptBuildNodeEntryChunk {
             r#"
                 var R=require({})({})
             "#,
-            StringifyJs(&*runtime_relative_path),
+            StringifyJs(&*runtime_request),
             StringifyJs(chunk_public_path),
         )?;
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -723,8 +723,13 @@ async fn process_default_internal(
             .project_path
             .get_relative_path_to(&loader.loader)
             .context("Loader path must be on project filesystem")?;
+        let loader_request = if loader_relative_path.starts_with("../") {
+            loader_relative_path
+        } else {
+            RcStr::from(format!("./{loader_relative_path}"))
+        };
         let webpack_loader_item = WebpackLoaderItem {
-            loader: loader_relative_path,
+            loader: loader_request,
             options: loader.options.clone(),
         };
         let loaders_vc = WebpackLoaderItems(vec![webpack_loader_item]).cell();

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -262,7 +262,11 @@ impl RuleCondition {
                     }
                     RuleCondition::ResourcePathGlob { glob, base } => {
                         return Ok(if let Some(rel_path) = base.get_relative_path_to(path) {
-                            glob.matches(&rel_path)
+                            if rel_path.starts_with("../") {
+                                glob.matches(&rel_path)
+                            } else {
+                                glob.matches(&format!("./{rel_path}"))
+                            }
                         } else {
                             glob.matches(&path.path)
                         });


### PR DESCRIPTION
When creating an NFT file in https://github.com/vercel/next.js/pull/98003, I store a generic list of "base" paths and then construct the final path in the JSON file as relative to the base path. For most files, these paths are relative to the `*.nft.json` file, but for additional roots, this base path is always an empty string (relative to the root of the filesystem), so being able to re-use the original `RcStr` instead of constructing a brand new string may be beneficial.

This also moves the unit tests to be colocated next to the functions that are actually being tested.