### PR TITLE
test: enable verified pages-router deploy tests

### DIFF
--- a/test/e2e/404-page-custom-error/404-page-custom-error.test.ts
+++ b/test/e2e/404-page-custom-error/404-page-custom-error.test.ts
@@ -1,9 +1,6 @@
 /* eslint-disable jest/no-standalone-expect */
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 
-// TODO(deploy-test-completion): This likely inspects local build artifacts that
-// deploy tests do not expose.
-// @force-gate !deploy
 // @force-gate !start || !turbopackDev
 // @force-gate !dev || !turbopackBuild
 describe('Default 404 Page with custom _error', () => {

--- a/test/e2e/404-page/404-page.test.ts
+++ b/test/e2e/404-page/404-page.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
-// @force-gate !deploy
 describe('404 Page Support', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/500-page/500-page.test.ts
+++ b/test/e2e/500-page/500-page.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
-// @force-gate !deploy
 describe('500 Page Support', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/api-resolver-query-writeable/api-resolver-query-writeable.test.ts
+++ b/test/e2e/api-resolver-query-writeable/api-resolver-query-writeable.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely controls the local Next.js build or server lifecycle.
-// @force-gate !deploy
 describe('api-resolver-query-writeable', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/app-document/client.test.ts
+++ b/test/e2e/app-document/client.test.ts
@@ -1,9 +1,6 @@
 import { retry } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely mutates files in the isolated local fixture after setup.
-// @force-gate !deploy
 describe('Document and App - Client side', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/disable-js/disable-js.test.ts
+++ b/test/e2e/disable-js/disable-js.test.ts
@@ -1,9 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import cheerio from 'cheerio'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('disabled runtime JS', () => {
   const { next, isNextDev, isNextStart } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/gip-identifier/gip-identifier.test.ts
+++ b/test/e2e/gip-identifier/gip-identifier.test.ts
@@ -2,9 +2,6 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import cheerio from 'cheerio'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely mutates files in the isolated local fixture after setup.
-// @force-gate !deploy
 describe('gip identifiers', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/i18n-data-fetching-redirect/redirect-from-context.test.ts
+++ b/test/e2e/i18n-data-fetching-redirect/redirect-from-context.test.ts
@@ -2,9 +2,6 @@ import { join } from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// The source only records that these assertions fail after deployment; the root cause is unknown.
-// @force-gate !deploy
 describe('i18n-data-fetching-redirect', () => {
   const { next } = nextTestSetup({
     files: {

--- a/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
+++ b/test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts
@@ -5,9 +5,6 @@ import fs from 'fs-extra'
 
 const locales = ['', '/en', '/sv', '/nl']
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely reads files from the isolated local fixture.
-// @force-gate !deploy
 describe('i18n-ignore-rewrite-source-locale with basepath', () => {
   const { next } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/legacy-link-behavior/index.test.ts
+++ b/test/e2e/legacy-link-behavior/index.test.ts
@@ -5,9 +5,6 @@ import {
   type ErrorSnapshot,
 } from '../../lib/add-redbox-matchers'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('Link with legacyBehavior', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/next-link-errors/next-link-errors.test.ts
+++ b/test/e2e/next-link-errors/next-link-errors.test.ts
@@ -1,8 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('next-link', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,

--- a/test/e2e/pages-performance-mark/index.test.ts
+++ b/test/e2e/pages-performance-mark/index.test.ts
@@ -2,9 +2,6 @@ import { nextTestSetup } from 'e2e-utils'
 
 // This test case doesn't indicate rendering duplicate head in _document is valid,
 // but it's a way to reproduce the performance mark crashing.
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
-// @force-gate !deploy
 describe('pages performance mark', () => {
   const { next } = nextTestSetup({
     files: __dirname,


### PR DESCRIPTION
## Summary

Remove 12 deployment exclusion gates and their associated TODO comments across 12 pages-router test files. The selected test scopes have passing evidence from prior ordinary deployment CI and the Cache Components variant where applicable.

The selection includes 3 additional scopes verified individually: unrelated skips or failures elsewhere in their files do not exclude these passing scopes. Existing mode, bundler, middleware, and Cache Components exclusions still apply; excluded variants are not counted as deployment coverage.

## Verification

- Compared the additional candidates with their tested revisions: executable code is unchanged.
- Checked gate transforms, comment-only changes, formatting, and lint.
- 78 gate infrastructure unit tests passed.
- Local integration reruns were blocked by missing package-level `ncc`/`microbundle` dependencies in the temporary worktree. Fresh PR CI will validate the updated stack.

<details>
<summary>Deployment evidence for the additional scopes</summary>

- `test/e2e/404-page-custom-error/404-page-custom-error.test.ts` — `describe('Default 404 Page with custom _error', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785205/job/102715905641), [cache](https://github.com/vercel/next.js/actions/runs/34426785205/job/102715905524).
- `test/e2e/404-page/404-page.test.ts` — `describe('404 Page Support', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785205/job/102715905631), [cache](https://github.com/vercel/next.js/actions/runs/34426785205/job/102715905599).
- `test/e2e/i18n-ignore-rewrite-source-locale/rewrites-with-basepath.test.ts` — `describe('i18n-ignore-rewrite-source-locale with basepath', () => {`: [normal](https://github.com/vercel/next.js/actions/runs/34426785205/job/102715905696), [cache](https://github.com/vercel/next.js/actions/runs/34426785205/job/102715905562).

</details>

<!-- NEXT_JS_LLM -->
