### PR TITLE
Deflake gc_interrupt_is_self_healing

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
@@ -92,51 +92,66 @@ async fn gc_min_progress_floor_beats_a_waiting_operation() {
     tt.stop_and_wait().await;
 }
 
-/// What an interrupted pass abandons must still be collectible by a later pass.
+/// Garbage an interrupted pass abandons must still be collectible by a later pass.
 ///
-/// The two phases are sequential, not concurrent: nothing here forces a pass to overlap with an
-/// operation. Phase 1 relies only on the zero `min_progress` floor, which makes *any* waiter
-/// observed by `GcBudget::should_stop` interrupt the pass immediately, so interrupts happen
-/// readily across the rounds instead of needing a mid-range floor that might interrupt none of
-/// them and assert nothing. Because that is still scheduling-dependent, the loop asserts only
-/// that at least one round interrupted — which is the premise phase 2 needs. Phase 2 then runs a
-/// deliberately *uninterruptible* pass (`gc_for_testing`) after phase 1 is fully over, and that
-/// pass is what must recover everything the interrupted rounds abandoned.
+/// Phase 1 runs rounds at a `min_progress` floor far shorter than a pass, so a waiter observed by
+/// `GcBudget::should_stop` interrupts the pass soon after it starts. Nothing here forces a pass to
+/// overlap with an operation, so how many rounds interrupt — and how much each collects before it
+/// stops — is up to the scheduler: in practice most interrupt partway, but a fast enough machine
+/// can drain the previous generation before a pass starts and interrupt none of them. Phase 2 then
+/// runs a deliberately *uninterruptible* pass (`gc_for_testing`) once phase 1 is over.
+///
+/// The assertion is deliberately independent of that split. Whatever phase 1 collected, phase 2
+/// must collect exactly the remainder — every generation but the live one is garbage, and all of
+/// it has to be accounted for. That holds when every round interrupts, when none do, and
+/// everywhere in between, so this test cannot fail for scheduling reasons; it fails only if an
+/// interrupted pass *loses* garbage instead of leaving it for the next pass.
+///
+/// Do not add an assertion on `interrupted_rounds`. An earlier version required at least one
+/// interrupt, on the theory that phase 2 was vacuous without one. It is not: with zero interrupts
+/// phase 1 simply collects everything and phase 2 collects nothing, and the totals still have to
+/// match. That assertion bought no coverage and failed in CI on a fast runner.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_interrupt_is_self_healing() {
+    // A floor short enough that passes still interrupt readily, but long enough that each one
+    // collects something first. At a zero floor `should_stop` trips on the very first job, before
+    // any shard is scanned, so rounds routinely collect nothing and phase 2 does all the work.
+    //
+    // This is a diagnostic choice, not a correctness one: the assertion below holds for any split,
+    // so no value here can make the test pass or fail. Measured at this graph size (8 runs each):
+    // 100us leaves phase 1 collecting anywhere from tens to thousands of tasks with 8-10 of 10
+    // rounds interrupting; 50us still bottoms out at zero; 250us starts letting whole passes
+    // complete; 500us and above are longer than a pass, so nothing interrupts at all. The useful
+    // band is roughly 50-250us. It needs no retuning if machines get faster — a drifted value only
+    // makes the phase 1 / phase 2 split less interesting to read, never wrong.
     let (tt, _persistence_dir) =
-        create_tt_with_gc_min_progress("gc_interrupt_is_self_healing", Duration::ZERO);
+        create_tt_with_gc_min_progress("gc_interrupt_is_self_healing", Duration::from_micros(100));
 
     build_generation(&tt, 0).await;
 
-    // Phase 1: accumulate garbage under passes that keep interrupting.
+    // Phase 1: accumulate garbage under passes that interrupt as the scheduler allows.
     const ROUNDS: u32 = 10;
-    let mut collected_while_interrupting = 0usize;
+    let mut collected_in_phase_1 = 0usize;
     let mut interrupted_rounds = 0usize;
     for gen_value in 1..=ROUNDS {
         build_generation(&tt, gen_value).await;
         let outcome = tt.backend().snapshot_and_evict_for_testing(&tt);
         let stats = outcome.gc_stats();
+        // Reported, never asserted on: when the totals below disagree, the per-round split is the
+        // first thing worth seeing.
         println!("round {gen_value}: {stats}");
-        collected_while_interrupting += stats.collected;
+        collected_in_phase_1 += stats.collected;
         interrupted_rounds += usize::from(stats.interrupted);
     }
 
