### PR TITLE
Turbopack: Deduplicate project options documentation

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -289,13 +289,18 @@ impl DebugBuildPathsRouteKeys {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectOptions {
-    /// An absolute root path (Unix or Windows path) from which all files must be nested under.
-    /// Trying to access a file outside this root will fail, so think of this as a chroot.
-    /// E.g. `/home/user/projects/my-repo`.
+    /// An [canonicalized][std::fs::canonicalize] root path (Unix or Windows path) from which all
+    /// files must be nested under. Trying to access a file outside this root will fail, so think
+    /// of this as a weak chroot. E.g. `/home/user/projects/my-repo`.
+    ///
+    /// This serves two purposes:
+    /// - It gives us a root to configure the file system watcher with.
+    /// - It ensures the cache is portable when the root path is moved, since every other path is
+    ///   relative to it.
     pub root_path: RcStr,
 
-    /// A path which contains the app/pages directories, relative to [`Project::project_path`],
-    /// always Unix path. E.g. `apps/my-app`
+    /// A path which contains the app/pages directories, relative to [`Project::project_path`].
+    /// Always a Unix-style (`/`-separated) path. E.g. `apps/my-app`.
     pub project_path: RcStr,
 
     /// The contents of next.config.js, serialized to JSON.
@@ -304,8 +309,7 @@ pub struct ProjectOptions {
     /// A map of environment variables to use when compiling code.
     pub env: Vec<(RcStr, RcStr)>,
 
-    /// A map of environment variables which should get injected at compile
-    /// time.
+    /// A map of environment variables which should get injected at compile time.
     pub define_env: DefineEnv,
 
     /// Filesystem watcher options.
@@ -326,9 +330,8 @@ pub struct ProjectOptions {
     /// The browserslist query to use for targeting browsers.
     pub browserslist_query: RcStr,
 
-    /// When the code is minified, this opts out of the default mangling of
-    /// local names for variables, functions etc., which can be useful for
-    /// debugging/profiling purposes.
+    /// When the code is minified, this opts out of the default mangling of local names for
+    /// variables, functions etc., which can be useful for debugging/profiling purposes.
     pub no_mangling: bool,
 
     /// Whether to write the route hashes manifest.
@@ -337,8 +340,8 @@ pub struct ProjectOptions {
     /// The version of Node.js that is available/currently running.
     pub current_node_js_version: RcStr,
 
-    /// Debug build paths for selective builds.
-    /// When set, only routes matching these paths will be included in the build.
+    /// Debug build paths for selective builds. When set, only routes matching these paths will be
+    /// included in the build.
     pub debug_build_paths: Option<DebugBuildPaths>,
 
     /// App-router page routes that should be built after non-deferred routes.
@@ -350,57 +353,42 @@ pub struct ProjectOptions {
     /// The version of Next.js that is running.
     pub next_version: RcStr,
 
-    /// Whether server-side HMR is enabled (disabled with --no-server-fast-refresh).
+    /// Whether server-side HMR is enabled (disabled with `--no-server-fast-refresh`).
     pub server_hmr: bool,
 }
 
+/// The subset of [`ProjectOptions`] that may change without restarting the process. Used by
+/// [`ProjectContainer::update`].
+///
+/// Refer to [`ProjectOptions`] for documentation on this struct's fields.
 #[derive(Default)]
 pub struct PartialProjectOptions {
-    /// A root path from which all files must be nested under. Trying to access
-    /// a file outside this root will fail. Think of this as a chroot.
     pub root_path: Option<RcStr>,
 
-    /// A path inside the root_path which contains the app/pages directories.
     pub project_path: Option<RcStr>,
 
-    /// The contents of next.config.js, serialized to JSON.
     pub next_config: Option<RcStr>,
 
-    /// A map of environment variables to use when compiling code.
     pub env: Option<Vec<(RcStr, RcStr)>>,
 
-    /// A map of environment variables which should get injected at compile
-    /// time.
     pub define_env: Option<DefineEnv>,
 
-    /// Filesystem watcher options.
     pub watch: Option<WatchOptions>,
 
-    /// The mode in which Next.js is running.
     pub dev: Option<bool>,
 
-    /// The server actions encryption key.
     pub encryption_key: Option<RcStr>,
 
-    /// The build id.
     pub build_id: Option<RcStr>,
 
-    /// Options for draft mode.
     pub preview_props: Option<DraftModeOptions>,
 
-    /// The browserslist query to use for targeting browsers.
     pub browserslist_query: Option<RcStr>,
 
-    /// When the code is minified, this opts out of the default mangling of
-    /// local names for variables, functions etc., which can be useful for
-    /// debugging/profiling purposes.
     pub no_mangling: Option<bool>,
 
-    /// Whether to write the route hashes manifest.
     pub write_routes_hashes_manifest: Option<bool>,
 
-    /// Debug build paths for selective builds.
-    /// When set, only routes matching these paths will be included in the build.
     pub debug_build_paths: Option<DebugBuildPaths>,
 }
 

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -220,53 +220,36 @@ pub struct NapiProjectOptions {
     pub server_hmr: Option<bool>,
 }
 
-/// [NapiProjectOptions] with all fields optional.
+/// The subset of [`NapiProjectOptions`] that may change without restarting the process. Used by
+/// [`project_update`].
+///
+/// Refer to [`NapiProjectOptions`] for documentation on this struct's fields.
 #[napi(object)]
 pub struct NapiPartialProjectOptions {
-    /// An absolute root path  (Unix or Windows path) from which all files must be nested under.
-    /// Trying to access a file outside this root will fail, so think of this as a chroot.
-    /// E.g. `/home/user/projects/my-repo`.
     pub root_path: Option<RcStr>,
 
-    /// A path which contains the app/pages directories, relative to [`Project::root_path`], always
-    /// a Unix path.
-    /// E.g. `apps/my-app`
     pub project_path: Option<RcStr>,
 
-    /// Filesystem watcher options.
     pub watch: Option<NapiWatchOptions>,
 
-    /// The contents of next.config.js, serialized to JSON.
     pub next_config: Option<RcStr>,
 
-    /// A map of environment variables to use when compiling code.
     pub env: Option<Vec<NapiEnvVar>>,
 
-    /// A map of environment variables which should get injected at compile
-    /// time.
     pub define_env: Option<NapiDefineEnv>,
 
-    /// The mode in which Next.js is running.
     pub dev: Option<bool>,
 
-    /// The server actions encryption key.
     pub encryption_key: Option<RcStr>,
 
-    /// The build id.
     pub build_id: Option<RcStr>,
 
-    /// Options for draft mode.
     pub preview_props: Option<NapiDraftModeOptions>,
 
-    /// The browserslist query to use for targeting browsers.
     pub browserslist_query: Option<RcStr>,
 
-    /// Whether to write the route hashes manifest.
     pub write_routes_hashes_manifest: Option<bool>,
 
-    /// When the code is minified, this opts out of the default mangling of
-    /// local names for variables, functions etc., which can be useful for
-    /// debugging/profiling purposes.
     pub no_mangling: Option<bool>,
 }
 

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -354,48 +354,25 @@ export interface NapiOptionEnvVar {
   value?: RcStr
 }
 
-/** [NapiProjectOptions] with all fields optional. */
+/**
+ * The subset of [`NapiProjectOptions`] that may change without restarting the process. Used by
+ * [`project_update`].
+ *
+ * Refer to [`NapiProjectOptions`] for documentation on this struct's fields.
+ */
 export interface NapiPartialProjectOptions {
-  /**
-   * An absolute root path  (Unix or Windows path) from which all files must be nested under.
-   * Trying to access a file outside this root will fail, so think of this as a chroot.
-   * E.g. `/home/user/projects/my-repo`.
-   */
   rootPath?: RcStr
-  /**
-   * A path which contains the app/pages directories, relative to [`Project::root_path`], always
-   * a Unix path.
-   * E.g. `apps/my-app`
-   */
   projectPath?: RcStr
-  /** Filesystem watcher options. */
   watch?: NapiWatchOptions
-  /** The contents of next.config.js, serialized to JSON. */
   nextConfig?: RcStr
-  /** A map of environment variables to use when compiling code. */
   env?: Array<NapiEnvVar>
-  /**
-   * A map of environment variables which should get injected at compile
-   * time.
-   */
   defineEnv?: NapiDefineEnv
-  /** The mode in which Next.js is running. */
   dev?: boolean
-  /** The server actions encryption key. */
   encryptionKey?: RcStr
-  /** The build id. */
   buildId?: RcStr
-  /** Options for draft mode. */
   previewProps?: NapiDraftModeOptions
-  /** The browserslist query to use for targeting browsers. */
   browserslistQuery?: RcStr
-  /** Whether to write the route hashes manifest. */
   writeRoutesHashesManifest?: boolean
-  /**
-   * When the code is minified, this opts out of the default mangling of
-   * local names for variables, functions etc., which can be useful for
-   * debugging/profiling purposes.
-   */
   noMangling?: boolean
 }
 


### PR DESCRIPTION
By documenting both the partial and non-partial versions of these objects, we were documenting everything multiple times.

Just reference the non-partial object from the partial object's documentation.