### PR TITLE
Fix duplicate background revalidation for `'use cache'`

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -350,6 +350,10 @@ const crossRequestPendingCacheInvocations = new Map<
   Promise<SharedCacheResult>
 >()
 
+// Prevent duplicate background revalidations for the same key until generation
+// and cache writes finish.
+const backgroundRevalidations = new Map<string, Promise<void>>()
+
 // The first argument at each call site is the full directive that produced
 // the invocation, e.g. "'use cache'" or "'use cache: remote'".
 const debug = process.env.NEXT_PRIVATE_DEBUG_CACHE
@@ -610,17 +614,16 @@ function serveJoinedCacheEntry(
 
 function saveToCacheHandler(
   cacheHandler: CacheReadWriteHandler,
-  workStore: WorkStore,
   id: string,
   cacheHandlerKeyBase: string,
   savedCacheResult: Promise<CollectedCacheResult>,
   rootParams: Params | undefined
-): Promise<CollectedCacheResult> {
+): Promise<void> {
   // Write the entry to the cache handler. With root params, this is a redirect
   // entry at the coarse key plus the actual entry at the specific key;
   // otherwise just the entry at the coarse key. Both set calls are fired
   // together and awaited in parallel.
-  const combinedSetPromise = savedCacheResult.then(async (collectedResult) => {
+  return savedCacheResult.then(async (collectedResult) => {
     const { entry: fullEntry, readRootParamNames } = collectedResult
 
     // Use the combined set (union of all historically observed reads) for both
@@ -644,7 +647,10 @@ function saveToCacheHandler(
         computeRootParamsCacheKeySuffix(rootParams, rootParamNames)
 
       setPromises.push(
-        cacheHandler.set(specificKey, Promise.resolve(fullEntry))
+        // Capture synchronous `set()` throws as rejected write promises.
+        new Promise<void>((resolve) => {
+          resolve(cacheHandler.set(specificKey, Promise.resolve(fullEntry)))
+        })
       )
 
       // The coarse key gets a redirect entry instead. On a cold server (empty
@@ -671,25 +677,22 @@ function saveToCacheHandler(
     }
 
     setPromises.push(
-      cacheHandler.set(cacheHandlerKeyBase, Promise.resolve(coarseEntry))
+      // Capture synchronous `set()` throws as rejected write promises.
+      new Promise<void>((resolve) => {
+        resolve(
+          cacheHandler.set(cacheHandlerKeyBase, Promise.resolve(coarseEntry))
+        )
+      })
     )
 
-    await Promise.all(setPromises)
+    // A failed write must not finish the operation while another write is
+    // pending.
+    for (const result of await Promise.allSettled(setPromises)) {
+      if (result.status === 'rejected') {
+        throw result.reason
+      }
+    }
   })
-
-  workStore.pendingRevalidateWrites ??= []
-  workStore.pendingRevalidateWrites.push(combinedSetPromise)
-
-  // A cross-request joiner reads its recomputed specific key only after it has
-  // awaited this entry's metadata, so gate the metadata on the writes landing:
-  // that guarantees the entry is present when the joiner re-reads. A failed
-  // write shouldn't reject the metadata (the joiner just misses and
-  // regenerates), so settle either way; a collection failure still propagates
-  // through `savedCacheResult`.
-  return combinedSetPromise.then(
-    () => savedCacheResult,
-    () => savedCacheResult
-  )
 }
 
 function generateCacheEntry(
@@ -3064,9 +3067,14 @@ export async function cache(
         }
 
         let entry: CacheEntry | undefined
+        let observedRevalidation: Promise<void> | undefined
 
         // We ignore existing cache entries when force revalidating.
         if (cacheHandler && !shouldForceRevalidate(workStore, workUnitStore)) {
+          // Record an existing revalidation before `get()` so a stale result
+          // does not start another revalidation. The existing revalidation may
+          // finish and remove its map entry before the lookup returns.
+          observedRevalidation = backgroundRevalidations.get(cacheHandlerKey)
           entry = await cacheHandler.get(cacheHandlerKey, implicitTags)
 
           // Check if this is a redirect entry (coarse key → specific key).
@@ -3084,6 +3092,8 @@ export async function cache(
               cacheHandlerKey =
                 cacheHandlerKeyBase +
                 computeRootParamsCacheKeySuffix(rootParams, paramNames)
+              observedRevalidation =
+                backgroundRevalidations.get(cacheHandlerKey)
               entry = await cacheHandler.get(cacheHandlerKey, implicitTags)
             }
           }
@@ -3386,13 +3396,23 @@ export async function cache(
             )
 
             if (cacheHandler) {
-              metadataSource = saveToCacheHandler(
+              const pendingWrite = saveToCacheHandler(
                 cacheHandler,
-                workStore,
                 id,
                 cacheHandlerKeyBase,
                 savedCacheResult,
                 rootParams
+              )
+              workStore.pendingRevalidateWrites ??= []
+              workStore.pendingRevalidateWrites.push(pendingWrite)
+              // Wait for cache writes before exposing metadata. Cross-request
+              // joiners may recompute their root-param-specific key from it,
+              // then read the handler again. A write failure does not reject
+              // the metadata: joiners can regenerate if no entry was stored.
+              // Collection failures still propagate through `savedCacheResult`.
+              metadataSource = pendingWrite.then(
+                () => savedCacheResult,
+                () => savedCacheResult
               )
             }
           }
@@ -3536,23 +3556,32 @@ export async function cache(
             }
           }
 
-          if (shouldTriggerBackgroundRevalidation) {
+          if (
+            shouldTriggerBackgroundRevalidation &&
+            // The revalidation observed before the lookup may have finished.
+            observedRevalidation === undefined &&
+            // A new revalidation may have started since the lookup began.
+            !backgroundRevalidations.has(cacheHandlerKey)
+          ) {
             const revalidateCacheHandlerKey = cacheHandlerKey
-            const revalidatePromise = generateCacheEntry(
-              workStore,
-              // The background revalidation preserves the outer store for
-              // reading (e.g. implicitTags) but skips propagation of cache life
-              // and tags back to the outer scope.
-              {
-                ...cacheContext,
-                skipPropagation: true,
-              },
-              clientReferenceManifest,
-              encodedCacheKeyParts,
-              fn,
-              timeoutError,
-              deadlockError
-            )
+            // Defer the call so synchronous setup errors reject the background
+            // task instead of failing the stale response. This also lets us
+            // register the task before generation starts.
+            const revalidatePromise = Promise.resolve()
+              .then(() =>
+                generateCacheEntry(
+                  workStore,
+                  // The background revalidation preserves the outer store for
+                  // reading (e.g. implicitTags) but skips propagation of cache
+                  // life and tags back to the outer scope.
+                  { ...cacheContext, skipPropagation: true },
+                  clientReferenceManifest,
+                  encodedCacheKeyParts,
+                  fn,
+                  timeoutError,
+                  deadlockError
+                )
+              )
               .then(async (result) => {
                 if (result.type === 'cached') {
                   const { stream: ignoredStream, pendingCacheResult } = result
@@ -3564,28 +3593,46 @@ export async function cache(
                     logPrefix
                   )
 
-                  if (cacheHandler) {
-                    saveToCacheHandler(
-                      cacheHandler,
-                      workStore,
-                      id,
-                      cacheHandlerKeyBase,
-                      savedCacheResult,
-                      rootParams
-                    )
-                  }
+                  const pendingWrite = cacheHandler
+                    ? saveToCacheHandler(
+                        cacheHandler,
+                        id,
+                        cacheHandlerKeyBase,
+                        savedCacheResult,
+                        rootParams
+                      )
+                    : savedCacheResult.then(() => {})
 
-                  await ignoredStream.cancel()
+                  for (const completion of await Promise.allSettled([
+                    ignoredStream.cancel(),
+                    pendingWrite,
+                  ])) {
+                    if (completion.status === 'rejected') {
+                      throw completion.reason
+                    }
+                  }
                 }
               })
-              .catch((error) => {
-                debug?.(
-                  logPrefix,
-                  'background cache revalidation failed for',
-                  revalidateCacheHandlerKey,
-                  error
-                )
+              .finally(() => {
+                if (
+                  backgroundRevalidations.get(revalidateCacheHandlerKey) ===
+                  revalidatePromise
+                ) {
+                  backgroundRevalidations.delete(revalidateCacheHandlerKey)
+                }
               })
+            backgroundRevalidations.set(
+              revalidateCacheHandlerKey,
+              revalidatePromise
+            )
+            revalidatePromise.catch((error) => {
+              debug?.(
+                logPrefix,
+                'background cache revalidation failed for',
+                revalidateCacheHandlerKey,
+                error
+              )
+            })
             workStore.pendingRevalidateWrites ??= []
             workStore.pendingRevalidateWrites.push(revalidatePromise)
           }

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-runtime/app/[lang]/[countryCode]/swr/page.tsx
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-runtime/app/[lang]/[countryCode]/swr/page.tsx
@@ -1,0 +1,43 @@
+import { cacheLife, cacheTag } from 'next/cache'
+import { lang, countryCode } from 'next/root-params'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+import { setTimeout } from 'timers/promises'
+
+type Props = { searchParams: Promise<{ key?: string | string[] }> }
+
+export default function Page(props: Props) {
+  return (
+    <Suspense fallback="Loading...">
+      <Runtime {...props} />
+    </Suspense>
+  )
+}
+
+async function Runtime({ searchParams }: Props) {
+  await connection()
+  const { key } = await searchParams
+  if (typeof key !== 'string' || !key) {
+    throw new Error('A query key is required')
+  }
+  const result = await getCachedData(key)
+  return (
+    <p>
+      <span id="lang">{result.lang}</span>
+      <span id="country-code">{result.countryCode}</span>
+      <span id="value">{result.value}</span>
+    </p>
+  )
+}
+
+async function getCachedData(key: string) {
+  'use cache: remote'
+
+  cacheLife('days')
+  const roots = { lang: await lang(), countryCode: await countryCode() }
+  cacheTag(`swr:${key}:${roots.lang}:${roots.countryCode}`)
+  console.log(`swr start ${key} ${roots.lang}/${roots.countryCode}`)
+  await setTimeout(1000)
+  console.log(`swr finish ${key} ${roots.lang}/${roots.countryCode}`)
+  return { ...roots, value: new Date().toISOString() }
+}

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-runtime/app/[lang]/[countryCode]/swr/revalidate/route.ts
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/use-cache-runtime/app/[lang]/[countryCode]/swr/revalidate/route.ts
@@ -1,0 +1,15 @@
+import { revalidateTag } from 'next/cache'
+import { NextRequest } from 'next/server'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ lang: string; countryCode: string }> }
+) {
+  const key = request.nextUrl.searchParams.get('key')
+  if (!key) {
+    return new Response('A query key is required', { status: 400 })
+  }
+  const { lang, countryCode } = await params
+  revalidateTag(`swr:${key}:${lang}:${countryCode}`, 'minutes')
+  return new Response(null, { status: 204 })
+}

--- a/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
@@ -1,10 +1,99 @@
 import { nextTestSetup } from 'e2e-utils'
+import { randomUUID } from 'crypto'
+import escapeStringRegexp from 'escape-string-regexp'
+import stripAnsi from 'strip-ansi'
 import { join } from 'path'
 import { assertNoConsoleErrors, retry, waitForNoRedbox } from 'next-test-utils'
 
 describe('app-root-param-getters - cache - at runtime', () => {
   const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'use-cache-runtime'),
+  })
+
+  async function readSWR(key: string, roots: string) {
+    const $ = await next.render$(`/${roots}/swr?key=${key}`)
+    expect(`${$('#lang').text()}/${$('#country-code').text()}`).toBe(roots)
+    const value = $('#value').text()
+    expect(value).toBeDateString()
+    return value
+  }
+
+  async function revalidateSWR(key: string, roots: string) {
+    const response = await next.fetch(`/${roots}/swr/revalidate?key=${key}`, {
+      method: 'POST',
+    })
+    expect(response.status).toBe(204)
+  }
+
+  it('should revalidate only the tagged root params', async () => {
+    const key = randomUUID()
+    const enValue = await readSWR(key, 'en/us')
+    const frValue = await readSWR(key, 'fr/ca')
+    expect(enValue).not.toBe(frValue)
+
+    await revalidateSWR(key, 'en/us')
+    // TODO: Restore this assertion on deploy when tag revalidation supports
+    // stale-while-revalidate for remote cache entries.
+    if (!isNextDeploy) {
+      expect(await readSWR(key, 'en/us')).toBe(enValue)
+    }
+    expect(await readSWR(key, 'fr/ca')).toBe(frValue)
+    await retry(async () => {
+      expect(new Date(await readSWR(key, 'en/us'))).toBeAfter(new Date(enValue))
+    })
+    expect(await readSWR(key, 'fr/ca')).toBe(frValue)
+  })
+
+  // @force-gate !deploy
+  it('should deduplicate background revalidation separately for each root pair', async () => {
+    const key = randomUUID()
+    const roots = ['en/us', 'fr/ca']
+    const values = await Promise.all(roots.map((root) => readSWR(key, root)))
+    await Promise.all(roots.map((root) => revalidateSWR(key, root)))
+    const outputIndex = next.cliOutput.length
+    const getOutput = () =>
+      stripAnsi(next.cliOutput.slice(outputIndex))
+        .split('\n')
+        .filter((line) => !line.includes(' Cache '))
+        .join('\n')
+
+    // Complete the triggering responses before more requests read the stale
+    // entries.
+    expect(await Promise.all(roots.map((root) => readSWR(key, root)))).toEqual(
+      values
+    )
+    expect(await Promise.all(roots.map((root) => readSWR(key, root)))).toEqual(
+      values
+    )
+
+    await retry(() => {
+      const output = getOutput()
+      for (const root of roots) {
+        expect(output).toIncludeRepeated(
+          escapeStringRegexp(`swr start ${key} ${root}`),
+          1
+        )
+        expect(output).toIncludeRepeated(
+          escapeStringRegexp(`swr finish ${key} ${root}`),
+          1
+        )
+      }
+    })
+    for (const [index, root] of roots.entries()) {
+      await retry(async () => {
+        expect(new Date(await readSWR(key, root))).toBeAfter(
+          new Date(values[index])
+        )
+      })
+      expect(getOutput()).toIncludeRepeated(
+        escapeStringRegexp(`swr start ${key} ${root}`),
+        1
+      )
+      expect(getOutput()).toIncludeRepeated(
+        escapeStringRegexp(`swr finish ${key} ${root}`),
+        1
+      )
+    }
   })
 
   if (isNextDev) {

--- a/test/e2e/app-dir/use-cache-route-handler-only/app/tag-revalidation/route.ts
+++ b/test/e2e/app-dir/use-cache-route-handler-only/app/tag-revalidation/route.ts
@@ -1,0 +1,34 @@
+import { cacheTag, revalidateTag } from 'next/cache'
+import { connection } from 'next/server'
+import { setTimeout } from 'timers/promises'
+
+async function getCachedDate(key: string) {
+  'use cache: remote'
+
+  cacheTag(key)
+  console.log(`tag-revalidation: generating ${key}`)
+  await setTimeout(1000)
+  console.log(`tag-revalidation: generated ${key}`)
+  return new Date().toISOString()
+}
+
+export async function GET(request: Request) {
+  await connection()
+
+  const key = new URL(request.url).searchParams.get('key')
+  if (!key) {
+    return new Response('Missing key', { status: 400 })
+  }
+
+  return Response.json(await getCachedDate(key))
+}
+
+export async function POST(request: Request) {
+  const key = new URL(request.url).searchParams.get('key')
+  if (!key) {
+    return new Response('Missing key', { status: 400 })
+  }
+
+  revalidateTag(key, 'minutes')
+  return new Response(null, { status: 204 })
+}

--- a/test/e2e/app-dir/use-cache-route-handler-only/use-cache-route-handler-only.test.ts
+++ b/test/e2e/app-dir/use-cache-route-handler-only/use-cache-route-handler-only.test.ts
@@ -1,5 +1,8 @@
+import { randomUUID } from 'crypto'
 import { nextTestSetup } from 'e2e-utils'
+import escapeStringRegexp from 'escape-string-regexp'
 import { retry } from 'next-test-utils'
+import stripAnsi from 'strip-ansi'
 
 // Explicitly don't mix route handlers with pages in this test app, to make sure
 // that this also works in isolation.
@@ -32,6 +35,67 @@ describe('use-cache-route-handler-only', () => {
       expect(first).toBe(second)
     })
   }
+
+  it('refreshes cached data after tag revalidation', async () => {
+    const path = `/tag-revalidation?key=${randomUUID()}`
+    const read = () => next.fetch(path).then((response) => response.json())
+    const initial = await read()
+    expect(initial).toBeDateString()
+    expect(await read()).toBe(initial)
+
+    expect((await next.fetch(path, { method: 'POST' })).status).toBe(204)
+    // TODO: Restore this assertion on deploy when tag revalidation supports
+    // stale-while-revalidate for remote cache entries.
+    if (!isNextDeploy) {
+      expect(await read()).toBe(initial)
+    }
+
+    await retry(async () => {
+      const fresh = await read()
+      expect(fresh).toBeDateString()
+      expect(new Date(fresh)).toBeAfter(new Date(initial))
+    })
+  })
+
+  // @force-gate !deploy
+  it('dedupes tag revalidation across requests while generation is pending', async () => {
+    const key = randomUUID()
+    const path = `/tag-revalidation?key=${key}`
+    const read = () => next.fetch(path).then((response) => response.json())
+    const initial = await read()
+    expect(initial).toBeDateString()
+    await retry(() => {
+      expect(next.cliOutput).toContain(`tag-revalidation: generated ${key}`)
+    })
+    const outputIndex = next.cliOutput.length
+    const getOutput = () =>
+      stripAnsi(next.cliOutput.slice(outputIndex))
+        .split('\n')
+        .filter((line) => !line.includes(' Cache '))
+        .join('\n')
+    const generating = `tag-revalidation: generating ${key}`
+    const generated = `tag-revalidation: generated ${key}`
+
+    expect((await next.fetch(path, { method: 'POST' })).status).toBe(204)
+    expect(await read()).toBe(initial)
+    await retry(() => {
+      expect(getOutput()).toContain(generating)
+    })
+    expect(getOutput()).not.toContain(generated)
+    expect(await read()).toBe(initial)
+
+    await retry(() => {
+      const output = getOutput()
+      expect(output).toIncludeRepeated(escapeStringRegexp(generating), 1)
+      expect(output).toIncludeRepeated(escapeStringRegexp(generated), 1)
+    })
+    await retry(async () => {
+      const fresh = await read()
+      expect(fresh).toBeDateString()
+      expect(new Date(fresh)).toBeAfter(new Date(initial))
+    })
+    expect(getOutput()).toIncludeRepeated(escapeStringRegexp(generating), 1)
+  })
 
   it('should be able to revalidate prerendered route handlers', async () => {
     const response1 = await next.fetch('/node')

--- a/test/e2e/app-dir/use-cache-swr/app/delayed-route/route.ts
+++ b/test/e2e/app-dir/use-cache-swr/app/delayed-route/route.ts
@@ -1,18 +1,26 @@
-import { cacheLife } from 'next/cache'
+import { cacheLife, cacheTag } from 'next/cache'
+import { connection } from 'next/server'
 import { setTimeout } from 'timers/promises'
 
-async function getCachedData() {
+async function getCachedData(id: string | null) {
   'use cache'
 
   cacheLife('seconds')
+  if (id !== null) {
+    cacheTag(id)
+  }
 
+  console.log('use-cache-swr: generating delayed data', id)
   await setTimeout(1000)
+  console.log('use-cache-swr: generated delayed data', id)
 
   return new Date().toISOString()
 }
 
-export async function GET() {
-  const cached = await getCachedData()
+export async function GET(request: Request) {
+  await connection()
+  const id = new URL(request.url).searchParams.get('id')
+  const cached = await getCachedData(id)
   const dynamic = new Date().toISOString()
 
   return Response.json({ cached, dynamic })

--- a/test/e2e/app-dir/use-cache-swr/handler.js
+++ b/test/e2e/app-dir/use-cache-swr/handler.js
@@ -21,12 +21,16 @@ const cacheHandler = {
   async get(cacheKey, softTags) {
     const pendingPromise = pendingSets.get(cacheKey)
     if (pendingPromise) {
+      console.log('PersistentCacheHandler::get-pending', cacheKey)
       await pendingPromise
     }
 
-    // Simulate some latency when fetching from a remote cache.
-    await setTimeout(200)
-    const entry = store.get(cacheKey)
+    // A slow backend read can return a value captured before revalidation
+    // finishes.
+    const isSlowRead = cacheKey.includes('"slow-read-')
+    const snapshot = isSlowRead ? store.get(cacheKey) : undefined
+    await setTimeout(isSlowRead ? 2000 : 200)
+    const entry = isSlowRead ? snapshot : store.get(cacheKey)
     if (!entry) {
       console.log('PersistentCacheHandler::get', cacheKey, softTags, '-> miss')
       return undefined
@@ -62,6 +66,12 @@ const cacheHandler = {
       // Consume the cloned stream to ensure the entry is fully resolved.
       const reader = clonedValue.getReader()
       while (!(await reader.read()).done) {}
+
+      if (entry.tags.some((tag) => tag.startsWith('write-completion-'))) {
+        console.log('PersistentCacheHandler::set-start', cacheKey)
+        // Simulate a slow cache backend after the entry has been collected.
+        await setTimeout(2000)
+      }
 
       store.set(cacheKey, entry)
       console.log('PersistentCacheHandler::set', cacheKey)

--- a/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
+++ b/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
@@ -1,12 +1,16 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
+import { randomUUID } from 'crypto'
+import escapeStringRegexp from 'escape-string-regexp'
+import stripAnsi from 'strip-ansi'
 
 // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
 // It likely asserts local CLI or runtime output that deploy tests do not expose.
 // @force-gate !deploy
 describe('use-cache-swr', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
+    env: { NEXT_PRIVATE_DEBUG_CACHE: '1' },
   })
 
   let outputIndex: number
@@ -14,6 +18,13 @@ describe('use-cache-swr', () => {
   beforeEach(() => {
     outputIndex = next.cliOutput.length
   })
+
+  function getOutput() {
+    return stripAnsi(next.cliOutput.slice(outputIndex))
+      .split('\n')
+      .filter((line) => !line.includes(' Cache '))
+      .join('\n')
+  }
 
   it('should serve stale data and then pre-warmed data on subsequent request', async () => {
     const browser = await next.browser('/')
@@ -178,45 +189,87 @@ describe('use-cache-swr', () => {
     expect(cliOutput).toMatch(/PersistentCacheHandler::get.*"inner".*_N_T_\//)
   })
 
-  it('should dedupe SWR regens across concurrent requests', async () => {
-    const browser = await next.browser('/')
-    await browser.elementById('outer-data').text()
+  it.each(['concurrent', 'slow-read'])(
+    'should dedupe SWR regens across %s requests',
+    async (mode) => {
+      const id = `${mode}-${randomUUID()}`
+      const pathname = `/delayed-route?id=${id}`
+      const initial = await (await next.fetch(pathname)).json()
+      expect(initial.cached).toBeDateString()
+      outputIndex = next.cliOutput.length
 
-    // Wait for the outer cache to go stale (revalidate: 5).
-    await new Promise((resolve) => setTimeout(resolve, 6000))
+      // The simulated I/O takes as long as this entry's revalidate interval.
+      // Complete one stale read before starting another to avoid sharing only the
+      // lookup.
+      expect((await (await next.fetch(pathname)).json()).cached).toBe(
+        initial.cached
+      )
+      expect((await (await next.fetch(pathname)).json()).cached).toBe(
+        initial.cached
+      )
 
-    // Reset output index to capture only the SWR-related logs.
+      await retry(() => {
+        const output = getOutput()
+        expect(output).toIncludeRepeated(
+          escapeStringRegexp(`use-cache-swr: generating delayed data ${id}`),
+          1
+        )
+        expect(output).toIncludeRepeated(
+          escapeStringRegexp(`use-cache-swr: generated delayed data ${id}`),
+          1
+        )
+      })
+
+      const fresh = await (await next.fetch(pathname)).json()
+      expect(fresh.cached).toBeDateString()
+      expect(fresh.cached).not.toBe(initial.cached)
+    }
+  )
+
+  it('should not start another regeneration for a read during a background cache write', async () => {
+    const id = `write-completion-${randomUUID()}`
+    const pathname = `/delayed-route?id=${id}`
+    const initial = await (await next.fetch(`${pathname}&request=warm`)).json()
+    expect(initial.cached).toBeDateString()
+    const writeFinished = `PersistentCacheHandler::set [^\\r\\n]*${escapeStringRegexp(id)}`
+    await retry(() => {
+      expect(getOutput()).toMatch(new RegExp(writeFinished))
+    })
     outputIndex = next.cliOutput.length
 
-    // Fire multiple concurrent requests that all find the stale entry.
-    // Only one of them should trigger a background regen.
-    await Promise.all([next.fetch('/'), next.fetch('/'), next.fetch('/')])
-
-    // Wait for the background regen to complete.
+    expect(
+      (await (await next.fetch(`${pathname}&request=trigger`)).json()).cached
+    ).toBe(initial.cached)
     await retry(() => {
-      const regenOutput = next.cliOutput.slice(outputIndex)
-      expect(regenOutput).toInclude('use-cache-swr: generating outer data')
+      expect(getOutput()).toMatch(
+        new RegExp(
+          `PersistentCacheHandler::set-start [^\\r\\n]*${escapeStringRegexp(id)}`
+        )
+      )
     })
-
-    const cliOutput = next.cliOutput.slice(outputIndex)
-
-    // The cache function should have been executed only once across all
-    // concurrent requests, not once per request.
-    const generationCalls = cliOutput.split('\n').filter(
-      (line) =>
-        line.includes('use-cache-swr: generating outer data') &&
-        // Ignore replayed logs that have a Cache badge.
-        !line.includes(' Cache ')
+    const fresh = await (
+      await next.fetch(`${pathname}&request=during-write`)
+    ).json()
+    expect(fresh.cached).toBeDateString()
+    expect(fresh.cached).not.toBe(initial.cached)
+    const completion = `pending revalidates promise finished for: ${pathname}&request=trigger`
+    await retry(() => {
+      const output = getOutput()
+      expect(output).toIncludeRepeated(escapeStringRegexp(completion), 1)
+      expect(output).toMatch(
+        new RegExp(
+          `${writeFinished}[^\\r\\n]*\\r?\\n[\\s\\S]*${escapeStringRegexp(completion)}`
+        )
+      )
+    })
+    expect(getOutput()).toMatch(
+      new RegExp(
+        `PersistentCacheHandler::get-pending [^\\r\\n]*${escapeStringRegexp(id)}`
+      )
     )
-
-    // In dev, warm reads resolve in a microtask via the built-in front handler,
-    // so the cross-request dedup window (the leader's read latency) is too
-    // small for concurrent requests to reliably join one leader. That is the
-    // intended dev-fast trade, and only costs a redundant regen in single-user
-    // dev. The strict dedup guarantee is a production concern, where the
-    // backing read holds the window open.
-    if (!isNextDev) {
-      expect(generationCalls).toHaveLength(1)
-    }
+    expect(getOutput()).toIncludeRepeated(
+      escapeStringRegexp(`use-cache-swr: generating delayed data ${id}`),
+      1
+    )
   })
 })


### PR DESCRIPTION
An early `cacheHandler.set()` call previously made subsequent same-key `get()` calls wait for generation and persistence. This prevented another background revalidation, but those requests waited instead of receiving the existing stale data.

The work in #94694 added private-cache persistence in dev. Its helper refactor made cross-request invocations wait for cache writes before retrying root-param-specific lookups. It also moved the coarse-key `set()` call after entry collection. That unintentionally allowed subsequent requests to receive stale data and start another background revalidation while one was already running.

This change tracks background work separately for each lookup key within a runtime instance. Subsequent requests can receive the existing stale entry without waiting for generation or starting duplicate work. The task remains registered until collection and its cache writes settle. Each lookup records existing work before calling `get()`, so a slow lookup does not start another revalidation after the task it observed has completed.

The handler still receives `set()` after collection, including asynchronous rendering of the cached result. Subsequent `get()` calls can still block while the handler persists the entry. We accept that remaining wait to preserve the cache-handler contract without bypassing handler reads.

**Alternatives Considered**

- Restore early `set()` calls and rely on the handler's pending-set promises. This would prevent duplicate regeneration, but would also make subsequent requests wait for generation again instead of receiving stale data.

- Extend the existing cross-request sharing mechanism through background revalidation. We prototyped retaining stale and regenerated results, but that required additional stream ownership, invalidation checks, and root-param matching. The separate background-task map avoids those changes and leaves cold and foreground generation unchanged.

Fixes #98326