### PR TITLE
fix: don't attach the client socket to the mocked response in the image optimizer

### DIFF
--- a/packages/next/src/server/lib/mock-request.test.ts
+++ b/packages/next/src/server/lib/mock-request.test.ts
@@ -1,4 +1,10 @@
-import { MockedRequest, MockedResponse } from './mock-request'
+import { Socket } from 'net'
+
+import {
+  MockedRequest,
+  MockedResponse,
+  createRequestResponseMocks,
+} from './mock-request'
 
 describe('MockedRequest', () => {
   it('should have the correct properties', () => {
@@ -83,5 +89,26 @@ describe('MockedResponse', () => {
     expect(res.getHeaders()).toEqual({
       'set-cookie': ['foo=bar2', 'bar2=foo'],
     })
+  })
+})
+
+describe('createRequestResponseMocks', () => {
+  it('should only attach the socket to the request, not the response', () => {
+    const socket = new Socket()
+    const { req, res } = createRequestResponseMocks({
+      url: '/_next/image?url=%2Ffoo.png',
+      socket,
+    })
+
+    // The request needs the socket so the router can read properties like
+    // `socket.encrypted` and `socket.remoteAddress` from it.
+    expect(req.socket).toBe(socket)
+
+    // The mocked response is a buffer rather than a wire, so it must not be
+    // tied to the client's socket. `on-finished` (used by the vendored `send`)
+    // treats a response with a non-writable socket as already finished, so a
+    // client disconnecting mid-request would otherwise prevent the internal
+    // response from ever completing and poison the response cache key.
+    expect(res.socket).toBe(null)
   })
 })

--- a/packages/next/src/server/lib/mock-request.ts
+++ b/packages/next/src/server/lib/mock-request.ts
@@ -471,6 +471,11 @@ interface RequestResponseMockerOptions {
   method?: string
   bodyReadable?: Stream.Readable
   resWriter?: (chunk: Uint8Array | Buffer | string) => boolean
+  /**
+   * The socket of the original client request, if available. It is attached to
+   * the mocked request only (the router reads `encrypted` and
+   * `remoteAddress` from it), never to the mocked response.
+   */
   socket?: Socket | null
   maximumResponseBody?: number
 }
@@ -492,6 +497,12 @@ export function createRequestResponseMocks({
       socket,
       readable: bodyReadable,
     }),
-    res: new MockedResponse({ socket, resWriter, maximumResponseBody }),
+    // The socket is only passed to the mocked request (e.g. so the router can
+    // read `encrypted` / `remoteAddress` from it). The mocked response is a
+    // buffer, not a wire, so it must not be tied to the client's socket:
+    // `on-finished` (used by `send`) treats a response with a non-writable
+    // socket as already finished, meaning a client that disconnects mid-request
+    // would cause the internal response to never complete.
+    res: new MockedResponse({ socket: null, resWriter, maximumResponseBody }),
   }
 }

