### PR TITLE
test: enable verified caching deploy tests

### DIFF
--- a/test/e2e/app-dir/app-client-cache/client-cache.original.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.original.test.ts
@@ -9,9 +9,6 @@ import {
 import path from 'path'
 
 // This preserves existing tests for the 30s/5min heuristic (previous router defaults)
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
-// @force-gate !deploy
 describe('app dir client cache semantics (30s/5min)', () => {
   const { next, isNextDev } = nextTestSetup({
     files: path.join(__dirname, 'fixtures', 'regular'),

--- a/test/e2e/app-dir/app-custom-cache-handler/index.test.ts
+++ b/test/e2e/app-dir/app-custom-cache-handler/index.test.ts
@@ -30,9 +30,6 @@ function runTests(
   })
 }
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('app-dir - custom-cache-handler - cjs', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
@@ -44,9 +41,6 @@ describe('app-dir - custom-cache-handler - cjs', () => {
   runTests('cjs module exports', { next, isNextDev })
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('app-dir - custom-cache-handler - cjs-default-export', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
@@ -58,9 +52,6 @@ describe('app-dir - custom-cache-handler - cjs-default-export', () => {
   runTests('cjs default export', { next, isNextDev })
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('app-dir - custom-cache-handler - esm', () => {
   const { next, isNextDev } = nextTestSetup({
     files: {
@@ -82,9 +73,6 @@ describe('app-dir - custom-cache-handler - esm', () => {
   runTests('esm default export', { next, isNextDev })
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('app-dir - custom-cache-handler - esm import.meta.resolve', () => {
   const { next, isNextDev } = nextTestSetup({
     files: {

--- a/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
+++ b/test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts
@@ -3,9 +3,6 @@ import { createRouterAct } from 'router-act'
 import { createTimeController } from './test-utils'
 import { join } from 'path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app dir - prefetching (custom staleTime)', () => {
   const { next, isNextDev } = nextTestSetup({
     files: {

--- a/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
@@ -291,9 +291,6 @@ describe('app-root-param-getters - cache - at build', () => {
   }
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// In deploy mode, concurrent requests could hit different lambdas.
-// @force-gate !deploy
 describe('app-root-param-getters - cache dedup with root params', () => {
   const { next, isNextDev } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'use-cache-dedup'),

--- a/test/e2e/app-dir/cache-components-errors/module-scope.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/module-scope.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('Lazy Module Init', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/lazy-module-init',

--- a/test/e2e/app-dir/cache-components/cache-components.connection.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.connection.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('cache-components', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/cache-components/cache-components.cookies.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.cookies.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('cache-components', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/cache-components/cache-components.date.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.date.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import expect from 'expect'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('cache-components', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/cache-components/cache-components.draft-mode.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.draft-mode.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('cache-components', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/cache-components/cache-components.node-crypto.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.node-crypto.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('cache-components', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/cache-components/cache-components.params.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.params.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // cSpell:words lowcard highcard
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('cache-components', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/cache-components/cache-components.random.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.random.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('cache-components', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/cache-components/cache-components.routes.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.routes.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('cache-components', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/cache-components/cache-components.search.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.search.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('cache-components', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/cache-components/cache-components.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.test.ts
@@ -5,9 +5,6 @@ import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/util
 import cheerio from 'cheerio'
 import { fetchViaHTTP, findPort } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('cache-components', () => {
   const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/cache-components/cache-components.web-crypto.test.ts
+++ b/test/e2e/app-dir/cache-components/cache-components.web-crypto.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('cache-components', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/instant-validation-static-shells/instant-validation-static-shells.test.ts
+++ b/test/e2e/app-dir/instant-validation-static-shells/instant-validation-static-shells.test.ts
@@ -2,9 +2,6 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitForNoErrorToast } from 'next-test-utils'
 import { join } from 'node:path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('instant validation - opting out of static shells', () => {
   const { next, isNextDev } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'valid'),

--- a/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
+++ b/test/e2e/app-dir/non-rsc-router-prefetch/non-rsc-router-prefetch.test.ts
@@ -4,9 +4,6 @@ import {
   RSC_HEADER,
 } from 'next/dist/client/components/app-router-headers'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('non-rsc-router-prefetch', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/use-cache-infinity-profile/use-cache-infinity-profile.test.ts
+++ b/test/e2e/app-dir/use-cache-infinity-profile/use-cache-infinity-profile.test.ts
@@ -3,9 +3,6 @@ import { nextTestSetup } from 'e2e-utils'
 const uuidRegExp =
   /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// Deployment platforms provide their own cache handlers.
-// @force-gate !deploy
 describe('use-cache-infinity-profile', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/use-cache-og-image-top-level-await/use-cache-og-image-top-level-await.test.ts
+++ b/test/e2e/app-dir/use-cache-og-image-top-level-await/use-cache-og-image-top-level-await.test.ts
@@ -1,9 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// The prerendered output can't be observed in a deployment, and without
-// it nothing distinguishes broken from fixed behavior.
-// @force-gate !deploy
 describe('use-cache-og-image-top-level-await', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
+++ b/test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts
@@ -3,9 +3,6 @@ import { renderViaHTTP, startCleanStaticServer } from 'next-test-utils'
 import { join } from 'path'
 import { AddressInfo, Server } from 'net'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('use-cache-output-export', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,


### PR DESCRIPTION
## Summary

Remove 24 deployment exclusion gates and their associated TODO comments across 21 caching test files. The selected test scopes have passing evidence from prior ordinary deployment CI and the Cache Components variant where applicable.

The selection includes 5 additional scopes verified individually: unrelated skips or failures elsewhere in their files do not exclude these passing scopes. Existing mode, bundler, middleware, and Cache Components exclusions still apply; excluded variants are not counted as deployment coverage.

## Verification

- Compared the additional candidates with their tested revisions: executable code is unchanged.
- Checked gate transforms, comment-only changes, formatting, and lint.
- 78 gate infrastructure unit tests passed.
- Local integration reruns were blocked by missing package-level `ncc`/`microbundle` dependencies in the temporary worktree. Fresh PR CI will validate the updated stack.

<details>
<summary>Deployment evidence for the additional scopes</summary>

- `test/e2e/app-dir/app-prefetch/prefetching.stale-times.test.ts` — `describe('app dir - prefetching (custom staleTime)', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785098/job/102728710370); Cache Components excluded by manifest.
- `test/e2e/app-dir/cache-components-errors/module-scope.test.ts` — `describe('Lazy Module Init', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785098/job/102728710410); Cache Components excluded by manifest.
- `test/e2e/app-dir/cache-components/cache-components.params.test.ts` — `describe('cache-components', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785098/job/102728710449); Cache Components excluded by manifest.
- `test/e2e/app-dir/instant-validation-static-shells/instant-validation-static-shells.test.ts` — `describe('instant validation - opting out of static shells', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785098/job/102728710456), [cache](https://github.com/vercel/next.js/actions/runs/34426785098/job/102728710457).
- `test/e2e/app-dir/use-cache-output-export/use-cache-output-export.test.ts` — `describe('use-cache-output-export', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785098/job/102728710496), [cache](https://github.com/vercel/next.js/actions/runs/34426785098/job/102728710503); Cache Components explicitly skipped for PPR.

</details>

<!-- NEXT_JS_LLM -->
