### PR TITLE
test: explain retained app-router deploy exclusions

### DIFF
--- a/test/e2e/app-dir/app-root-params-getters/generate-static-params-error.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/generate-static-params-error.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite starts an intentionally invalid fixture and asserts build diagnostics.
+// The deploy harness requires setup to succeed, so the fixture cannot be deployed.
 // @force-gate !deploy
 describe('app-root-param-getters - generateStaticParams error', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/client-reference-chunking/client-reference-chunking.test.ts
+++ b/test/e2e/app-dir/client-reference-chunking/client-reference-chunking.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { getClientReferenceManifest } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
+// This suite reads page_client-reference-manifest.js from the local .next directory.
+// Deployment mode does not expose the generated client-reference manifest.
 // @force-gate !deploy
 describe('client-reference-chunking', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
+++ b/test/e2e/app-dir/conflicting-page-segments/conflicting-page-segments.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite starts an intentionally invalid fixture and asserts build diagnostics.
+// The deploy harness requires setup to succeed, so the fixture cannot be deployed.
 // @force-gate !deploy
 describe('conflicting-page-segments', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
+++ b/test/e2e/app-dir/empty-generate-static-params/empty-generate-static-params.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('empty-generate-static-params', () => {
   const { next, isNextDev, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
+++ b/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
@@ -6,8 +6,8 @@ import {
   retry,
 } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('app-dir - error-on-next-codemod-comment', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -1323,8 +1323,8 @@ describe('instant-navigation-testing-api - partial prefetching (App Shells)', ()
 // lock) is a dev-time concern, so this suite uses a dedicated fixture and runs
 // in dev only; `next start`/deploy register a single placeholder so the build
 // is never attempted.
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
+// This suite exercises the development navigation/validation testing API.
+// A deployed production build does not provide that dev-server behavior.
 // @force-gate !deploy
 describe('instant-navigation-testing-api - blocking routes (dev only)', () => {
   if (!isNextDev) {

--- a/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
+++ b/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
@@ -2,8 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import type { ValidationEvent } from 'next/dist/server/app-render/dev-validation-events'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite exercises the development navigation/validation testing API.
+// A deployed production build does not provide that dev-server behavior.
 // @force-gate !deploy
 describe('instant validation causes', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
+++ b/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('app dir - instant-validation-client', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/instant-validation-level-default/instant-validation-level-default.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-default/instant-validation-level-default.test.ts
@@ -11,8 +11,8 @@ import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 // For exhaustive coverage of explicit levels and per-segment overrides,
 // see the sibling `instant-validation-level-{warning,manual-warning,error,
 // manual-error}` fixtures.
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely controls the local Next.js build or server lifecycle.
+// This suite invokes next.build() and inspects local build results.
+// Deployment mode cannot run these additional local builds.
 // @force-gate !deploy
 describe('instant validation - default level', () => {
   const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/instant-validation-level-error/instant-validation-level-error.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-error/instant-validation-level-error.test.ts
@@ -5,8 +5,8 @@ import {
 } from 'e2e-utils/instant-validation'
 import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('instant validation - level error', () => {
   const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/instant-validation-level-manual-error/instant-validation-level-manual-error.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-manual-error/instant-validation-level-manual-error.test.ts
@@ -5,8 +5,8 @@ import {
 } from 'e2e-utils/instant-validation'
 import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('instant validation - level manual-error', () => {
   const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/instant-validation-level-manual-warning/instant-validation-level-manual-warning.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-manual-warning/instant-validation-level-manual-warning.test.ts
@@ -7,8 +7,8 @@ import {
 import { getPrerenderOutput } from '../cache-components-errors/utils'
 import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('instant validation - level manual-warning', () => {
   const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/instant-validation-level-warning/instant-validation-level-warning.test.ts
+++ b/test/e2e/app-dir/instant-validation-level-warning/instant-validation-level-warning.test.ts
@@ -5,8 +5,8 @@ import {
 } from 'e2e-utils/instant-validation'
 import { waitForNoErrorToast } from '../../../lib/next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('instant validation - level warning', () => {
   const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/instant-validation/parallel-slots.test.ts
+++ b/test/e2e/app-dir/instant-validation/parallel-slots.test.ts
@@ -7,8 +7,8 @@ import {
 } from 'e2e-utils/instant-validation'
 import { retry, waitForNoErrorToast } from '../../../lib/next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('instant validation - parallel slot configs', () => {
   const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/instant-validation/server-errors.test.ts
+++ b/test/e2e/app-dir/instant-validation/server-errors.test.ts
@@ -6,8 +6,8 @@ import {
 import { retry, waitForRedbox } from '../../../lib/next-test-utils'
 import { createRedboxSnapshot } from '../../../lib/add-redbox-matchers'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('instant validation - server errors', () => {
   const { next, isNextDev, isNextStart, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/proxy-runtime/proxy-runtime.test.ts
+++ b/test/e2e/app-dir/proxy-runtime/proxy-runtime.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import stripAnsi from 'strip-ansi'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('proxy-runtime', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/types/types.test.ts
+++ b/test/e2e/app-dir/types/types.test.ts
@@ -1,8 +1,8 @@
 import { execSync } from 'child_process'
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely controls the local Next.js build or server lifecycle.
+// This suite invokes the local typegen CLI and checks generated types.
+// Deployment mode does not expose that local command or its output files.
 // @force-gate !deploy
 describe('app-dir types', () => {
   const { next } = nextTestSetup({


### PR DESCRIPTION
## Summary

Replace 17 deployment-exclusion TODO comments with concrete reasons across 17 app-router test files. These are the same retained exclusions selected in the 180-location review.

This explanation stack is based on `jstory/deploy-tests/remove-skip-api`. The separately reviewed passing-test removals are now in the stack rooted on canary at #98523.

## Verification

- Executable ASTs and all gate directives match the current upstream base in every edited file.
- The complete explanation stack replaces exactly 180 TODOs across 147 files, preserving the previous explanations.
- Formatting and lint passed.
- Full local bootstrap was blocked by missing package-level dependencies in the temporary worktree.

<!-- NEXT_JS_LLM -->