--- a/test/e2e/image-optimizer/client-disconnect.test.ts
+++ b/test/e2e/image-optimizer/client-disconnect.test.ts
@@ -1,0 +1,89 @@
+import net from 'net'
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+
+/**
+ * Regression test for https://github.com/vercel/next.js/issues/98402.
+ *
+ * When a client disconnects while `/_next/image` is optimizing an image, the
+ * internal fetch of the original image used to attach the client's socket to
+ * the mocked response. `on-finished` (used by the vendored `send`) treats a
+ * response with a non-writable socket as already finished, so the internal
+ * response never completed. The `responseGenerator` passed to the response
+ * cache then never settled, permanently poisoning that cache key for every
+ * later request (they hang until the server is restarted).
+ */
+describe('Image Optimizer client disconnect', () => {
+  const { next, skipped } = nextTestSetup({
+    files: join(__dirname, 'app'),
+    skipDeployment: true,
+  })
+  if (skipped) return
+
+  // Each attempt uses a distinct cache key (width) so a poisoned entry from
+  // one attempt cannot mask the result of another. The abort delay is varied
+  // to land the disconnect inside the internal fetch window across different
+  // machine speeds.
+  const attempts = [
+    { width: 640, delay: 1 },
+    { width: 750, delay: 2 },
+    { width: 828, delay: 3 },
+    { width: 1080, delay: 4 },
+    { width: 1200, delay: 5 },
+    { width: 1920, delay: 8 },
+    { width: 2048, delay: 12 },
+    { width: 3840, delay: 20 },
+  ]
+
+  for (const { width, delay } of attempts) {
+    it(`should not hang subsequent requests after a client disconnects mid-request (w=${width})`, async () => {
+      const port = Number(new URL(next.url).port)
+      const query = `/_next/image?url=${encodeURIComponent('/mountains.jpg')}&w=${width}&q=75`
+
+      // Send the request over a raw socket and destroy the connection
+      // shortly after, before the optimization can finish. This mimics a
+      // browser cancelling an image request (viewport resize, navigation,
+      // tab close).
+      await new Promise<void>((resolve, reject) => {
+        const socket = net.createConnection({
+          host: '127.0.0.1',
+          port,
+        })
+        socket.once('connect', () => {
+          socket.write(
+            `GET ${query} HTTP/1.1\r\n` +
+              `Host: 127.0.0.1:${port}\r\n` +
+              `Accept: image/webp\r\n` +
+              `Connection: close\r\n\r\n`
+          )
+          setTimeout(() => {
+            socket.destroy()
+            resolve()
+          }, delay)
+        })
+        socket.once('error', reject)
+      })
+
+      // A follow-up request for the same cache key must complete instead of
+      // hanging forever.
+      let timeout: ReturnType<typeof setTimeout> | undefined
+      try {
+        const res = await Promise.race([
+          next.fetch(query, { headers: { accept: 'image/webp' } }),
+          new Promise<never>((_, reject) => {
+            timeout = setTimeout(() => {
+              reject(
+                new Error(
+                  'Follow-up image request did not complete. The cache key was likely poisoned by the aborted request (see #98402).'
+                )
+              )
+            }, 15_000)
+          }),
+        ])
+        expect(res.status).toBe(200)
+      } finally {
+        clearTimeout(timeout)
+      }
+    })
+  }
+})


### PR DESCRIPTION
Fixes #98402

As reproduced in #98402 (the reporter included a standalone repro): aborting a `/_next/image` request a few milliseconds in — which is exactly what a browser does when it cancels an image request on viewport resize, navigation or tab close — permanently poisons that cache key on a self-hosted server. Every later request for the same image at the same width and quality hangs forever, for every client, until the server is restarted, and nothing is logged. One visitor cancelling one request is enough to make "some images never load" for everybody.

## Root cause

When `/_next/image` optimizes a local image, `fetchInternalImage` builds an internal request/response pair through `createRequestResponseMocks` to serve the original file, and it passes the client's socket to both the mocked request and the mocked response.

The mocked response is a buffer, not a wire, so tying it to the client's socket doesn't make sense. The original file is served by the vendored `send` module, which uses `on-finished` to detect completed responses — and `on-finished` treats a response as finished when `res.finished` is true **or the response's socket is no longer writable**. So on a mid-request client disconnect, `send` believes the response is already finished, writes no body, and never calls `res.end()`.

From there it cascades: `res.hasStreamed` never settles, so the `responseGenerator` handed to `ResponseCache.get` never settles, so `Batcher.batch` never deletes the pending entry. The next request for the same key is handed the same dead promise and hangs too.

## Fix

Keep the socket on the mocked **request** only (the router reads `socket.encrypted` and `socket.remoteAddress` from it) and construct the mocked **response** without one, so the internal response always completes regardless of the client's connection state.

`fetchInternalImage` is the only caller passing a socket to `createRequestResponseMocks`, so the change is effectively scoped to the image optimizer path, and nothing else in the codebase reads `MockedResponse#socket` — the only consumers were `on-finished`/`send`, which is exactly the faulty interaction being removed.

## Tests

- `test/e2e/image-optimizer/client-disconnect.test.ts`: for a set of distinct cache keys, sends `GET /_next/image?...` over a raw TCP socket, destroys the socket a few milliseconds in (before the optimization can finish), then issues a normal request for the same key and asserts it returns 200 within a timeout instead of hanging. Confirmed it fails on current `canary` (both `next start` and `next dev`) and passes with this change in `next start`, `next dev` and Turbopack dev.
- `mock-request.test.ts`: unit coverage that the mocks factory attaches the socket to the request only and leaves `res.socket` null.

The rest of `test/e2e/image-optimizer/` passes in production mode with this change.

<!-- NEXT_JS_LLM -->
