### PR TITLE
Fix dev shell validation for novel parameter values

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1273,7 +1273,10 @@ type RenderToReadableStreamServerOptions = NonNullable<
 async function stagedRenderWithoutCachesInDevNode(
   ctx: AppRenderContext,
   requestStore: RequestStore,
-  getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
+  getPayload: (
+    ctx: AppRenderContext,
+    requestStore: RequestStore
+  ) => Promise<RSCPayload>,
   options: Omit<RenderToReadableStreamServerOptions, 'environmentName'>
 ) {
   // We're rendering while bypassing caches,
@@ -1305,7 +1308,7 @@ async function stagedRenderWithoutCachesInDevNode(
   )
 
   const { clientModules } = getClientReferenceManifest()
-  const rscPayload = await getPayload(requestStore)
+  const rscPayload = await getPayload(ctx, requestStore)
 
   return await runInSequentialTasks(
     () => {
@@ -1350,6 +1353,37 @@ function getEnvironmentNameForStageWithoutCaches(stage: RenderStage) {
   }
 }
 
+function getDevValidationFallbackRouteParams(
+  req: BaseNextRequest,
+  requestFallbackRouteParams: OpaqueFallbackRouteParams | null
+) {
+  const validationFallbackRouteParams = getRequestMeta(
+    req,
+    'devPrerenderValidationFallbackParams'
+  )
+
+  // Keep the foreground's opaque tokens when the two shapes agree.
+  return validationFallbackRouteParams === undefined ||
+    hasSameFallbackRouteParams(
+      validationFallbackRouteParams,
+      requestFallbackRouteParams
+    )
+    ? requestFallbackRouteParams
+    : validationFallbackRouteParams
+}
+
+function hasSameFallbackRouteParams(
+  left: OpaqueFallbackRouteParams | null,
+  right: OpaqueFallbackRouteParams | null
+): boolean {
+  if (left === right) return true
+  if (left === null || right === null || left.size !== right.size) return false
+  for (const key of left.keys()) {
+    if (!right.has(key)) return false
+  }
+  return true
+}
+
 /**
  * Fork of `generateDynamicFlightRenderResult` that renders using `renderWithRestartOnCacheMissInDev`
  * to ensure correct separation of environments Prerender/Server (for use in Cache Components)
@@ -1374,7 +1408,6 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
     },
     url,
   } = ctx
-
   const {
     onInstrumentationRequestError,
     setReactDebugChannel,
@@ -1409,13 +1442,16 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
     (initialRequestStore.isHmrRefresh === true ||
       (await anySegmentNeedsInstantValidationInDev(loaderTree)))
 
-  const getPayload = async (requestStore: RequestStore) => {
+  const getPayload = async (
+    payloadCtx: AppRenderContext,
+    requestStore: RequestStore
+  ) => {
     const payload: RSCPayload &
       RSCPayloadDevProperties &
       RSCInitialPayloadPartialDev = await workUnitAsyncStorage.run(
       requestStore,
       generateDynamicRSCPayload,
-      ctx,
+      payloadCtx,
       undefined
     )
 
@@ -1512,7 +1548,10 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
       getPayload,
       onError,
       shouldValidate,
-      fallbackRouteParams: fallbackParams,
+      validationFallbackRouteParams: getDevValidationFallbackRouteParams(
+        req,
+        fallbackParams
+      ),
       getDevRenderDidError: () => didErrorObservably,
       navigationKind: {
         type: 'prefetched-client',
@@ -3547,7 +3586,6 @@ async function renderToStream(
     requestId,
     workStore,
   } = ctx
-
   const {
     basePath,
     buildManifest,
@@ -3729,18 +3767,20 @@ async function renderToStream(
       ) {
         let debugChannelClientStream: ReplayableNodeStream | undefined
 
-        // eslint-disable-next-line @typescript-eslint/no-shadow
-        const getPayload = async (requestStore: RequestStore) => {
+        const getPayload = async (
+          payloadCtx: AppRenderContext,
+          payloadRequestStore: RequestStore
+        ) => {
           const payload: InitialRSCPayload & RSCPayloadDevProperties =
             await workUnitAsyncStorage.run(
-              requestStore,
+              payloadRequestStore,
               getRSCPayload,
               tree,
-              ctx,
+              payloadCtx,
               { is404: res.statusCode === 404, isPrerendering: false }
             )
 
-          if (isBypassingCachesInDev(requestStore, workStore)) {
+          if (isBypassingCachesInDev(payloadRequestStore, workStore)) {
             // Mark the RSC payload to indicate that caches were bypassed in dev.
             // This lets the client know not to cache anything based on this render.
             if (renderOpts.setCacheStatus) {
@@ -3782,7 +3822,8 @@ async function renderToStream(
               getPayload,
               onError: serverComponentsErrorHandler,
               shouldValidate: true,
-              fallbackRouteParams: fallbackParams,
+              validationFallbackRouteParams:
+                getDevValidationFallbackRouteParams(req, fallbackParams),
               getDevRenderDidError: () => didErrorObservably,
               // An initial HTML load serves the static shell; runtime and
               // dynamic content stream in afterward.
@@ -4757,11 +4798,58 @@ function runDevValidationInBackground(
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
   getDevRenderDidError: () => boolean,
   createRequestStore: () => RequestStore,
-  getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
+  getPayload: (
+    ctx: AppRenderContext,
+    requestStore: RequestStore
+  ) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
   validationGeneration: DevValidationGeneration
 ): void {
   const validationAbortSignal = validationGeneration.signal
+  let validationCtx = ctx
+  let validationRequestStore = requestStore
+  let createValidationRequestStore = createRequestStore
+
+  // Depending on how the foreground render was entered, its fallback params
+  // may be stored on the render context, the request store, or both.
+  const hasSameParamShape =
+    hasSameFallbackRouteParams(ctx.fallbackRouteParams, fallbackRouteParams) &&
+    hasSameFallbackRouteParams(
+      requestStore.fallbackParams ?? null,
+      fallbackRouteParams
+    )
+  if (!hasSameParamShape) {
+    const validationInterpolatedParams = interpolateParallelRouteParams(
+      ctx.componentMod.routeModule.userland.loaderTree,
+      ctx.renderOpts.params ?? {},
+      ctx.pagePath,
+      fallbackRouteParams
+    )
+    const getDynamicParamFromSegment = makeGetDynamicParamFromSegment(
+      validationInterpolatedParams,
+      fallbackRouteParams,
+      ctx.renderOpts.experimental.optimisticRouting
+    )
+    validationCtx = {
+      ...ctx,
+      getDynamicParamFromSegment,
+      interpolatedParams: validationInterpolatedParams,
+      fallbackRouteParams,
+    }
+    const validationRootParams = getRootParams(
+      ctx.componentMod.routeModule.userland.loaderTree,
+      getDynamicParamFromSegment
+    )
+    createValidationRequestStore = () =>
+      Object.assign(createRequestStore(), {
+        rootParams: validationRootParams,
+        fallbackParams: fallbackRouteParams,
+      })
+    validationRequestStore = createValidationRequestStore()
+    // This new shape has not been staged yet. Do not assume that its static
+    // shell and app shell resolve data in the same stages.
+    validationRequestStore.hasIncompatibleShellContent = true
+  }
 
   void consoleAsyncStorage
     .run({ dim: true }, async () => {
@@ -4795,14 +4883,15 @@ function runDevValidationInBackground(
               prefetchMode,
               navigationKind,
               result,
-              requestStore,
+              validationRequestStore,
               validationDebugChannel,
-              ctx,
+              validationCtx,
               prerenderResumeDataCache,
-              createRequestStore,
+              createValidationRequestStore,
               getPayload,
               onError,
-              validationAbortSignal
+              validationAbortSignal,
+              hasSameParamShape
             )
 
             // If we need to do multiple renders, do them in parallel.
@@ -4848,7 +4937,7 @@ function runDevValidationInBackground(
 
             if (devValidationWorker) {
               const snapshot = await buildDevValidationSnapshot(
-                ctx,
+                validationCtx,
                 instantInputs,
                 staticInputs,
                 prefetchMode,
@@ -4892,7 +4981,7 @@ function runDevValidationInBackground(
                     prefetchMode,
                     instantInputs,
                     staticInputs,
-                    toValidationRenderContext(ctx),
+                    toValidationRenderContext(validationCtx),
                     fallbackRouteParams,
                     devRenderDidError,
                     validationAbortSignal
@@ -5049,13 +5138,21 @@ async function prepareValidationInputs(
   ctx: AppRenderContext,
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
   createRequestStore: () => RequestStore,
-  getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
+  getPayload: (
+    ctx: AppRenderContext,
+    requestStore: RequestStore
+  ) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
-  validationAbortSignal: AbortSignal
+  validationAbortSignal: AbortSignal,
+  hasSameParamShape: boolean
 ): Promise<PrepareValidationInputsResult> {
   // Check if we can re-use the main render for validation.
   let inputsFromNavigation: ResolvedValidationInputs | null
-  if (!result.hadCacheMiss && !('syncInterruptReason' in result.outcome)) {
+  if (
+    hasSameParamShape &&
+    !result.hadCacheMiss &&
+    !('syncInterruptReason' in result.outcome)
+  ) {
     inputsFromNavigation = {
       accumulatedChunks: result.outcome.accumulatedChunks,
       startTime: result.outcome.startTime,
@@ -5064,7 +5161,8 @@ async function prepareValidationInputs(
       debugChannelClient: validationDebugChannel,
     }
   } else {
-    // Cache miss or sync IO. We can't re-use the main render.
+    // Cache miss, sync IO, or a different param shape. The foreground Flight
+    // chunks cannot seed validation; use the existing warm-render path instead.
     dropValidationDebugChannel(validationDebugChannel)
     inputsFromNavigation = null
   }
@@ -5100,7 +5198,10 @@ async function prepareValidationInputsInPartialPrefetching(
   ctx: AppRenderContext,
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
   createRequestStore: () => RequestStore,
-  getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
+  getPayload: (
+    ctx: AppRenderContext,
+    requestStore: RequestStore
+  ) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
   inputsFromNavigation: ResolvedValidationInputs | null,
   validationAbortSignal: AbortSignal
@@ -5202,7 +5303,10 @@ async function prepareValidationInputsInLegacyPrefetching(
   ctx: AppRenderContext,
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
   createRequestStore: () => RequestStore,
-  getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
+  getPayload: (
+    ctx: AppRenderContext,
+    requestStore: RequestStore
+  ) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
   inputsFromNavigation: ResolvedValidationInputs | null,
   validationAbortSignal: AbortSignal
@@ -5759,7 +5863,10 @@ function getStageEndTimes(
 async function renderWithWarmCachesForValidationInDev(
   ctx: AppRenderContext,
   createRequestStore: () => RequestStore,
-  getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
+  getPayload: (
+    ctx: AppRenderContext,
+    requestStore: RequestStore
+  ) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
   prefetchMode: PrefetchingMode,
@@ -5795,7 +5902,7 @@ async function renderWithWarmCachesForValidationInDev(
   const environmentName = () =>
     getEnvironmentNameForStage(stageController.currentStage)
 
-  const rscPayload = await getPayload(requestStore)
+  const rscPayload = await getPayload(ctx, requestStore)
 
   let startTime = -Infinity
   const accumulatedChunks = await runInSequentialTasks(
@@ -5854,16 +5961,22 @@ async function renderWithWarmCachesForValidationInDev(
 
 interface StagedRenderWithCachesInDevOptions extends StagedDevRenderOptions {
   createRequestStore: () => RequestStore
-  getPayload: (requestStore: RequestStore) => Promise<RSCPayload>
+  getPayload: (
+    ctx: AppRenderContext,
+    requestStore: RequestStore
+  ) => Promise<RSCPayload>
   shouldValidate: boolean
-  fallbackRouteParams: OpaqueFallbackRouteParams | null
+  validationFallbackRouteParams: OpaqueFallbackRouteParams | null
   getDevRenderDidError: () => boolean
 }
 
 async function prerenderWithWarmCachesForStaticValidationInDev(
   ctx: AppRenderContext,
   createRequestStore: () => RequestStore,
-  getPayload: (requestStore: RequestStore) => Promise<RSCPayload>,
+  getPayload: (
+    ctx: AppRenderContext,
+    requestStore: RequestStore
+  ) => Promise<RSCPayload>,
   onError: (error: unknown) => void,
   prerenderResumeDataCache: ReturnType<typeof createPrerenderResumeDataCache>,
   validationAbortSignal: AbortSignal
@@ -5914,7 +6027,7 @@ async function prerenderWithWarmCachesForStaticValidationInDev(
   const environmentName = () =>
     getEnvironmentNameForStage(stageController.currentStage)
 
-  const rscPayload = await getPayload(requestStore)
+  const rscPayload = await getPayload(ctx, requestStore)
 
   let startTime = -Infinity
   const collectedChunksByStage = createStageChunksAccumulator()
@@ -6045,7 +6158,7 @@ async function stagedRenderWithCachesInDev({
   getPayload,
   onError,
   shouldValidate,
-  fallbackRouteParams,
+  validationFallbackRouteParams,
   getDevRenderDidError,
   navigationKind,
   requestAbortSignal,
@@ -6079,7 +6192,7 @@ async function stagedRenderWithCachesInDev({
 
     // The stage controller starts in the `Before` stage, where sync IO doesn't
     // abort, so it's fine if it happens while creating the payload.
-    const rscPayload = await getPayload(requestStore)
+    const rscPayload = await getPayload(ctx, requestStore)
 
     const { stream, resultPromise } = await streamStagedRenderInDev({
       prefetchMode,
@@ -6137,7 +6250,7 @@ async function stagedRenderWithCachesInDev({
           requestStore,
           validationDebugChannel,
           ctx,
-          fallbackRouteParams,
+          validationFallbackRouteParams,
           prerenderResumeDataCache,
           getDevRenderDidError,
           createRequestStore,

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2762,8 +2762,21 @@ export default abstract class Server<
           let perUrlFallbackRouteParams: NonNullable<
             (typeof pathsResults.prerenderedRoutes)[number]['fallbackRouteParams']
           > | null = null
+          // Validation checks the most-specific shape generated for the route,
+          // independently of which literal values this request contains. If gSP
+          // supplies only `top: 't1'`, both `/t1/b1` and `/t2/b2` validate with
+          // only `bottom` unknown. The foreground selection remains per-URL.
+          let validationFallbackRouteParams:
+            | PrerenderedRoute['fallbackRouteParams']
+            | undefined
           for (const route of pathsResults.prerenderedRoutes) {
             const fallbackRouteParams = route.fallbackRouteParams ?? []
+            if (
+              validationFallbackRouteParams === undefined ||
+              fallbackRouteParams.length < validationFallbackRouteParams.length
+            ) {
+              validationFallbackRouteParams = fallbackRouteParams
+            }
             if (!getRouteRegex(route.pathname).re.test(urlPathname)) {
               continue
             }
@@ -2782,6 +2795,13 @@ export default abstract class Server<
               req,
               'fallbackParams',
               createOpaqueFallbackRouteParams(perUrlFallbackRouteParams)!
+            )
+          }
+          if (validationFallbackRouteParams) {
+            addRequestMeta(
+              req,
+              'devPrerenderValidationFallbackParams',
+              createOpaqueFallbackRouteParams(validationFallbackRouteParams)
             )
           }
         }

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -324,6 +324,9 @@ export interface RequestMeta {
    */
   fallbackParams?: OpaqueFallbackRouteParams
 
+  /** DEV only: params made unknown while validating the build-time shell shape. */
+  devPrerenderValidationFallbackParams?: OpaqueFallbackRouteParams | null
+
   /**
    * DEV only: Request timings in process.hrtime.bigint()
    */

--- a/test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts
+++ b/test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts
@@ -1,10 +1,21 @@
-import { nextTestSetup } from 'e2e-utils'
+import { nextTestSetup, type Playwright } from 'e2e-utils'
+import { getDevCliValidationOutput } from 'e2e-utils/instant-validation'
 import { waitForNoRedbox } from 'next-test-utils'
 
 describe('Cache Components Fallback Validation', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    env: { NEXT_TEST_LOG_VALIDATION: '1' },
   })
+
+  async function expectNoValidationErrors(browser: Playwright) {
+    // Validation runs after the response. Wait for it to finish before checking
+    // for errors, including for novel values not returned by generateStaticParams.
+    expect(
+      await getDevCliValidationOutput(await browser.url(), () => next.cliOutput)
+    ).not.toContain('Error: Route')
+    await waitForNoRedbox(browser)
+  }
 
   it('should not warn about missing Suspense when accessing params if static params are completely known at build time', async () => {
     // when the params are complete we don't expect to see any errors await params regarless of where there
@@ -12,24 +23,24 @@ describe('Cache Components Fallback Validation', () => {
     const browser = await next.browser(
       '/complete/prerendered/wrapped/prerendered'
     )
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(`${next.url}/complete/prerendered/wrapped/novel`)
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(`${next.url}/complete/novel/wrapped/novel`)
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(
       `${next.url}/complete/prerendered/unwrapped/prerendered`
     )
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(`${next.url}/complete/prerendered/unwrapped/novel`)
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(`${next.url}/complete/novel/unwrapped/novel`)
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
   })
 
   it('should warn about missing Suspense when accessing params if static params are partially known at build time', async () => {
@@ -38,13 +49,13 @@ describe('Cache Components Fallback Validation', () => {
     const browser = await next.browser(
       '/partial/prerendered/wrapped/prerendered'
     )
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(`${next.url}/partial/prerendered/wrapped/novel`)
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(`${next.url}/partial/novel/wrapped/novel`)
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(
       `${next.url}/partial/prerendered/unwrapped/prerendered`
@@ -84,11 +95,11 @@ describe('Cache Components Fallback Validation', () => {
        "description": "Next.js encountered runtime data during prerendering.",
        "environmentLabel": "Server",
        "label": "Blocking Route",
-       "source": "app/partial/[top]/unwrapped/layout.tsx (8:3) @ Layout
-     >  8 |   await params
-          |   ^",
+       "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
+     > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
+         |                          ^",
        "stack": [
-         "Layout app/partial/[top]/unwrapped/layout.tsx (8:3)",
+         "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
        ],
      }
     `)

--- a/test/development/app-dir/cache-components-dev-fallback-validation/next.config.js
+++ b/test/development/app-dir/cache-components-dev-fallback-validation/next.config.js
@@ -3,6 +3,13 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  experimental: {
+    instantInsights: {
+      // This suite checks build-equivalent static shells, not the separate
+      // automatic validation of individual navigation boundaries.
+      validationLevel: 'manual-warning',
+    },
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## Summary

Fix Cache Components development validation so it checks the most-specific parameter shape produced by `generateStaticParams`, regardless of the literal parameter values in the request.

This is a standalone fix for existing behavior, with no experimental matching API or feature flag. It forms the bottom of the parameter-matching stack. #97393 builds on this separation to let explicit fallback directives choose an earlier validation boundary, so this fix can land without committing to the new API.

## Why

The dev server currently chooses fallback parameters by matching the requested URL against the generated paths. That is appropriate for staging the foreground response, but that same selection also reaches background static-shell validation. A novel value therefore causes validation to check a more generic shell than the build requires.

For `/[top]/items/[bottom]`, suppose `generateStaticParams` returns:

```ts
return [{ top: 't1' }]
```

The build validates `/t1/items/[bottom]`: `top` is available, while `bottom` remains dynamic. A dev request for `/t2/items/b2` should exercise the same shape using its actual `top: 't2'` value. It should not require the shell to work with both `top` and `bottom` unknown.

| Generated example | Dev request | Unknown parameters during static-shell validation |
| --- | --- | --- |
| `{ top: 't1', bottom: 'b1' }` | `/t2/items/b2` | None |
| `{ top: 't1' }` | `/t2/items/b2` | `bottom` |
| No examples | `/t2/items/b2` | `top`, `bottom` |

This restores the value-independent validation semantics that were lost when #95066 made foreground staging value-sensitive. It does not revert that foreground staging change.

## Changes

- Select the smallest fallback-parameter set across all generated paths for validation, separately from the per-URL set used by the foreground render.
- Pass that validation shape through dev-only request metadata.
- When the two shapes differ, construct a separate validation context and request store. Do not reuse Flight chunks produced with the foreground parameter shape; use the existing background validation render instead.
- Require an explicit render context at every dev payload call site, rather than defaulting to a captured foreground context or introducing a separate validation wrapper.
- Keep production rendering, build output, cache-miss routing, and the foreground dev response unchanged.
- Strengthen the existing no-API fixture to wait for background validation before asserting success. Restore the novel-`top` error expectation to the page that reads the genuinely dynamic `bottom`, rather than the layout that reads `top`.
- Limit this fixture to static-shell validation so automatic navigation-boundary insights do not obscure the behavior under test.

## Verification

- Reproduced two failing regression cases against the unchanged baseline, then passed the suite with the fix.
- `CI=1 pnpm build-all` (uses the installed native package)
- `pnpm --filter=next types`
- ESLint and Prettier for the changed files
- `pnpm test-dev-webpack test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts`
- `pnpm test-dev-turbo test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts`
- `pnpm test-dev-webpack test/development/app-dir/cache-components-dev-warmup -t 'mixed static and fallback params resolve in the correct phase'` (24 checks across eight configurations; also passed against the unchanged baseline)

<!-- NEXT_JS_LLM -->

