### PR TITLE
Render the streamed-metadata wrapper as a custom element, not a <div>

### DIFF
--- a/packages/next/src/lib/metadata/constants.ts
+++ b/packages/next/src/lib/metadata/constants.ts
@@ -13,3 +13,14 @@ export const ViewportMetaKeys: { [k in keyof ViewportLayout]: string } = {
 } as const
 
 export const IconKeys: (keyof Icons)[] = ['icon', 'shortcut', 'apple', 'other']
+
+/**
+ * The element streamed metadata is rendered inside. React needs a host
+ * element around a top-level Suspense boundary, and this one becomes the
+ * first child of `<body>`. It is a custom element rather than a `<div>`
+ * because React hydrates `<body>` children by tag name: a third-party script
+ * that prepends its own `<div>` to `<body>` before hydration would otherwise
+ * be claimed for this wrapper, hydration would fail, and the client-side
+ * regeneration would delete the third party's DOM.
+ */
+export const HIDDEN_METADATA_WRAPPER_TAG = 'next-metadata'

--- a/packages/next/src/lib/metadata/metadata-parallel.tsx
+++ b/packages/next/src/lib/metadata/metadata-parallel.tsx
@@ -5,6 +5,7 @@ import type { LoaderTree } from '../../server/lib/app-dir-module'
 import type { SearchParams } from '../../server/request/search-params'
 import { createServerSearchParamsForMetadata } from '../../server/request/search-params'
 import { createServerPathnameForMetadata } from '../../server/request/pathname'
