### PR TITLE
test: explain retained caching deploy exclusions

### DIFF
--- a/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
+++ b/test/e2e/app-dir/app-invalid-revalidate/app-invalid-revalidate.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite reads and rewrites fixture source/configuration before restarting Next.js.
+// Deployment mode cannot read or mutate the deployed fixture.
 // @force-gate !deploy
 describe('app-invalid-revalidate', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/cache-components-console/cache-components.console.test.ts
+++ b/test/e2e/app-dir/cache-components-console/cache-components.console.test.ts
@@ -3,8 +3,8 @@ import { retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 // TODO(restart-on-cache-miss): cacheSignal timing changes break console log dimming/hiding tests
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// These console-dimming checks exercise dev diagnostics or explicit local builds.
+// A deployed production app does not expose those dev/build operations.
 // @force-gate !deploy
 // @force-gate TODO
 describe('cache-components - Console Dimming - Validation', () => {
@@ -201,8 +201,8 @@ describe('cache-components - Console Dimming - Validation', () => {
 
 // TODO(restart-on-cache-miss): cacheSignal timing changes break console log dimming/hiding tests
 describe.skip('cache-components - Logging after Abort', () => {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // These console-dimming checks exercise dev diagnostics or explicit local builds.
+  // A deployed production app does not expose those dev/build operations.
   // @force-gate !deploy
   describe('(default) With Dimming - Server', () => {
     const { next, isTurbopack } = nextTestSetup({
@@ -377,8 +377,8 @@ describe.skip('cache-components - Logging after Abort', () => {
     })
   })
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // These console-dimming checks exercise dev diagnostics or explicit local builds.
+  // A deployed production app does not expose those dev/build operations.
   // @force-gate !deploy
   describe('(default) With Dimming - Client', () => {
     const { next, isTurbopack } = nextTestSetup({
@@ -544,8 +544,8 @@ describe.skip('cache-components - Logging after Abort', () => {
     })
   })
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // These console-dimming checks exercise dev diagnostics or explicit local builds.
+  // A deployed production app does not expose those dev/build operations.
   // @force-gate !deploy
   describe('With Hiding - Server', () => {
     const { next } = nextTestSetup({
@@ -643,8 +643,8 @@ describe.skip('cache-components - Logging after Abort', () => {
     })
   })
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // These console-dimming checks exercise dev diagnostics or explicit local builds.
+  // A deployed production app does not expose those dev/build operations.
   // @force-gate !deploy
   describe('With Hiding - Client', () => {
     const { next } = nextTestSetup({

--- a/test/e2e/app-dir/cache-components-create-component-tree/cache-components-create-component-tree.test.ts
+++ b/test/e2e/app-dir/cache-components-create-component-tree/cache-components-create-component-tree.test.ts
@@ -1,8 +1,8 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { waitForNoRedbox } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite invokes next.build() and inspects local build results.
+// Deployment mode cannot run these additional local builds.
 // @force-gate !deploy
 describe('hello-world', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/client-hook-abort-reasons.test.ts
@@ -1,8 +1,8 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { getPrerenderOutput } from './utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('Cache Components Errors - Client Hook Abort Reasons', () => {
   const { next, isTurbopack, isNextStart } = nextTestSetup({

--- a/test/e2e/app-dir/cache-components-errors/client.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/client.test.ts
@@ -1,8 +1,8 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { getPrerenderOutput } from './utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('Cache Components Errors - Client Components', () => {
   const { next, isTurbopack, isNextStart } = nextTestSetup({

--- a/test/e2e/app-dir/cache-components-errors/console-patch.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/console-patch.test.ts
@@ -2,8 +2,8 @@ import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { getPrerenderOutput } from './utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('Cache Components Errors', () => {
   const { next, isTurbopack, isNextStart } = nextTestSetup({

--- a/test/e2e/app-dir/cache-components-errors/http-access-fallback-prerender.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/http-access-fallback-prerender.test.ts
@@ -2,8 +2,8 @@ import { isNextDev, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { getPrerenderOutput } from './utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite invokes next.build() and inspects local build results.
+// Deployment mode cannot run these additional local builds.
 // @force-gate !deploy
 describe('Cache Components HTTP Access Fallback Prerender', () => {
   const { next, isNextStart } = nextTestSetup({

--- a/test/e2e/app-dir/cache-components-request-apis/cache-components-request-apis.test.ts
+++ b/test/e2e/app-dir/cache-components-request-apis/cache-components-request-apis.test.ts
@@ -74,8 +74,8 @@ describe(`Request Promises`, () => {
       )
     })
   })
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This suite starts an intentionally invalid fixture and asserts build diagnostics.
+  // The deploy harness requires setup to succeed, so the fixture cannot be deployed.
   // @force-gate !deploy
   describe('On Prerender Interruption', () => {
     const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
@@ -5,8 +5,8 @@ import {
   getRedboxSource,
 } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite starts an intentionally invalid fixture and asserts build diagnostics.
+// The deploy harness requires setup to succeed, so the fixture cannot be deployed.
 // @force-gate !deploy
 describe('cache-components-route-handler-errors', () => {
   const { next, isNextDev, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
@@ -23,8 +23,8 @@ function filterToErrorHeaders(output: string): string {
 
 // Only Turbopack runs the transform on the layout once in edge and non-edge contexts
 // so we only test this on Turbopack
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite starts an intentionally invalid fixture and asserts build diagnostics.
+// The deploy harness requires setup to succeed, so the fixture cannot be deployed.
 // @force-gate !deploy
 // @force-gate turbopack
 describe('cache-components-edge-deduplication', () => {

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
@@ -6,8 +6,8 @@ import {
   getRedboxSource,
 } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite starts an intentionally invalid fixture and asserts build diagnostics.
+// The deploy harness requires setup to succeed, so the fixture cannot be deployed.
 // @force-gate !deploy
 describe('cache-components-segment-configs', () => {
   const { next, isNextDev, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/instant-validation-static-shells/instant-validation-static-shells.test.ts
+++ b/test/e2e/app-dir/instant-validation-static-shells/instant-validation-static-shells.test.ts
@@ -31,8 +31,8 @@ describe('instant validation - opting out of static shells', () => {
 })
 
 describe('instant validation', () => {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This suite starts an intentionally invalid fixture and asserts build diagnostics.
+  // The deploy harness requires setup to succeed, so the fixture cannot be deployed.
   // @force-gate !deploy
   describe('requires a static shell if a below a static layout page is configured as blocking', () => {
     const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/ppr-missing-root-params/ppr-missing-root-params.test.ts
+++ b/test/e2e/app-dir/ppr-missing-root-params/ppr-missing-root-params.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite starts an intentionally invalid fixture and asserts build diagnostics.
+// The deploy harness requires setup to succeed, so the fixture cannot be deployed.
 // @force-gate !deploy
 describe('ppr-missing-root-params (single)', () => {
   const { next, isNextDev } = nextTestSetup({
@@ -27,8 +27,8 @@ describe('ppr-missing-root-params (single)', () => {
   })
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite starts an intentionally invalid fixture and asserts build diagnostics.
+// The deploy harness requires setup to succeed, so the fixture cannot be deployed.
 // @force-gate !deploy
 describe('ppr-missing-root-params (multiple)', () => {
   const { next, isNextDev } = nextTestSetup({
@@ -53,8 +53,8 @@ describe('ppr-missing-root-params (multiple)', () => {
   })
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite starts an intentionally invalid fixture and asserts build diagnostics.
+// The deploy harness requires setup to succeed, so the fixture cannot be deployed.
 // @force-gate !deploy
 describe('ppr-missing-root-params (nested)', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
+++ b/test/e2e/app-dir/ppr-partial-hydration/ppr-partial-hydration.test.ts
@@ -7,9 +7,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// the file-patching strategy we use for synchronizing the test doesn't work
-// on deployments
+// This suite calls next.patchFile() to change fixture files after setup.
+// Deployment mode cannot mutate the deployed fixture.
 // @force-gate !deploy
 describe('PPR - partial hydration', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
+++ b/test/e2e/app-dir/use-cache-close-over-function/use-cache-close-over-function.test.ts
@@ -7,8 +7,8 @@ import {
 } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('use-cache-close-over-function', () => {
   const { next, isNextDev, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/use-cache-configured-timeout/use-cache-configured-timeout.test.ts
+++ b/test/e2e/app-dir/use-cache-configured-timeout/use-cache-configured-timeout.test.ts
@@ -8,8 +8,8 @@ function expectedTimeoutErrorMessage(route: string) {
   return `Route "${route}": ${timeoutErrorMessage}`
 }
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite starts an intentionally invalid fixture and asserts build diagnostics.
+// The deploy harness requires setup to succeed, so the fixture cannot be deployed.
 // @force-gate !deploy
 describe('use-cache-configured-timeout', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/use-cache-deadlock-probe/use-cache-deadlock-probe.test.ts
+++ b/test/e2e/app-dir/use-cache-deadlock-probe/use-cache-deadlock-probe.test.ts
@@ -24,8 +24,8 @@ function expectedDeadlockMessage(route: string) {
 // than detected as a deadlock. Revisit by surfacing these deadlocks at build
 // time via `next build --debug-prerender`, then re-enable (and retarget) this
 // suite.
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// The deadlock probe and its error overlay are development-only behavior.
+// A deployed production build does not run the dev probe.
 // @force-gate !deploy
 // @force-gate TODO
 describe('use-cache-deadlock-probe', () => {

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -17,8 +17,8 @@ function expectedTimeoutErrorMessage(route: string) {
   return `Route "${route}": ${timeoutErrorMessage}`
 }
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('use-cache-hanging-inputs', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/use-cache-hanging/use-cache-hanging.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging/use-cache-hanging.test.ts
@@ -9,8 +9,8 @@ function expectedTimeoutErrorMessage(route: string) {
   return `Route "${route}": ${timeoutErrorMessage}`
 }
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite starts an intentionally invalid fixture and asserts build diagnostics.
+// The deploy harness requires setup to succeed, so the fixture cannot be deployed.
 // @force-gate !deploy
 describe('use-cache-hanging', () => {
   const { next, isNextDev, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
+++ b/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
@@ -5,8 +5,8 @@ import stripAnsi from 'strip-ansi'
 const getExpectedErrorMessage = (route: string) =>
   `Route "${route}": \`searchParams\` can't be read inside \`"use cache"\`. Await it outside the cached function and pass what you need as an argument.\nLearn more: https://nextjs.org/docs/messages/next-request-in-use-cache`
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('use-cache-search-params', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -2,8 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { waitForRedbox } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('use-cache-segment-configs', () => {
   const { next, isNextDev, isTurbopack, isRspack } = nextTestSetup({

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -9,8 +9,8 @@ import {
 import stripAnsi from 'strip-ansi'
 import { createSandbox } from 'development-sandbox'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('use-cache-unknown-cache-kind', () => {
   const { next, isNextStart, isTurbopack, isRspack } = nextTestSetup({

--- a/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
+++ b/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
@@ -13,8 +13,8 @@ const nextConfigWithUseCache: NextConfig = {
   experimental: { useCache: true },
 }
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('use-cache-without-experimental-flag', () => {
   const { next, isNextStart, isTurbopack, isRspack } = nextTestSetup({

--- a/test/e2e/custom-cache-handler-image/custom-cache-handler-image.test.ts
+++ b/test/e2e/custom-cache-handler-image/custom-cache-handler-image.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite asserts server log output produced by requests or cache operations.
+// Deploy-mode cliOutput contains build logs, not the live runtime logs under test.
 // @force-gate !deploy
 describe('custom-cache-handler-image', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/filesystem-cache/build-cache-default.test.ts
+++ b/test/e2e/filesystem-cache/build-cache-default.test.ts
@@ -9,8 +9,8 @@ import path from 'path'
 // This is a Turbopack + build (start) mode test. It runs `next build` with
 // controlled local and CI environments and checks whether anything is written
 // to `.next/cache/turbopack`.
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely mutates files in the isolated local fixture after setup.
+// This suite rebuilds a fixture and inspects filesystem-cache output.
+// Deployment mode cannot run these local builds or inspect their cache files.
 // @force-gate !deploy
 // @force-gate turbopack
 // @force-gate start

--- a/test/e2e/filesystem-cache/evict-after-snapshot.test.ts
+++ b/test/e2e/filesystem-cache/evict-after-snapshot.test.ts
@@ -3,8 +3,8 @@ import { retry, waitFor } from 'next-test-utils'
 
 // Eviction requires the dev server (HMR) and persistent caching (Turbopack).
 // Skip entirely in prod/start mode.
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely mutates files in the isolated local fixture after setup.
+// This suite changes fixture files to exercise filesystem-cache eviction.
+// Deployment mode cannot mutate the deployed application.
 // @force-gate !deploy
 // @force-gate dev
 describe('evict-after-snapshot', () => {

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -28,8 +28,8 @@ async function getDirectorySize(dirPath: string): Promise<number> {
 }
 
 for (const cacheEnabled of [false, true]) {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely mutates files in the isolated local fixture after setup.
+  // This suite calls next.patchFile() to change fixture files after setup.
+  // Deployment mode cannot mutate the deployed fixture.
   // @force-gate !deploy
   describe(`filesystem-caching with cache ${cacheEnabled ? 'enabled' : 'disabled'}`, () => {
     beforeAll(() => {

--- a/test/e2e/filesystem-cache/warm-restart-task-stats.test.ts
+++ b/test/e2e/filesystem-cache/warm-restart-task-stats.test.ts
@@ -25,8 +25,8 @@ type TaskStats = Record<string, TaskFunctionStatistics>
 
 const STATS_RELATIVE_PATH = '.next/warm-restart-task-stats.json'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely inspects local build artifacts that deploy tests do not expose.
+// This suite rebuilds and restarts the local server to inspect filesystem-cache task statistics.
+// Deployment mode does not expose that build/server lifecycle.
 // @force-gate !deploy
 // @force-gate turbopack
 describe('warm-restart task statistics', () => {

--- a/test/e2e/persistent-caching-migration/persistent-caching-migration.test.ts
+++ b/test/e2e/persistent-caching-migration/persistent-caching-migration.test.ts
@@ -18,8 +18,8 @@ const CASES = [
 
 describe('persistent-caching-migration', () => {
   for (const [option, error] of CASES) {
-    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-    // It likely expects a local build failure instead of a successful deployment.
+    // This suite runs next.build() to inspect build output or errors.
+    // Deploy mode requires a successful deployment and cannot run these local builds.
     // @force-gate !deploy
     describe(option, () => {
       const { next, isTurbopack, isNextStart } = nextTestSetup({


### PR DESCRIPTION
## Summary

Replace 35 deployment-exclusion TODO comments with concrete reasons across 29 caching test files. These are the same retained exclusions selected in the 180-location review.

This explanation stack is based on `jstory/deploy-tests/remove-skip-api`. The separately reviewed passing-test removals are now in the stack rooted on canary at #98523.

## Verification

- Executable ASTs and all gate directives match the current upstream base in every edited file.
- The complete explanation stack replaces exactly 180 TODOs across 147 files, preserving the previous explanations.
- Formatting and lint passed.
- Full local bootstrap was blocked by missing package-level dependencies in the temporary worktree.

<!-- NEXT_JS_LLM -->
