### PR TITLE
fix(turbopack): add `get_relative_request_to` for paths used as module requests

### DIFF
--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -353,15 +353,11 @@ pub async fn resolve_babel_plugin_react_compiler(
 
     // The relative path should only ever fail to resolve when the `fs` is different, which should
     // only happen due to eventual consistency.
-    let plugin_path = project_path
-        .get_relative_path_to(&source.ident().await?.path.parent())
-        .context("failed to resolve relative path for react compiler plugin")?;
-
-    Ok(Some(if plugin_path.starts_with("../") {
-        plugin_path
-    } else {
-        RcStr::from(format!("./{plugin_path}"))
-    }))
+    Ok(Some(
+        project_path
+            .get_relative_request_to(&source.ident().await?.path.parent())
+            .context("failed to resolve relative path for react compiler plugin")?,
+    ))
 }
 
 #[turbo_tasks::value]

--- a/turbopack/crates/turbo-tasks-fs/src/path.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/path.rs
@@ -12,7 +12,9 @@ use turbo_tasks::{
     turbobail, turbofmt,
 };
 use turbo_tasks_hash::HashAlgorithm;
-use turbo_unix_path::{get_parent_path, get_relative_path_to, join_path, normalize_path};
+use turbo_unix_path::{
+    get_parent_path, get_relative_path_to, get_relative_request_to, join_path, normalize_path,
+};
 
 use crate::{
     DirectoryContent, DirectoryEntry, FileContent, FileJsonContent, FileMeta, FileSystem,
@@ -97,8 +99,13 @@ impl FileSystemPath {
         }
     }
 
