### PR TITLE
[ci] Fix scheduled Rspack test job

### DIFF
--- a/.github/workflows/rspack-nextjs-build-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-build-integration-tests.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
     uses: ./.github/workflows/integration_tests_reusable.yml
     with:
       name: rspack-production

--- a/.github/workflows/rspack-nextjs-dev-integration-tests.yml
+++ b/.github/workflows/rspack-nextjs-dev-integration-tests.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
     uses: ./.github/workflows/integration_tests_reusable.yml
     with:
       name: rspack-development


### PR DESCRIPTION
This workflow is responsible for periodically updating the manifest. The workflow broke in https://github.com/vercel/next.js/pull/97590 since the [called workflow requires `pull_request: write`](https://github.com/vercel/next.js/blob/626ab223bae3f9b29b3ec8cbd18a58d86b871ec1/.github/workflows/integration_tests_reusable.yml#L172) to open the update PR. 

Fixes
```
[Invalid workflow file: .github/workflows/rspack-nextjs-build-integration-tests.yml#L10](https://github.com/vercel/next.js/actions/runs/34439645923/workflow)
The workflow is not valid. .github/workflows/rspack-nextjs-build-integration-tests.yml (Line: 10, Col: 3): Error calling workflow 'vercel/next.js/.github/workflows/integration_tests_reusable.yml@334052ffbb383395b74cac6a90e0b15c7317957b'. The nested job 'collect_nextjs_development_integration_stat' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.
```
-- https://github.com/vercel/next.js/actions/runs/34439645923