### PR TITLE
Prevent synchronous IO from entering Cached Navigations

### DIFF
--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -150,6 +150,10 @@ export function createInitialRouterState({
         // native Promise so we can chain `.then` on it safely.
         Promise.resolve(initialStaticStageByteLength)
           .then(async (byteLength) => {
+            if (byteLength === 0) {
+              initialFlightStreamForCache.cancel()
+              return
+            }
             const staticStageResponse =
               await decodeStageUntilBoundary<InitialRSCPayload>(
                 initialFlightStreamForCache,

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -160,6 +160,9 @@ export function createInitialRouterState({
                 byteLength,
                 undefined
               )
+            if (staticStageResponse === null) {
+              return
+            }
             spawnStaticStageCacheWrite(
               Date.now(),
               staticStageResponse,

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -469,6 +469,10 @@ async function resolveStaticStageResponse<
       // Partially static — truncate the body clone at the byte boundary and
       // decode it.
       const staticStageByteLength = await flightResponse.l
+      if (staticStageByteLength === 0) {
+        staticBodyClone.cancel()
+        return null
+      }
       return decodeStageUntilBoundary<T>(
         staticBodyClone,
         staticStageByteLength,
@@ -513,6 +517,10 @@ export async function resolveShellStageResponse<
   }
 
   const shellByteLength = await flightResponse.a
+  if (shellByteLength === 0) {
+    shellBodyClone.cancel()
+    return null
+  }
   if (shellByteLength === null) {
     // The shell IS the full response (no shell/full split). Return the full
     // response itself — callers detect this case by reference equality —

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -536,16 +536,42 @@ export async function resolveShellStageResponse<
 
 /**
  * Truncates and buffers a Flight stream clone at the given byte boundary and
- * decodes the prefix as a Flight payload. Used by the static-stage and
- * shell-stage extraction helpers.
+ * decodes the prefix as an optional Flight payload. Returns null if extraction
+ * fails or the root does not resolve before the next task. The caller can still
+ * use the full response.
  */
 export async function decodeStageUntilBoundary<T>(
   responseBodyClone: ReadableStream<Uint8Array>,
   byteLength: number,
   headers: RequestHeaders | undefined
-): Promise<T> {
-  const buffer = await bufferPrefetchResponseBody(responseBodyClone, byteLength)
-  return decodeBufferedStage<T>(buffer, headers)
+): Promise<T | null> {
+  try {
+    const buffer = await bufferPrefetchResponseBody(
+      responseBodyClone,
+      byteLength
+    )
+    const response = decodeBufferedStage<T>(buffer, headers)
+
+    // The caller already has the full response root, but this prefix may omit
+    // rows that the root needs. Bound this optional extraction so it cannot
+    // hold up the full response. This deadline applies to the outer root, not
+    // to Client Components that continue loading through lazy references.
+    return await new Promise<T | null>((resolve) => {
+      const timeout = setTimeout(() => resolve(null), 0)
+      response.then(
+        (root) => {
+          clearTimeout(timeout)
+          resolve(root)
+        },
+        () => {
+          clearTimeout(timeout)
+          resolve(null)
+        }
+      )
+    })
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1071,13 +1071,14 @@ async function generateStagedDynamicFlightRenderResultNode(
 
   const selectStaleTime = createSelectStaleTime(experimental)
   const staleTimeIterable = new StaleTimeIterable()
+  const prefetchMode = await getPrefetchingModeForPage(renderOpts, loaderTree)
 
   const stageController = new StagedRenderingController({
     abortSignal: null,
     abandonController: null,
     // Synchronous request-time data ends the static stage before its result can
     // enter the Cached Navigation.
-    syncIO: SyncIOMode.AllowedInRuntimeOrDynamic,
+    syncIO: getSyncIOMode(prefetchMode),
     finalStage: null,
   })
 
@@ -1110,10 +1111,7 @@ async function generateStagedDynamicFlightRenderResultNode(
   // fill caches and then spawn a final runtime prerender whose result stream
   // is embedded in the RSC payload. This is gated because it adds extra server
   // processing and increases the response payload size.
-  if (
-    Boolean(renderOpts.partialPrefetching) ||
-    (await anySegmentHasPartialPrefetchingEnabled(loaderTree))
-  ) {
+  if (prefetchMode === PrefetchingMode.Partial) {
     // Create a mutable cache that gets filled during the dynamic render.
     const prerenderResumeDataCache = createPrerenderResumeDataCache()
     requestStore.resumeDataCache = prerenderResumeDataCache
@@ -1177,18 +1175,8 @@ async function generateStagedDynamicFlightRenderResultNode(
 
       void countShellAndStaticStageBytes(staticStream, stageController).then(
         (byteLengths) => {
-          // A sync interruption can precede the Flight root row. Do not expose
-          // that incomplete prefix as a cacheable payload.
-          staticStageByteLengthDeferred.resolve(
-            stageController.getSyncInterruptReason()
-              ? 0
-              : byteLengths[RenderStage.Static]
-          )
-          shellByteLengthDeferred.resolve(
-            stageController.getSyncInterruptReason()
-              ? 0
-              : byteLengths[RenderStage.ShellStatic]
-          )
+          staticStageByteLengthDeferred.resolve(byteLengths[RenderStage.Static])
+          shellByteLengthDeferred.resolve(byteLengths[RenderStage.ShellStatic])
         }
       )
 
@@ -3853,13 +3841,14 @@ async function renderToStream(
 
         const selectStaleTime = createSelectStaleTime(experimental)
         const staleTimeIterable = new StaleTimeIterable()
+        const prefetchMode = await getPrefetchingModeForPage(renderOpts, tree)
 
         const stageController = new StagedRenderingController({
           abortSignal: null,
           abandonController: null,
           // Synchronous request-time data ends the static stage before its
           // result can enter the Cached Navigation.
-          syncIO: SyncIOMode.AllowedInRuntimeOrDynamic,
+          syncIO: getSyncIOMode(prefetchMode),
           finalStage: null,
         })
 
@@ -3895,10 +3884,7 @@ async function renderToStream(
         // Partial Prefetching is on for the route, either per segment (a
         // `prefetch` of 'partial') or globally (the
         // `partialPrefetching` config).
-        if (
-          Boolean(renderOpts.partialPrefetching) ||
-          (await anySegmentHasPartialPrefetchingEnabled(tree))
-        ) {
+        if (prefetchMode === PrefetchingMode.Partial) {
           const prerenderResumeDataCache = createPrerenderResumeDataCache()
           requestStore.resumeDataCache = prerenderResumeDataCache
 
@@ -3962,14 +3948,10 @@ async function renderToStream(
               stageController
             ).then((byteLengths) => {
               staticStageByteLengthDeferred.resolve(
-                stageController.getSyncInterruptReason()
-                  ? 0
-                  : byteLengths[RenderStage.Static]
+                byteLengths[RenderStage.Static]
               )
               shellByteLengthDeferred.resolve(
-                stageController.getSyncInterruptReason()
-                  ? 0
-                  : byteLengths[RenderStage.ShellStatic]
+                byteLengths[RenderStage.ShellStatic]
               )
             })
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1075,10 +1075,9 @@ async function generateStagedDynamicFlightRenderResultNode(
   const stageController = new StagedRenderingController({
     abortSignal: null,
     abandonController: null,
-    // TODO(cached-navs): this assumes that we checked during build that there's no sync IO.
-    // but it can happen e.g. after a revalidation or conditionally for a param that wasn't prerendered.
-    // we should change this to track sync IO, log an error and advance to dynamic.
-    syncIO: SyncIOMode.Untracked,
+    // Synchronous request-time data ends the static stage before its result can
+    // enter the Cached Navigation.
+    syncIO: SyncIOMode.AllowedInRuntimeOrDynamic,
     finalStage: null,
   })
 
@@ -1178,8 +1177,18 @@ async function generateStagedDynamicFlightRenderResultNode(
 
       void countShellAndStaticStageBytes(staticStream, stageController).then(
         (byteLengths) => {
-          staticStageByteLengthDeferred.resolve(byteLengths[RenderStage.Static])
-          shellByteLengthDeferred.resolve(byteLengths[RenderStage.ShellStatic])
+          // A sync interruption can precede the Flight root row. Do not expose
+          // that incomplete prefix as a cacheable payload.
+          staticStageByteLengthDeferred.resolve(
+            stageController.getSyncInterruptReason()
+              ? 0
+              : byteLengths[RenderStage.Static]
+          )
+          shellByteLengthDeferred.resolve(
+            stageController.getSyncInterruptReason()
+              ? 0
+              : byteLengths[RenderStage.ShellStatic]
+          )
         }
       )
 
@@ -3848,10 +3857,9 @@ async function renderToStream(
         const stageController = new StagedRenderingController({
           abortSignal: null,
           abandonController: null,
-          // TODO(cached-navs): this assumes that we checked during build that there's no sync IO.
-          // but it can happen e.g. after a revalidation or conditionally for a param that wasn't prerendered.
-          // we should change this to track sync IO, log an error and advance to dynamic.
-          syncIO: SyncIOMode.Untracked,
+          // Synchronous request-time data ends the static stage before its
+          // result can enter the Cached Navigation.
+          syncIO: SyncIOMode.AllowedInRuntimeOrDynamic,
           finalStage: null,
         })
 
@@ -3954,10 +3962,14 @@ async function renderToStream(
               stageController
             ).then((byteLengths) => {
               staticStageByteLengthDeferred.resolve(
-                byteLengths[RenderStage.Static]
+                stageController.getSyncInterruptReason()
+                  ? 0
+                  : byteLengths[RenderStage.Static]
               )
               shellByteLengthDeferred.resolve(
-                byteLengths[RenderStage.ShellStatic]
+                stageController.getSyncInterruptReason()
+                  ? 0
+                  : byteLengths[RenderStage.ShellStatic]
               )
             })
 

--- a/test/e2e/app-dir/cached-navigations-sync-io/app/delayed-sync-io/page.tsx
+++ b/test/e2e/app-dir/cached-navigations-sync-io/app/delayed-sync-io/page.tsx
@@ -1,0 +1,21 @@
+import { unstable_navigation } from 'next/cache'
+import { Suspense } from 'react'
+import UncachedTimePage from '../uncached-time/page'
+
+async function Content() {
+  // The navigation stage defers this subtree past the initial Flight rows. The
+  // private cache in UncachedTimePage still resolves before the dynamic stage.
+  await unstable_navigation()
+  return <UncachedTimePage />
+}
+
+export default function Page() {
+  return (
+    <>
+      <p>Content before sync IO</p>
+      <Suspense fallback={<p>Loading target...</p>}>
+        <Content />
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/cached-navigations-sync-io/app/hub-b/page.tsx
+++ b/test/e2e/app-dir/cached-navigations-sync-io/app/hub-b/page.tsx
@@ -19,6 +19,9 @@ export default function Page() {
       <LinkAccordion href="/uncached-time#full-prefetch" prefetch={true}>
         Full prefetch
       </LinkAccordion>
+      <LinkAccordion href="/delayed-sync-io" prefetch={false}>
+        Delayed sync IO
+      </LinkAccordion>
     </>
   )
 }

--- a/test/e2e/app-dir/cached-navigations-sync-io/app/hub-b/page.tsx
+++ b/test/e2e/app-dir/cached-navigations-sync-io/app/hub-b/page.tsx
@@ -1,0 +1,24 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+import { LinkAccordion } from '../../components/link-accordion'
+
+async function HubContent() {
+  await connection()
+  return <h1>Hub B</h1>
+}
+
+export default function Page() {
+  return (
+    <>
+      <Suspense fallback={<p>Loading hub...</p>}>
+        <HubContent />
+      </Suspense>
+      <LinkAccordion href="/uncached-time" prefetch={false}>
+        Target
+      </LinkAccordion>
+      <LinkAccordion href="/uncached-time#full-prefetch" prefetch={true}>
+        Full prefetch
+      </LinkAccordion>
+    </>
+  )
+}

--- a/test/e2e/app-dir/cached-navigations-sync-io/app/layout.tsx
+++ b/test/e2e/app-dir/cached-navigations-sync-io/app/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cached-navigations-sync-io/app/page.tsx
+++ b/test/e2e/app-dir/cached-navigations-sync-io/app/page.tsx
@@ -31,6 +31,9 @@ export default function Page() {
       <LinkAccordion href="/uncached-time" prefetch={false}>
         Target
       </LinkAccordion>
+      <LinkAccordion href="/delayed-sync-io" prefetch={false}>
+        Delayed sync IO
+      </LinkAccordion>
     </>
   )
 }

--- a/test/e2e/app-dir/cached-navigations-sync-io/app/page.tsx
+++ b/test/e2e/app-dir/cached-navigations-sync-io/app/page.tsx
@@ -1,0 +1,36 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+import { LinkAccordion } from '../components/link-accordion'
+
+async function enableSyncIO() {
+  'use server'
+  const cookieStore = await cookies()
+  cookieStore.set('sync-io-enabled', 'true')
+}
+
+async function CookieStatus() {
+  const cookieStore = await cookies()
+  const enabled = cookieStore.get('sync-io-enabled')?.value === 'true'
+  return (
+    <p id="sync-io-status">
+      {enabled ? 'Sync IO enabled' : 'Sync IO disabled'}
+    </p>
+  )
+}
+
+export default function Page() {
+  return (
+    <>
+      <h1>Hub A</h1>
+      <form action={enableSyncIO}>
+        <button id="enable-sync-io">Enable sync IO</button>
+      </form>
+      <Suspense fallback={<p>Loading cookie...</p>}>
+        <CookieStatus />
+      </Suspense>
+      <LinkAccordion href="/uncached-time" prefetch={false}>
+        Target
+      </LinkAccordion>
+    </>
+  )
+}

--- a/test/e2e/app-dir/cached-navigations-sync-io/app/uncached-time/page.tsx
+++ b/test/e2e/app-dir/cached-navigations-sync-io/app/uncached-time/page.tsx
@@ -1,0 +1,45 @@
+import { cacheLife } from 'next/cache'
+import { cookies } from 'next/headers'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+import { LinkAccordion } from '../../components/link-accordion'
+
+async function isSyncIOEnabled() {
+  'use cache: private'
+  cacheLife({ stale: 120 })
+  const cookieStore = await cookies()
+  return cookieStore.get('sync-io-enabled')?.value === 'true'
+}
+
+async function Timestamp() {
+  // The private cache suspends during static prerendering. A staged dynamic
+  // render can resolve it during the static stage. The uncached timestamp must
+  // end that stage.
+  const enabled = await isSyncIOEnabled()
+  if (!enabled) {
+    return <p>Sync IO disabled</p>
+  }
+  return <p id="timestamp">Uncached time: {Date.now()}</p>
+}
+
+async function DynamicContent() {
+  await connection()
+  return <p>Dynamic content</p>
+}
+
+export default function Page() {
+  return (
+    <>
+      <h1>Sync IO target</h1>
+      <Suspense fallback={<p>Loading timestamp...</p>}>
+        <Timestamp />
+      </Suspense>
+      <Suspense fallback={<p>Loading dynamic content...</p>}>
+        <DynamicContent />
+      </Suspense>
+      <LinkAccordion href="/hub-b" prefetch={false}>
+        Hub B
+      </LinkAccordion>
+    </>
+  )
+}

--- a/test/e2e/app-dir/cached-navigations-sync-io/cached-navigations-sync-io.test.ts
+++ b/test/e2e/app-dir/cached-navigations-sync-io/cached-navigations-sync-io.test.ts
@@ -1,0 +1,117 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+// @force-gate prod
+describe('cached-navigations-sync-io', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  async function startBrowser() {
+    let page: Playwright.Page | undefined
+    const startDate = Date.now()
+    const browser = await next.browser('/', {
+      async beforePageLoad(browserPage: Playwright.Page) {
+        page = browserPage
+        await page.clock.install()
+        await page.clock.setFixedTime(startDate)
+      },
+    })
+    if (!page) {
+      throw new Error('The browser page was not initialized')
+    }
+
+    const act = createRouterAct(page)
+    await act(
+      async () => {
+        await browser.elementById('enable-sync-io').click()
+      },
+      { includes: 'Sync IO enabled' }
+    )
+    expect(await browser.elementById('sync-io-status').text()).toBe(
+      'Sync IO enabled'
+    )
+
+    async function navigate(href: string) {
+      await browser.elementByCss(`input[data-link-accordion="${href}"]`).click()
+      await browser.elementByCss(`a[href="${href}"]`).click()
+    }
+
+    return { browser, page, act, startDate, navigate }
+  }
+
+  for (const source of ['dynamic RSC', 'initial HTML']) {
+    it(`does not reuse uncached time from ${source}`, async () => {
+      const { browser, page, act, startDate, navigate } = await startBrowser()
+
+      if (source === 'dynamic RSC') {
+        await act(() => navigate('/uncached-time'), {
+          includes: 'Dynamic content',
+        })
+      } else {
+        const response = await page.goto(next.url + '/uncached-time')
+        expect(response?.status()).toBe(200)
+        expect(await response?.text()).toContain('Uncached time:')
+      }
+
+      const timestamp = await browser.elementById('timestamp').text()
+      expect(timestamp).toMatch(/^Uncached time: \d+$/)
+
+      await act(() => navigate('/hub-b'), { includes: 'Hub B' })
+      expect(await browser.elementByCss('h1').text()).toBe('Hub B')
+      await page.clock.setFixedTime(startDate + 60_000)
+
+      await act(async () => {
+        await act(() => navigate('/uncached-time'), {
+          includes: 'Dynamic content',
+          block: true,
+        })
+
+        const content = await browser.elementByCss('main').text()
+        expect(content).not.toContain('Uncached time:')
+        expect(content).not.toContain('Dynamic content')
+      })
+
+      expect(await browser.elementById('timestamp').text()).not.toBe(timestamp)
+      expect(await browser.elementByCss('main').text()).toContain(
+        'Dynamic content'
+      )
+    })
+  }
+
+  it('finishes a full prefetch after synchronous IO interrupts its static stage', async () => {
+    const { browser, act, navigate } = await startBrowser()
+    await act(() => navigate('/uncached-time'), { includes: 'Dynamic content' })
+    const timestamp = await browser.elementById('timestamp').text()
+    expect(timestamp).toMatch(/^Uncached time: \d+$/)
+
+    await act(() => navigate('/hub-b'), { includes: 'Hub B' })
+    await act(
+      async () => {
+        await browser.eval('window.next.router.refresh()')
+      },
+      { includes: 'Hub B' }
+    )
+
+    // Refresh clears segment data and BFCache but retains the route tree. The
+    // full prefetch must fetch new data without a cold static tree prerender.
+    const href = '/uncached-time#full-prefetch'
+    await act(
+      async () => {
+        await browser
+          .elementByCss(`input[data-link-accordion="${href}"]`)
+          .click()
+      },
+      { includes: 'Dynamic content' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss(`a[href="${href}"]`).click()
+    }, 'no-requests')
+    expect(await browser.elementById('timestamp').text()).not.toBe(timestamp)
+    expect(await browser.elementByCss('main').text()).toContain(
+      'Dynamic content'
+    )
+  })
+})

--- a/test/e2e/app-dir/cached-navigations-sync-io/cached-navigations-sync-io.test.ts
+++ b/test/e2e/app-dir/cached-navigations-sync-io/cached-navigations-sync-io.test.ts
@@ -41,43 +41,63 @@ describe('cached-navigations-sync-io', () => {
     return { browser, page, act, startDate, navigate }
   }
 
-  for (const source of ['dynamic RSC', 'initial HTML']) {
-    it(`does not reuse uncached time from ${source}`, async () => {
-      const { browser, page, act, startDate, navigate } = await startBrowser()
+  for (const { pathname, description } of [
+    { pathname: '/uncached-time', description: 'does not reuse uncached time' },
+    {
+      pathname: '/delayed-sync-io',
+      description: 'reuses content before synchronous IO',
+    },
+  ]) {
+    for (const source of ['dynamic RSC', 'initial HTML']) {
+      it(`${description} from ${source}`, async () => {
+        const { browser, page, act, startDate, navigate } = await startBrowser()
 
-      if (source === 'dynamic RSC') {
-        await act(() => navigate('/uncached-time'), {
-          includes: 'Dynamic content',
+        if (source === 'dynamic RSC') {
+          await act(() => navigate(pathname), {
+            includes: 'Dynamic content',
+          })
+        } else {
+          const response = await page.goto(next.url + pathname)
+          expect(response?.status()).toBe(200)
+          expect(await response?.text()).toContain('Uncached time:')
+        }
+
+        const timestamp = await browser.elementById('timestamp').text()
+        expect(timestamp).toMatch(/^Uncached time: \d+$/)
+        await browser.eval('window.navigationMarker = "same document"')
+
+        await act(() => navigate('/hub-b'), { includes: 'Hub B' })
+        expect(await browser.elementByCss('h1').text()).toBe('Hub B')
+        await page.clock.setFixedTime(startDate + 60_000)
+
+        await act(async () => {
+          await act(() => navigate(pathname), {
+            includes: 'Dynamic content',
+            block: true,
+          })
+
+          const content = await browser.elementByCss('main').text()
+          expect(content).not.toContain('Uncached time:')
+          expect(content).not.toContain('Dynamic content')
+          if (pathname === '/delayed-sync-io') {
+            expect(content).toContain('Content before sync IO')
+          }
+          expect(await browser.eval('window.navigationMarker')).toBe(
+            'same document'
+          )
         })
-      } else {
-        const response = await page.goto(next.url + '/uncached-time')
-        expect(response?.status()).toBe(200)
-        expect(await response?.text()).toContain('Uncached time:')
-      }
 
-      const timestamp = await browser.elementById('timestamp').text()
-      expect(timestamp).toMatch(/^Uncached time: \d+$/)
-
-      await act(() => navigate('/hub-b'), { includes: 'Hub B' })
-      expect(await browser.elementByCss('h1').text()).toBe('Hub B')
-      await page.clock.setFixedTime(startDate + 60_000)
-
-      await act(async () => {
-        await act(() => navigate('/uncached-time'), {
-          includes: 'Dynamic content',
-          block: true,
-        })
-
-        const content = await browser.elementByCss('main').text()
-        expect(content).not.toContain('Uncached time:')
-        expect(content).not.toContain('Dynamic content')
+        expect(await browser.elementById('timestamp').text()).not.toBe(
+          timestamp
+        )
+        expect(await browser.elementByCss('main').text()).toContain(
+          'Dynamic content'
+        )
+        expect(await browser.eval('window.navigationMarker')).toBe(
+          'same document'
+        )
       })
-
-      expect(await browser.elementById('timestamp').text()).not.toBe(timestamp)
-      expect(await browser.elementByCss('main').text()).toContain(
-        'Dynamic content'
-      )
-    })
+    }
   }
 
   it('finishes a full prefetch after synchronous IO interrupts its static stage', async () => {
@@ -85,6 +105,7 @@ describe('cached-navigations-sync-io', () => {
     await act(() => navigate('/uncached-time'), { includes: 'Dynamic content' })
     const timestamp = await browser.elementById('timestamp').text()
     expect(timestamp).toMatch(/^Uncached time: \d+$/)
+    await browser.eval('window.navigationMarker = "same document"')
 
     await act(() => navigate('/hub-b'), { includes: 'Hub B' })
     await act(
@@ -113,5 +134,6 @@ describe('cached-navigations-sync-io', () => {
     expect(await browser.elementByCss('main').text()).toContain(
       'Dynamic content'
     )
+    expect(await browser.eval('window.navigationMarker')).toBe('same document')
   })
 })

--- a/test/e2e/app-dir/cached-navigations-sync-io/components/link-accordion.tsx
+++ b/test/e2e/app-dir/cached-navigations-sync-io/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link from 'next/link'
+import { useState, type ReactNode } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: ReactNode
+  prefetch: boolean
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/cached-navigations-sync-io/next.config.ts
+++ b/test/e2e/app-dir/cached-navigations-sync-io/next.config.ts
@@ -1,0 +1,11 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  partialPrefetching: false,
+  experimental: {
+    cachedNavigations: true,
+  },
+}
+
+export default nextConfig


### PR DESCRIPTION
Cached Navigations incorrectly reused uncached timestamps as static page content. A repeat visit showed the previous request's `Date.now()` result while the new response was still pending. This affected both dynamic RSC responses and the RSC payload embedded in the initial HTML.

The production renderer left synchronous IO untracked because it assumed the build had already checked it. A private cache exposed the gap: the static prerender suspended at the cache call and never reached the `Date.now()` after it. A production request resolved the private cache during the static stage and included the uncached timestamp in the reusable response.

Production staged renders now end the static stage when synchronous request-time IO occurs. They mark the interrupted static and shell prefixes as empty, while the rest of the response renders normally. The client skips those prefixes instead of waiting for a Flight root that the interrupted stage may not have emitted.

The regression tests cover dynamic RSC navigation, initial HTML hydration, and full prefetching with a paramless private-cache fixture.