### PR TITLE
[backport] Fix use cache prerender signal retention

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -1405,8 +1405,13 @@ async function generateCacheEntryImpl(
       )
 
       clearTimeout(timer)
+      const didTimeout = timeoutAbortController.signal.aborted
+      if (dynamicAccessAbortSignal) {
+        // Release React's listener from the composite signal.
+        timeoutAbortController.abort()
+      }
 
-      if (timeoutAbortController.signal.aborted) {
+      if (didTimeout) {
         // When the timeout is reached we always error the stream. Even for
         // fallback shell prerenders we don't want to return a hanging promise,
         // which would allow the function to become a dynamic hole. Because that


### PR DESCRIPTION
Backports [#97476](https://github.com/vercel/next.js/pull/97476) ("Fix use cache prerender signal retention") to `next-16-3`.

Cherry-picked from 4a95af8084a681e3f26a847331ee5f2f8de52a42, no conflicts. The hunk applied against identical surrounding context; only the line offset differs.

<!-- NEXT_JS_LLM -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)