### PR TITLE
test: explain retained tooling deploy exclusions

### DIFF
--- a/test/e2e/500-page/500-page-build.test.ts
+++ b/test/e2e/500-page/500-page-build.test.ts
@@ -3,8 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 // This test exercises `next build` outputs and `next start` behaviour, so it
 // is meaningless in dev mode where the dev server bypasses production build
 // artifacts (e.g. statically prerendered 500.html from getStaticProps).
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite calls next.patchFile() to change fixture files after setup.
+// Deployment mode cannot mutate the deployed fixture.
 // @force-gate !deploy
 // @force-gate !dev
 describe('500 Page build validation', () => {

--- a/test/e2e/app-dir/actions/app-action-export.test.ts
+++ b/test/e2e/app-dir/actions/app-action-export.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite changes configuration to test Server Actions with static export.
+// The export/build validation requires local fixture and build control.
 // @force-gate !deploy
 describe('app-dir action handling - next export', () => {
   const { next, isNextStart } = nextTestSetup({

--- a/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
+++ b/test/e2e/app-dir/instant-validation-build/instant-validation-build.test.ts
@@ -6,8 +6,8 @@ import {
   parseValidationMessages,
 } from 'e2e-utils/instant-validation'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() and inspects generated validation output.
+// Deployment mode cannot perform that local build or read its artifacts.
 // @force-gate !deploy
 describe('instant-validation-build', () => {
   const { next, isNextStart, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/interception-routes-output-export/interception-routes-output-export.test.ts
+++ b/test/e2e/app-dir/interception-routes-output-export/interception-routes-output-export.test.ts
@@ -2,8 +2,8 @@ import type { ChildProcess } from 'child_process'
 import { isNextDev, isNextStart, nextTestSetup } from 'e2e-utils'
 import { findPort, killApp, retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('interception-routes-output-export', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
+++ b/test/e2e/app-dir/loader-file-named-export-custom-loader-error/loader-file-named-export-custom-loader-error.test.ts
@@ -10,8 +10,8 @@ async function testDev(browser, errorRegex) {
 }
 
 describe('Error test if the loader file export a named function', () => {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely expects a local build failure instead of a successful deployment.
+  // This scope asserts a development error overlay for an invalid image loader.
+  // A deployed production build cannot exercise the dev overlay.
   // @force-gate !deploy
   describe('in Development', () => {
     const { next, isNextDev } = nextTestSetup({
@@ -31,8 +31,8 @@ describe('Error test if the loader file export a named function', () => {
     })
   })
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely expects a local build failure instead of a successful deployment.
+  // This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+  // The deploy harness requires a successful build before test assertions can run.
   // @force-gate !deploy
   describe('in Build and Start', () => {
     const { next, isNextStart } = nextTestSetup({

--- a/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
+++ b/test/e2e/app-dir/multiple-lockfiles/multiple-lockfiles.test.ts
@@ -2,8 +2,8 @@ import { join } from 'path'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This fixture creates parent-directory lockfiles to test workspace-root diagnostics.
+// The deployment upload does not preserve the local parent-directory layout under test.
 // @force-gate !deploy
 describe('multiple-lockfiles', () => {
   const { next, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-cjs.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-cjs.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 describe('next-config-ts-type-error-cjs', () => {
   // TODO: Remove this once we bump minimum Node.js version to v22

--- a/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-mts/type-error/next-config-ts-type-error-esm.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 describe('next-config-ts-type-error-esm', () => {
   // TODO: Remove this once we bump minimum Node.js version to v22

--- a/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-cjs.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-cjs.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 describe('next-config-ts-type-error-cjs', () => {
   // TODO: Remove this once we bump minimum Node.js version to v22

--- a/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts-native-ts/type-error/next-config-ts-type-error-esm.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 describe('next-config-ts-type-error-esm', () => {
   // TODO: Remove this once we bump minimum Node.js version to v22

--- a/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-cjs.test.ts
+++ b/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-cjs.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('next-config-ts-type-error-cjs', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-esm.test.ts
+++ b/test/e2e/app-dir/next-config-ts/type-error/next-config-ts-type-error-esm.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('next-config-ts-type-error-esm', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
+++ b/test/e2e/app-dir/parallel-routes-leaf-segments/parallel-routes-leaf-segments.build-error.test.ts
@@ -2,8 +2,8 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('parallel-routes-leaf-segments-build-error', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/proxy-missing-export/proxy-missing-export.test.ts
+++ b/test/e2e/app-dir/proxy-missing-export/proxy-missing-export.test.ts
@@ -15,8 +15,8 @@ To fix it:
 
 Learn more: https://nextjs.org/docs/messages/middleware-to-proxy`
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite invokes next.build() and inspects local build results.
+// Deployment mode cannot run these additional local builds.
 // @force-gate !deploy
 describe('proxy-missing-export', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/root-detection/git-repository-boundary.test.ts
+++ b/test/e2e/app-dir/root-detection/git-repository-boundary.test.ts
@@ -8,8 +8,8 @@ import { packageJson, packageLock } from './test-utils'
 //     ├── .git/
 //     ├── package-lock.json
 //     └── app/                 the Next.js app
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite creates a local Git boundary and checks diagnostics with next.testDir paths.
+// A deployment has a different checkout layout and filesystem paths.
 // @force-gate !deploy
 describe('root-detection - git repository boundary', () => {
   const { next, isTurbopack } = nextTestSetup({

--- a/test/e2e/app-dir/root-detection/git-worktree-boundary.test.ts
+++ b/test/e2e/app-dir/root-detection/git-worktree-boundary.test.ts
@@ -13,8 +13,8 @@ import {
 //     ├── .git                         a file pointing at the Git directory
 //     ├── package-lock.json
 //     └── app/                         the Next.js app
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite creates local .git worktree metadata and asserts its absolute paths.
+// A deployment does not preserve that local worktree layout.
 // @force-gate !deploy
 describe('root-detection - git worktree boundary', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
+++ b/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
@@ -5,8 +5,8 @@ import { getDistDir, retry } from 'next-test-utils'
 const strictRouteTypes =
   process.env.__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES === 'true'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('typed-routes-validator', () => {
   const { next, isNextDev, isNextStart } = nextTestSetup({

--- a/test/e2e/app-dir/typed-routes/typed-links.test.ts
+++ b/test/e2e/app-dir/typed-routes/typed-links.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite calls next.deleteFile() to change fixture files after setup.
+// Deployment mode cannot mutate the deployed fixture.
 // @force-gate !deploy
 describe('typed-links', () => {
   const { next, isNextStart } = nextTestSetup({

--- a/test/e2e/app-dir/typed-routes/typed-routes.test.ts
+++ b/test/e2e/app-dir/typed-routes/typed-routes.test.ts
@@ -12,8 +12,8 @@ type RewriteRoutes = "/api-legacy/[version]/[[...endpoint]]" | "/docs-old/[...pa
 type Routes = AppRoutes | PageRoutes | LayoutRoutes | RedirectRoutes | RewriteRoutes | AppRouteHandlerRoutes
 `
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite calls next.deleteFile() to change fixture files after setup.
+// Deployment mode cannot mutate the deployed fixture.
 // @force-gate !deploy
 describe('typed-routes', () => {
   const { next, isNextDev, isNextStart } = nextTestSetup({

--- a/test/e2e/app-dir/typegen-bundler-env/typegen-bundler-env.test.ts
+++ b/test/e2e/app-dir/typegen-bundler-env/typegen-bundler-env.test.ts
@@ -11,8 +11,8 @@ const baseEnv = {
 
 // cssChunking: "graph", is Turbopack-only, so we use this as to verify whether
 // typegen is selecting the right bundler
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely controls the local Next.js build or server lifecycle.
+// This suite invokes the local typegen CLI with different bundler flags.
+// Deploying the fixture does not exercise those local command invocations.
 // @force-gate !deploy
 describe('typegen bundler env', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/typegen-error-diagnostic/typegen-error-diagnostic.test.ts
+++ b/test/e2e/app-dir/typegen-error-diagnostic/typegen-error-diagnostic.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { runNextCommand } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely controls the local Next.js build or server lifecycle.
+// This fixture intentionally rejects production configuration to test typegen errors.
+// Deployment setup fails before the diagnostic assertions can run.
 // @force-gate !deploy
 describe('typegen error diagnostic', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/undefined-default-export/undefined-default-export.test.ts
+++ b/test/e2e/app-dir/undefined-default-export/undefined-default-export.test.ts
@@ -1,8 +1,8 @@
 import path from 'path'
 import { isNextStart, nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('Undefined default export', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/upward-distdir/upward-distdir.test.ts
+++ b/test/e2e/app-dir/upward-distdir/upward-distdir.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely controls the local Next.js build or server lifecycle.
+// This fixture writes its build output above the project root.
+// Deployment setup expects project build artifacts and cannot find this fixture's BUILD_ID.
 // @force-gate !deploy
 describe('upward-distdir', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/webpack-loader-errors/webpack-loader-errors.test.ts
+++ b/test/e2e/app-dir/webpack-loader-errors/webpack-loader-errors.test.ts
@@ -2,8 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry, waitForRedbox, getRedboxSource } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite exercises development-only loader errors and dev-server diagnostics.
+// Its invalid loader fixtures cannot complete deployment setup.
 // @force-gate !deploy
 describe('webpack-loader-errors', () => {
   const { next, isNextDev, isTurbopack } = nextTestSetup({

--- a/test/e2e/cli/cli.test.ts
+++ b/test/e2e/cli/cli.test.ts
@@ -15,8 +15,8 @@ const reactDependencies = {
   'react-dom': '19.3.0-canary-fef12a01-20260413',
 }
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely mutates files in the isolated local fixture after setup.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('CLI Usage', () => {
   const { next, isNextStart } = nextTestSetup({
@@ -1223,8 +1223,8 @@ Next.js Config:
   })
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely mutates files in the isolated local fixture after setup.
+// This CLI test changes local dependency/configuration files.
+// Deploying the fixture does not exercise those local CLI operations.
 // @force-gate !deploy
 describe('CLI Usage: duplicate sass dependencies', () => {
   const { next, isNextStart } = nextTestSetup({

--- a/test/e2e/dist-dir/dist-dir.test.ts
+++ b/test/e2e/dist-dir/dist-dir.test.ts
@@ -28,8 +28,8 @@ describe('distDir', () => {
 })
 
 if (isNextStart) {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This suite runs next.build() to inspect build output or errors.
+  // Deploy mode requires a successful deployment and cannot run these local builds.
   // @force-gate !deploy
   describe('distDir config validation', () => {
     const { next } = nextTestSetup({

--- a/test/e2e/externals-pages-bundle/externals-pages-bundle.test.ts
+++ b/test/e2e/externals-pages-bundle/externals-pages-bundle.test.ts
@@ -2,8 +2,8 @@ import fs from 'fs/promises'
 import { join } from 'path'
 import { nextTestSetup, isNextStart, isNextDev } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely mutates files in the isolated local fixture after setup.
+// This suite inspects local build output to verify external dependency bundling.
+// Deployment mode cannot expose those generated files or run additional builds.
 // @force-gate !deploy
 describe('externals-pages-bundle', () => {
   const { next, isTurbopack } = nextTestSetup({

--- a/test/e2e/next-analyze/next-analyze.test.ts
+++ b/test/e2e/next-analyze/next-analyze.test.ts
@@ -4,8 +4,8 @@ import path from 'node:path'
 import type { ChildProcess } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely inspects local build artifacts that deploy tests do not expose.
+// This suite starts a local analyzer process and reads .next/diagnostics/analyze files.
+// Deployment mode does not expose that process or its generated files.
 // @force-gate !deploy
 describe('next experimental-analyze', () => {
   if (!shouldUseTurbopack()) {

--- a/test/e2e/nullish-config/nullish-config.test.ts
+++ b/test/e2e/nullish-config/nullish-config.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite calls next.patchFile() to change fixture files after setup.
+// Deployment mode cannot mutate the deployed fixture.
 // @force-gate !deploy
 describe('Nullish configs in next.config.js', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/swc-plugins/index.test.ts
+++ b/test/e2e/swc-plugins/index.test.ts
@@ -18,8 +18,8 @@ describe('swcPlugins', () => {
       expect(html).not.toContain('data-custom-attribute')
     })
   })
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely expects a local build failure instead of a successful deployment.
+  // This scope checks development diagnostics for an invalid SWC plugin.
+  // The invalid plugin cannot produce a successful deployment for these assertions.
   // @force-gate !deploy
   // @force-gate dev
   describe('incompatible plugin version', () => {
@@ -58,8 +58,8 @@ describe('swcPlugins', () => {
       }
     })
   })
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely expects a local build failure instead of a successful deployment.
+  // This scope checks development diagnostics for an invalid SWC plugin.
+  // The invalid plugin cannot produce a successful deployment for these assertions.
   // @force-gate !deploy
   // @force-gate dev
   describe('invalid plugin name', () => {

--- a/test/e2e/transpile-packages-typescript-foreign/index.test.ts
+++ b/test/e2e/transpile-packages-typescript-foreign/index.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('transpile-packages-typescript-foreign', () => {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This suite starts an intentionally invalid fixture and asserts build diagnostics.
+  // The deploy harness requires setup to succeed, so the fixture cannot be deployed.
   // @force-gate !deploy
   describe('without transpilePackages', () => {
     const { next } = nextTestSetup({

--- a/test/e2e/typescript-version-warning/typescript-version-warning.test.ts
+++ b/test/e2e/typescript-version-warning/typescript-version-warning.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This fixture deliberately uses an old TypeScript version and inspects build diagnostics.
+// Its compiler rejects the production build, so deployment setup cannot complete.
 // @force-gate !deploy
 describe('typescript-version-warning', () => {
   const { next, isNextDeploy, isNextDev } = nextTestSetup({

--- a/test/e2e/typescript/typescript.test.ts
+++ b/test/e2e/typescript/typescript.test.ts
@@ -99,8 +99,8 @@ export default function EvilPage(): JSX.Element {
     })
   }
 })
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 // @force-gate start
 describe('TypeScript production compilation', () => {

--- a/test/e2e/undefined-webpack-config/undefined-webpack-config.test.ts
+++ b/test/e2e/undefined-webpack-config/undefined-webpack-config.test.ts
@@ -5,8 +5,8 @@ const expectedErr =
   /Webpack config is undefined. You may have forgot to return properly from within the "webpack" method of your next.config.js/
 
 // Webpack-specific test, not needed for Turbopack
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 // @force-gate !turbopack
 describe('undefined webpack config error', () => {

--- a/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
+++ b/test/e2e/webpack-loader-parse-error/webpack-loader-parse-error.test.ts
@@ -75,8 +75,8 @@ function extractErrorBlock(output: string, errorTitle: string): string {
   return block.trimEnd()
 }
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 describe('webpack-loader-parse-error (development)', () => {
   const { next, isTurbopack, isNextDev } = nextTestSetup({
@@ -199,8 +199,8 @@ describe('webpack-loader-parse-error (development)', () => {
   })
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 describe('webpack-loader-parse-error (production)', () => {
   const { next, isNextStart, isTurbopack } = nextTestSetup({


### PR DESCRIPTION
## Summary

Replace 39 deployment-exclusion TODO comments with concrete reasons across 35 tooling test files. These are the same retained exclusions selected in the 180-location review.

This explanation stack is based on `jstory/deploy-tests/remove-skip-api`. The separately reviewed passing-test removals are now in the stack rooted on canary at #98523.

## Verification

- Executable ASTs and all gate directives match the current upstream base in every edited file.
- The complete explanation stack replaces exactly 180 TODOs across 147 files, preserving the previous explanations.
- Formatting and lint passed.
- Full local bootstrap was blocked by missing package-level dependencies in the temporary worktree.

<!-- NEXT_JS_LLM -->
