### PR TITLE
Test cacheTag propagation to route handler ISR entries

### DIFF
--- a/test/e2e/app-dir/use-cache-route-handler-tags/app/cached/route.ts
+++ b/test/e2e/app-dir/use-cache-route-handler-tags/app/cached/route.ts
@@ -1,0 +1,15 @@
+import { cacheLife, cacheTag } from 'next/cache'
+
+async function getCachedValue() {
+  'use cache'
+
+  // Keep time-based revalidation from masking missing tag propagation.
+  cacheLife('hours')
+  cacheTag('route-handler-tag')
+
+  return Math.random()
+}
+
+export async function GET() {
+  return Response.json({ value: await getCachedValue() })
+}

--- a/test/e2e/app-dir/use-cache-route-handler-tags/app/revalidate/route.ts
+++ b/test/e2e/app-dir/use-cache-route-handler-tags/app/revalidate/route.ts
@@ -1,0 +1,7 @@
+import { revalidateTag } from 'next/cache'
+
+export async function POST() {
+  revalidateTag('route-handler-tag', { expire: 0 })
+
+  return new Response(null, { status: 204 })
+}

--- a/test/e2e/app-dir/use-cache-route-handler-tags/next.config.ts
+++ b/test/e2e/app-dir/use-cache-route-handler-tags/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/use-cache-route-handler-tags/use-cache-route-handler-tags.test.ts
+++ b/test/e2e/app-dir/use-cache-route-handler-tags/use-cache-route-handler-tags.test.ts
@@ -1,0 +1,53 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('use-cache-route-handler-tags', () => {
+  const { next, isNextDev, isNextDeploy } = nextTestSetup({
+    files: __dirname,
+  })
+
+  const retryDuration = isNextDeploy ? 30_000 : 3_000
+
+  async function readCachedValue(): Promise<number> {
+    const response = await next.fetch('/cached')
+    expect(response.status).toBe(200)
+
+    if (!isNextDev) {
+      // Verify that the response itself is cached, not just the function's
+      // return value. On Vercel this must be a hit in the deployed ISR cache.
+      const cacheHeader = isNextDeploy ? 'x-vercel-cache' : 'x-nextjs-cache'
+      expect(response.headers.get(cacheHeader)).toBe('HIT')
+    }
+
+    const { value } = await response.json()
+    expect(value).toEqual(expect.any(Number))
+    return value
+  }
+
+  it('propagates cacheTag to prerendered and regenerated ISR entries', async () => {
+    let value = await retry(readCachedValue, retryDuration)
+    expect(await readCachedValue()).toBe(value)
+
+    // Invalidate both the build-time entry and the entry produced by ISR.
+    for (const entry of ['prerendered', 'regenerated']) {
+      const response = await next.fetch('/revalidate', { method: 'POST' })
+      expect(response.status).toBe(204)
+
+      const previousValue = value
+
+      // Tag invalidation and regeneration can take time to propagate on Vercel.
+      value = await retry(
+        async () => {
+          const updatedValue = await readCachedValue()
+          expect(updatedValue).not.toBe(previousValue)
+          return updatedValue
+        },
+        retryDuration,
+        500,
+        `invalidate the ${entry} route handler entry`
+      )
+
+      expect(await readCachedValue()).toBe(value)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Adds a deploy-enabled repro for reports that `cacheTag` inside a `"use cache"` function called by a GET route handler does not propagate to the handler's ISR entry on Vercel.

The test confirms a cached response (`x-vercel-cache: HIT` on Vercel), then expires only the custom tag twice. Each invalidation must produce a new response that is cached again, covering both prerendered and regenerated ISR entries. A long cache lifetime prevents time-based revalidation from masking missing tag propagation.

## Verification

- Passes locally in production and development with Turbopack.
- Deploy verification is pending the PR's changed-test deploy jobs.

<!-- NEXT_JS_LLM -->