-    // The premise of phase 2: without an interrupt, nothing was abandoned to heal from.
-    assert!(
-        interrupted_rounds > 0,
-        "no pass interrupted across {ROUNDS} rounds at a zero floor: nothing was abandoned, so \
-         this test proves nothing"
-    );
-
-    // Phase 2: a completing pass must recover what was left behind.
+    // Phase 2: a completing pass must recover exactly what phase 1 left behind.
     let healed = tt.backend().gc_for_testing(&tt);
 
     let produced = (2 * WIDTH as usize) * (ROUNDS as usize);
-    let total_collected = collected_while_interrupting + healed;
+    let total_collected = collected_in_phase_1 + healed;
     println!(
-        "self-healing: collected_while_interrupting={collected_while_interrupting} \
-         healed={healed} total_collected={total_collected} produced={produced} \
+        "self-healing: collected_in_phase_1={collected_in_phase_1} healed={healed} \
+         total_collected={total_collected} produced={produced} \
          interrupted_rounds={interrupted_rounds}/{ROUNDS}"
     );
 
@@ -146,9 +161,9 @@ async fn gc_interrupt_is_self_healing() {
     // show up here as a shortfall.
     assert_eq!(
         total_collected, produced,
-        "collected {total_collected} of {produced} garbage tasks ({collected_while_interrupting} \
-         across {interrupted_rounds} interrupted rounds, {healed} in the completing pass): \
-         interrupted passes are losing garbage rather than leaving it"
+        "collected {total_collected} of {produced} garbage tasks ({collected_in_phase_1} in phase \
+         1 across {interrupted_rounds}/{ROUNDS} interrupted rounds, {healed} in the completing \
+         pass): interrupted passes are losing garbage rather than leaving it"
     );
 
     tt.stop_and_wait().await;

--- a/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/gc_interrupt.rs
@@ -93,37 +93,12 @@ async fn gc_min_progress_floor_beats_a_waiting_operation() {
 }
 
 /// Garbage an interrupted pass abandons must still be collectible by a later pass.
-///
-/// Phase 1 runs rounds at a `min_progress` floor far shorter than a pass, so a waiter observed by
-/// `GcBudget::should_stop` interrupts the pass soon after it starts. Nothing here forces a pass to
-/// overlap with an operation, so how many rounds interrupt — and how much each collects before it
-/// stops — is up to the scheduler: in practice most interrupt partway, but a fast enough machine
-/// can drain the previous generation before a pass starts and interrupt none of them. Phase 2 then
-/// runs a deliberately *uninterruptible* pass (`gc_for_testing`) once phase 1 is over.
-///
-/// The assertion is deliberately independent of that split. Whatever phase 1 collected, phase 2
-/// must collect exactly the remainder — every generation but the live one is garbage, and all of
-/// it has to be accounted for. That holds when every round interrupts, when none do, and
-/// everywhere in between, so this test cannot fail for scheduling reasons; it fails only if an
-/// interrupted pass *loses* garbage instead of leaving it for the next pass.
-///
-/// Do not add an assertion on `interrupted_rounds`. An earlier version required at least one
-/// interrupt, on the theory that phase 2 was vacuous without one. It is not: with zero interrupts
-/// phase 1 simply collects everything and phase 2 collects nothing, and the totals still have to
-/// match. That assertion bought no coverage and failed in CI on a fast runner.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gc_interrupt_is_self_healing() {
     // A floor short enough that passes still interrupt readily, but long enough that each one
     // collects something first. At a zero floor `should_stop` trips on the very first job, before
     // any shard is scanned, so rounds routinely collect nothing and phase 2 does all the work.
     //
-    // This is a diagnostic choice, not a correctness one: the assertion below holds for any split,
-    // so no value here can make the test pass or fail. Measured at this graph size (8 runs each):
-    // 100us leaves phase 1 collecting anywhere from tens to thousands of tasks with 8-10 of 10
-    // rounds interrupting; 50us still bottoms out at zero; 250us starts letting whole passes
-    // complete; 500us and above are longer than a pass, so nothing interrupts at all. The useful
-    // band is roughly 50-250us. It needs no retuning if machines get faster — a drifted value only
-    // makes the phase 1 / phase 2 split less interesting to read, never wrong.
     let (tt, _persistence_dir) =
         create_tt_with_gc_min_progress("gc_interrupt_is_self_healing", Duration::from_micros(100));
 


### PR DESCRIPTION
This test is trying to race two operations, but cannot guarantee it.

So drop the assertion on `interrupted` count.  This is very reliable locally but flaky on CI (linux scheduling is just different?).  It is still useful, trying to force races and then ensuring that we always recover