### PR TITLE
test: restore deployment exclusion for shared Cache Components tests

### DIFF
--- a/test/e2e/app-dir/cache-components-errors/shared.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/shared.util.ts
@@ -18,14 +18,18 @@ export interface CacheComponentsErrorsContext {
 export function runCacheComponentsErrorsTests(
   registerTests: (ctx: CacheComponentsErrorsContext) => void
 ) {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // No deploy-specific incompatibility is documented.
-  // @force-gate !deploy
   describe('Cache Components Errors', () => {
-    const { next, isTurbopack, isNextStart, isRspack } = nextTestSetup({
-      files: __dirname + '/fixtures/default',
-      skipStart: !isNextDev,
-    })
+    const { next, isTurbopack, isNextStart, isRspack, skipped } = nextTestSetup(
+      {
+        files: __dirname + '/fixtures/default',
+        skipStart: !isNextDev,
+        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
+        // No deploy-specific incompatibility is documented.
+        skipDeployment: true,
+      }
+    )
+
+    if (skipped) return
 
     afterEach(async () => {
       if (isNextStart) {


### PR DESCRIPTION
## Summary

Restore `skipDeployment` and the early return in the shared Cache Components error-test runner. The migration in #98154 replaced them with a force-gate pragma, but the gate transformer only processes `.test.*` files, so the pragma in `shared.util.ts` did not preserve the deployment exclusion.

This is a temporary rollback to unblock deploy testing. Moving the test definitions out of the helper and migrating them again will be evaluated separately; this PR does not change the transformer or refactor the tests.

## Verification

- Ran all 12 importing test files through Jest in deploy mode with deployment setup mocked to throw before any fixture or deployment work. Before the rollback, all 12 reached that guard and failed. After the rollback, all 12 take the legacy exclusion path and no deployment setup is attempted.
- `pnpm typescript --skipLibCheck` passes.
- Full type-check reports the existing nine Octokit dependency declaration errors; no errors in the changed file.

<!-- NEXT_JS_LLM -->