### PR TITLE
fix: separate prefetch requests in response cache

### DIFF
--- a/packages/next/src/server/response-cache/index.test.ts
+++ b/packages/next/src/server/response-cache/index.test.ts
@@ -102,4 +102,76 @@ describe('ResponseCache', () => {
       expect(followUp).not.toBeNull()
     })
   })
+
+  it('should not collapse concurrent prefetch and normal requests for the same key', async () => {
+    const cache = new ResponseCache(false)
+    const incrementalCache = mockIncrementalCache()
+
+    let releasePrefetch = () => {}
+    let markPrefetchStarted = () => {}
+
+    const prefetchStarted = new Promise<void>((resolve) => {
+      markPrefetchStarted = resolve
+    })
+
+    const continuePrefetch = new Promise<void>((resolve) => {
+      releasePrefetch = resolve
+    })
+
+    const prefetchGenerator = jest.fn(async () => {
+      markPrefetchStarted()
+      await continuePrefetch
+      return makeCacheEntry('prefetch-response')
+    })
+
+    const normalGenerator = jest.fn(async () =>
+      makeCacheEntry('normal-response')
+    )
+
+    const prefetchPromise = cache.get('/mixed-prefetch', prefetchGenerator, {
+      routeKind: RouteKind.APP_PAGE,
+      incrementalCache,
+      isPrefetch: true,
+    })
+
+    await prefetchStarted
+
+    const normalPromise = cache.get('/mixed-prefetch', normalGenerator, {
+      routeKind: RouteKind.APP_PAGE,
+      incrementalCache,
+      isPrefetch: false,
+    })
+
+    releasePrefetch()
+
+    const [prefetchResult, normalResult] = await Promise.all([
+      prefetchPromise,
+      normalPromise,
+    ])
+
+    expect(prefetchResult).not.toBeNull()
+    expect(normalResult).not.toBeNull()
+
+    expect(normalResult).not.toBe(prefetchResult)
+
+    expect(prefetchResult?.value?.kind).toBe(CachedRouteKind.APP_PAGE)
+    expect(normalResult?.value?.kind).toBe(CachedRouteKind.APP_PAGE)
+
+    if (
+      !prefetchResult?.value ||
+      prefetchResult.value.kind !== CachedRouteKind.APP_PAGE ||
+      !normalResult?.value ||
+      normalResult.value.kind !== CachedRouteKind.APP_PAGE
+    ) {
+      throw new Error('expected APP_PAGE cache entries')
+    }
+
+    expect(prefetchResult.value.html.toUnchunkedString()).toBe(
+      'prefetch-response'
+    )
+    expect(normalResult.value.html.toUnchunkedString()).toBe('normal-response')
+
+    expect(prefetchGenerator).toHaveBeenCalledTimes(1)
+    expect(normalGenerator).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/next/src/server/response-cache/index.ts
+++ b/packages/next/src/server/response-cache/index.ts
@@ -106,14 +106,19 @@ export * from './types'
 
 export default class ResponseCache implements ResponseCacheBase {
   private readonly getBatcher = Batcher.create<
-    { key: string; isOnDemandRevalidate: boolean },
+    {
+      key: string
+      isOnDemandRevalidate: boolean
+      isPrefetch: boolean
+    },
     IncrementalResponseCacheEntry | null,
     string
   >({
-    // Ensure on-demand revalidate doesn't block normal requests, it should be
-    // safe to run an on-demand revalidate for the same key as a normal request.
-    cacheKeyFn: ({ key, isOnDemandRevalidate }) =>
-      `${key}-${isOnDemandRevalidate ? '1' : '0'}`,
+    // Ensure requests with different response semantics don't collapse into
+    // the same render. Prefetches can intentionally serve fallback shells,
+    // while normal requests must generate the concrete response.
+    cacheKeyFn: ({ key, isOnDemandRevalidate, isPrefetch }) =>
+      `${key}-${isOnDemandRevalidate ? '1' : '0'}-${isPrefetch ? '1' : '0'}`,
     // We wait to do any async work until after we've added our promise to
     // `pendingResponses` to ensure that any any other calls will reuse the
     // same promise until we've fully finished our work.
@@ -271,7 +276,7 @@ export default class ResponseCache implements ResponseCacheBase {
     } = context
 
     const response = await this.getBatcher.batch(
-      { key, isOnDemandRevalidate },
+      { key, isOnDemandRevalidate, isPrefetch },
       ({ resolve }) => {
         const promise = this.handleGet(
           key,


### PR DESCRIPTION
### Fixing a bug
I found that prefetch requests and normal requests may be batched together when they use the same cache key.

I changed the batching key to include isPrefetch so that the two types of requests are handled separately.

I ran the unit tests and E2E tests, and they both passed.
