### PR TITLE
test: explain retained pages-router deploy exclusions

### DIFF
--- a/test/e2e/404-page/404-page.test.ts
+++ b/test/e2e/404-page/404-page.test.ts
@@ -135,8 +135,8 @@ describe('404 Page Support', () => {
     })
   }
 })
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 // @force-gate start
 describe('404 Page build validation', () => {

--- a/test/e2e/catches-missing-getStaticProps/catches-missing-getStaticProps.test.ts
+++ b/test/e2e/catches-missing-getStaticProps/catches-missing-getStaticProps.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
-// TODO(deploy-test-completion): This asserts local build/runtime output that
-// deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 // @force-gate !start || !turbopackDev
 // @force-gate !dev || !turbopackBuild

--- a/test/e2e/client-max-body-size/index.test.ts
+++ b/test/e2e/client-max-body-size/index.test.ts
@@ -2,8 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP } from 'next-test-utils'
 
 describe('client-max-body-size', () => {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // Deployed environment has it's own configured limits.
+  // These assertions require large requests to reach Next.js for body buffering.
+  // The deployment rejects the tested requests with 413 before that behavior can be checked.
   // @force-gate !deploy
   describe('default 10MB limit', () => {
     const { next } = nextTestSetup({
@@ -76,8 +76,8 @@ describe('client-max-body-size', () => {
     })
   })
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // These assertions require large requests to reach Next.js for body buffering.
+  // The deployment rejects the tested requests with 413 before that behavior can be checked.
   // @force-gate !deploy
   describe('custom limit with string format', () => {
     const { next } = nextTestSetup({
@@ -194,8 +194,8 @@ describe('client-max-body-size', () => {
     })
   })
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // These assertions require large requests to reach Next.js for body buffering.
+  // The deployment rejects the tested requests with 413 before that behavior can be checked.
   // @force-gate !deploy
   describe('large custom limit', () => {
     const { next } = nextTestSetup({

--- a/test/e2e/conflicting-app-page-error/index.test.ts
+++ b/test/e2e/conflicting-app-page-error/index.test.ts
@@ -8,8 +8,8 @@ import {
 } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('Conflict between app file and pages file', () => {
   const { next, isNextDev, isNextStart, isNextDeploy } = nextTestSetup({

--- a/test/e2e/conflicting-public-file-page/conflicting-public-file-page.test.ts
+++ b/test/e2e/conflicting-public-file-page/conflicting-public-file-page.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('Errors on conflict between public file and page file', () => {
   const { next, isNextDeploy } = nextTestSetup({

--- a/test/e2e/custom-app-render/custom-app-render.test.ts
+++ b/test/e2e/custom-app-render/custom-app-render.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope tests app.render() in a custom server and its deprecation warning.
+// The deploy harness does not run that custom server or expose its runtime logs.
 // @force-gate !deploy
 describe('custom-app-render', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/data-fetching-errors/data-fetching-errors.test.ts
+++ b/test/e2e/data-fetching-errors/data-fetching-errors.test.ts
@@ -6,8 +6,8 @@ import {
 } from '../../../packages/next/dist/lib/constants'
 
 describe('GS(S)P Page Errors', () => {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely expects a local build failure instead of a successful deployment.
+  // This scope mutates fixture files to assert development error diagnostics.
+  // A deployed production app cannot exercise those dev-server updates.
   // @force-gate !deploy
   // @force-gate dev
   describe('development mode', () => {
@@ -105,8 +105,8 @@ describe('GS(S)P Page Errors', () => {
       )
     })
   })
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely expects a local build failure instead of a successful deployment.
+  // This scope mutates fixture files and rebuilds to assert production errors.
+  // Deployment mode cannot perform those local file changes and builds.
   // @force-gate !deploy
   // @force-gate start
   describe('production mode', () => {

--- a/test/e2e/dynamic-optional-routing/dynamic-optional-routing.test.ts
+++ b/test/e2e/dynamic-optional-routing/dynamic-optional-routing.test.ts
@@ -217,8 +217,8 @@ describe('Dynamic Optional Routing', () => {
   }
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite calls next.patchFile() to change fixture files after setup.
+// Deployment mode cannot mutate the deployed fixture.
 // @force-gate !deploy
 describe('Dynamic Optional Routing - build validation', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/invalid-custom-routes/invalid-custom-routes.test.ts
+++ b/test/e2e/invalid-custom-routes/invalid-custom-routes.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 describe('Errors on invalid custom routes', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/multi-zone/multi-zone.test.ts
+++ b/test/e2e/multi-zone/multi-zone.test.ts
@@ -2,8 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { check, waitFor } from 'next-test-utils'
 import path from 'path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely mutates files in the isolated local fixture after setup.
+// This fixture builds multiple zones and runs a custom server to route between them.
+// The deploy harness does not reproduce that multi-server setup.
 // @force-gate !deploy
 describe('multi-zone', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/next-phase/index.test.ts
+++ b/test/e2e/next-phase/index.test.ts
@@ -1,8 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// This test is skipped when deployed because it asserts against runtime
-// logs that cannot be queried in a deployed environment.
+// This scope checks the phase passed when the local production server starts.
+// Deploy build logs do not expose the next start configuration phase under test.
 // @force-gate !deploy
 describe('next-phase', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/next-test/next-test.test.ts
+++ b/test/e2e/next-test/next-test.test.ts
@@ -25,8 +25,8 @@ function createTemporaryFixture(fixtureName: string) {
   return dir
 }
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// This doesn't need to be deployed as it's using `experimental-test` mode
+// This scope exercises the local next test CLI rather than a deployed application.
+// The deployment harness does not run the configured local command.
 // @force-gate !deploy
 // @force-gate TODO
 describe('next test', () => {

--- a/test/e2e/repeated-slashes/repeated-slashes.test.ts
+++ b/test/e2e/repeated-slashes/repeated-slashes.test.ts
@@ -428,8 +428,8 @@ describe('404 handling', () => {
 
       runTests({ next, isDev: isNextDev, isPages404: false })
     })
-    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-    // It likely mutates files in the isolated local fixture after setup.
+    // This scope runs a local static export and starts a server over the generated out directory.
+    // Deployment mode cannot perform that build or control the local static server.
     // @force-gate !deploy
     // @force-gate start
     describe('export mode', () => {
@@ -474,8 +474,8 @@ describe('404 handling', () => {
   })
 
   describe('pages/404', () => {
-    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-    // It likely mutates files in the isolated local fixture after setup.
+    // This suite deletes fixture files before checking Next.js behavior.
+    // Deployment mode cannot delete files in the deployed application.
     // @force-gate !deploy
     describe('server mode', () => {
       const { next } = nextTestSetup({
@@ -505,8 +505,8 @@ describe('404 handling', () => {
 
       runTests({ next, isDev: isNextDev, isPages404: true })
     })
-    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-    // It likely mutates files in the isolated local fixture after setup.
+    // This suite deletes fixture files before checking Next.js behavior.
+    // Deployment mode cannot delete files in the deployed application.
     // @force-gate !deploy
     // @force-gate start
     describe('pages/404 export mode', () => {


### PR DESCRIPTION
## Summary

Replace 18 deployment-exclusion TODO comments with concrete reasons across 13 pages-router test files. These are the same retained exclusions selected in the 180-location review.

This explanation stack is based on `jstory/deploy-tests/remove-skip-api`. The separately reviewed passing-test removals are now in the stack rooted on canary at #98523.

## Verification

- Executable ASTs and all gate directives match the current upstream base in every edited file.
- The complete explanation stack replaces exactly 180 TODOs across 147 files, preserving the previous explanations.
- Formatting and lint passed.
- Full local bootstrap was blocked by missing package-level dependencies in the temporary worktree.

<!-- NEXT_JS_LLM -->
