### PR TITLE
test: migrate legacy deployment exclusion callers

### DIFF
--- a/test/e2e/app-dir/cache-components-errors/error-attribution.partial-prefetching.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/error-attribution.partial-prefetching.test.ts
@@ -3,4 +3,8 @@ import { registerErrorAttributionTests } from './error-attribution.util'
 
 process.env.__NEXT_PARTIAL_PREFETCHING = 'true'
 
-runCacheComponentsErrorsTests(registerErrorAttributionTests)
+// These tests run local builds to inspect prerender error diagnostics.
+// @force-gate !deploy
+describe('Cache Components Errors', () => {
+  runCacheComponentsErrorsTests(registerErrorAttributionTests)
+})

--- a/test/e2e/app-dir/cache-components-errors/error-attribution.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/error-attribution.test.ts
@@ -1,4 +1,8 @@
 import { runCacheComponentsErrorsTests } from './shared.util'
 import { registerErrorAttributionTests } from './error-attribution.util'
 
-runCacheComponentsErrorsTests(registerErrorAttributionTests)
+// These tests run local builds to inspect prerender error diagnostics.
+// @force-gate !deploy
+describe('Cache Components Errors', () => {
+  runCacheComponentsErrorsTests(registerErrorAttributionTests)
+})

--- a/test/e2e/app-dir/cache-components-errors/metadata-and-viewport.partial-prefetching.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/metadata-and-viewport.partial-prefetching.test.ts
@@ -3,4 +3,8 @@ import { registerMetadataAndViewportTests } from './metadata-and-viewport.util'
 
 process.env.__NEXT_PARTIAL_PREFETCHING = 'true'
 
-runCacheComponentsErrorsTests(registerMetadataAndViewportTests)
+// These tests run local builds to inspect prerender error diagnostics.
+// @force-gate !deploy
+describe('Cache Components Errors', () => {
+  runCacheComponentsErrorsTests(registerMetadataAndViewportTests)
+})

--- a/test/e2e/app-dir/cache-components-errors/metadata-and-viewport.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/metadata-and-viewport.test.ts
@@ -1,4 +1,8 @@
 import { runCacheComponentsErrorsTests } from './shared.util'
 import { registerMetadataAndViewportTests } from './metadata-and-viewport.util'
 
-runCacheComponentsErrorsTests(registerMetadataAndViewportTests)
+// These tests run local builds to inspect prerender error diagnostics.
+// @force-gate !deploy
+describe('Cache Components Errors', () => {
+  runCacheComponentsErrorsTests(registerMetadataAndViewportTests)
+})

