### PR TITLE
test: explain retained mode-specific deploy exclusions

### DIFF
--- a/test/production/numeric-sep/numeric-sep.test.ts
+++ b/test/production/numeric-sep/numeric-sep.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('Numeric Separator Support', () => {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // No deploy-specific incompatibility is documented.
+  // This scope only checks compiler output for a numeric-separator build regression.
+  // It belongs to local build validation and has no deployed runtime assertion.
   // @force-gate !deploy
   describe('production mode', () => {
     const { next } = nextTestSetup({


### PR DESCRIPTION
## Summary

Replace 1 deployment-exclusion TODO comments with concrete reasons across 1 mode-specific test files. These are the same retained exclusions selected in the 180-location review.

This explanation stack is based on `jstory/deploy-tests/remove-skip-api`. The separately reviewed passing-test removals are now in the stack rooted on canary at #98523.

## Verification

- Executable ASTs and all gate directives match the current upstream base in every edited file.
- The complete explanation stack replaces exactly 180 TODOs across 147 files, preserving the previous explanations.
- Formatting and lint passed.
- Full local bootstrap was blocked by missing package-level dependencies in the temporary worktree.

<!-- NEXT_JS_LLM -->
