### PR TITLE
test: enable verified tooling deploy tests

### DIFF
--- a/test/e2e/app-dir/app-config-crossorigin/index.test.ts
+++ b/test/e2e/app-dir/app-config-crossorigin/index.test.ts
@@ -4,9 +4,6 @@ import { isNextStart, nextTestSetup } from 'e2e-utils'
 const assetPrefix = 'https://example.vercel.sh'
 
 if (!isNextStart) {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // No deploy-specific incompatibility is documented.
-  // @force-gate !deploy
   describe('app dir - crossOrigin config', () => {
     const { next } = nextTestSetup({
       files: __dirname,

--- a/test/e2e/app-dir/import-meta-glob-text-type/import-meta-glob-text-type.test.ts
+++ b/test/e2e/app-dir/import-meta-glob-text-type/import-meta-glob-text-type.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // `turbopack.rules` is a Turbopack-only feature; skip under webpack
-// TODO(deploy-test-completion): No deploy-specific incompatibility is
-// documented.
-// @force-gate !deploy
 // @force-gate turbopack
 describe('turbopack `text` / `raw` module types', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-output-file-tracing-root.test.ts
@@ -1,9 +1,6 @@
 import { join } from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('multiple-lockfiles - has-output-file-tracing-root', () => {
   const { next } = nextTestSetup({
     files: {

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles-with-turbo-root.test.ts
@@ -1,9 +1,6 @@
 import { join } from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('multiple-lockfiles - has-turbo-root', () => {
   const { next } = nextTestSetup({
     files: {

--- a/test/e2e/app-dir/segment-config-ts/segment-config-ts.test.ts
+++ b/test/e2e/app-dir/segment-config-ts/segment-config-ts.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely inspects local build artifacts that deploy tests do not expose.
-// @force-gate !deploy
 describe('TypeScript type expressions in route segment config', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
+++ b/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
@@ -3,9 +3,6 @@ import { join } from 'path'
 import { existsSync } from 'fs'
 import { parseTraceFile } from '../../../lib/parse-trace-file'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely inspects local build artifacts that deploy tests do not expose.
-// @force-gate !deploy
 describe('trace-build-file', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/turbopack-loader-content-type/turbopack-loader-content-type.test.ts
+++ b/test/e2e/app-dir/turbopack-loader-content-type/turbopack-loader-content-type.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('turbopack-loader-content-type', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/webpack-loader-conditions/webpack-loader-conditions.test.ts
+++ b/test/e2e/app-dir/webpack-loader-conditions/webpack-loader-conditions.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // Specifically tests turbopack.rules.*.foreign config
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 // @force-gate turbopack
 describe('webpack-loader-conditions', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/webpack-loader-fs/webpack-loader-fs.test.ts
+++ b/test/e2e/app-dir/webpack-loader-fs/webpack-loader-fs.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('webpack-loader-fs', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/webpack-loader-import-module/webpack-loader-import-module.test.ts
+++ b/test/e2e/app-dir/webpack-loader-import-module/webpack-loader-import-module.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('webpack-loader-import-module', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
+++ b/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('webpack-loader-module-type', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/webpack-loader-resolve/webpack-loader-resolve.test.ts
+++ b/test/e2e/app-dir/webpack-loader-resolve/webpack-loader-resolve.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// This test is skipped because it's only expected to run in turbopack, which isn't enabled for builds
-// @force-gate !deploy
 describe('webpack-loader-resolve', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
+++ b/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('webpack-loader-resource-query', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/webpack-loader-ts-transform/webpack-loader-ts-transform.test.ts
+++ b/test/e2e/app-dir/webpack-loader-ts-transform/webpack-loader-ts-transform.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// This test is skipped because it's only expected to run in turbopack, which isn't enabled for builds
-// @force-gate !deploy
 describe('webpack-loader-ts-transform', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-dir/with-babel/with-babel.test.ts
+++ b/test/e2e/app-dir/with-babel/with-babel.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely inspects local build artifacts that deploy tests do not expose.
-// @force-gate !deploy
 describe('with babel', () => {
   const { next, isNextStart, isTurbopack } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/config-schema-check/index.test.ts
+++ b/test/e2e/config-schema-check/index.test.ts
@@ -2,9 +2,6 @@ import stripAnsi from 'strip-ansi'
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('next.config.js schema validating - defaultConfig', () => {
   const { next } = nextTestSetup({
     files: {
@@ -28,9 +25,6 @@ describe('next.config.js schema validating - defaultConfig', () => {
   })
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('next.config.js schema validating - invalid config', () => {
   const { next, isNextStart } = nextTestSetup({
     files: {

--- a/test/e2e/import-meta-env/import-meta-env.test.ts
+++ b/test/e2e/import-meta-env/import-meta-env.test.ts
@@ -1,8 +1,5 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): No deploy-specific incompatibility is
-// documented.
-// @force-gate !deploy
 // @force-gate turbopack
 describe('import.meta.env', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/import-meta-glob/import-meta-glob.test.ts
+++ b/test/e2e/import-meta-glob/import-meta-glob.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // import.meta.glob is a Turbopack-only feature; skip under webpack
-// TODO(deploy-test-completion): No deploy-specific incompatibility is
-// documented.
-// @force-gate !deploy
 // @force-gate turbopack
 describe('import-meta-glob', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/jsconfig-baseurl/jsconfig-baseurl.test.ts
+++ b/test/e2e/jsconfig-baseurl/jsconfig-baseurl.test.ts
@@ -2,9 +2,6 @@ import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('jsconfig.json baseurl', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/swc-plugins-env/index.test.ts
+++ b/test/e2e/swc-plugins-env/index.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('swc-plugins-env', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/swc-plugins/index.test.ts
+++ b/test/e2e/swc-plugins/index.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('swcPlugins', () => {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely expects a local build failure instead of a successful deployment.
-  // @force-gate !deploy
   describe('supports swcPlugins', () => {
     const { next } = nextTestSetup({
       files: __dirname,

--- a/test/e2e/transpile-packages-typescript-foreign/index.test.ts
+++ b/test/e2e/transpile-packages-typescript-foreign/index.test.ts
@@ -36,9 +36,6 @@ Module parse failed: Unexpected token`)
     })
   })
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
-  // @force-gate !deploy
   describe('with transpilePackages', () => {
     const { next } = nextTestSetup({
       files: __dirname,

--- a/test/e2e/turbopack-import-with-type/index.test.ts
+++ b/test/e2e/turbopack-import-with-type/index.test.ts
@@ -5,9 +5,6 @@ const jsContent = `export const nope = 'nope'
 throw new Error('please dont execute me')
 `
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 // @force-gate turbopack
 describe('turbopack-import-with-type', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/turbopack-loader-config/index.test.ts
+++ b/test/e2e/turbopack-loader-config/index.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('turbopack-loader-config', () => {
   const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/typescript/typescript.test.ts
+++ b/test/e2e/typescript/typescript.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('TypeScript Features', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: __dirname,


### PR DESCRIPTION
## Summary

Remove 26 deployment exclusion gates and their associated TODO comments across 25 tooling test files. The selected test scopes have passing evidence from prior ordinary deployment CI and the Cache Components variant where applicable.

The selection includes 7 additional scopes verified individually: unrelated skips or failures elsewhere in their files do not exclude these passing scopes. Existing mode, bundler, middleware, and Cache Components exclusions still apply; excluded variants are not counted as deployment coverage.

## Verification

- Compared the additional candidates with their tested revisions: executable code is unchanged.
- Checked gate transforms, comment-only changes, formatting, and lint.
- 78 gate infrastructure unit tests passed.
- Local integration reruns were blocked by missing package-level `ncc`/`microbundle` dependencies in the temporary worktree. Fresh PR CI will validate the updated stack.

<details>
<summary>Deployment evidence for the additional scopes</summary>

- `test/e2e/app-dir/app-config-crossorigin/index.test.ts` — `describe('app dir - crossOrigin config', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742650), [cache](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742724).
- `test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts` — `describe('webpack-loader-module-type', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742634), [cache](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742671).
- `test/e2e/app-dir/with-babel/with-babel.test.ts` — `describe('with babel', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742666), [cache](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742685).
- `test/e2e/jsconfig-baseurl/jsconfig-baseurl.test.ts` — `describe('jsconfig.json baseurl', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742650), [cache](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742724).
- `test/e2e/swc-plugins/index.test.ts` — `describe('supports swcPlugins', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742599), [cache](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742667).
- `test/e2e/transpile-packages-typescript-foreign/index.test.ts` — `describe('with transpilePackages', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742666), [cache](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742685).
- `test/e2e/typescript/typescript.test.ts` — `describe('TypeScript Features', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742666), [cache](https://github.com/vercel/next.js/actions/runs/34426785087/job/102715742685).

</details>

<!-- NEXT_JS_LLM -->