--- a/test/e2e/app-dir/cache-components-errors/shared.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/shared.util.ts
@@ -14,73 +14,50 @@ export interface CacheComponentsErrorsContext {
 // into one `*.test.ts` entry file per group of sections (each with a
 // `.partial-prefetching` variant), all sharing this wrapper. Each entry
 // boots its own server (and, in `next start` mode, runs its own builds).
-// Snapshots can be updated with the sibling update-snapshots.sh script.
+// Each entry owns its gated describe because pragmas are only transformed in
+// test files. Snapshots can be updated with the sibling update-snapshots.sh script.
 export function runCacheComponentsErrorsTests(
   registerTests: (ctx: CacheComponentsErrorsContext) => void
 ) {
-  describe('Cache Components Errors', () => {
-    const { next, isTurbopack, isNextStart, isRspack, skipped } = nextTestSetup(
-      {
-        files: __dirname + '/fixtures/default',
-        skipStart: !isNextDev,
-        // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-        // No deploy-specific incompatibility is documented.
-        skipDeployment: true,
-      }
-    )
+  const { next, isTurbopack, isNextStart, isRspack } = nextTestSetup({
+    files: __dirname + '/fixtures/default',
+    skipStart: !isNextDev,
+  })
 
-    if (skipped) return
-
-    afterEach(async () => {
-      if (isNextStart) {
-        await next.stop()
-      }
-    })
-
-    const testCases: { isDebugPrerender: boolean; name: string }[] = []
-
-    if (isNextDev) {
-      testCases.push({ isDebugPrerender: false, name: 'Dev' })
-    } else {
-      const prerenderMode = process.env.NEXT_TEST_DEBUG_PRERENDER
-      // The snapshots can't be created for both modes at the same time because of
-      // an issue in the typescript plugin for prettier. Defining
-      // NEXT_TEST_DEBUG_PRERENDER allows us to run them sequentially, when we
-      // need to update the snapshots.
-      if (!prerenderMode || prerenderMode === 'true') {
-        testCases.push({
-          isDebugPrerender: true,
-          name: 'Build With --prerender-debug',
-        })
-      }
-      if (!prerenderMode || prerenderMode === 'false') {
-        testCases.push({
-          isDebugPrerender: false,
-          name: 'Build Without --prerender-debug',
-        })
-      }
+  afterEach(async () => {
+    if (isNextStart) {
+      await next.stop()
     }
+  })
 
-    describe.each(testCases)('$name', ({ isDebugPrerender }) => {
-      beforeAll(async () => {
-        if (isNextStart) {
-          const args = ['--experimental-build-mode', 'compile']
+  const testCases: { isDebugPrerender: boolean; name: string }[] = []
 
-          if (isDebugPrerender) {
-            args.push('--debug-prerender')
-          }
-
-          await next.build({ args })
-        }
+  if (isNextDev) {
+    testCases.push({ isDebugPrerender: false, name: 'Dev' })
+  } else {
+    const prerenderMode = process.env.NEXT_TEST_DEBUG_PRERENDER
+    // The snapshots can't be created for both modes at the same time because of
+    // an issue in the typescript plugin for prettier. Defining
+    // NEXT_TEST_DEBUG_PRERENDER allows us to run them sequentially, when we
+    // need to update the snapshots.
+    if (!prerenderMode || prerenderMode === 'true') {
+      testCases.push({
+        isDebugPrerender: true,
+        name: 'Build With --prerender-debug',
       })
+    }
+    if (!prerenderMode || prerenderMode === 'false') {
+      testCases.push({
+        isDebugPrerender: false,
+        name: 'Build Without --prerender-debug',
+      })
+    }
+  }
 
-      const prerender = async (pathname: string) => {
-        const args = [
-          '--experimental-build-mode',
-          'generate',
-          '--debug-build-paths',
-          `app${pathname}/page.tsx`,
-        ]
+  describe.each(testCases)('$name', ({ isDebugPrerender }) => {
+    beforeAll(async () => {
+      if (isNextStart) {
+        const args = ['--experimental-build-mode', 'compile']
 
         if (isDebugPrerender) {
           args.push('--debug-prerender')
@@ -88,15 +65,30 @@ export function runCacheComponentsErrorsTests(
 
         await next.build({ args })
       }
+    })
 
-      registerTests({
-        next,
-        isTurbopack,
-        isRspack,
-        isNextStart,
-        isDebugPrerender,
-        prerender,
-      })
+    const prerender = async (pathname: string) => {
+      const args = [
+        '--experimental-build-mode',
+        'generate',
+        '--debug-build-paths',
+        `app${pathname}/page.tsx`,
+      ]
+
+      if (isDebugPrerender) {
+        args.push('--debug-prerender')
+      }
+
+      await next.build({ args })
+    }
+
+    registerTests({
+      next,
+      isTurbopack,
+      isRspack,
+      isNextStart,
+      isDebugPrerender,
+      prerender,
     })
   })
 }

--- a/test/e2e/app-dir/cache-components-errors/sync-dynamic.partial-prefetching.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/sync-dynamic.partial-prefetching.test.ts
@@ -7,7 +7,11 @@ process.env.__NEXT_PARTIAL_PREFETCHING = 'true'
 // Registers two section groups in one entry: dynamic-root-and-boundary is too
 // small to justify its own CI test file (per-file server boot and, in start
 // mode, build costs).
-runCacheComponentsErrorsTests((ctx) => {
-  registerDynamicRootAndBoundaryTests(ctx)
-  registerSyncDynamicTests(ctx)
+// These tests run local builds to inspect prerender error diagnostics.
+// @force-gate !deploy
+describe('Cache Components Errors', () => {
+  runCacheComponentsErrorsTests((ctx) => {
+    registerDynamicRootAndBoundaryTests(ctx)
+    registerSyncDynamicTests(ctx)
+  })
 })

--- a/test/e2e/app-dir/cache-components-errors/sync-dynamic.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/sync-dynamic.test.ts
@@ -5,7 +5,11 @@ import { registerSyncDynamicTests } from './sync-dynamic.util'
 // Registers two section groups in one entry: dynamic-root-and-boundary is too
 // small to justify its own CI test file (per-file server boot and, in start
 // mode, build costs).
-runCacheComponentsErrorsTests((ctx) => {
-  registerDynamicRootAndBoundaryTests(ctx)
-  registerSyncDynamicTests(ctx)
+// These tests run local builds to inspect prerender error diagnostics.
+// @force-gate !deploy
+describe('Cache Components Errors', () => {
+  runCacheComponentsErrorsTests((ctx) => {
+    registerDynamicRootAndBoundaryTests(ctx)
+    registerSyncDynamicTests(ctx)
+  })
 })

--- a/test/e2e/app-dir/cache-components-errors/sync-io-node-crypto.partial-prefetching.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/sync-io-node-crypto.partial-prefetching.test.ts
@@ -3,4 +3,8 @@ import { registerSyncIoNodeCryptoTests } from './sync-io-node-crypto.util'
 
 process.env.__NEXT_PARTIAL_PREFETCHING = 'true'
 
-runCacheComponentsErrorsTests(registerSyncIoNodeCryptoTests)
+// These tests run local builds to inspect prerender error diagnostics.
+// @force-gate !deploy
+describe('Cache Components Errors', () => {
+  runCacheComponentsErrorsTests(registerSyncIoNodeCryptoTests)
+})

--- a/test/e2e/app-dir/cache-components-errors/sync-io-node-crypto.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/sync-io-node-crypto.test.ts
@@ -1,4 +1,8 @@
 import { runCacheComponentsErrorsTests } from './shared.util'
 import { registerSyncIoNodeCryptoTests } from './sync-io-node-crypto.util'
 
-runCacheComponentsErrorsTests(registerSyncIoNodeCryptoTests)
+// These tests run local builds to inspect prerender error diagnostics.
+// @force-gate !deploy
+describe('Cache Components Errors', () => {
+  runCacheComponentsErrorsTests(registerSyncIoNodeCryptoTests)
+})

--- a/test/e2e/app-dir/cache-components-errors/sync-io-time-and-random.partial-prefetching.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/sync-io-time-and-random.partial-prefetching.test.ts
@@ -3,4 +3,8 @@ import { registerSyncIoTimeAndRandomTests } from './sync-io-time-and-random.util
 
 process.env.__NEXT_PARTIAL_PREFETCHING = 'true'
 
-runCacheComponentsErrorsTests(registerSyncIoTimeAndRandomTests)
+// These tests run local builds to inspect prerender error diagnostics.
+// @force-gate !deploy
+describe('Cache Components Errors', () => {
+  runCacheComponentsErrorsTests(registerSyncIoTimeAndRandomTests)
+})

--- a/test/e2e/app-dir/cache-components-errors/sync-io-time-and-random.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/sync-io-time-and-random.test.ts
@@ -1,4 +1,8 @@
 import { runCacheComponentsErrorsTests } from './shared.util'
 import { registerSyncIoTimeAndRandomTests } from './sync-io-time-and-random.util'
 
-runCacheComponentsErrorsTests(registerSyncIoTimeAndRandomTests)
+// These tests run local builds to inspect prerender error diagnostics.
+// @force-gate !deploy
+describe('Cache Components Errors', () => {
+  runCacheComponentsErrorsTests(registerSyncIoTimeAndRandomTests)
+})

--- a/test/e2e/app-dir/cache-components-errors/use-cache.partial-prefetching.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/use-cache.partial-prefetching.test.ts
@@ -7,7 +7,11 @@ process.env.__NEXT_PARTIAL_PREFETCHING = 'true'
 // Registers two section groups in one entry: use-cache-private is too small
 // to justify its own CI test file (per-file server boot and, in start mode,
 // build costs).
-runCacheComponentsErrorsTests((ctx) => {
-  registerUseCacheTests(ctx)
-  registerUseCachePrivateTests(ctx)
+// These tests run local builds to inspect prerender error diagnostics.
+// @force-gate !deploy
+describe('Cache Components Errors', () => {
+  runCacheComponentsErrorsTests((ctx) => {
+    registerUseCacheTests(ctx)
+    registerUseCachePrivateTests(ctx)
+  })
 })

--- a/test/e2e/app-dir/cache-components-errors/use-cache.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/use-cache.test.ts
@@ -5,7 +5,11 @@ import { registerUseCachePrivateTests } from './use-cache-private.util'
 // Registers two section groups in one entry: use-cache-private is too small
 // to justify its own CI test file (per-file server boot and, in start mode,
 // build costs).
-runCacheComponentsErrorsTests((ctx) => {
-  registerUseCacheTests(ctx)
-  registerUseCachePrivateTests(ctx)
+// These tests run local builds to inspect prerender error diagnostics.
+// @force-gate !deploy
+describe('Cache Components Errors', () => {
+  runCacheComponentsErrorsTests((ctx) => {
+    registerUseCacheTests(ctx)
+    registerUseCachePrivateTests(ctx)
+  })
 })

--- a/test/e2e/app-dir/segment-cache/prefetch-app-shell-revalidation/prefetch-app-shell-revalidation.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-app-shell-revalidation/prefetch-app-shell-revalidation.test.ts
@@ -28,12 +28,13 @@ const REPRODUCE_STATIC_PAGE_UPGRADE_BUG =
 const REPRODUCE_STATIC_SHELL_PRECEDENCE_BUG =
   !!process.env.REPRODUCE_STATIC_SHELL_PRECEDENCE_BUG || false
 
+// The fixture rewrites value.json during requests; deployments do not provide
+// a writable, shared application filesystem.
+// @force-gate !deploy
 describe('App Shell revalidation', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true, // modifies files at runtime
   })
-  if (skipped) return
   if (isNextDev) {
     it('is skipped', () => {})
     return

--- a/test/production/app-dir/output-file-tracing-includes-read-glob/output-file-tracing-includes-read-glob.test.ts
+++ b/test/production/app-dir/output-file-tracing-includes-read-glob/output-file-tracing-includes-read-glob.test.ts
@@ -1,16 +1,17 @@
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
+// Runs a local build and reads its page.js.nft.json file to verify traced files.
+// Deployment mode does not expose those local build artifacts.
+// @force-gate !deploy
 describe('outputFileTracingIncludes read glob', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
       'lightningcss-wasm': '1.28.2',
     },
     skipStart: true,
-    skipDeployment: true,
   })
-  if (skipped) return
 
   it('traces a file from the monorepo node_modules directory', async () => {
     const wasmPath = require.resolve(


### PR DESCRIPTION
## Summary

Migrate the shared cache-components error tests and two additional legacy deployment exclusions from `skipDeployment`/`skipped` to test gates, so these callers can land on canary before the API is removed.

Place the cache-error gate on the existing named `describe` boundary in each of the 12 `.test.ts` entry files. Jest transforms gate pragmas in test files; a gate in the shared utility would be inert. The helper continues registering the same tests inside those entry-level suites, preserving their names and snapshots. These tests inspect local prerender builds and cannot run against a deployment.

The other two callers cover segment-cache fixture mutation and production output-file tracing. This is a standalone preparatory migration, not the removal of the legacy API itself.

## Verification

- Rebased onto canary at `ccef3db535`; the stable patch ID matches the original migration exactly.
- On the rebased tree, all 77 gate infrastructure unit tests passed.
- Deploy-mode Jest collection of all 12 cache-error entry files: 236 skipped, zero executed, and no deployment started.
- Prettier, ESLint, and diff whitespace checks passed.
- Full bootstrap attempted but blocked by missing package-level dependencies (`microbundle`) in the temporary worktree; no full dev/start integration run is claimed.

<!-- NEXT_JS_LLM -->
