### PR TITLE
[ci] Show full logs under GitHub Actions debug logging

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -405,7 +405,7 @@ async function main() {
 
   const options = {
     concurrency: argv.concurrency ?? envConcurrency ?? DEFAULT_CONCURRENCY,
-    debug: argv.debug ?? false,
+    debug: argv.debug ?? core.isDebug(),
     timings: argv.timings ?? false,
     writeTimings: argv.writeTimings ?? false,
     group: argv.group ?? false,


### PR DESCRIPTION
Logs of passed tests are hidden by default in CI.
There's an argument to be made to always show them in CI. For now we just wire up GitHub's built-in "re-run with debug logging enabled" to show logs of passed tests.

<img width="1358" height="936" alt="CleanShot 2026-09-10 at 19 00 18@2x" src="https://github.com/user-attachments/assets/70fb9c56-c681-4394-958b-7fa9aea19970" />


## test plan

- [x] [PR run with debug logging shows passed test logs](https://github.com/vercel/next.js/actions/runs/34483747384/job/102909958899?pr=98501)