-    /// Returns a unix-style path of `other` relative to `self`. Supports traversing upwards (`../`)
-    /// within the filesystem.
+    /// Returns a unix-style path of `other` relative to `self`, as a plain path: `dir/file.js`,
+    /// `../file.js`, or `.`. Supports traversing upwards (`../`) within the filesystem.
+    ///
+    /// Returns [`None`] when the two are on different filesystems.
+    ///
+    /// The result is not prefixed with `./`, so it is a path and not a module request. Use
+    /// [`FileSystemPath::get_relative_request_to`] to build an import specifier.
     pub fn get_relative_path_to(&self, other: &FileSystemPath) -> Option<RcStr> {
         if self.fs != other.fs {
             return None;
@@ -106,6 +113,25 @@ impl FileSystemPath {
 
         Some(match get_relative_path_to(&self.path, &other.path) {
             Cow::Borrowed(path) if std::ptr::eq(path, other.path.as_str()) => other.path.clone(),
+            Cow::Borrowed(path) => path.into(),
+            Cow::Owned(path) => path.into(),
+        })
+    }
+
+    /// Returns a unix-style path of `other` relative to `self`, as an explicitly relative module
+    /// request: `./dir/file.js`, `../file.js`, or `.`. Supports traversing upwards (`../`) within
+    /// the filesystem.
+    ///
+    /// Returns [`None`] when the two are on different filesystems.
+    ///
+    /// The `./` prefix is what makes the result a relative request rather than a reference to a
+    /// package of that name. Use [`FileSystemPath::get_relative_path_to`] for a plain path.
+    pub fn get_relative_request_to(&self, other: &FileSystemPath) -> Option<RcStr> {
+        if self.fs != other.fs {
+            return None;
+        }
+
+        Some(match get_relative_request_to(&self.path, &other.path) {
             Cow::Borrowed(path) => path.into(),
             Cow::Owned(path) => path.into(),
         })
@@ -767,6 +793,102 @@ mod tests {
 
     use super::*;
     use crate::VirtualFileSystem;
+
+    /// Builds two paths on the same filesystem and returns them.
+    fn paths_on_one_fs(
+        fs: ResolvedVc<Box<dyn FileSystem>>,
+        from: &str,
+        target: &str,
+    ) -> (FileSystemPath, FileSystemPath) {
+        (
+            FileSystemPath::new_normalized_unchecked(fs, from.into()),
+            FileSystemPath::new_normalized_unchecked(fs, target.into()),
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_get_relative_path_to() {
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        tt.run_once(async move {
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(VirtualFileSystem::new())
+                .to_resolved()
+                .await?;
+
+            for (from, target, expected) in [
+                ("a/b/c", "a/b/c", "."),
+                ("a/c/d", "a/b/c", "../../b/c"),
+                ("", "a/b/c", "a/b/c"),
+                ("a/b", "a/b/c", "c"),
+                ("a/b/c", "", "../../.."),
+                ("a/b/c", "c/b/a", "../../../c/b/a"),
+            ] {
+                let (from_path, target_path) = paths_on_one_fs(fs, from, target);
+                assert_eq!(
+                    from_path.get_relative_path_to(&target_path).as_deref(),
+                    Some(expected),
+                    "{from:?} -> {target:?}"
+                );
+            }
+
+            // A path on another filesystem is not reachable relatively.
+            let (from_path, _) = paths_on_one_fs(fs, "a/b", "a/b/c");
+            let other_fs = Vc::upcast::<Box<dyn FileSystem>>(VirtualFileSystem::new())
+                .to_resolved()
+                .await?;
+            let on_other_fs = FileSystemPath::new_normalized_unchecked(other_fs, rcstr!("a/b/c"));
+            assert_eq!(from_path.get_relative_path_to(&on_other_fs), None);
+
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
+    /// The cases this covers are the ones `get_relative_path_to` was asserted against before it
+    /// stopped prefixing `./`, so they pin that the request form still produces them.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_get_relative_request_to() {
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        tt.run_once(async move {
+            let fs = Vc::upcast::<Box<dyn FileSystem>>(VirtualFileSystem::new())
+                .to_resolved()
+                .await?;
+
+            for (from, target, expected) in [
+                ("a/b/c", "a/b/c", "."),
+                ("a/c/d", "a/b/c", "../../b/c"),
+                ("", "a/b/c", "./a/b/c"),
+                ("a/b", "a/b/c", "./c"),
+                ("a/b/c", "", "../../.."),
+                ("a/b/c", "c/b/a", "../../../c/b/a"),
+            ] {
+                let (from_path, target_path) = paths_on_one_fs(fs, from, target);
+                assert_eq!(
+                    from_path.get_relative_request_to(&target_path).as_deref(),
+                    Some(expected),
+                    "{from:?} -> {target:?}"
+                );
+            }
+
+            // A path on another filesystem is not reachable relatively.
+            let (from_path, _) = paths_on_one_fs(fs, "a/b", "a/b/c");
+            let other_fs = Vc::upcast::<Box<dyn FileSystem>>(VirtualFileSystem::new())
+                .to_resolved()
+                .await?;
+            let on_other_fs = FileSystemPath::new_normalized_unchecked(other_fs, rcstr!("a/b/c"));
+            assert_eq!(from_path.get_relative_request_to(&on_other_fs), None);
+
+            anyhow::Ok(())
+        })
+        .await
+        .unwrap();
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn with_extension() {

--- a/turbopack/crates/turbo-unix-path/src/lib.rs
+++ b/turbopack/crates/turbo-unix-path/src/lib.rs
@@ -119,6 +119,13 @@ pub fn normalize_request(str: &str) -> String {
     segments.join("/")
 }
 
+/// Returns the path of `target` relative to `from`, as a plain path: `"c"`, `"../c"`, or `"."` when
+/// the two are equal.
+///
+/// The result is not prefixed with `./`, so it is a path and not a module request. Use
+/// [`get_relative_request_to`] to build an import specifier, where a bare `"c"` would be read as a
+/// package name rather than as a file next to `from`.
+///
 /// Returns `"."` by reference when the paths are identical, or `target` by reference when `from`
 /// is empty.
 pub fn get_relative_path_to<'a>(from: &str, target: &'a str) -> Cow<'a, str> {
@@ -126,6 +133,24 @@ pub fn get_relative_path_to<'a>(from: &str, target: &'a str) -> Cow<'a, str> {
         return Cow::Borrowed(target);
     }
 
+    relative_to(from, target, false)
+}
+
+/// Returns the path of `target` relative to `from`, as an explicitly relative module request:
+/// `"./c"`, `"../c"`, or `"."` when the two are equal.
+///
+/// The `./` prefix is what makes the result a relative request: without it, `"c"` resolves as the
+/// package `c` instead of the file `c` next to `from`. Use [`get_relative_path_to`] when a plain
+/// path is wanted instead.
+///
+/// Returns `"."` by reference when the paths are identical.
+pub fn get_relative_request_to<'a>(from: &str, target: &'a str) -> Cow<'a, str> {
+    relative_to(from, target, true)
+}
+
+/// Shared by [`get_relative_path_to`] and [`get_relative_request_to`]; `explicitly_relative` adds
+/// the leading `./` that distinguishes a request from a path.
+fn relative_to<'a>(from: &str, target: &'a str, explicitly_relative: bool) -> Cow<'a, str> {
     fn split(s: &str) -> impl Iterator<Item = &str> {
         let mut iterator = s.split('/');
         if s.is_empty() {
@@ -147,6 +172,9 @@ pub fn get_relative_path_to<'a>(from: &str, target: &'a str) -> Cow<'a, str> {
         while from_segments.next().is_some() {
             result.push("..");
         }
+    } else if explicitly_relative {
+        // Nothing to walk up, so the path would be bare (`c`) without this.
+        result.push(".");
     }
     for segment in target_segments {
         result.push(segment);
@@ -207,6 +235,30 @@ mod tests {
         #[case] borrowed: bool,
     ) {
         let relative = get_relative_path_to(from, target);
+        assert_eq!(relative, expected);
+        assert_eq!(matches!(relative, Cow::Borrowed(_)), borrowed);
+    }
+
+    /// The same cases as [`test_get_relative_path_to`], so the two forms can be compared row by
+    /// row. They differ only where the result would otherwise be a bare path, which is exactly
+    /// where a request needs its `./`.
+    #[rstest]
+    #[case("a/b/c", "a/b/c", ".", true)]
+    #[case("a/c/d", "a/b/c", "../../b/c", false)]
+    #[case("", "a/b/c", "./a/b/c", false)]
+    #[case("", "", ".", true)]
+    #[case("a/b", "a/b/c", "./c", false)]
+    #[case("a/b", "a/b/c/d", "./c/d", false)]
+    #[case("a/b/c", "", "../../..", false)]
+    #[case("a/b/c", "c/b/a", "../../../c/b/a", false)]
+    #[case("file:///a/b/c", "file:///c/b/a", "../../../c/b/a", false)]
+    fn test_get_relative_request_to(
+        #[case] from: &str,
+        #[case] target: &str,
+        #[case] expected: &str,
+        #[case] borrowed: bool,
+    ) {
+        let relative = get_relative_request_to(from, target);
         assert_eq!(relative, expected);
         assert_eq!(matches!(relative, Cow::Borrowed(_)), borrowed);
     }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -3149,14 +3149,7 @@ async fn resolved(
         path.parent(),
         options,
         options_value,
-        |package_path| {
-            let path = package_path.get_relative_path_to(&path_ref)?;
-            Some(if path.starts_with("../") {
-                path
-            } else {
-                RcStr::from(format!("./{path}"))
-            })
-        },
+        |package_path| package_path.get_relative_request_to(&path_ref),
         query.clone(),
         fragment.clone(),
     )

--- a/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/import_meta_glob.rs
@@ -544,24 +544,20 @@ impl ImportMetaGlobMap {
                     // matching and user-visible specifiers have one explicit source of truth. The
                     // module resolver resolves this logical request and tracks its symlink chain.
                     let logical_path = scan_dir.join(scan_relative)?;
-                    let Some(origin_relative) = origin_path.get_relative_path_to(&logical_path)
+                    let Some(origin_relative) = origin_path.get_relative_request_to(&logical_path)
                     else {
                         bail!(
                             "import.meta.glob: failed to compute relative path from origin to \
                              matched file"
                         );
                     };
-                    let origin_relative = if origin_relative.starts_with("../") {
-                        origin_relative
-                    } else {
-                        RcStr::from(format!("./{origin_relative}"))
-                    };
 
                     // Compute the user-visible key of this entry.
                     let key: RcStr = if let Some(key_base) = key_base {
-                        // Vite keys the result relative to `base` when it is provided.
+                        // Vite keys the result relative to `base` when it is provided, and its
+                        // keys are `./`-prefixed like the origin-relative ones below.
                         // https://vite.dev/guide/features.html#base-path
-                        let Some(key) = key_base.get_relative_path_to(&logical_path) else {
+                        let Some(key) = key_base.get_relative_request_to(&logical_path) else {
                             bail!(
                                 "import.meta.glob: failed to compute relative path from base to \
                                  matched file"
@@ -583,7 +579,7 @@ impl ImportMetaGlobMap {
                                  of the project to matched file"
                             );
                         };
-                        format!("/{}", relative.strip_prefix("./").unwrap_or(&relative)).into()
+                        format!("/{relative}").into()
                     } else {
                         origin_relative.clone()
                     };

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -90,12 +90,11 @@ impl DirList {
         for (_, entry) in entries.iter().flat_map(|m| m.iter()) {
             match entry {
                 DirectoryEntry::File(path) => {
-                    if let Some(relative_path) = root_val.get_relative_path_to(path) {
-                        // Webpack always chacks the RegExp against a path prefixed with `./`
-                        let relative_path = RcStr::from(format!("./{relative_path}"));
-                        if regex.is_match(&relative_path) {
-                            list.insert(relative_path, DirListEntry::File(path.clone()));
-                        }
+                    // Webpack always checks the RegExp against a path prefixed with `./`
+                    if let Some(relative_path) = root_val.get_relative_request_to(path)
+                        && regex.is_match(&relative_path)
+                    {
+                        list.insert(relative_path, DirListEntry::File(path.clone()));
                     }
                 }
                 DirectoryEntry::Directory(path) if recursive => {
@@ -195,13 +194,8 @@ impl RequireContextMap {
         let mut map = FxIndexMap::default();
 
         for (context_relative, path) in list {
-            let Some(origin_relative) = origin_path.get_relative_path_to(path) else {
+            let Some(origin_relative) = origin_path.get_relative_request_to(path) else {
                 bail!("invariant error: this was already checked in `list_dir`");
-            };
-            let origin_relative = if origin_relative.starts_with("../") {
-                origin_relative
-            } else {
-                RcStr::from(format!("./{origin_relative}"))
             };
 
             let request = Request::parse(origin_relative.clone().into())

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -2,7 +2,6 @@ use std::io::Write;
 
 use anyhow::Result;
 use indoc::writedoc;
-use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc, turbobail};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
@@ -76,8 +75,8 @@ impl EcmascriptBuildNodeEntryChunk {
         let chunk_path = self.path().owned().await?;
         let chunk_directory = self.path().await?.parent();
         let runtime_path = self.runtime_chunk().path().owned().await?;
-        let runtime_relative_path =
-            if let Some(path) = chunk_directory.get_relative_path_to(&runtime_path) {
+        let runtime_request =
+            if let Some(path) = chunk_directory.get_relative_request_to(&runtime_path) {
                 path
             } else {
                 turbobail!(
@@ -85,11 +84,6 @@ impl EcmascriptBuildNodeEntryChunk {
                      chunk ({runtime_path})",
                 );
             };
-        let runtime_request = if runtime_relative_path.starts_with("../") {
-            runtime_relative_path
-        } else {
-            RcStr::from(format!("./{runtime_relative_path}"))
-        };
         let chunk_public_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path
         } else {

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -719,15 +719,10 @@ async fn process_default_internal(
         .to_resolved()
         .await?;
 
-        let loader_relative_path = execution_context_value
+        let loader_request = execution_context_value
             .project_path
-            .get_relative_path_to(&loader.loader)
+            .get_relative_request_to(&loader.loader)
             .context("Loader path must be on project filesystem")?;
-        let loader_request = if loader_relative_path.starts_with("../") {
-            loader_relative_path
-        } else {
-            RcStr::from(format!("./{loader_relative_path}"))
-        };
         let webpack_loader_item = WebpackLoaderItem {
             loader: loader_request,
             options: loader.options.clone(),

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -261,12 +261,8 @@ impl RuleCondition {
                         return Ok(source.ident().await?.content_type.is_none());
                     }
                     RuleCondition::ResourcePathGlob { glob, base } => {
-                        return Ok(if let Some(rel_path) = base.get_relative_path_to(path) {
-                            if rel_path.starts_with("../") {
-                                glob.matches(&rel_path)
-                            } else {
-                                glob.matches(&format!("./{rel_path}"))
-                            }
+                        return Ok(if let Some(rel_path) = base.get_relative_request_to(path) {
+                            glob.matches(&rel_path)
                         } else {
                             glob.matches(&path.path)
                         });


### PR DESCRIPTION
### What?

Adds `get_relative_request_to`, next to `get_relative_path_to`, for callers that need a relative
path they can hand to the resolver as a module request. It returns `./c`, `../c` or `.`, where
`get_relative_path_to` returns `c`, `../c` or `.`.

Fixes `import.meta.glob`'s `base`-relative keys, which currently come back without the leading `./`:
`{ base: '../outside' }` produces `one.js` where Vite (and our own docs, and the existing execution
fixture) expect `./one.js`. That fixture is failing on `canary` today; it passes here unchanged.

### Why?

The `./` prefix is not decoration — it is what makes a string a *relative* request. Without it, `c`
resolves as the package `c` rather than the file next to `from`.

`get_relative_path_to` stopped emitting the prefix for a path below `from`, and every caller that
builds a request had to add it back by hand. Eight of them do, each with the same three lines. That
works, but it puts the requirement in the call sites instead of the API, and nothing tells a new
caller that it exists — so the ninth request-building call site, `import.meta.glob`'s `base`-relative
key, was written without it and silently produced the wrong keys. The two changes were authored
independently and each was green on its own; only together do they produce the bug, which is why CI
caught it on `canary` rather than on either pull request.

Rather than add a tenth hand-written prefix, this makes "give me a request" something you can ask
for. The failure mode it removes is the silent one: a caller that forgets is no longer possible,
because the choice is now the function you call.

### How?

`get_relative_request_to` shares its traversal with `get_relative_path_to` through one private
helper, so the two can't drift; the only difference is whether a result that would be bare gets the
prefix. `get_relative_path_to` keeps its signature and behaviour exactly, including the fast path
that returns `target` by reference when `from` is empty — the request form can't borrow there, and
the unit tests assert that difference so the fast path isn't reused by mistake. `FileSystemPath`
gains the matching method.

The eight hand-written prefixes now call the new function and drop their snippets. Deciding which
call sites to convert needed care, because the callers of `get_relative_path_to` genuinely want
different things, and the ones that want a plain path deliberately keep it:

- source-map paths reported back to the client,
- the Next.js template expander, whose invariant check expects the bare form,
- the paths written into NFT files, which are data rather than requests.

Two locals that hold requests rather than paths are renamed accordingly, and one leftover
`strip_prefix("./")` is removed — it had become a no-op undoing a prefix that is no longer produced.

### Testing

The `import-meta-glob-relative` execution fixture already asserts the correct keys and currently
fails, so the fix is verified by that fixture passing **unmodified** — its expectations were right
all along.

The unit test that covered these cases before the prefix went away is restored, now run against both
functions and against `FileSystemPath`, which had been left with no coverage of either method. Its
original assertions turn out to describe the request form exactly, so they pin that
`get_relative_request_to` reproduces the earlier contract rather than merely resembling it.

Beyond that: the full `turbopack-tests` suite, and the `next-server-nft` and `next-taskless` tests,
which are what would break if a call site that wants a plain path had been converted by mistake.

<!-- NEXT_JS_LLM -->

<!-- fleet 3acc7e63-52a8-4472-89cd-b1bbb8ad59fa -->