### PR TITLE
test: explain retained assets deploy exclusions

### DIFF
--- a/test/e2e/app-dir/css-server-chunks/css-server-chunks.test.ts
+++ b/test/e2e/app-dir/css-server-chunks/css-server-chunks.test.ts
@@ -3,8 +3,8 @@ import { listClientChunks } from 'next-test-utils'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely reads files from the isolated local fixture.
+// This suite scans .next/static to inspect generated CSS chunks.
+// Deployment mode does not expose the local build output directory.
 // @force-gate !deploy
 describe('css-server-chunks', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/metadata-invalid-image-file/metadata-invalid-image-file.test.ts
+++ b/test/e2e/app-dir/metadata-invalid-image-file/metadata-invalid-image-file.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('metadata-invalid-image-file', () => {
   const { next, isTurbopack, isNextDev, isRspack } = nextTestSetup({

--- a/test/e2e/app-dir/next-image-legacy-src-with-query-without-local-patterns/next-image-legacy-src-with-query-without-local-patterns.test.ts
+++ b/test/e2e/app-dir/next-image-legacy-src-with-query-without-local-patterns/next-image-legacy-src-with-query-without-local-patterns.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('next-image-legacy-src-with-query-without-local-patterns', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/next-image-src-with-query-without-local-patterns/next-image-src-with-query-without-local-patterns.test.ts
+++ b/test/e2e/app-dir/next-image-src-with-query-without-local-patterns/next-image-src-with-query-without-local-patterns.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('next-image-src-with-query-without-local-patterns', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/next-image/next-image-https.test.ts
+++ b/test/e2e/app-dir/next-image/next-image-https.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 
 // TODO: Test didn't (or maybe) never ran in CI but it should.
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely controls the local Next.js build or server lifecycle.
+// This scope starts next dev with --experimental-https to test its image loading.
+// Deployment HTTPS does not exercise the development server's HTTPS implementation.
 // @force-gate !deploy
 // @force-gate TODO
 describe('app dir - next-image (with https)', () => {

--- a/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global-with-app/invalid-global-with-app.test.ts
@@ -3,8 +3,8 @@
 import { isNextStart, nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, getRedboxSource } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('Invalid Global CSS with Custom App', () => {
   const { next, isTurbopack, isRspack } = nextTestSetup({

--- a/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/invalid-global/invalid-global.test.ts
@@ -3,8 +3,8 @@
 import { isNextStart, nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, getRedboxSource } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('Invalid Global CSS', () => {
   const { next, isTurbopack, isRspack } = nextTestSetup({

--- a/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
+++ b/test/e2e/app-dir/scss/invalid-module-document/invalid-module-document.test.ts
@@ -4,8 +4,8 @@ import { isNextStart, nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, getRedboxSource } from 'next-test-utils'
 
 // Importing module CSS in _document is allowed in Turbopack
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 // @force-gate !turbopack
 describe('Invalid SCSS in _document', () => {

--- a/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
+++ b/test/e2e/app-dir/scss/npm-import-bad/npm-import-bad.test.ts
@@ -3,8 +3,8 @@
 import { isNextStart, nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, getRedboxSource } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('CSS Import from node_modules', () => {
   const { next, isTurbopack, isRspack } = nextTestSetup({

--- a/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
+++ b/test/e2e/app-dir/scss/valid-and-invalid-global/valid-and-invalid-global.test.ts
@@ -3,8 +3,8 @@
 import { isNextStart, nextTestSetup } from 'e2e-utils'
 import { waitForRedbox, getRedboxSource } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('Valid and Invalid Global CSS with Custom App', () => {
   const { next, isTurbopack, isRspack } = nextTestSetup({

--- a/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
+++ b/test/e2e/app-dir/scss/webpack-error/webpack-error.test.ts
@@ -1,8 +1,8 @@
 /* eslint-env jest */
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('SCSS Support', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/css-features/css-modules-ordering.test.ts
+++ b/test/e2e/css-features/css-modules-ordering.test.ts
@@ -155,8 +155,8 @@ describe('Basic CSS Modules Ordering', () => {
 })
 
 describe('Ordering with Global CSS and Modules', () => {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope changes CSS fixture files to test updates in the running application.
+  // Deployment mode cannot patch those files after deployment.
   // @force-gate !deploy
   describe('useLightningcss(true)', () => {
     const { next } = nextTestSetup({
@@ -246,8 +246,8 @@ describe('Ordering with Global CSS and Modules', () => {
     })
   })
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope changes CSS fixture files to test updates in the running application.
+  // Deployment mode cannot patch those files after deployment.
   // @force-gate !deploy
   describe('useLightningcss(false)', () => {
     const { next } = nextTestSetup({

--- a/test/e2e/image-optimizer/image-optimizer.test.ts
+++ b/test/e2e/image-optimizer/image-optimizer.test.ts
@@ -14,8 +14,8 @@ function toQueryString(query: Record<string, any>): string {
 const largeSize = 1080
 
 describe('Image Optimizer', () => {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This suite calls next.patchFile() to change fixture files after setup.
+  // Deployment mode cannot mutate the deployed fixture.
   // @force-gate !deploy
   describe('config checks', () => {
     const { next } = nextTestSetup({
@@ -362,8 +362,8 @@ describe('Image Optimizer', () => {
       )
     })
   })
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope tests the development image endpoint with a Cloudinary loader.
+  // A deployed production app does not exercise that dev-server endpoint behavior.
   // @force-gate !deploy
   // @force-gate dev
   describe('dev support next.config.js cloudinary loader', () => {
@@ -405,8 +405,8 @@ describe('Image Optimizer', () => {
       expect(res.status).toBe(404)
     })
   })
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope checks the local image optimizer's imgOptMaxInputPixels fallback.
+  // A response from the deployment image service does not validate that local optimizer setting.
   // @force-gate !deploy
   // @force-gate dev
   describe('experimental.imgOptMaxInputPixels in next.config.js', () => {
@@ -426,8 +426,8 @@ describe('Image Optimizer', () => {
       expect(res.headers.get('Content-Type')).toBe('image/jpeg')
     })
   })
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope clears and inspects the local image cache while testing external rewrites.
+  // Deployment mode does not expose that cache directory.
   // @force-gate !deploy
   // @force-gate start
   describe('External rewrite support with for serving static content in images', () => {
@@ -479,8 +479,8 @@ describe('Image Optimizer', () => {
       await expectWidth(res, 64)
     })
   })
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope tests the development-only blur-placeholder image size handling.
+  // A deployed production build does not run that dev image path.
   // @force-gate !deploy
   // @force-gate dev
   describe('dev support for dynamic blur placeholder', () => {

--- a/test/e2e/next-image-legacy-src-with-query-without-local-patterns/next-image-legacy-src-with-query-without-local-patterns.test.ts
+++ b/test/e2e/next-image-legacy-src-with-query-without-local-patterns/next-image-legacy-src-with-query-without-local-patterns.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 describe('next-image-legacy-src-with-query-without-local-patterns', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/next-image-legacy/base-path/base-path-static.test.ts
+++ b/test/e2e/next-image-legacy/base-path/base-path-static.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup, isNextDev, type Playwright } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite changes fixture source or configuration with next.patchFile().
+// Deployment mode cannot modify the deployed application.
 // @force-gate !deploy
 describe('Build Error Tests for basePath', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/next-image-legacy/default/default-static.test.ts
+++ b/test/e2e/next-image-legacy/default/default-static.test.ts
@@ -7,8 +7,8 @@ import {
 } from 'e2e-utils'
 import cheerio from 'cheerio'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 describe('Build Error Tests', () => {
   const { next, isTurbopack, isRspack } = nextTestSetup({

--- a/test/e2e/next-image-legacy/typescript/typescript.test.ts
+++ b/test/e2e/next-image-legacy/typescript/typescript.test.ts
@@ -2,8 +2,8 @@ import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import fs from 'fs-extra'
 import { join } from 'path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This fixture intentionally fails TypeScript checking and inspects the failed build.
+// Deployment mode requires a successful build before the test can run.
 // @force-gate !deploy
 describe('TypeScript Image Component', () => {
   const { next, isNextDeploy } = nextTestSetup({

--- a/test/e2e/next-image-new/app-dir/app-dir-static.test.ts
+++ b/test/e2e/next-image-new/app-dir/app-dir-static.test.ts
@@ -5,8 +5,8 @@ import cheerio from 'cheerio'
 // without a Suspense boundary so that the priority image preload is committed
 // into <head>. That pattern is incompatible with cache components mode, which
 // errors on uncached runtime data outside of a Suspense boundary.
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite changes fixture source or configuration with next.patchFile().
+// Deployment mode cannot modify the deployed application.
 // @force-gate !deploy
 // @force-gate !cacheComponents
 describe('Build Error Tests', () => {

--- a/test/e2e/next-image-new/base-path/base-path-static.test.ts
+++ b/test/e2e/next-image-new/base-path/base-path-static.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup, isNextDev, type Playwright } from 'e2e-utils'
 import cheerio from 'cheerio'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite changes fixture source or configuration with next.patchFile().
+// Deployment mode cannot modify the deployed application.
 // @force-gate !deploy
 describe('Build Error Tests', () => {
   const { next, isTurbopack, isRspack } = nextTestSetup({

--- a/test/e2e/next-image-new/default/default-static.test.ts
+++ b/test/e2e/next-image-new/default/default-static.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup, isNextDev, type Playwright } from 'e2e-utils'
 import cheerio from 'cheerio'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite changes fixture source or configuration with next.patchFile().
+// Deployment mode cannot modify the deployed application.
 // @force-gate !deploy
 describe('Build Error Tests', () => {
   const { next, isRspack } = nextTestSetup({

--- a/test/e2e/next-image-new/typescript/typescript.test.ts
+++ b/test/e2e/next-image-new/typescript/typescript.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This fixture intentionally fails TypeScript checking and inspects the failed build.
+// Deployment mode requires a successful build before the test can run.
 // @force-gate !deploy
 describe('TypeScript Image Component Build Errors', () => {
   if (isNextDev) {
@@ -41,8 +41,8 @@ describe('TypeScript Image Component Build Errors', () => {
   })
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This fixture intentionally fails TypeScript checking and inspects the failed build.
+// Deployment mode requires a successful build before the test can run.
 // @force-gate !deploy
 describe('TypeScript Image Component Dev', () => {
   if (!isNextDev) {

--- a/test/e2e/next-image-src-with-query-without-local-patterns/next-image-src-with-query-without-local-patterns.test.ts
+++ b/test/e2e/next-image-src-with-query-without-local-patterns/next-image-src-with-query-without-local-patterns.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 describe('next-image-src-with-query-without-local-patterns', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/script-loader/partytown-missing.test.ts
+++ b/test/e2e/script-loader/partytown-missing.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 describe('script-loader - partytown-missing', () => {
   const { next, isNextDev } = nextTestSetup({


### PR DESCRIPTION
## Summary

Replace 29 deployment-exclusion TODO comments with concrete reasons across 23 assets test files. These are the same retained exclusions selected in the 180-location review.

This explanation stack is based on `jstory/deploy-tests/remove-skip-api`. The separately reviewed passing-test removals are now in the stack rooted on canary at #98523.

## Verification

- Executable ASTs and all gate directives match the current upstream base in every edited file.
- The complete explanation stack replaces exactly 180 TODOs across 147 files, preserving the previous explanations.
- Formatting and lint passed.
- Full local bootstrap was blocked by missing package-level dependencies in the temporary worktree.

<!-- NEXT_JS_LLM -->
