### PR TITLE
test: explain retained runtime deploy exclusions

### DIFF
--- a/test/e2e/app-dir/app-basepath-custom-server/index.test.ts
+++ b/test/e2e/app-dir/app-basepath-custom-server/index.test.ts
@@ -2,8 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { check, retry } from 'next-test-utils'
 import { join } from 'path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely controls the local Next.js build or server lifecycle.
+// This suite runs node server.js and asserts cookies set by that custom server.
+// The deploy harness does not run the custom startCommand on Vercel.
 // @force-gate !deploy
 describe('custom-app-server-action-redirect', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/app-edge/app-edge-invalid-reexport.test.ts
+++ b/test/e2e/app-dir/app-edge/app-edge-invalid-reexport.test.ts
@@ -1,8 +1,8 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely expects a local build failure instead of a successful deployment.
+// This suite starts an intentionally invalid fixture and asserts build diagnostics.
+// The deploy harness requires setup to succeed, so the fixture cannot be deployed.
 // @force-gate !deploy
 describe('app-dir edge SSR invalid reexport', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/instrumentation-order/instrumentation-order.test.ts
+++ b/test/e2e/app-dir/instrumentation-order/instrumentation-order.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite splits local server output at "Ready in" to assert instrumentation order.
+// Deploy-mode cliOutput has build logs, not that server startup/runtime stream.
 // @force-gate !deploy
 describe('instrumentation-order', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/logging/fetch-logging.test.ts
+++ b/test/e2e/app-dir/logging/fetch-logging.test.ts
@@ -43,8 +43,8 @@ function parseLogsFromCli(cliOutput: string) {
   }, [])
 }
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite calls next.patchFile() to change fixture files after setup.
+// Deployment mode cannot mutate the deployed fixture.
 // @force-gate !deploy
 describe('app-dir - fetch logging', () => {
   const { next, isNextDev } = nextTestSetup({
@@ -81,8 +81,8 @@ describe('app-dir - fetch logging', () => {
   })
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite calls next.patchFile() to change fixture files after setup.
+// Deployment mode cannot mutate the deployed fixture.
 // @force-gate !deploy
 describe('app-dir - logging', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/logging/fetch-warning.test.ts
+++ b/test/e2e/app-dir/logging/fetch-warning.test.ts
@@ -1,8 +1,8 @@
 import { retry } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite calls next.deleteFile() to change fixture files after setup.
+// Deployment mode cannot mutate the deployed fixture.
 // @force-gate !deploy
 describe('app-dir - fetch warnings', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/proxy-with-middleware/proxy-with-middleware.test.ts
+++ b/test/e2e/app-dir/proxy-with-middleware/proxy-with-middleware.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite runs next.build() to inspect build output or errors.
+// Deploy mode requires a successful deployment and cannot run these local builds.
 // @force-gate !deploy
 describe('proxy-with-middleware', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/server-action-logging/server-action-logging.test.ts
+++ b/test/e2e/app-dir/server-action-logging/server-action-logging.test.ts
@@ -2,8 +2,8 @@ import stripAnsi from 'strip-ansi'
 import { retry } from 'next-test-utils'
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite checks server-action request logs (including their absence in start mode).
+// Deploy-mode cliOutput does not contain the runtime request logs being asserted.
 // @force-gate !deploy
 describe('server-action-logging', () => {
   const { next, isNextStart } = nextTestSetup({
@@ -188,8 +188,8 @@ describe('server-action-logging', () => {
   })
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite verifies that runtime server-action logging is disabled.
+// Deploy-mode build logs cannot establish the absence of runtime log messages.
 // @force-gate !deploy
 describe('server-action-logging when logging.serverFunctions is disabled', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/fake-frame-source-maps.test.ts
@@ -122,8 +122,8 @@ async function resolveSourceMapLikeADebugger(
   return { sourceMap: JSON.parse(data), mapURL: null }
 }
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite attaches to the local Next.js Node inspector on 127.0.0.1.
+// Deployment mode does not expose the server process or its inspector port.
 // @force-gate !deploy
 describe('app-dir - server source maps - fake frame source maps', () => {
   const dependencies = {

--- a/test/e2e/app-dir/unhandled-rejection-logging/unhandled-rejection-logging.test.ts
+++ b/test/e2e/app-dir/unhandled-rejection-logging/unhandled-rejection-logging.test.ts
@@ -2,8 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry, waitFor } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite asserts server log output produced by requests or cache operations.
+// Deploy-mode cliOutput contains build logs, not the live runtime logs under test.
 // @force-gate !deploy
 describe('unhandled-rejection-logging', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/custom-server/custom-server.test.ts
+++ b/test/e2e/custom-server/custom-server.test.ts
@@ -22,8 +22,8 @@ describe.each([
       ? new https.Agent({ rejectUnauthorized: false })
       : undefined
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope exercises the configured custom server's methods, options, or instrumentation.
+  // The deploy harness does not run that custom server, so generic HTTP success is insufficient.
   // @force-gate !deploy
   describe('with dynamic assetPrefix', () => {
     const { next } = nextTestSetup({
@@ -148,8 +148,8 @@ describe.each([
       )
     })
   })
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope exercises the configured custom server's methods, options, or instrumentation.
+  // The deploy harness does not run that custom server, so generic HTTP success is insufficient.
   // @force-gate !deploy
   // @force-gate !dev
   describe('with generateEtags enabled', () => {
@@ -172,8 +172,8 @@ describe.each([
     })
   })
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope exercises the configured custom server's methods, options, or instrumentation.
+  // The deploy harness does not run that custom server, so generic HTTP success is insufficient.
   // @force-gate !deploy
   describe('with generateEtags disabled', () => {
     const { next } = nextTestSetup({
@@ -196,8 +196,8 @@ describe.each([
   })
 
   if (useHttps === 'false') {
-    // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-    // It likely asserts local CLI or runtime output that deploy tests do not expose.
+    // This scope patches files to test HMR through a custom development server.
+    // A deployed production app has neither that custom server nor HMR.
     // @force-gate !deploy
     // @force-gate dev
     describe('HMR with custom server', () => {
@@ -243,8 +243,8 @@ describe.each([
     })
   }
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope exercises the configured custom server's methods, options, or instrumentation.
+  // The deploy harness does not run that custom server, so generic HTTP success is insufficient.
   // @force-gate !deploy
   describe('Error when rendering without starting slash', () => {
     const { next } = nextTestSetup({
@@ -277,8 +277,8 @@ describe.each([
     })
   })
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope exercises the configured custom server's methods, options, or instrumentation.
+  // The deploy harness does not run that custom server, so generic HTTP success is insufficient.
   // @force-gate !deploy
   describe('with a custom fetch polyfill', () => {
     const { next } = nextTestSetup({
@@ -300,8 +300,8 @@ describe.each([
     })
   })
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope exercises the configured custom server's methods, options, or instrumentation.
+  // The deploy harness does not run that custom server, so generic HTTP success is insufficient.
   // @force-gate !deploy
   describe('unhandled rejection', () => {
     const { next } = nextTestSetup({
@@ -328,8 +328,8 @@ describe.each([
     })
   })
 
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope exercises the configured custom server's methods, options, or instrumentation.
+  // The deploy harness does not run that custom server, so generic HTTP success is insufficient.
   // @force-gate !deploy
   describe('legacy NextCustomServer methods', () => {
     const { next } = nextTestSetup({

--- a/test/e2e/edge-runtime-configurable-guards/edge-runtime-configurable-guards.test.ts
+++ b/test/e2e/edge-runtime-configurable-guards/edge-runtime-configurable-guards.test.ts
@@ -14,8 +14,8 @@ const LIB_PATH = 'node_modules/lib/index.js'
 jest.setTimeout(120 * 1000)
 
 describe('Edge runtime configurable guards', () => {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely expects a local build failure instead of a successful deployment.
+  // This scope mutates Edge fixtures to assert development module/guard diagnostics.
+  // Deployment mode cannot patch the running fixture or expose the dev diagnostics.
   // @force-gate !deploy
   // @force-gate dev
   describe('development mode', () => {
@@ -343,8 +343,8 @@ describe('Edge runtime configurable guards', () => {
       }
     )
   })
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely expects a local build failure instead of a successful deployment.
+  // This scope builds intentionally invalid Edge fixtures and inspects their diagnostics.
+  // Deployment setup requires a successful build before assertions can run.
   // @force-gate !deploy
   // @force-gate start
   describe('production mode', () => {

--- a/test/e2e/edge-runtime-module-errors/edge-runtime-module-errors.test.ts
+++ b/test/e2e/edge-runtime-module-errors/edge-runtime-module-errors.test.ts
@@ -116,8 +116,8 @@ function createVariants(opts: {
 
 describe('Edge runtime module errors', () => {
   // ==================== DEVELOPMENT MODE ====================
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope mutates Edge fixtures to assert development module/guard diagnostics.
+  // Deployment mode cannot patch the running fixture or expose the dev diagnostics.
   // @force-gate !deploy
   // @force-gate dev
   describe('development mode', () => {
@@ -576,8 +576,8 @@ describe('Edge runtime module errors', () => {
   })
 
   // ==================== PRODUCTION MODE ====================
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope builds intentionally invalid Edge fixtures and inspects their diagnostics.
+  // Deployment setup requires a successful build before assertions can run.
   // @force-gate !deploy
   // @force-gate start
   describe('production mode', () => {

--- a/test/e2e/edge-runtime-response-error/edge-runtime-response-error.test.ts
+++ b/test/e2e/edge-runtime-response-error/edge-runtime-response-error.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// This suite asserts runtime server messages in next.cliOutput.
+// Deployment mode captures build output, not the runtime logs these assertions require.
 // @force-gate !deploy
 describe('Edge runtime response error', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/edge-runtime-streaming-error/edge-runtime-streaming-error.test.ts
+++ b/test/e2e/edge-runtime-streaming-error/edge-runtime-streaming-error.test.ts
@@ -2,8 +2,8 @@ import stripAnsi from 'next/dist/compiled/strip-ansi'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// Assertions don't apply to deploy mode (output differs vs. local Next.js server).
+// This scope asserts the server-side diagnostic from an invalid streaming response.
+// Deploy cliOutput contains build logs, not the runtime error being checked.
 // @force-gate !deploy
 describe('edge-runtime-streaming-error', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/edge-runtime-with-node.js-apis/edge-runtime-with-node.js-apis.test.ts
+++ b/test/e2e/edge-runtime-with-node.js-apis/edge-runtime-with-node.js-apis.test.ts
@@ -27,8 +27,8 @@ const unsupportedClasses = [
   'WritableStreamDefaultController',
 ]
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// Vercel deployment fails to build/deploy this fixture in CI; skip in deploy mode.
+// This scope builds intentionally invalid Edge fixtures and inspects their diagnostics.
+// Deployment setup requires a successful build before assertions can run.
 // @force-gate !deploy
 describe('Edge runtime with Node.js APIs', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/instrumentation-hook-src/instrumentation-hook-src.test.ts
+++ b/test/e2e/instrumentation-hook-src/instrumentation-hook-src.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { check } from 'next-test-utils'
 describe('instrumentation-hook-rsc', () => {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely asserts local CLI or runtime output that deploy tests do not expose.
+  // This scope mutates instrumentation files and checks new runtime hook messages.
+  // Deployment mode cannot change those files or expose the runtime log stream.
   // @force-gate !deploy
   describe('instrumentation', () => {
     const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/instrumentation-hook/register-once/register-once.test.ts
+++ b/test/e2e/instrumentation-hook/register-once/register-once.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite asserts runtime server messages in next.cliOutput.
+// Deployment mode captures build output, not the runtime logs these assertions require.
 // @force-gate !deploy
 describe('instrumentation-hook - register-once', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/invalid-middleware-matchers/invalid-middleware-matchers.test.ts
+++ b/test/e2e/invalid-middleware-matchers/invalid-middleware-matchers.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope deliberately triggers compiler or configuration errors and checks diagnostics.
+// The deploy harness requires a successful build before test assertions can run.
 // @force-gate !deploy
 describe('Errors on invalid custom middleware matchers', () => {
   const { next, isTurbopack } = nextTestSetup({

--- a/test/e2e/middleware-src-node/middleware-src-node.test.ts
+++ b/test/e2e/middleware-src-node/middleware-src-node.test.ts
@@ -4,8 +4,8 @@ import { retry } from 'next-test-utils'
 const srcHeader = 'X-From-Src-Middleware'
 const rootHeader = 'X-From-Root-Middleware'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite changes fixture source or configuration with next.patchFile().
+// Deployment mode cannot modify the deployed application.
 // @force-gate !deploy
 describe('middleware-src-node', () => {
   const { next, isTurbopack } = nextTestSetup({

--- a/test/e2e/middleware-src/middleware-src.test.ts
+++ b/test/e2e/middleware-src/middleware-src.test.ts
@@ -4,8 +4,8 @@ import { retry } from 'next-test-utils'
 const srcHeader = 'X-From-Src-Middleware'
 const rootHeader = 'X-From-Root-Middleware'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite changes fixture source or configuration with next.patchFile().
+// Deployment mode cannot modify the deployed application.
 // @force-gate !deploy
 describe('middleware-src', () => {
   const { next, isTurbopack } = nextTestSetup({

--- a/test/e2e/node-cli-args/node-cli-args.test.ts
+++ b/test/e2e/node-cli-args/node-cli-args.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely controls the local Next.js build or server lifecycle.
+// This scope verifies Node.js flags and failures of the local start command.
+// The deploy harness does not launch the server with that custom Node.js command.
 // @force-gate !deploy
 describe('node-cli-args', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/on-request-error/basic/basic.test.ts
+++ b/test/e2e/on-request-error/basic/basic.test.ts
@@ -2,8 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { getOutputLogJson } from '../_testing/utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite changes fixture source or configuration with next.patchFile().
+// Deployment mode cannot modify the deployed application.
 // @force-gate !deploy
 describe('on-request-error - basic', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/on-request-error/dynamic-routes/dynamic-routes.test.ts
+++ b/test/e2e/on-request-error/dynamic-routes/dynamic-routes.test.ts
@@ -2,8 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { getOutputLogJson } from '../_testing/utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite changes fixture source or configuration with next.patchFile().
+// Deployment mode cannot modify the deployed application.
 // @force-gate !deploy
 describe('on-request-error - dynamic-routes', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/on-request-error/otel/otel.test.ts
+++ b/test/e2e/on-request-error/otel/otel.test.ts
@@ -2,8 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { getOutputLogJson } from '../_testing/utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite changes fixture source or configuration with next.patchFile().
+// Deployment mode cannot modify the deployed application.
 // @force-gate !deploy
 describe('on-request-error - otel', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/on-request-error/server-action-error/server-action-error.test.ts
+++ b/test/e2e/on-request-error/server-action-error/server-action-error.test.ts
@@ -2,8 +2,8 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import { getOutputLogJson } from '../_testing/utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This suite changes fixture source or configuration with next.patchFile().
+// Deployment mode cannot modify the deployed application.
 // @force-gate !deploy
 describe('on-request-error - server-action-error', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -2075,8 +2075,8 @@ describe('opentelemetry with disabled fetch tracing', () => {
   )
 })
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely controls the local Next.js build or server lifecycle.
+// This scope exercises the configured custom server's methods, options, or instrumentation.
+// The deploy harness does not run that custom server, so generic HTTP success is insufficient.
 // @force-gate !deploy
 describe('opentelemetry with custom server', () => {
   const { next } = nextTestSetup({
@@ -2251,8 +2251,8 @@ describe('opentelemetry with custom server', () => {
 })
 
 if (isNextStart) {
-  // TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-  // It likely controls the local Next.js build or server lifecycle.
+  // This scope invokes the direct local server entrypoint and collects its spans.
+  // A deployment does not exercise that entrypoint or the runner-local collector.
   // @force-gate !deploy
   describe('opentelemetry with direct entrypoint handler', () => {
     const { next } = nextTestSetup({

--- a/test/e2e/telemetry/config.test.ts
+++ b/test/e2e/telemetry/config.test.ts
@@ -10,8 +10,8 @@ import {
   retry,
 } from 'next-test-utils'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope builds with different configurations and reads local telemetry output.
+// Deployment mode cannot perform those additional local builds.
 // @force-gate !deploy
 describe('config telemetry', () => {
   const { next, isNextStart, isTurbopack } = nextTestSetup({

--- a/test/e2e/telemetry/telemetry.test.ts
+++ b/test/e2e/telemetry/telemetry.test.ts
@@ -9,8 +9,8 @@ import { findAllTelemetryEvents } from 'next-test-utils'
 // first". The telemetry feature itself is not React-version-specific, so
 // skipping under React 18 is fine until the underlying build/server lifecycle
 // race is fixed.
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// It likely asserts local CLI or runtime output that deploy tests do not expose.
+// This scope invokes the local telemetry CLI and checks its configuration files.
+// Deploying an application does not exercise those local CLI operations.
 // @force-gate !deploy
 // @force-gate !react18
 describe('Telemetry CLI', () => {

--- a/test/e2e/testmode/testmode.test.ts
+++ b/test/e2e/testmode/testmode.test.ts
@@ -1,8 +1,8 @@
 import { nextTestSetup } from 'e2e-utils'
 import { createProxyServer } from 'next/experimental/testmode/proxy'
 
-// TODO(deploy-test-completion): Re-enable this suite in deploy mode.
-// No deploy-specific incompatibility is documented.
+// This scope relies on a test-runner proxy intercepting server fetch requests.
+// Requests from a remote deployment do not reach that local interception proxy.
 // @force-gate !deploy
 describe('testmode', () => {
   const { next } = nextTestSetup({


### PR DESCRIPTION
## Summary

Replace 41 deployment-exclusion TODO comments with concrete reasons across 29 runtime test files. These are the same retained exclusions selected in the 180-location review.

This explanation stack is based on `jstory/deploy-tests/remove-skip-api`. The separately reviewed passing-test removals are now in the stack rooted on canary at #98523.

## Verification

- Executable ASTs and all gate directives match the current upstream base in every edited file.
- The complete explanation stack replaces exactly 180 TODOs across 147 files, preserving the previous explanations.
- Formatting and lint passed.
- Full local bootstrap was blocked by missing package-level dependencies in the temporary worktree.

<!-- NEXT_JS_LLM -->
