### PR TITLE
test: enable verified app-router deploy tests

### DIFF
--- a/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-allowed-origins.test.ts
@@ -2,9 +2,6 @@ import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 import { join } from 'path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app-dir action allowed origins', () => {
   const { next } = nextTestSetup({
     files: join(__dirname, 'safe-origins'),

--- a/test/e2e/app-dir/actions-allowed-origins/app-action-opaque-origin.test.ts
+++ b/test/e2e/app-dir/actions-allowed-origins/app-action-opaque-origin.test.ts
@@ -2,9 +2,6 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { join } from 'path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app-dir action allowed from opaque origins', () => {
   const { next } = nextTestSetup({
     files: join(__dirname, 'opaque-origin'),

--- a/test/e2e/app-dir/app-a11y/index.test.ts
+++ b/test/e2e/app-dir/app-a11y/index.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup, type Playwright } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app a11y features', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/app-rendering/rendering.test.ts
+++ b/test/e2e/app-dir/app-rendering/rendering.test.ts
@@ -2,9 +2,6 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 import cheerio from 'cheerio'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app dir rendering', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/app-validation/validation.test.ts
+++ b/test/e2e/app-dir/app-validation/validation.test.ts
@@ -4,9 +4,6 @@ import {
   computeLegacyCacheBustingSearchParam,
 } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app dir - validation', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/async-component-preload/async-component-preload.test.ts
+++ b/test/e2e/app-dir/async-component-preload/async-component-preload.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('async-component-preload', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/client-reference-side-effects/client-reference-side-effects.test.ts
+++ b/test/e2e/app-dir/client-reference-side-effects/client-reference-side-effects.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('client-reference-side-effects', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/duplicate-layout-components/duplicate-layout-components.test.ts
+++ b/test/e2e/app-dir/duplicate-layout-components/duplicate-layout-components.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app dir - duplicate layout components', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
+++ b/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
@@ -2,9 +2,6 @@ import { nextTestSetup } from 'e2e-utils'
 
 process.env.__TEST_SENTINEL = 'at buildtime'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('dynamic-data', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/main',

--- a/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
+++ b/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely mutates files in the isolated local fixture after setup.
-// @force-gate !deploy
 describe('dynamic-href', () => {
   const { isNextDev: isDev, next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/dynamic-import-tree-shaking/dynamic-import-tree-shaking.test.ts
+++ b/test/e2e/app-dir/dynamic-import-tree-shaking/dynamic-import-tree-shaking.test.ts
@@ -2,9 +2,6 @@ import { nextTestSetup } from 'e2e-utils'
 import fs from 'fs'
 import path from 'path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely inspects local build artifacts that deploy tests do not expose.
-// @force-gate !deploy
 describe('dynamic-import-tree-shaking', () => {
   const { next, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/dynamic-in-generate-params/index.test.ts
+++ b/test/e2e/app-dir/dynamic-in-generate-params/index.test.ts
@@ -11,9 +11,6 @@ function assertSitemapResponse(res: Response) {
   expect(res.headers.get('content-type')).toContain('application/xml')
 }
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app-dir - dynamic in generate params', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/dynamic/dynamic.test.ts
+++ b/test/e2e/app-dir/dynamic/dynamic.test.ts
@@ -2,9 +2,6 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import path from 'path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely mutates files in the isolated local fixture after setup.
-// @force-gate !deploy
 describe('app dir - next/dynamic', () => {
   const { next, isNextStart, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/forbidden/default/forbidden-default.test.ts
+++ b/test/e2e/app-dir/forbidden/default/forbidden-default.test.ts
@@ -5,9 +5,6 @@ import {
   getRedboxDescription,
 } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app dir - forbidden with default forbidden boundary', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/global-error/catch-all/index.test.ts
+++ b/test/e2e/app-dir/global-error/catch-all/index.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app dir - global error - with catch-all route', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/global-error/layout-error/index.test.ts
+++ b/test/e2e/app-dir/global-error/layout-error/index.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app dir - global error - layout error', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/io/io.test.ts
+++ b/test/e2e/app-dir/io/io.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('io with cache components', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/cache-components',
@@ -55,9 +52,6 @@ describe('io with cache components', () => {
   })
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('io without cache components', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname + '/fixtures/default',

--- a/test/e2e/app-dir/metadata-json-manifest/index.test.ts
+++ b/test/e2e/app-dir/metadata-json-manifest/index.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app-dir metadata-json-manifest', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/metadata-suspense/index.test.ts
+++ b/test/e2e/app-dir/metadata-suspense/index.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app dir - metadata dynamic routes suspense', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/metadata-warnings/metadata-warnings-with-metadatabase.test.ts
+++ b/test/e2e/app-dir/metadata-warnings/metadata-warnings-with-metadatabase.test.ts
@@ -3,9 +3,6 @@ import { nextTestSetup } from 'e2e-utils'
 const METADATA_BASE_WARN_STRING =
   'metadataBase property in metadata export is not set for resolving social open graph or twitter images,'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('app dir - metadata missing metadataBase', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/not-found-with-layout-and-group-not-found/index.test.ts
+++ b/test/e2e/app-dir/not-found-with-layout-and-group-not-found/index.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app dir - not found with nested layouts and custom not-found', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/not-found-with-nested-layouts/index.test.ts
+++ b/test/e2e/app-dir/not-found-with-nested-layouts/index.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app dir - not found with nested layouts', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/not-found/default/default.test.ts
+++ b/test/e2e/app-dir/not-found/default/default.test.ts
@@ -2,9 +2,6 @@ import { nextTestSetup } from 'e2e-utils'
 
 const isPPREnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely inspects local build artifacts that deploy tests do not expose.
-// @force-gate !deploy
 describe('app dir - not-found - default', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts
+++ b/test/e2e/app-dir/not-found/group-route-root-not-found/index.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app dir - group routes with root not-found', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/parallel-routes-and-interception-nested-dynamic-routes/parallel-routes-and-interception-nested-dynamic-routes.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception-nested-dynamic-routes/parallel-routes-and-interception-nested-dynamic-routes.test.ts
@@ -1,9 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// TODO: re-enable when resolved related thread
-// https://vercel.slack.com/archives/C07UCHRBWGK/p1759165345308879
-// @force-gate !deploy
 describe('parallel-routes-and-interception-nested-dynamic-routes', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -1056,10 +1056,6 @@ describe.each([true, false])(
   }
 )
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// This is skipped when deployed as it appears to cause an issue when tracing Next.js files
-// TODO: Investigate why this causes an issue when deployed
-// @force-gate !deploy
 describe('parallel-routes-and-interception-conflicting-pages', () => {
   const { next } = nextTestSetup({
     files: {

--- a/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
+++ b/test/e2e/app-dir/parallel-routes-not-found/parallel-routes-not-found.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// TODO: remove after deployment handling is updated
-// @force-gate !deploy
 describe('parallel-routes-and-interception', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/root-layout-render-once/index.test.ts
+++ b/test/e2e/app-dir/root-layout-render-once/index.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app-dir root layout render once', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/root-layout/root-layout.test.ts
+++ b/test/e2e/app-dir/root-layout/root-layout.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, check, getRedboxSource } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app-dir root layout', () => {
   const { next, isNextDev: isDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/root-suspense-dynamic/root-suspense-dynamic.test.ts
+++ b/test/e2e/app-dir/root-suspense-dynamic/root-suspense-dynamic.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('Root Suspense Dynamic Rendering', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname + '/fixtures/default',

--- a/test/e2e/app-dir/similar-pages-paths/similar-pages-paths.test.ts
+++ b/test/e2e/app-dir/similar-pages-paths/similar-pages-paths.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app-dir similar pages paths', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/unauthorized/default/unauthorized-default.test.ts
+++ b/test/e2e/app-dir/unauthorized/default/unauthorized-default.test.ts
@@ -5,9 +5,6 @@ import {
   getRedboxDescription,
 } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('app dir - unauthorized with default unauthorized boundary', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,


### PR DESCRIPTION
## Summary

Remove 33 deployment exclusion gates and their associated TODO comments across 32 app-router test files. The selected test scopes have passing evidence from prior ordinary deployment CI and the Cache Components variant where applicable.

The selection includes 7 additional scopes verified individually: unrelated skips or failures elsewhere in their files do not exclude these passing scopes. Existing mode, bundler, middleware, and Cache Components exclusions still apply; excluded variants are not counted as deployment coverage.

## Verification

- Compared the additional candidates with their tested revisions: executable code is unchanged.
- Checked gate transforms, comment-only changes, formatting, and lint.
- 78 gate infrastructure unit tests passed.
- Local integration reruns were blocked by missing package-level `ncc`/`microbundle` dependencies in the temporary worktree. Fresh PR CI will validate the updated stack.

<details>
<summary>Deployment evidence for the additional scopes</summary>

- `test/e2e/app-dir/app-rendering/rendering.test.ts` — `describe('app dir rendering', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426784855/job/102715677110); Cache Components excluded by manifest.
- `test/e2e/app-dir/dynamic-data/dynamic-data.test.ts` — `describe('dynamic-data', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426784855/job/102715677056); Cache Components excluded by manifest.
- `test/e2e/app-dir/forbidden/default/forbidden-default.test.ts` — `describe('app dir - forbidden with default forbidden boundary', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426784855/job/102715677074); Cache Components excluded by manifest.
- `test/e2e/app-dir/root-layout/root-layout.test.ts` — `describe('app-dir root layout', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426784855/job/102715677110); Cache Components excluded by manifest.
- `test/e2e/app-dir/unauthorized/default/unauthorized-default.test.ts` — `describe('app dir - unauthorized with default unauthorized boundary', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426784855/job/102715677110); Cache Components excluded by manifest.
- `test/e2e/app-dir/actions-allowed-origins/app-action-opaque-origin.test.ts` — `describe('app-dir action allowed from opaque origins', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426784855/job/102715677074), [cache](https://github.com/vercel/next.js/actions/runs/34426784855/job/102715677108); this scope passed although another scope in the file failed.
- `test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts` — `describe('parallel-routes-and-interception-conflicting-pages', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426784855/job/102715677110); Cache Components excluded by manifest; this scope passed although another scope in the file failed.

</details>

<!-- NEXT_JS_LLM -->