+import { HIDDEN_METADATA_WRAPPER_TAG } from './constants'
 import type { MetadataErrorType } from './metadata-resolution-primitives'
 import {
   resolveMetadataForBranch,

--- a/packages/next/src/lib/metadata/metadata-parallel.tsx
+++ b/packages/next/src/lib/metadata/metadata-parallel.tsx
@@ -126,14 +126,15 @@ export function createMetadataComponents({
         </MetadataBoundary>
       )
     }
-    return (
-      <div hidden>
-        <MetadataBoundary>
-          <Suspense name="Next.Metadata">
-            <Metadata />
-          </Suspense>
-        </MetadataBoundary>
-      </div>
+    // Not a <div>: see the same spot in ./metadata.tsx.
+    return React.createElement(
+      HIDDEN_METADATA_WRAPPER_TAG,
+      { hidden: true },
+      <MetadataBoundary>
+        <Suspense name="Next.Metadata">
+          <Metadata />
+        </Suspense>
+      </MetadataBoundary>
     )
   }
 

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -10,6 +10,7 @@ import {
   resolveViewport,
 } from './resolve-metadata'
 import { isHTTPAccessFallbackError } from '../../client/components/http-access-fallback/http-access-fallback'
+import { HIDDEN_METADATA_WRAPPER_TAG } from './constants'
 import type { MetadataContext } from './types/resolvers'
 import { createServerSearchParamsForMetadata } from '../../server/request/search-params'
 import { createServerPathnameForMetadata } from '../../server/request/pathname'
@@ -121,14 +122,22 @@ export function createMetadataComponents({
         </MetadataBoundary>
       )
     }
-    return (
-      <div hidden>
-        <MetadataBoundary>
-          <Suspense name="Next.Metadata">
-            <Metadata />
-          </Suspense>
-        </MetadataBoundary>
-      </div>
+    // React requires a host element around a top-level Suspense boundary, and
+    // this one ends up as the first child of <body>. It must not be a <div>:
+    // React hydrates <body> children by tag name and claims the first element
+    // whose tag matches, so a third-party script that prepends its own <div>
+    // to <body> before hydration (consent managers do exactly this) would be
+    // taken for this wrapper, hydration would fail, and the whole document
+    // would be regenerated on the client — deleting the third party's DOM.
+    // A custom element is a tag nothing else prepends.
+    return React.createElement(
+      HIDDEN_METADATA_WRAPPER_TAG,
+      { hidden: true },
+      <MetadataBoundary>
+        <Suspense name="Next.Metadata">
+          <Metadata />
+        </Suspense>
+      </MetadataBoundary>
     )
   }
 

--- a/test/e2e/app-dir/metadata-streaming/app/third-party-prepend/page.tsx
+++ b/test/e2e/app-dir/metadata-streaming/app/third-party-prepend/page.tsx
@@ -1,0 +1,30 @@
+// A third-party script (consent managers, chat widgets, some extensions)
+// that prepends its own <div> to <body> before React has hydrated. React
+// hydrates <body> children by tag name, so whatever Next renders as the
+// first child of <body> must not be a <div>, or that foreign node is claimed
+// for it, hydration fails, and the whole document is regenerated on the
+// client — which deletes the third party's DOM.
+const PREPEND_A_DIV = `
+  var el = document.createElement('div');
+  el.id = 'third-party';
+  el.textContent = 'third party';
+  document.body.insertBefore(el, document.body.firstChild);
+`
+
+export default function Page() {
+  return (
+    <>
+      <script dangerouslySetInnerHTML={{ __html: PREPEND_A_DIV }} />
+      <p id="content">third-party prepend page</p>
+    </>
+  )
+}
+
+export async function generateMetadata() {
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  return {
+    title: 'third-party prepend page',
+  }
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
+++ b/test/e2e/app-dir/metadata-streaming/metadata-streaming.test.ts
@@ -89,6 +89,36 @@ describe('app-dir - metadata-streaming', () => {
     expect($('body meta').length).toBe(9)
   })
 
+  it('should not wrap streamed metadata in a <div>, so a third-party <div> prepended to <body> before hydration is skipped rather than claimed', async () => {
+    const $ = await next.render$('/third-party-prepend')
+    // The streamed metadata wrapper is the first child of <body>. React
+    // hydrates <body> children by tag name, so it must be a tag no third
+    // party prepends — a foreign <div> in front of a <div> wrapper is claimed
+    // for it and hydration fails.
+    expect($('body > *').first().is('div')).toBe(false)
+    expect($('body > next-metadata[hidden]').length).toBe(1)
+
+    const browser = await next.browser('/third-party-prepend')
+    await retry(async () => {
+      expect(await browser.elementByCss('title').text()).toBe(
+        'third-party prepend page'
+      )
+    })
+
+    // The foreign node is still there — a failed hydration regenerates the
+    // document and would have removed it.
+    expect(await browser.elementByCss('#third-party').text()).toBe(
+      'third party'
+    )
+    const logs = await browser.log()
+    const hydrationErrors = logs.filter(
+      (log) =>
+        log.source === 'error' &&
+        /hydrat|Minified React error #(418|423|425)/i.test(log.message)
+    )
+    expect(hydrationErrors).toEqual([])
+  })
+
   describe('dynamic api', () => {
     it('should render metadata to body', async () => {
       const $ = await next.render$('/dynamic-api')


### PR DESCRIPTION
### What?

Render the streamed-metadata wrapper as a custom element, `<next-metadata hidden>`, instead of `<div hidden>`, in both `metadata.tsx` and `metadata-parallel.tsx`. Adds an e2e test that prepends a third-party `<div>` to `<body>` before hydration and asserts that hydration succeeds and the node survives.

### Why?

With streaming metadata (the default, and forced for every prerendered page by the export worker), `MetadataWrapper` is rendered above the root layout, so its `<div hidden>` is the **first child of `<body>`** on every App Router page.

React 19 hydrates `<body>` children by tag name and skips a foreign node only when its tag differs (`canHydrateInstance`, `inRootOrSingleton`). So a third-party script that prepends its own `<div>` to `<body>` before hydration finishes — consent managers do exactly this (InMobi/Quantcast Choice prepends `#qc-cmp2-container`), as do chat widgets and some extensions — gets that `<div>` claimed for Next's wrapper. The wrapper's expected child (a Suspense comment) is not found inside it, hydration fails at the root (#418), and React regenerates the document with `clearContainerSparingly`, which deletes every element in `<body>` it does not own — the third party's UI included.

An application cannot work around this: the wrapper precedes anything the root layout renders, so an app whose own first body child is an `<a>` or a `<header>` is exposed purely because of the framework's wrapper. React's own source describes the tag-name skip as intentional and a prepended `<div>` as "an edge case"; a `<div>` wrapper in first position turns that edge case into the default for every site.

React's requirement here (#77620) is a *host element* around the top-level Suspense boundary, not a `<div>` specifically. A custom element satisfies it, renders identically (`hidden=""`, `display: none` from the UA stylesheet), hydrates identically, and is a tag nothing else prepends. Next already uses `<next-route-announcer>` in the same spirit.

Measured on a production site (Next 16.3.4, React 19.2.8) with a consented CMP: a foreign `<div>` prepended before hydration → #418 on 2/2 loads and the node deleted; a foreign `<aside>` in the same place → no error, node kept. Verified in jsdom that `renderToString` emits `<next-metadata hidden=""><!--$--><!--/$--></next-metadata>` and that `hydrateRoot` with a prepended foreign `<div>` reports no recoverable error and keeps the node.

Fixes #98500 (supersedes #98498, which the bot closed for lacking a repository link; reproduction: https://github.com/nickkosmides/next-metadata-wrapper-prepend-repro)

### How?

- `HIDDEN_METADATA_WRAPPER_TAG = 'next-metadata'` in `lib/metadata/constants.ts`, used via `React.createElement` in both wrappers (no JSX intrinsic-element typing needed).
- `test/e2e/app-dir/metadata-streaming/app/third-party-prepend/page.tsx` prepends a `<div>` during parsing; the new case in `metadata-streaming.test.ts` asserts the wrapper is not a `<div>`, that `#third-party` is still in the DOM after hydration, and that no hydration error was logged.

Note: I authored this against a sparse checkout and could not run the monorepo's test suite locally; the patch is a tag-name change plus one test, and I will address CI feedback promptly.
