### PR TITLE
Align fallback parameter staging with shell validation

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -338,6 +338,11 @@ export interface DynamicPrerenderManifestRoute
   remainingPrerenderableParams?: readonly FallbackRouteParam[]
 
   /**
+   * Whether this candidate must produce a nonempty static shell.
+   */
+  throwOnEmptyStaticShell?: boolean
+
+  /**
    * When defined, it describes the revalidation configuration for the fallback
    * route.
    */
@@ -3888,6 +3893,8 @@ export default async function build(
                   experimentalPPR: isRoutePPREnabled,
                   remainingPrerenderableParams:
                     route.remainingPrerenderableParams,
+                  throwOnEmptyStaticShell:
+                    prerenderCandidate?.throwOnEmptyStaticShell,
                   renderingMode: isAppPPREnabled
                     ? isRoutePPREnabled
                       ? RenderingMode.PARTIALLY_STATIC

--- a/packages/next/src/build/templates/app-page-runtime.ts
+++ b/packages/next/src/build/templates/app-page-runtime.ts
@@ -34,6 +34,7 @@ import { UNDERSCORE_NOT_FOUND_ROUTE } from '../../shared/lib/entry-constants' wi
 import {
   getFallbackRouteParams,
   getPlaceholderFallbackRouteParams,
+  getStagedFallbackParams,
   buildDynamicSegmentPlaceholder,
   createOpaqueFallbackRouteParams,
   type OpaqueFallbackRouteParams,
@@ -585,6 +586,42 @@ export function createAppPageEntrypoint({
       prerenderInfo?.fallback === null &&
       (prerenderInfo.fallbackRootParams?.length ?? 0) > 0
 
+    // SSG writes and navigation RDC reads use the same completed-shell key.
+    // Completion uses the matched shell rather than the fully resolved
+    // pathname. A request for `/prefix/c/foo` can complete
+    // `/prefix/[one]/[two]` to `/prefix/c/[two]`. This avoids creating an entry
+    // for every value of `two`.
+    //
+    // The completed-shell key also applies when unresolved root params require
+    // a blocking render. A source shell cannot be shared across root branches.
+    // Completion resolves the params into the key as follows:
+    // - Root params and other prerenderable params use concrete values.
+    // - Never-prerenderable params remain placeholders.
+    // The values of those placeholder params must not partition the cache.
+    const fallbackPathname = prerenderMatch
+      ? typeof prerenderInfo?.fallback === 'string'
+        ? prerenderInfo.fallback
+        : prerenderMatch.source
+      : null
+    let completedShellCacheKey: string | null = null
+    if (
+      nextConfig.partialPrefetching &&
+      fallbackPathname &&
+      prerenderInfo?.fallbackRouteParams?.length &&
+      remainingPrerenderableParams.length > 0
+    ) {
+      const cacheKey = buildCompletedShellCacheKey(
+        fallbackPathname,
+        remainingPrerenderableParams,
+        params
+      )
+
+      // Only a more complete shell gets a separate cache entry.
+      if (cacheKey !== fallbackPathname) {
+        completedShellCacheKey = cacheKey
+      }
+    }
+
     let ssgCacheKey: string | null = null
     let usesCompletedShellCacheKey = false
     if (
@@ -595,22 +632,6 @@ export function createAppPageEntrypoint({
       !hasPostponedState &&
       !isDynamicRSCRequest
     ) {
-      // For normal SSG routes we cache by the fully resolved pathname. For
-      // partial fallbacks we instead derive the cache key from the shell
-      // that matched this request so `/prefix/[one]/[two]` can specialize into
-      // `/prefix/c/[two]` without promoting all the way to `/prefix/c/foo`.
-      // This includes entries with unresolved ROOT params: those requests are
-      // served blocking (no shell can be shared across root branches), but
-      // the entry they produce is still keyed by the completed shell — root
-      // params and any other prerenderable params resolve into the key while
-      // params that `generateStaticParams` can never provide stay as
-      // placeholders and must not partition the cache.
-      const fallbackPathname = prerenderMatch
-        ? typeof prerenderInfo?.fallback === 'string'
-          ? prerenderInfo.fallback
-          : prerenderMatch.source
-        : null
-
       if (
         // Partial fallback shells are only specialized per request when Partial
         // Prefetching is enabled, mirroring the `partialFallback` flag the
@@ -622,21 +643,8 @@ export function createAppPageEntrypoint({
         fallbackPathname &&
         prerenderInfo?.fallbackRouteParams?.length
       ) {
-        if (remainingPrerenderableParams.length > 0) {
-          const completedShellCacheKey = buildCompletedShellCacheKey(
-            fallbackPathname,
-            remainingPrerenderableParams,
-            params
-          )
-
-          // If applying the current request params doesn't make the shell any
-          // more complete, then this shell is already at its most complete
-          // form and should remain shared rather than creating a new cache entry.
-          if (completedShellCacheKey !== fallbackPathname) {
-            ssgCacheKey = completedShellCacheKey
-            usesCompletedShellCacheKey = true
-          }
-        }
+        ssgCacheKey = completedShellCacheKey
+        usesCompletedShellCacheKey = completedShellCacheKey !== null
       } else {
         ssgCacheKey = resolvedPathname
       }
@@ -1204,43 +1212,28 @@ export function createAppPageEntrypoint({
                   fallbackRouteParams = null
                 }
               } else {
-                // In dev the prerender manifest isn't populated for ad-hoc
-                // prefetches (`fallbackMode` is undefined for not-fully-generated
-                // routes, so the on-demand manifest write is skipped, and
-                // `getPrerenderManifest` is cached regardless). So
-                // `prerenderInfo` is unavailable here. Instead base-server
-                // derives the per-URL fallback set from the dev `getStaticPaths`
-                // result and threads it via the `fallbackParams` request meta —
-                // the most-specific prerendered route matching this URL, so
-                // `generateStaticParams`-covered params resolve in the shell and
-                // only the uncovered ones are deferred, matching what a
-                // production build serves. `isDebugFallbackShell` (the explicit
-                // fallback-shell debug flow) still forces the worst case.
+                // Dev selects the source for static-shell debug renders from
+                // the per-URL `getStaticPaths` result. The dev prerender
+                // manifest does not contain these ad-hoc paths. `base-server`
+                // passes the source's fallback params in request metadata.
+                // These renders need the source set, not the completed target's
+                // potentially smaller `stagedFallbackParams`.
                 if (isDebugFallbackShell) {
                   fallbackRouteParams = getFallbackRouteParams(
                     normalizedSrcPage,
                     routeModule
                   )
                 } else if (isDebugStaticShell) {
-                  // base-server threads the per-URL fallback set via the
-                  // `fallbackParams` meta for every dev Cache Components dynamic
-                  // request, so reuse it as the fallback route params for this
-                  // shell render. It only sets the meta for routes that still
-                  // have uncovered params, so an absent meta means this URL is
-                  // fully covered by `generateStaticParams` and there is nothing
-                  // to defer (`null`).
                   fallbackRouteParams =
-                    getRequestMeta(req, 'fallbackParams') ?? null
+                    getRequestMeta(req, 'fallbackRouteParams') ?? null
                 } else {
                   fallbackRouteParams = null
                 }
               }
 
-              // When rendering a debug static shell, override the fallback
-              // params on the request so that the staged rendering correctly
-              // defers params that are not statically known.
-              if (isDebugStaticShell && fallbackRouteParams) {
-                addRequestMeta(req, 'fallbackParams', fallbackRouteParams)
+              // Debug rendering stages the params of the selected source shell.
+              if (isDebugStaticShell) {
+                addRequestMeta(req, 'stagedFallbackParams', fallbackRouteParams)
               }
 
               // We use the response cache here to handle the revalidation and
@@ -1355,6 +1348,7 @@ export function createAppPageEntrypoint({
             !isOnDemandRevalidate && !isRevalidating && minimalPostponed
               ? minimalPostponed
               : undefined
+          let hasFullyStaticCacheEntry = false
 
           if (
             // If this is a dynamic RSC request or a server action request, we should
@@ -1377,8 +1371,10 @@ export function createAppPageEntrypoint({
             // from entering an infinite loop of revalidations.
             !forceStaticRender
           ) {
+            const incrementalCacheKey =
+              completedShellCacheKey ?? resolvedPathname
             const incrementalCacheEntry = await incrementalCache.get(
-              resolvedPathname,
+              incrementalCacheKey,
               {
                 kind: IncrementalCacheKind.APP_PAGE,
                 isRoutePPREnabled: true,
@@ -1396,6 +1392,7 @@ export function createAppPageEntrypoint({
               // CRITICAL: we're assigning the postponed data from the cache entry
               // here as we're using the RDC to resume the render.
               postponed = incrementalCacheEntry.value.postponed
+              hasFullyStaticCacheEntry = postponed === undefined
 
               // If the cache entry is stale, we should trigger a background
               // revalidation so that subsequent requests will get a fresh response.
@@ -1414,7 +1411,7 @@ export function createAppPageEntrypoint({
 
                   try {
                     await responseCache.revalidate(
-                      resolvedPathname,
+                      incrementalCacheKey,
                       incrementalCache,
                       isRoutePPREnabled,
                       false,
@@ -1530,17 +1527,20 @@ export function createAppPageEntrypoint({
                   effectiveFallbackRouteParams.length <
                     (prerenderInfo?.fallbackRouteParams?.length ?? 0)
                 ? createOpaqueFallbackRouteParams(effectiveFallbackRouteParams)
-                : // A render cached under a completed shell cache key must keep
-                  // deferring the params the key leaves as placeholders (the
-                  // ones `generateStaticParams` can never provide) so they
-                  // resume per request instead of baking into the shared entry.
-                  // This is the blocking analog of the background shell
-                  // upgrade above and is likewise self-hosted only: in minimal
-                  // mode the platform proxy owns this contract by stripping
-                  // never-prerenderable params from the request, which defers
-                  // them through the placeholder handling instead.
+                : // This render defers the params left unresolved in its key.
+                  // The render must not store their concrete values in the
+                  // shared entry. Per-request resumes resolve those params
+                  // instead. Blocking renders and RSC-triggered revalidations
+                  // both need this restriction.
+                  //
+                  // The serving modes obtain the unresolved params differently:
+                  // - `next start` defers them in this branch.
+                  // - Minimal mode uses the platform's placeholders above.
+                  // The platform strips never-prerenderable param values before
+                  // calling the origin.
                   !isMinimalMode &&
-                    usesCompletedShellCacheKey &&
+                    (usesCompletedShellCacheKey ||
+                      (forceStaticRender && completedShellCacheKey !== null)) &&
                     remainingFallbackRouteParams.length > 0
                   ? createOpaqueFallbackRouteParams(
                       remainingFallbackRouteParams
@@ -1549,24 +1549,35 @@ export function createAppPageEntrypoint({
                     ? getFallbackRouteParams(normalizedSrcPage, routeModule)
                     : null
 
-          // For staged dynamic rendering (Cached Navigations) and debug static
-          // shell rendering, pass the fallback params via request meta so the
-          // RequestStore knows which params to defer. We don't pass them as
-          // fallbackRouteParams because that would replace actual param values
-          // with opaque placeholders during segment resolution.
+          // Staging defers params without replacing their values with opaque
+          // placeholders. A resumed render reads the selected artifact's mask
+          // from its postponed state.
           if (
             (isProduction || isDebugStaticShell) &&
-            nextConfig.cacheComponents &&
-            !isPrerendered &&
-            prerenderInfo?.fallbackRouteParams
+            nextConfig.cacheComponents
           ) {
-            const fallbackParams = createOpaqueFallbackRouteParams(
-              fallbackRouteParamsForRender ?? prerenderInfo.fallbackRouteParams
-            )
-
-            if (fallbackParams) {
-              addRequestMeta(req, 'fallbackParams', fallbackParams)
+            let stagedFallbackParams: OpaqueFallbackRouteParams | null
+            if (hasPlaceholderFallbackRouteParams) {
+              stagedFallbackParams = createOpaqueFallbackRouteParams(
+                placeholderFallbackRouteParams
+              )
+            } else if (isDebugStaticShell) {
+              stagedFallbackParams = fallbackRouteParams
+            } else if (hasFullyStaticCacheEntry || isPrerendered) {
+              stagedFallbackParams = null
+            } else if (postponed && prerenderInfo?.fallbackRouteParams) {
+              // App-render uses this source-shell set only when the supplied
+              // state does not record its own fallback params.
+              stagedFallbackParams = createOpaqueFallbackRouteParams(
+                prerenderInfo.fallbackRouteParams
+              )
+            } else if (prerenderInfo) {
+              stagedFallbackParams = getStagedFallbackParams(prerenderInfo)
+            } else {
+              stagedFallbackParams = null
             }
+
+            addRequestMeta(req, 'stagedFallbackParams', stagedFallbackParams)
           }
 
           // Forced static and debug renders are prerenders even when the
@@ -2094,19 +2105,14 @@ export function createAppPageEntrypoint({
         const transformer = new TransformStream<Uint8Array, Uint8Array>()
         body.push(transformer.readable)
 
-        // Plumb fallback params via request meta so the RequestStore created
-        // downstream in app-render.tsx knows which params to defer during the
-        // resume. We don't pass them as `fallbackRouteParams` because that
-        // would replace actual param values with opaque placeholders during
-        // segment resolution; the resolved values are baked into the URL and
-        // already interpolated into the postponed state.
+        // This metadata supplies fallback params when the saved state does not
+        // record them. App-render uses the saved state's own set when present.
         if (nextConfig.cacheComponents && prerenderInfo?.fallbackRouteParams) {
-          const fallbackParams = createOpaqueFallbackRouteParams(
-            prerenderInfo.fallbackRouteParams
+          addRequestMeta(
+            req,
+            'stagedFallbackParams',
+            createOpaqueFallbackRouteParams(prerenderInfo.fallbackRouteParams)
           )
-          if (fallbackParams) {
-            addRequestMeta(req, 'fallbackParams', fallbackParams)
-          }
         }
 
         // Perform the render again, but this time, provide the postponed state.
@@ -2115,8 +2121,8 @@ export function createAppPageEntrypoint({
         doRender({
           span,
           postponed: cachedData.postponed,
-          // This is a resume render, not a fallback render. Fallback params
-          // (for cacheComponents routes) are plumbed via request meta above.
+          // The resume retains concrete param values; staging only defers
+          // access.
           fallbackRouteParams: null,
           renderOperation: 'render',
         })

--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -452,9 +452,9 @@ export function processMessage(
     }
     case HMR_MESSAGE_SENT_TO_BROWSER.STATIC_PARAMS_CHANGED: {
       // Re-fetch the current router tree so the render picks up the new set of
-      // statically-known params (and thus the fresh `fallbackParams`). Unlike
-      // `SERVER_COMPONENT_CHANGES` this does not store an HMR refresh hash, so
-      // it doesn't invalidate `"use cache"` entries.
+      // statically-known params (and thus the fresh `stagedFallbackParams`).
+      // Unlike `SERVER_COMPONENT_CHANGES` this does not store an HMR refresh
+      // hash, so it doesn't invalidate `"use cache"` entries.
       if (
         RuntimeErrorHandler.hadRuntimeError ||
         document.documentElement.id === '__next_error__'

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -784,7 +784,7 @@ export async function handleAction({
   // which to resume the destination page.
   const isActionOnlyFallbackRequest =
     isFetchAction &&
-    requestStore.fallbackParams != null &&
+    ctx.fallbackRouteParams != null &&
     typeof ctx.renderOpts.postponed === 'string'
   const shouldSkipPageRendering =
     actionWasForwarded || isActionOnlyFallbackRequest

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1356,7 +1356,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
   ctx: AppRenderContext,
   initialRequestStore: RequestStore,
   createRequestStore: (() => RequestStore) | undefined,
-  fallbackParams: OpaqueFallbackRouteParams | null
+  stagedFallbackParams: OpaqueFallbackRouteParams | null
 ): Promise<RenderResult> {
   const {
     htmlRequestId,
@@ -1509,7 +1509,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
       getPayload,
       onError,
       shouldValidate,
-      fallbackRouteParams: fallbackParams,
+      fallbackRouteParams: stagedFallbackParams,
       getDevRenderDidError: () => didErrorObservably,
       navigationKind: {
         type: 'prefetched-client',
@@ -3006,7 +3006,10 @@ async function renderAppPage(
     null
 
   const rootParams = getRootParams(loaderTree, ctx.getDynamicParamFromSegment)
-  const fallbackParams = getRequestMeta(req, 'fallbackParams') || null
+  const stagedFallbackParams =
+    postponedState?.stagedFallbackParams !== undefined
+      ? postponedState.stagedFallbackParams
+      : (getRequestMeta(req, 'stagedFallbackParams') ?? null)
   const hmrRefreshHash = getRequestMeta(req, 'hmrRefreshHash')
 
   const createRequestStore = createRequestStoreForRender.bind(
@@ -3021,7 +3024,7 @@ async function renderAppPage(
     isHmrRefresh,
     serverComponentsHmrCache,
     renderResumeDataCache,
-    fallbackParams,
+    stagedFallbackParams,
     hmrRefreshHash
   )
   const requestStore = createRequestStore()
@@ -3066,7 +3069,7 @@ async function renderAppPage(
           ctx,
           requestStore,
           createRequestStore,
-          fallbackParams
+          stagedFallbackParams
         )
       } else if (cacheComponents && cachedNavigations) {
         // MARK: RSC cacheComponents
@@ -3113,7 +3116,7 @@ async function renderAppPage(
           postponedState,
           metadata,
           undefined, // Prevent restartable-render behavior in dev + Cache Components mode
-          fallbackParams
+          stagedFallbackParams
         )
 
         return new RenderResult(stream, {
@@ -3155,7 +3158,7 @@ async function renderAppPage(
     // and we currently we don't copy changes over when creating a new store,
     // so the restarted render wouldn't be correct.
     didExecuteServerAction ? undefined : createRequestStore,
-    fallbackParams
+    stagedFallbackParams
   )
 
   // Forward an invalid-dynamic-usage error recorded by `'use cache'` only
@@ -3531,7 +3534,7 @@ async function renderToStream(
   postponedState: PostponedState | null,
   metadata: AppPageRenderResultMetadata,
   createRequestStore: (() => RequestStore) | undefined,
-  fallbackParams: OpaqueFallbackRouteParams | null
+  stagedFallbackParams: OpaqueFallbackRouteParams | null
 ): Promise<AnyStream> {
   /* eslint-disable @next/internal/no-ambiguous-jsx -- React Client */
   // MARK: renderToStream setup
@@ -3779,7 +3782,7 @@ async function renderToStream(
               getPayload,
               onError: serverComponentsErrorHandler,
               shouldValidate: true,
-              fallbackRouteParams: fallbackParams,
+              fallbackRouteParams: stagedFallbackParams,
               getDevRenderDidError: () => didErrorObservably,
               // An initial HTML load serves the static shell; runtime and
               // dynamic content stream in afterward.
@@ -6683,8 +6686,9 @@ export async function runValidationInDevFromSnapshot(
 
   // `requestFallbackRouteParams` reproduces `ctx.getDynamicParamFromSegment`
   // exactly, so the depth-loop segment keys match the seed render's Flight.
-  // `fallbackRouteParams` is separate and only marks params unknown in the
-  // prerender stores.
+  // `fallbackRouteParams` is the staged set of the main-thread request store.
+  // It marks params unknown in the prerender stores, and the worker's request
+  // store defers the same params, so both validation paths stage alike.
   //
   // TODO: Those two fallback params sets are very confusing in the whole code
   // base. We should maybe refactor this to make their different roles clearer.
@@ -6733,7 +6737,7 @@ export async function runValidationInDevFromSnapshot(
     isHmrRefresh: message.request.isHmrRefresh,
     hmrRefreshHash: message.request.hmrRefreshHash,
     serverComponentsHmrCache: undefined,
-    fallbackParams: requestFallbackRouteParams,
+    stagedFallbackParams: fallbackRouteParams,
   })
 
   const staticInputs = toDevValidationInputs(message.staticInputs, requestStore)
@@ -9584,7 +9588,8 @@ async function prerenderToStream(
             resumeDataCache,
             cacheComponents,
             renderOpts.experimental.maxPostponedStateSizeBytes,
-            renderOpts.experimental.disableResumeDataCacheCompression
+            renderOpts.experimental.disableResumeDataCacheCompression,
+            fallbackRouteParams
           )
         }
         reactServerResult.consume()
@@ -10125,7 +10130,8 @@ async function prerenderToStream(
             originalResumeDataCache,
             cacheComponents,
             renderOpts.experimental.maxPostponedStateSizeBytes,
-            renderOpts.experimental.disableResumeDataCacheCompression
+            renderOpts.experimental.disableResumeDataCacheCompression,
+            fallbackRouteParams
           )
           originalFlightPrerenderResult.consume()
           errorServerResult.consume()

--- a/packages/next/src/server/app-render/postponed-state.test.ts
+++ b/packages/next/src/server/app-render/postponed-state.test.ts
@@ -1,5 +1,6 @@
 import {
   createPrerenderResumeDataCache,
+  deflateResumeDataCache,
   stringifyResumeDataCache,
 } from '../resume-data-cache/resume-data-cache'
 import {
@@ -85,6 +86,12 @@ describe('getDynamicHTMLPostponedState', () => {
          "imageResponses": Map {},
          "mutable": false,
        },
+       "stagedFallbackParams": Map {
+         "slug" => [
+           "%%drp:slug:e9615126684e5%%",
+           "d",
+         ],
+       },
        "type": 2,
      }
     `)
@@ -125,6 +132,7 @@ describe('getDynamicHTMLPostponedState', () => {
     const parsed = parsePostponedState(state, params, undefined)
     expect(parsed).toEqual({
       type: DynamicState.HTML,
+      stagedFallbackParams: fallbackRouteParams,
       data: [1, { [value]: value }],
       renderResumeDataCache: {
         cache: new Map(),
@@ -142,44 +150,84 @@ describe('getDynamicHTMLPostponedState', () => {
 })
 
 describe('getDynamicDataPostponedState', () => {
-  it('serializes a data postponed state with fallback params', async () => {
-    const state = await getDynamicDataPostponedState(
-      createPrerenderResumeDataCache(),
-      isCacheComponentsEnabled
-    )
-    expect(state).toMatchInlineSnapshot(`"4:nullnull"`)
-  })
+  it.each([undefined, null, new Map()])(
+    'serializes a data postponed state with no fallback params (%p)',
+    async (fallbackRouteParams) => {
+      const state = await getDynamicDataPostponedState(
+        createPrerenderResumeDataCache(),
+        isCacheComponentsEnabled,
+        undefined,
+        false,
+        fallbackRouteParams
+      )
+      expect(state).toBe(
+        fallbackRouteParams === undefined ? '4:nullnull' : '7:2[]nullnull'
+      )
+      const parsed = parsePostponedState(state, {}, undefined)
+      expect(parsed.type).toBe(DynamicState.DATA)
+      expect(parsed.stagedFallbackParams).toBe(
+        fallbackRouteParams === undefined ? undefined : null
+      )
+    }
+  )
 
-  it('serializes and parses an uncompressed cache when compression is disabled', async () => {
-    const resumeDataCache = createPrerenderResumeDataCache()
-    resumeDataCache.fetch.set('cache-key', {
-      kind: CachedRouteKind.FETCH,
-      data: {
-        headers: {},
-        body: 'cached body',
-        url: 'https://example.com',
-      },
-      revalidate: 60,
-    })
+  it.each([false, true])(
+    'serializes and parses fallback params and a cache (disableResumeDataCacheCompression: %s)',
+    async (disableResumeDataCacheCompression) => {
+      const fallbackRouteParams = createMockOpaqueFallbackRouteParams({
+        slug: ['%%drp:slug:e9615126684e5%%', 'd'],
+      })
+      const resumeDataCache = createPrerenderResumeDataCache()
+      resumeDataCache.fetch.set('cache-key', {
+        kind: CachedRouteKind.FETCH,
+        data: {
+          headers: {},
+          body: 'cached body',
+          url: 'https://example.com',
+        },
+        revalidate: 60,
+      })
 
-    const serializedResumeDataCache = await stringifyResumeDataCache(
-      resumeDataCache,
-      isCacheComponentsEnabled
-    )
-    const state = await getDynamicDataPostponedState(
-      resumeDataCache,
-      isCacheComponentsEnabled,
-      undefined,
-      true
-    )
+      const serializedResumeDataCache = await stringifyResumeDataCache(
+        resumeDataCache,
+        isCacheComponentsEnabled
+      )
+      const state = await getDynamicDataPostponedState(
+        resumeDataCache,
+        isCacheComponentsEnabled,
+        undefined,
+        disableResumeDataCacheCompression,
+        fallbackRouteParams
+      )
 
-    expect(state).toBe(`4:null${serializedResumeDataCache}`)
+      expect(state).toBe(
+        `51:45[["slug",["%%drp:slug:e9615126684e5%%","d"]]]null${
+          disableResumeDataCacheCompression
+            ? serializedResumeDataCache
+            : deflateResumeDataCache(serializedResumeDataCache)
+        }`
+      )
 
-    const parsed = parsePostponedState(state, {}, undefined, true)
-    expect(parsed.renderResumeDataCache.fetch.get('cache-key')).toEqual(
-      resumeDataCache.fetch.get('cache-key')
-    )
-  })
+      const parsed = parsePostponedState(
+        state,
+        { slug: '123' },
+        undefined,
+        disableResumeDataCacheCompression
+      )
+      expect(parsed.type).toBe(DynamicState.DATA)
+      expect(parsed.stagedFallbackParams).toEqual(fallbackRouteParams)
+      expect(parsed.renderResumeDataCache.fetch.get('cache-key')).toEqual(
+        resumeDataCache.fetch.get('cache-key')
+      )
+      expect(
+        parseResumeDataCacheFromPostponedState(
+          state,
+          undefined,
+          disableResumeDataCacheCompression
+        ).fetch.get('cache-key')
+      ).toEqual(resumeDataCache.fetch.get('cache-key'))
+    }
+  )
 
   it('warns when the uncompressed state would exceed the size limit', async () => {
     const resumeDataCache = createPrerenderResumeDataCache()
@@ -282,6 +330,7 @@ describe('parsePostponedState', () => {
     // Ensure that it parsed it correctly.
     expect(parsed).toEqual({
       type: DynamicState.HTML,
+      stagedFallbackParams: new Map([['slug', '%%drp:slug:e9615126684e5%%']]),
       data: expect.any(Object),
       renderResumeDataCache: {
         cache: new Map(),
@@ -305,6 +354,7 @@ describe('parsePostponedState', () => {
     // Ensure that it parsed it correctly.
     expect(parsed).toEqual({
       type: DynamicState.HTML,
+      stagedFallbackParams: null,
       data: expect.any(Object),
       renderResumeDataCache: {
         cache: new Map(),
@@ -317,7 +367,7 @@ describe('parsePostponedState', () => {
     })
   })
 
-  it('parses a data postponed state', () => {
+  it('parses a legacy data postponed state', () => {
     const state = '4:nullnull'
     const parsed = parsePostponedState(state, {}, undefined)
 
@@ -333,5 +383,6 @@ describe('parsePostponedState', () => {
         mutable: false,
       },
     })
+    expect(parsed).not.toHaveProperty('stagedFallbackParams')
   })
 })

--- a/packages/next/src/server/app-render/postponed-state.ts
+++ b/packages/next/src/server/app-render/postponed-state.ts
@@ -26,13 +26,20 @@ export enum DynamicState {
 }
 
 /**
- * The postponed state for dynamic data.
+ * A postponed state with a resume data cache but no React HTML-resume state.
  */
 export type DynamicDataPostponedState = {
   /**
    * The type of dynamic state.
    */
   readonly type: DynamicState.DATA
+
+  /**
+   * The params to defer during the resumed render. The render uses request
+   * metadata when this field is absent. `null` explicitly means no fallback
+   * params.
+   */
+  readonly stagedFallbackParams?: OpaqueFallbackRouteParams | null
 
   /**
    * The immutable resume data cache.
@@ -48,6 +55,13 @@ export type DynamicHTMLPostponedState = {
    * The type of dynamic state.
    */
   readonly type: DynamicState.HTML
+
+  /**
+   * The params to defer during the resumed render. An HTML state always records
+   * this set, and `null` means the prerender had no fallback params. Unlike the
+   * data state, it never falls back to request metadata.
+   */
+  readonly stagedFallbackParams: OpaqueFallbackRouteParams | null
 
   /**
    * The postponed data used by React.
@@ -156,10 +170,23 @@ export async function getDynamicDataPostponedState(
   resumeDataCache: PrerenderResumeDataCache | RenderResumeDataCache,
   isCacheComponentsEnabled: boolean,
   maxPostponedStateSizeBytes?: number,
-  disableResumeDataCacheCompression = false
+  disableResumeDataCacheCompression = false,
+  fallbackRouteParams?: OpaqueFallbackRouteParams | null
 ): Promise<string> {
+  let postponedString = 'null'
+  if (fallbackRouteParams !== undefined) {
+    const replacements: OpaqueFallbackRouteParamEntries = fallbackRouteParams
+      ? Array.from(fallbackRouteParams.entries())
+      : []
+    const replacementsString = JSON.stringify(replacements)
+
+    // An empty replacements table records that this shell has no fallback
+    // params.
+    postponedString = `${replacementsString.length}${replacementsString}null`
+  }
+
   return serializePostponedState(
-    'null',
+    postponedString,
     resumeDataCache,
     isCacheComponentsEnabled,
     maxPostponedStateSizeBytes,
@@ -234,6 +261,9 @@ export function parsePostponedState(
 
     try {
       if (postponedString === 'null') {
+        // Leave `stagedFallbackParams` unset for the `4:null<cache>` form. It
+        // contains no fallback-parameter information. A platform can send
+        // `4:nullnull` when it invokes the renderer without a cached shell.
         return { type: DynamicState.DATA, renderResumeDataCache }
       }
 
@@ -254,8 +284,18 @@ export function parsePostponedState(
             match.length + length
           )
         ) as OpaqueFallbackRouteParamEntries
+        const stagedFallbackParams =
+          replacements.length > 0 ? new Map(replacements) : null
 
         let postponed = postponedString.slice(match.length + length)
+        if (postponed === 'null') {
+          return {
+            type: DynamicState.DATA,
+            stagedFallbackParams,
+            renderResumeDataCache,
+          }
+        }
+
         for (const [
           segmentKey,
           [searchValue, dynamicParamType],
@@ -281,6 +321,7 @@ export function parsePostponedState(
 
         return {
           type: DynamicState.HTML,
+          stagedFallbackParams,
           data: JSON.parse(postponed),
           renderResumeDataCache,
         }
@@ -288,6 +329,7 @@ export function parsePostponedState(
 
       return {
         type: DynamicState.HTML,
+        stagedFallbackParams: null,
         data: JSON.parse(postponedString),
         renderResumeDataCache,
       }

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -98,7 +98,11 @@ export interface RequestStore extends CommonWorkUnitStore {
   hasIncompatibleShellContent?: boolean
 
   cacheSignal?: CacheSignal | null
-  fallbackParams?: OpaqueFallbackRouteParams | null
+  /**
+   * These params resolve after the static stage without replacing their
+   * concrete values.
+   */
+  stagedFallbackParams?: OpaqueFallbackRouteParams | null
   varyParamsAccumulator?: ResponseVaryParamsAccumulator | null
 
   // Only in build-time instant-validation or when rendering

--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -146,7 +146,7 @@ export type RequestStoreInputs = {
    * edit, for every client, regardless of whether it runs the HMR client.
    */
   hmrRefreshHash: string | undefined
-  fallbackParams: OpaqueFallbackRouteParams | null | undefined
+  stagedFallbackParams: OpaqueFallbackRouteParams | null | undefined
 }
 
 /**
@@ -193,7 +193,7 @@ export function createRequestStoreForRender(
   isHmrRefresh: RequestContext['isHmrRefresh'],
   serverComponentsHmrCache: RequestContext['serverComponentsHmrCache'],
   resumeDataCache: ResumeDataCache | null,
-  fallbackParams: OpaqueFallbackRouteParams | null,
+  stagedFallbackParams: OpaqueFallbackRouteParams | null,
   hmrRefreshHash: string | undefined
 ): RequestStore {
   return createRequestStore({
@@ -215,7 +215,7 @@ export function createRequestStoreForRender(
     isHmrRefresh,
     serverComponentsHmrCache,
     hmrRefreshHash,
-    fallbackParams,
+    stagedFallbackParams,
   })
 }
 
@@ -240,7 +240,7 @@ export function createRequestStoreForAPI(
     isHmrRefresh: false,
     serverComponentsHmrCache: undefined,
     hmrRefreshHash,
-    fallbackParams: null,
+    stagedFallbackParams: null,
   })
 }
 
@@ -264,7 +264,7 @@ export function createRequestStore(inputs: RequestStoreInputs): RequestStore {
     isHmrRefresh,
     serverComponentsHmrCache,
     hmrRefreshHash,
-    fallbackParams,
+    stagedFallbackParams,
   } = inputs
 
   const cache: {
@@ -347,7 +347,7 @@ export function createRequestStore(inputs: RequestStoreInputs): RequestStore {
       serverComponentsHmrCache ||
       (globalThis as any).__serverComponentsHmrCache,
     hmrRefreshHash,
-    fallbackParams,
+    stagedFallbackParams,
   }
 }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -159,7 +159,10 @@ import { fixMojibake } from './lib/fix-mojibake'
 import { setCacheBustingSearchParamWithHash } from '../client/components/router-reducer/set-cache-busting-search-param'
 import type { CacheControl } from './lib/cache-control'
 import type { PrerenderedRoute } from '../build/static-paths/types'
-import { createOpaqueFallbackRouteParams } from './request/fallback-params'
+import {
+  createOpaqueFallbackRouteParams,
+  getStagedFallbackParams,
+} from './request/fallback-params'
 import { RouteKind } from './route-kind'
 import type { ErrorModule } from './load-default-error-components'
 import {
@@ -2746,44 +2749,39 @@ export default abstract class Server<
 
       if (isAppPath && this.nextConfig.cacheComponents) {
         if (pathsResults.prerenderedRoutes?.length) {
-          // Replicate, on demand, the per-URL fallback set a production build
-          // writes to the prerender manifest. Production matches the requested
-          // URL to the most-specific prerendered route and defers that route's
-          // `fallbackRouteParams` (so `generateStaticParams`-covered params
-          // resolve in the static shell and only the uncovered ones are
-          // deferred). The dev prerender manifest isn't populated for these
-          // ad-hoc routes, but `getStaticPaths` already computed every
-          // prerendered route here, so we do the same match: among the routes
-          // whose canonical regex matches this URL, pick the one with the
-          // fewest fallback params (the most-specific) and thread it via the
-          // `fallbackParams` meta. A fully-covered concrete route (e.g.
-          // `/blog/a`) has zero fallback params and is the most-specific match
-          // for its own URL, so it must be considered alongside the others: it
-          // wins over the base dynamic route (`/blog/[slug]`) and leaves its
-          // statically-known params out of the deferred set.
-          let perUrlFallbackRouteParams: NonNullable<
-            (typeof pathsResults.prerenderedRoutes)[number]['fallbackRouteParams']
-          > | null = null
+          // The source selection includes concrete routes with no fallback
+          // params. Otherwise it could choose a generic fallback for a fully
+          // generated URL.
+          let matchedRoute: PrerenderedRoute | undefined
           for (const route of pathsResults.prerenderedRoutes) {
-            const fallbackRouteParams = route.fallbackRouteParams ?? []
             if (!getRouteRegex(route.pathname).re.test(urlPathname)) {
               continue
             }
             if (
-              perUrlFallbackRouteParams === null ||
-              fallbackRouteParams.length < perUrlFallbackRouteParams.length
+              matchedRoute === undefined ||
+              (route.fallbackRouteParams?.length ?? 0) <
+                (matchedRoute.fallbackRouteParams?.length ?? 0)
             ) {
-              perUrlFallbackRouteParams = fallbackRouteParams
+              matchedRoute = route
             }
           }
-          if (
-            perUrlFallbackRouteParams &&
-            perUrlFallbackRouteParams.length > 0
-          ) {
+          if (matchedRoute) {
+            // Explicit shell requests render the matched artifact. Ordinary
+            // requests stage and validate the same required or completed shell
+            // target.
             addRequestMeta(
               req,
-              'fallbackParams',
-              createOpaqueFallbackRouteParams(perUrlFallbackRouteParams)!
+              'fallbackRouteParams',
+              matchedRoute.fallbackRouteParams
+                ? createOpaqueFallbackRouteParams(
+                    matchedRoute.fallbackRouteParams
+                  )
+                : null
+            )
+            addRequestMeta(
+              req,
+              'stagedFallbackParams',
+              getStagedFallbackParams(matchedRoute)
             )
           }
         }

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -889,12 +889,12 @@ export default class DevServer extends Server {
         }
         this.staticPathsCache.set(pathname, value)
 
-        // Since generateStaticParams runs in the background, the fallbackParams
-        // accessed during a render are derived from the previous result served
-        // by the static paths cache. Now that the cache holds the new result,
-        // trigger a refresh so the next render picks up the new fallbackParams
-        // (e.g. so blocking-route validation reflects params that just became
-        // statically known).
+        // Since generateStaticParams runs in the background, the
+        // stagedFallbackParams accessed during a render are derived from the
+        // previous result served by the static paths cache. Now that the cache
+        // holds the new result, trigger a refresh so the next render picks up
+        // the new stagedFallbackParams (e.g. so blocking-route validation
+        // reflects params that just became statically known).
         if (
           isAppPath &&
           this.nextConfig.cacheComponents &&

--- a/packages/next/src/server/dev/use-cache-probe-worker.ts
+++ b/packages/next/src/server/dev/use-cache-probe-worker.ts
@@ -169,7 +169,7 @@ export async function probeUseCache(msg: ProbeMessage): Promise<boolean> {
       isHmrRefresh: msg.request.isHmrRefresh,
       serverComponentsHmrCache: undefined,
       hmrRefreshHash: msg.request.hmrRefreshHash,
-      fallbackParams: null,
+      stagedFallbackParams: null,
     })
 
     await workAsyncStorage.run(workStore, () =>

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -319,10 +319,36 @@ export interface RequestMeta {
   minimalMode?: boolean
 
   /**
-   * The fallback params for this route. In dev, used for validating prerenders.
-   * In production, used to defer params resolution during staged rendering.
+   * Staged renders defer these route params until after the static stage. They
+   * keep their concrete request values instead of replacing them with
+   * placeholders. Dev static-shell validation uses the same set for the
+   * selected shell.
+   *
+   * For `/t2/items/b2` with selected shell `/t2/items/[bottom]`, this map
+   * contains only `bottom`:
+   * - A layout's `params` containing only `top` can resolve statically.
+   * - A page's `params` containing `bottom` waits until after the static stage.
+   *
+   * A set recorded in postponed state overrides this metadata on a resume,
+   * including an explicitly empty set.
    */
-  fallbackParams?: OpaqueFallbackRouteParams
+  stagedFallbackParams?: OpaqueFallbackRouteParams | null
+
+  /**
+   * Dev static-shell debug renders use these params to prerender the matched
+   * source shell. The Instant Navigation Testing API uses this path too. The
+   * prerender substitutes opaque placeholders for these params rather than
+   * using their request values.
+   *
+   * Suppose `generateStaticParams` returns `[{ top: 't1' }]` for
+   * `/[top]/items/[bottom]`. A request for `/t2/items/b2` has:
+   * - Source `/[top]/items/[bottom]`: `top` and `bottom` are unresolved.
+   * - Completed shell `/t2/items/[bottom]`: only `bottom` is unresolved.
+   *
+   * This map contains the source's `top` and `bottom`. A debug render of that
+   * source also uses this map as `stagedFallbackParams`.
+   */
+  fallbackRouteParams?: OpaqueFallbackRouteParams | null
 
   /**
    * DEV only: Request timings in process.hrtime.bigint()

--- a/packages/next/src/server/request/fallback-params.ts
+++ b/packages/next/src/server/request/fallback-params.ts
@@ -6,6 +6,7 @@ import type AppPageRouteModule from '../route-modules/app-page/module'
 import { parseNormalizedAppRoute } from '../../shared/lib/router/routes/app'
 import { extractPathnameRouteParamSegmentsFromLoaderTree } from '../../build/static-paths/app/extract-pathname-route-param-segments-from-loader-tree'
 import { getParamProperties } from '../../shared/lib/router/utils/get-segment-param'
+import { InvariantError } from '../../shared/lib/invariant-error'
 
 export type OpaqueFallbackRouteParamValue = [
   /**
@@ -73,6 +74,56 @@ export function createOpaqueFallbackRouteParams(
   }
 
   return keys
+}
+
+/**
+ * Selects the params that a staged render defers for the shell target that a
+ * request selects. Dev static-shell validation stages the same set, so it
+ * checks the shell that the build validates.
+ *
+ * The set derives from the build's shell metadata, not from the serving mode. A
+ * required shell (`throwOnEmptyStaticShell`) is the most specific shell the
+ * build generated for its params, and the build fails when its prelude is
+ * empty. Staging defers all of its fallback params, because the build validated
+ * exactly that shape. Any other shell may be empty, and a request completes it
+ * with the params that `generateStaticParams` can still supply. Only the params
+ * that completion never resolves stay deferred.
+ *
+ * `next start` without `partialPrefetching` keys ISR entries by the full
+ * pathname, so such an entry resolves every param. A cold staged render then
+ * defers params that the entry resolves, so its static stage contains less
+ * content. A resume reads the recorded set from the entry's postponed state.
+ */
+export function getStagedFallbackParams(route: {
+  fallbackRouteParams: readonly FallbackRouteParam[] | undefined
+  remainingPrerenderableParams?: readonly FallbackRouteParam[]
+  throwOnEmptyStaticShell?: boolean
+}): OpaqueFallbackRouteParams | null {
+  const { fallbackRouteParams, remainingPrerenderableParams } = route
+  if (!fallbackRouteParams?.length) {
+    return null
+  }
+
+  if (route.throwOnEmptyStaticShell === undefined) {
+    throw new InvariantError(
+      'Expected throwOnEmptyStaticShell for a route with fallback params'
+    )
+  }
+
+  // A required shell keeps all of its fallback params deferred.
+  if (route.throwOnEmptyStaticShell || !remainingPrerenderableParams?.length) {
+    return createOpaqueFallbackRouteParams(fallbackRouteParams)
+  }
+
+  return createOpaqueFallbackRouteParams(
+    fallbackRouteParams.filter(
+      (param) =>
+        !remainingPrerenderableParams.some(
+          (prerenderableParam) =>
+            prerenderableParam.paramName === param.paramName
+        )
+    )
+  )
 }
 
 export function buildDynamicSegmentPlaceholder(

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -101,12 +101,12 @@ export function createParamsFromClient(
           )
         }
         if (process.env.NODE_ENV === 'development') {
-          const fallbackParams = workUnitStore.fallbackParams
+          const stagedFallbackParams = workUnitStore.stagedFallbackParams
           const userspaceParams = underlyingParams
           return createRenderParamsInDev(
             underlyingParams,
             userspaceParams,
-            fallbackParams,
+            stagedFallbackParams,
             workStore,
             workUnitStore
           )
@@ -178,12 +178,12 @@ export function createServerParamsForRoute(
       }
       case 'request':
         if (process.env.NODE_ENV === 'development') {
-          const fallbackParams = workUnitStore.fallbackParams
+          const stagedFallbackParams = workUnitStore.stagedFallbackParams
           const userspaceParams = underlyingParams
           return createRenderParamsInDev(
             underlyingParams,
             userspaceParams,
-            fallbackParams,
+            stagedFallbackParams,
             workStore,
             workUnitStore
           )
@@ -501,11 +501,11 @@ function createRenderParamsForPage(
 
   // No staged rendering = no cacheComponents, or cacheComponents prod without cachedNavigations
   if (process.env.NODE_ENV === 'development') {
-    const fallbackParams = workUnitStore.fallbackParams
+    const stagedFallbackParams = workUnitStore.stagedFallbackParams
     return createRenderParamsInDev(
       underlyingParams,
       userspaceParams,
-      fallbackParams,
+      stagedFallbackParams,
       workStore,
       workUnitStore
     )
@@ -556,7 +556,9 @@ function createStagedRenderParamsImpl(
 
   // If we have fallback params, then they should always resolve in the runtime link data stage.
   // We do this indirectly via the shared params parent for better debug info.
-  if (hasFallbackRouteParams(underlyingParams, workUnitStore.fallbackParams)) {
+  if (
+    hasFallbackRouteParams(underlyingParams, workUnitStore.stagedFallbackParams)
+  ) {
     return createParamsPromiseFromTrigger(
       asyncApiPromises.sharedParamsParent,
       userspaceParams
@@ -661,14 +663,14 @@ function createRenderParamsInProd(userspaceParams: Params): Promise<Params> {
 function createRenderParamsInDev(
   underlyingParams: Params,
   userpaceParams: Params,
-  fallbackParams: OpaqueFallbackRouteParams | null | undefined,
+  stagedFallbackParams: OpaqueFallbackRouteParams | null | undefined,
   workStore: WorkStore,
   requestStore: RequestStore
 ): Promise<Params> {
   return makeDynamicallyTrackedParamsWithDevWarnings(
     underlyingParams,
     userpaceParams,
-    hasFallbackRouteParams(underlyingParams, fallbackParams),
+    hasFallbackRouteParams(underlyingParams, stagedFallbackParams),
     workStore,
     requestStore
   )

--- a/test/development/app-dir/cache-components-dev-fallback-validation/app/catchall/[...slug]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-fallback-validation/app/catchall/[...slug]/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from 'react'
+
+async function Content({ params }: { params: Promise<{ slug: string[] }> }) {
+  const { slug } = await params
+  return <p id="catchall">{slug.join('/')}</p>
+}
+
+export default function Page(props: { params: Promise<{ slug: string[] }> }) {
+  return (
+    <Suspense fallback="Loading params...">
+      <Content {...props} />
+    </Suspense>
+  )
+}

--- a/test/development/app-dir/cache-components-dev-fallback-validation/app/mixed/[top]/[bottom]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-fallback-validation/app/mixed/[top]/[bottom]/page.tsx
@@ -1,0 +1,12 @@
+export function generateStaticParams() {
+  return [{ top: 'short' }, { top: 'long', bottom: 'example' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ top: string; bottom: string }>
+}) {
+  const { top, bottom } = await params
+  return <p>{`${top}/${bottom}`}</p>
+}

--- a/test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts
+++ b/test/development/app-dir/cache-components-dev-fallback-validation/cache-components-dev-fallback-validation.test.ts
@@ -1,10 +1,19 @@
-import { nextTestSetup } from 'e2e-utils'
+import { nextTestSetup, type Playwright } from 'e2e-utils'
+import { getDevCliValidationOutput } from 'e2e-utils/instant-validation'
 import { waitForNoRedbox } from 'next-test-utils'
 
 describe('Cache Components Fallback Validation', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    env: { NEXT_TEST_LOG_VALIDATION: '1' },
   })
+
+  async function expectNoValidationErrors(browser: Playwright) {
+    expect(
+      await getDevCliValidationOutput(await browser.url(), () => next.cliOutput)
+    ).not.toContain('Error: Route')
+    await waitForNoRedbox(browser)
+  }
 
   it('should not warn about missing Suspense when accessing params if static params are completely known at build time', async () => {
     // when the params are complete we don't expect to see any errors await params regarless of where there
@@ -12,24 +21,24 @@ describe('Cache Components Fallback Validation', () => {
     const browser = await next.browser(
       '/complete/prerendered/wrapped/prerendered'
     )
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(`${next.url}/complete/prerendered/wrapped/novel`)
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(`${next.url}/complete/novel/wrapped/novel`)
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(
       `${next.url}/complete/prerendered/unwrapped/prerendered`
     )
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(`${next.url}/complete/prerendered/unwrapped/novel`)
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(`${next.url}/complete/novel/unwrapped/novel`)
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
   })
 
   it('should warn about missing Suspense when accessing params if static params are partially known at build time', async () => {
@@ -38,13 +47,13 @@ describe('Cache Components Fallback Validation', () => {
     const browser = await next.browser(
       '/partial/prerendered/wrapped/prerendered'
     )
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(`${next.url}/partial/prerendered/wrapped/novel`)
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(`${next.url}/partial/novel/wrapped/novel`)
-    await waitForNoRedbox(browser)
+    await expectNoValidationErrors(browser)
 
     await browser.loadPage(
       `${next.url}/partial/prerendered/unwrapped/prerendered`
@@ -84,14 +93,42 @@ describe('Cache Components Fallback Validation', () => {
        "description": "Next.js encountered runtime data during prerendering.",
        "environmentLabel": "Server",
        "label": "Blocking Route",
-       "source": "app/partial/[top]/unwrapped/layout.tsx (8:3) @ Layout
-     >  8 |   await params
-          |   ^",
+       "source": "app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26) @ Page
+     > 6 |       Top: {(await props.params).top}, Bottom: {(await props.params).bottom}
+         |                          ^",
        "stack": [
-         "Layout app/partial/[top]/unwrapped/layout.tsx (8:3)",
+         "Page app/partial/[top]/unwrapped/[bottom]/page.tsx (6:26)",
        ],
      }
     `)
+  })
+
+  it('validates a required partial shell even when another branch can complete', async () => {
+    const browser = await next.browser('/mixed/short/novel')
+    const output = await getDevCliValidationOutput(
+      await browser.url(),
+      () => next.cliOutput
+    )
+
+    expect(output).toContain('Error: Route "/mixed/[top]/[bottom]"')
+    expect(output).toContain('app/mixed/[top]/[bottom]/page.tsx')
+  })
+
+  it('uses the complete shape for a branch with a more-specific example', async () => {
+    const browser = await next.browser('/mixed/long/novel')
+    await expectNoValidationErrors(browser)
+
+    await browser.loadPage(`${next.url}/mixed/novel/novel`)
+    await expectNoValidationErrors(browser)
+  })
+
+  it('preserves concrete catch-all values during validation', async () => {
+    const outputIndex = next.cliOutput.length
+    const browser = await next.browser('/catchall/one/two')
+
+    expect(await browser.elementById('catchall').text()).toBe('one/two')
+    await expectNoValidationErrors(browser)
+    expect(next.cliOutput.slice(outputIndex)).not.toContain('TypeError')
   })
 
   it('should warn about missing Suspense when accessing params if static params are entirely missing at build time', async () => {

--- a/test/development/app-dir/cache-components-dev-fallback-validation/next.config.js
+++ b/test/development/app-dir/cache-components-dev-fallback-validation/next.config.js
@@ -3,6 +3,11 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  experimental: {
+    instantInsights: {
+      validationLevel: 'manual-warning',
+    },
+  },
 }
 
 module.exports = nextConfig

--- a/test/development/app-dir/cache-components-dev-warmup/dev-warmup.util.ts
+++ b/test/development/app-dir/cache-components-dev-warmup/dev-warmup.util.ts
@@ -338,6 +338,8 @@ export function runDevWarmupTests({
           // TODO: we should only label this as "Prefetch" if there's a prefetch config.
           assertLog(logs, `after cookies`, 'Prefetch')
           assertLog(logs, `after headers`, 'Prefetch')
+          // This route has no `generateStaticParams`, so its param stays
+          // runtime-only.
           assertLog(logs, `after params`, 'Prefetch')
           assertLog(logs, `after searchParams`, 'Prefetch')
 
@@ -378,59 +380,14 @@ export function runDevWarmupTests({
       })
 
       describe('mixed static and fallback params resolve in the correct phase', () => {
-        it('covered leading param', async () => {
+        it('generated lang and novel id', async () => {
           const path = '/mixed/en/123'
 
           const assertLogs = async (browser: Playwright) => {
             const logs = await browser.log()
-            // `en` is covered by `generateStaticParams`, so `lang` resolves in
-            // the static shell, unless we're rendering an App Shell, in which
-            // case they're deferred to the runtiem stage.
-            assertLog(logs, 'after params - lang', STATIC_LINK_DATA)
-            // `id` is never covered, so it's deferred to the runtime stage.
-            assertLog(logs, 'after params - id', RUNTIME_LINK_DATA)
-          }
-
-          if (isInitialLoad) {
-            await testInitialLoad(path, assertLogs)
-          } else {
-            await testNavigation(path, assertLogs)
-          }
-        })
-
-        it('uncovered leading param', async () => {
-          const path = '/mixed/fr/123'
-
-          const assertLogs = async (browser: Playwright) => {
-            const logs = await browser.log()
-            // `fr` is not covered by `generateStaticParams`, so the most-specific
-            // prerendered route matching this URL is the base route and its
-            // fallback set is both params. `lang` must therefore defer to the
-            // runtime stage too, not resolve in the static shell. (Picking the
-            // fewest-param route without matching the URL would resolve `lang`
-            // in `Prerender` here.)
-            assertLog(logs, 'after params - lang', RUNTIME_LINK_DATA)
-            assertLog(logs, 'after params - id', RUNTIME_LINK_DATA)
-          }
-
-          if (isInitialLoad) {
-            await testInitialLoad(path, assertLogs)
-          } else {
-            await testNavigation(path, assertLogs)
-          }
-        })
-
-        it('fully covered params', async () => {
-          const path = '/mixed/en/x'
-
-          const assertLogs = async (browser: Playwright) => {
-            const logs = await browser.log()
-            // Both `en` and `x` are covered by `generateStaticParams`, so this
-            // is a fully prerendered concrete route and both params resolve in
-            // the static shell unless we're rendering an App Shell, in which
-            // case they're deferred to the runtime stage.
-            // (Skipping the concrete route before matching the URL would let
-            // the base route win and defer the statically-known `id`.)
+            // The generators produce { lang: 'en', id: 'x' }. The optional
+            // /mixed/en/[id] shell can complete the novel id statically.
+            // `STATIC_LINK_DATA` accounts for App Shell deferral on navigation.
             assertLog(logs, 'after params - lang', STATIC_LINK_DATA)
             assertLog(logs, 'after params - id', STATIC_LINK_DATA)
           }
@@ -441,6 +398,66 @@ export function runDevWarmupTests({
             await testNavigation(path, assertLogs)
           }
         })
+
+        it('novel lang and id', async () => {
+          const path = '/mixed/fr/123'
+
+          const assertLogs = async (browser: Playwright) => {
+            const logs = await browser.log()
+            // Both params have generators. The optional /mixed/[lang]/[id]
+            // shell can complete both novel values statically.
+            assertLog(logs, 'after params - lang', STATIC_LINK_DATA)
+            assertLog(logs, 'after params - id', STATIC_LINK_DATA)
+          }
+
+          if (isInitialLoad) {
+            await testInitialLoad(path, assertLogs)
+          } else {
+            await testNavigation(path, assertLogs)
+          }
+        })
+
+        it('fully generated params', async () => {
+          const path = '/mixed/en/x'
+
+          const assertLogs = async (browser: Playwright) => {
+            const logs = await browser.log()
+            // This URL matches the concrete generated route. Neither param
+            // needs completion or fallback staging.
+            assertLog(logs, 'after params - lang', STATIC_LINK_DATA)
+            assertLog(logs, 'after params - id', STATIC_LINK_DATA)
+          }
+
+          if (isInitialLoad) {
+            await testInitialLoad(path, assertLogs)
+          } else {
+            await testNavigation(path, assertLogs)
+          }
+        })
+
+        // Only lang has a generator, so id stays runtime-only.
+        // - en selects the required /partial/en/[id] shell.
+        // - fr completes lang from the optional /partial/[lang]/[id] shell.
+        it.each(['en', 'fr'])(
+          'partial generation with lang %s',
+          async (lang) => {
+            const path = `/partial/${lang}/123`
+
+            const assertLogs = async (browser: Playwright) => {
+              const logs = await browser.log()
+              assertLog(logs, 'after params - lang', STATIC_LINK_DATA)
+              assertLog(logs, 'after cache read - layout', STATIC_LINK_DATA)
+              assertLog(logs, 'after params - id', RUNTIME_LINK_DATA)
+              assertLog(logs, 'after cache read - page', RUNTIME_LINK_DATA)
+            }
+
+            if (isInitialLoad) {
+              await testInitialLoad(path, assertLogs)
+            } else {
+              await testNavigation(path, assertLogs)
+            }
+          }
+        )
       })
 
       it('sync IO in the static phase', async () => {

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/mixed/[lang]/[id]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/mixed/[lang]/[id]/page.tsx
@@ -1,9 +1,7 @@
 import { Suspense } from 'react'
 
-// `id` is covered by `generateStaticParams` only for `x`, so `/mixed/en/x` is a
-// fully prerendered route (both params resolve in the static shell) while other
-// ids such as `123` are deferred to the runtime stage. The parent `[lang]`
-// layout reads `lang`; this page reads only `id`.
+// Both params have generators, so the route has a fully generated shape. Novel
+// values can complete an optional shell without deferring either param.
 export function generateStaticParams() {
   return [{ id: 'x' }]
 }

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/mixed/[lang]/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/mixed/[lang]/layout.tsx
@@ -3,9 +3,9 @@ import { ReactNode, Suspense } from 'react'
 export const instant = true
 export const prefetch = 'partial'
 
-// `lang` is covered by `generateStaticParams`. At this segment `params` only
-// contains `lang`, so reading it here (rather than in the deeper page) lets us
-// observe the stage `lang` resolves in independently of the uncovered `id`.
+// The layout logs the resolution stage of `lang` independently of `id`. Its
+// `params` object contains only `lang`, so the staging check does not consider
+// `id`.
 export function generateStaticParams() {
   return [{ lang: 'en' }]
 }

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/page.tsx
@@ -33,6 +33,12 @@ export default function Page() {
           <Link href="/mixed/en/x">/mixed/en/x</Link>
         </li>
         <li>
+          <Link href="/partial/en/123">/partial/en/123</Link>
+        </li>
+        <li>
+          <Link href="/partial/fr/123">/partial/fr/123</Link>
+        </li>
+        <li>
           <Link href="/sync-io/static">/sync-io/static</Link>
         </li>
         <li>

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/partial/[lang]/[id]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/partial/[lang]/[id]/page.tsx
@@ -1,0 +1,33 @@
+import { Suspense } from 'react'
+import { CachedData } from '../../../data-fetching'
+
+const CACHE_KEY = __dirname + '/__PAGE__'
+
+export default function PartialIdPage({
+  params,
+}: {
+  params: Promise<{ lang: string; id: string }>
+}) {
+  return (
+    <main>
+      <Suspense fallback={<p>Waiting for id...</p>}>
+        <IdLabel params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function IdLabel({
+  params,
+}: {
+  params: Promise<{ lang: string; id: string }>
+}) {
+  const { id } = await params
+  console.log('after params - id')
+  return (
+    <>
+      <p>id: {id}</p>
+      <CachedData label="page" cacheKey={`${CACHE_KEY}-${id}`} />
+    </>
+  )
+}

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/partial/[lang]/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/partial/[lang]/layout.tsx
@@ -1,0 +1,40 @@
+import { ReactNode, Suspense } from 'react'
+import { CachedData } from '../../data-fetching'
+
+export const instant = true
+export const prefetch = 'partial'
+
+const CACHE_KEY = __dirname + '/__LAYOUT__'
+
+// Only lang has a generator. The child page leaves id as a fallback param.
+export function generateStaticParams() {
+  return [{ lang: 'en' }]
+}
+
+export default function PartialLangLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ lang: string }>
+}) {
+  return (
+    <>
+      <Suspense fallback={<p>Waiting for lang...</p>}>
+        <LangLabel params={params} />
+      </Suspense>
+      {children}
+    </>
+  )
+}
+
+async function LangLabel({ params }: { params: Promise<{ lang: string }> }) {
+  const { lang } = await params
+  console.log('after params - lang')
+  return (
+    <>
+      <p>lang: {lang}</p>
+      <CachedData label="layout" cacheKey={`${CACHE_KEY}-${lang}`} />
+    </>
+  )
+}

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/mixed/[lang]/[id]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/mixed/[lang]/[id]/page.tsx
@@ -1,9 +1,7 @@
 import { Suspense } from 'react'
 
-// `id` is covered by `generateStaticParams` only for `x`, so `/mixed/en/x` is a
-// fully prerendered route (both params resolve in the static shell) while other
-// ids such as `123` are deferred to the runtime stage. The parent `[lang]`
-// layout reads `lang`; this page reads only `id`.
+// Both params have generators, so the route has a fully generated shape. Novel
+// values can complete an optional shell without deferring either param.
 export function generateStaticParams() {
   return [{ id: 'x' }]
 }

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/mixed/[lang]/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/mixed/[lang]/layout.tsx
@@ -1,8 +1,8 @@
 import { ReactNode, Suspense } from 'react'
 
-// `lang` is covered by `generateStaticParams`. At this segment `params` only
-// contains `lang`, so reading it here (rather than in the deeper page) lets us
-// observe the stage `lang` resolves in independently of the uncovered `id`.
+// The layout logs the resolution stage of `lang` independently of `id`. Its
+// `params` object contains only `lang`, so the staging check does not consider
+// `id`.
 export function generateStaticParams() {
   return [{ lang: 'en' }]
 }

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/page.tsx
@@ -33,6 +33,12 @@ export default function Page() {
           <Link href="/mixed/en/x">/mixed/en/x</Link>
         </li>
         <li>
+          <Link href="/partial/en/123">/partial/en/123</Link>
+        </li>
+        <li>
+          <Link href="/partial/fr/123">/partial/fr/123</Link>
+        </li>
+        <li>
           <Link href="/sync-io/static">/sync-io/static</Link>
         </li>
         <li>

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/partial/[lang]/[id]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/partial/[lang]/[id]/page.tsx
@@ -1,0 +1,33 @@
+import { Suspense } from 'react'
+import { CachedData } from '../../../data-fetching'
+
+const CACHE_KEY = __dirname + '/__PAGE__'
+
+export default function PartialIdPage({
+  params,
+}: {
+  params: Promise<{ lang: string; id: string }>
+}) {
+  return (
+    <main>
+      <Suspense fallback={<p>Waiting for id...</p>}>
+        <IdLabel params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function IdLabel({
+  params,
+}: {
+  params: Promise<{ lang: string; id: string }>
+}) {
+  const { id } = await params
+  console.log('after params - id')
+  return (
+    <>
+      <p>id: {id}</p>
+      <CachedData label="page" cacheKey={`${CACHE_KEY}-${id}`} />
+    </>
+  )
+}

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/partial/[lang]/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/without-prefetch-config/app/partial/[lang]/layout.tsx
@@ -1,0 +1,37 @@
+import { ReactNode, Suspense } from 'react'
+import { CachedData } from '../../data-fetching'
+
+const CACHE_KEY = __dirname + '/__LAYOUT__'
+
+// Only lang has a generator. The child page leaves id as a fallback param.
+export function generateStaticParams() {
+  return [{ lang: 'en' }]
+}
+
+export default function PartialLangLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ lang: string }>
+}) {
+  return (
+    <>
+      <Suspense fallback={<p>Waiting for lang...</p>}>
+        <LangLabel params={params} />
+      </Suspense>
+      {children}
+    </>
+  )
+}
+
+async function LangLabel({ params }: { params: Promise<{ lang: string }> }) {
+  const { lang } = await params
+  console.log('after params - lang')
+  return (
+    <>
+      <p>lang: {lang}</p>
+      <CachedData label="layout" cacheKey={`${CACHE_KEY}-${lang}`} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/app/[slug]/cache/page.tsx
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/app/[slug]/cache/page.tsx
@@ -9,11 +9,11 @@ import {
   TracedComponentActiveSpan,
 } from '../../traced-work'
 
-// A navigation to an uncovered slug reads a deferred `params`, which is a
-// blocking navigation. This suite exercises span creation during cache
-// component validation, not Instant Navigation, so opt the route out of that
-// validation: otherwise its blocking-route insight masks the `startActiveSpan`
-// console error these tests assert.
+// These routes exercise OTEL span creation during Cache Components validation.
+// Automatic navigation-boundary insights are not the subject of this suite.
+// Non-root params remain outside an App Shell even when statically available.
+// The blocking opt-out keeps those insights from replacing the intentional
+// `startActiveSpan` console error that the tests inspect.
 export const instant = false
 
 export function generateStaticParams() {

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/app/[slug]/server/page.tsx
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/app/[slug]/server/page.tsx
@@ -9,11 +9,11 @@ import {
   TracedComponentActiveSpan,
 } from '../../traced-work'
 
-// A navigation to an uncovered slug reads a deferred `params`, which is a
-// blocking navigation. This suite exercises span creation during cache
-// component validation, not Instant Navigation, so opt the route out of that
-// validation: otherwise its blocking-route insight masks the `startActiveSpan`
-// console error these tests assert.
+// These routes exercise OTEL span creation during Cache Components validation.
+// Automatic navigation-boundary insights are not the subject of this suite.
+// Non-root params remain outside an App Shell even when statically available.
+// The blocking opt-out keeps those insights from replacing the intentional
+// `startActiveSpan` console error that the tests inspect.
 export const instant = false
 
 export function generateStaticParams() {

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/app/runtime/[slug]/page.tsx
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/app/runtime/[slug]/page.tsx
@@ -1,0 +1,3 @@
+export { default } from '../../[slug]/server/page'
+
+export const instant = false

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts
@@ -1,4 +1,9 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
+import {
+  getRedboxDescription,
+  getRedboxEnvironmentLabel,
+  openRedbox,
+} from 'next-test-utils'
 
 describe('cache-components OTEL spans', () => {
   const { next, isTurbopack, isNextDeploy } = nextTestSetup({
@@ -10,7 +15,7 @@ describe('cache-components OTEL spans', () => {
   })
 
   if (isNextDev) {
-    it('should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Cache Component - without prerendering the page', async () => {
+    it('should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Cache Component - with a novel slug', async () => {
       const browser = await next.browser('/novel/cache')
       if (isTurbopack) {
         await expect(browser).toDisplayCollapsedRedbox(`
@@ -57,8 +62,9 @@ describe('cache-components OTEL spans', () => {
       console.log('t7', await t7.textContent())
       console.log('t8', await t8.textContent())
     })
-    it('should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Cache Component - with prerendering the page', async () => {
-      // In dev there really isn't any prerendering but since this test case exists for prod testing I want to keep it exercised in the dev pathway too
+    it('should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Cache Component - with a generated slug', async () => {
+      // Dev has no build-time page artifact; this case exercises the generated
+      // slug.
       const browser = await next.browser('/prerendered/cache')
       if (isTurbopack) {
         await expect(browser).toDisplayCollapsedRedbox(`
@@ -105,13 +111,13 @@ describe('cache-components OTEL spans', () => {
       console.log('t7', await t7.textContent())
       console.log('t8', await t8.textContent())
     })
-    it('should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Server Component - without prerendering the page', async () => {
+    it('should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Server Component - with a novel slug', async () => {
       const browser = await next.browser('/novel/server')
       if (isTurbopack) {
         await expect(browser).toDisplayCollapsedRedbox(`
          {
            "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
-           "environmentLabel": "Prefetch",
+           "environmentLabel": "Prerender",
            "label": "Console Error",
            "source": "app/traced-work.tsx (26:19) @ <anonymous>
          > 26 |     return tracer.startActiveSpan('span-active-span', fn)
@@ -128,7 +134,7 @@ describe('cache-components OTEL spans', () => {
         await expect(browser).toDisplayCollapsedRedbox(`
          {
            "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
-           "environmentLabel": "Prefetch",
+           "environmentLabel": "Prerender",
            "label": "Console Error",
            "source": "app/traced-work.tsx (26:19) @ eval
          > 26 |     return tracer.startActiveSpan('span-active-span', fn)
@@ -154,8 +160,9 @@ describe('cache-components OTEL spans', () => {
       console.log('t7', await t7.textContent())
       console.log('t8', await t8.textContent())
     })
-    it('should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Server Component - with prerendering the page', async () => {
-      // In dev there really isn't any prerendering but since this test case exists for prod testing I want to keep it exercised in the dev pathway too
+    it('should allow creating spans during cache component validation without triggering sync IO bailouts - inside a Server Component - with a generated slug', async () => {
+      // Dev has no build-time page artifact; this case exercises the generated
+      // slug.
       const browser = await next.browser('/prerendered/server')
       if (isTurbopack) {
         await expect(browser).toDisplayCollapsedRedbox(`
@@ -203,6 +210,19 @@ describe('cache-components OTEL spans', () => {
 
       console.log('t7', await t7.textContent())
       console.log('t8', await t8.textContent())
+    })
+    it('keeps span diagnostics in the runtime stage when no slug is generated', async () => {
+      const browser = await next.browser('/runtime/novel')
+      await openRedbox(browser)
+      expect(await getRedboxDescription(browser)).toContain(
+        'A Cache Function (`use cache`) was passed to startActiveSpan'
+      )
+      expect(await getRedboxEnvironmentLabel(browser)).toBe('Prefetch')
+
+      for (const id of ['t7', 't8']) {
+        const spanId = await browser.elementByCss(`#${id} .span`).text()
+        expect(parseInt(spanId, 10)).toBeGreaterThan(0)
+      }
     })
   } else {
     it('should allow creating Spans during prerendering during the build - inside a Cache Components', async () => {

--- a/test/e2e/app-dir/cache-components-errors/use-cache.util.ts
+++ b/test/e2e/app-dir/cache-components-errors/use-cache.util.ts
@@ -1277,12 +1277,12 @@ Learn more: https://nextjs.org/docs/messages/blocking-prerender-dynamic`
           // Regression test for NAR-491: after adding `generateStaticParams`
           // that covers the requested slug, the slug is no longer a fallback
           // param, so the blocking-route validation must clear. This requires
-          // the render to pick up the fresh `fallbackParams`. Because
+          // the render to pick up the fresh `stagedFallbackParams`. Because
           // `generateStaticParams` is recomputed in the background (the static
           // paths cache serves the previous result until then), the render
-          // triggered by the edit itself still uses the stale `fallbackParams`;
-          // a follow-up HMR update, sent once the recompute lands, is what
-          // syncs them.
+          // triggered by the edit itself still uses the stale
+          // `stagedFallbackParams`; a follow-up HMR update, sent once the
+          // recompute lands, is what syncs them.
           const browser = await next.browser('/use-cache-params/foo')
 
           await expect(browser).toDisplayCollapsedRedbox(`

--- a/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
+++ b/test/e2e/app-dir/instant-validation/head-and-reporting.util.ts
@@ -647,11 +647,13 @@ export function registerHeadAndReportingTests(
           const result = await prerender(
             '/shells/(default)/invalid-runtime-params/[slug]'
           )
-          // TODO(app-shells): missing fallback params in build validation
-          // It seems like `workUnitStore.fallbackParams` is undefined
-          // during the validation render, which makes us treat these params as static.
-          // In partialPrefetching, static params are also delayed until the runtime stage,
-          // which ultimately makes the validation fail, but also hides the underlying issue.
+          // TODO(app-shells): Verify fallback params in build validation.
+          //
+          // This assertion can pass even if
+          // `workUnitStore.stagedFallbackParams` is missing. Without that set,
+          // validation treats these params as static. Partial Prefetching still
+          // delays them to the runtime stage, so the expected error does not
+          // detect the missing fallback params.
 
           expect(extractBuildValidationError(result.cliOutput))
             .toMatchInlineSnapshot(`

--- a/test/e2e/app-dir/instant-validation/suspense-boundaries.util.ts
+++ b/test/e2e/app-dir/instant-validation/suspense-boundaries.util.ts
@@ -464,11 +464,12 @@ export function registerSuspenseBoundariesTests(
       const result = await prerender(
         '/suspense-in-root/runtime/invalid-no-suspense-around-params/[param]'
       )
-      // TODO(app-shells): missing fallback params in build validation
-      // It seems like `workUnitStore.fallbackParams` is undefined
-      // during the validation render, which makes us treat these params as static.
-      // In partialPrefetching, static params are also delayed until the runtime stage,
-      // which ultimately makes the validation fail, but also hides the underlying issue.
+      // TODO(app-shells): Verify fallback params in build validation.
+      //
+      // This assertion can pass even if `workUnitStore.stagedFallbackParams` is
+      // missing. Without that set, validation treats these params as static.
+      // Partial Prefetching still delays them to the runtime stage, so the
+      // expected error does not detect the missing fallback params.
 
       expect(extractBuildValidationError(result.cliOutput))
         .toMatchInlineSnapshot(`

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/fixtures/default/app/mixed/[top]/[bottom]/page.tsx
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/fixtures/default/app/mixed/[top]/[bottom]/page.tsx
@@ -1,0 +1,39 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export function generateStaticParams() {
+  // The short entry requires a partial shell. The long entry also makes bottom
+  // prerenderable on demand.
+  return [{ top: 'short' }, { top: 'long', bottom: 'example' }]
+}
+
+export default function Page({
+  params,
+}: {
+  params: Promise<{ top: string; bottom: string }>
+}) {
+  return (
+    <>
+      <Suspense fallback={<div id="bottom-fallback">loading bottom...</div>}>
+        <Bottom params={params} />
+      </Suspense>
+      <Suspense fallback={<div id="dynamic-fallback">loading dynamic...</div>}>
+        <Dynamic />
+      </Suspense>
+    </>
+  )
+}
+
+async function Bottom({
+  params,
+}: {
+  params: Promise<{ top: string; bottom: string }>
+}) {
+  const { bottom } = await params
+  return <div id="bottom">{bottom}</div>
+}
+
+async function Dynamic() {
+  await connection()
+  return <div id="dynamic">Dynamic content</div>
+}

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/fixtures/default/app/mixed/[top]/layout.tsx
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/fixtures/default/app/mixed/[top]/layout.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ top: string }>
+}) {
+  const { top } = await params
+
+  return (
+    <div>
+      <div id="top">{top}</div>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/fixtures/default/app/mixed/layout.tsx
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/fixtures/default/app/mixed/layout.tsx
@@ -1,0 +1,9 @@
+import { Suspense, type ReactNode } from 'react'
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <Suspense fallback={<div id="top-fallback">loading top...</div>}>
+      {children}
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
@@ -1,4 +1,5 @@
 import cheerio from 'cheerio'
+import { randomUUID } from 'crypto'
 import { nextTestSetup } from 'e2e-utils'
 import { splitResponseWithPPRSentinel } from 'e2e-utils/ppr'
 import { retry, waitFor } from 'next-test-utils'
@@ -130,6 +131,51 @@ describe('partial-fallback-shell-upgrade', () => {
     expect(result.static$('#two').length).toBe(0)
     expect(result.dynamicPart).toContain('<div id="two">bar</div>')
     expect(result.dynamicPart).not.toContain('<div id="two">foo</div>')
+  })
+
+  it('should upgrade a required fallback shell with mixed generateStaticParams lengths', async () => {
+    // A second cold path must still use the required source shell after the
+    // first exact path completes.
+    for (const bottom of [`first-${randomUUID()}`, `second-${randomUUID()}`]) {
+      const pathname = `/mixed/short/${bottom}`
+      const firstResult = await fetchSplitHTML(pathname)
+
+      expect(firstResult.static$('#top').text()).toBe('short')
+      expect(firstResult.static$('#top-fallback').length).toBe(0)
+      expect(firstResult.static$('#bottom').length).toBe(0)
+      expect(firstResult.static$('#bottom-fallback').text()).toBe(
+        'loading bottom...'
+      )
+      expect(firstResult.dynamicPart).toContain(
+        `<div id="bottom">${bottom}</div>`
+      )
+      expect(firstResult.static$('#dynamic').length).toBe(0)
+      expect(firstResult.static$('#dynamic-fallback').text()).toBe(
+        'loading dynamic...'
+      )
+      expect(firstResult.dynamicPart).toContain(
+        '<div id="dynamic">Dynamic content</div>'
+      )
+
+      await retry(async () => {
+        const completedResult = await fetchSplitHTML(pathname)
+
+        expect(completedResult.static$('#top').text()).toBe('short')
+        expect(completedResult.static$('#top-fallback').length).toBe(0)
+        expect(completedResult.static$('#bottom').text()).toBe(bottom)
+        expect(completedResult.static$('#bottom-fallback').length).toBe(0)
+        expect(completedResult.dynamicPart).not.toContain(
+          `<div id="bottom">${bottom}</div>`
+        )
+        expect(completedResult.static$('#dynamic').length).toBe(0)
+        expect(completedResult.static$('#dynamic-fallback').text()).toBe(
+          'loading dynamic...'
+        )
+        expect(completedResult.dynamicPart).toContain(
+          '<div id="dynamic">Dynamic content</div>'
+        )
+      })
+    }
   })
 
   it('should not keep upgrading once only fully dynamic params remain', async () => {

--- a/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
@@ -1,3 +1,4 @@
+import cheerio from 'cheerio'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
@@ -5,7 +6,7 @@ import type * as Playwright from 'playwright'
 import { createRouterAct } from 'router-act'
 
 describe('cached navigations', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: path.join(__dirname, 'default'),
   })
 
@@ -402,6 +403,303 @@ describe('cached navigations', () => {
     expect(await browser.elementById('connection-boundary').text()).toContain(
       'Dynamic content'
     )
+  })
+
+  it.each([
+    { source: 'dynamic RSC', top: 't2' },
+    { source: 'initial HTML with partial resume', top: 't3' },
+  ])(
+    'caches a required fallback shell from $source for repeated navigations',
+    async ({ source, top }) => {
+      const route = `/required-fallback-params/${top}/b1`
+      const startDate = Date.now()
+      let bottomIsStatic = false
+      let page: Playwright.Page
+      let initialDocument: Promise<Playwright.Response>
+      const browser = await next.browser(
+        source === 'dynamic RSC' ? `/fallback-params-hub/${top}/start` : route,
+        {
+          async beforePageLoad(p: Playwright.Page) {
+            page = p
+            await page.clock.install()
+            await page.clock.setFixedTime(startDate)
+            initialDocument = page.waitForResponse((response) =>
+              response.request().isNavigationRequest()
+            )
+          },
+        }
+      )
+      const act = createRouterAct(page)
+
+      if (source === 'dynamic RSC') {
+        await act(
+          async () => {
+            await browser
+              .elementByCss(`input[data-link-accordion="${route}"]`)
+              .click()
+            await browser.elementByCss(`a[href="${route}"]`).click()
+          },
+          { includes: 'Dynamic content' }
+        )
+      } else {
+        // Inspect the document that populated this browser's cache, not a
+        // separate prefetch or a later request after the shell was cached.
+        const html = await (await initialDocument).text()
+        const [shell, resume] = html.split('<!-- PPR_BOUNDARY_SENTINEL -->')
+        expect(resume).toBeDefined()
+        const $ = cheerio.load(shell)
+        expect($('#top').text()).toBe(`Top: ${top}`)
+        bottomIsStatic = $('#bottom').length > 0
+        expect($('#bottom-boundary').text()).toBe(
+          bottomIsStatic ? 'Bottom: b1' : 'Loading bottom...'
+        )
+        expect($('#connection-boundary').text()).toBe('Loading connection...')
+        expect(resume).toContain('id="dynamic-content"')
+      }
+
+      expect(await browser.elementById('top').text()).toBe(`Top: ${top}`)
+      expect(await browser.elementById('bottom').text()).toBe('Bottom: b1')
+      expect(await browser.elementById('dynamic-content').text()).toBe(
+        'Dynamic content'
+      )
+
+      for (const [index, step] of ['a', 'b'].entries()) {
+        const hub = `/fallback-params-hub/${top}/${step}`
+        await act(
+          async () => {
+            await browser
+              .elementByCss(`input[data-link-accordion="${hub}"]`)
+              .click()
+            await browser.elementByCss(`a[href="${hub}"]`).click()
+          },
+          { includes: `Fallback params hub ${step}` }
+        )
+        expect(await browser.elementByCss('h1').text()).toBe(
+          `Fallback params hub ${step}`
+        )
+        await page.clock.setFixedTime(startDate + (index + 1) * 60_000)
+
+        await act(async () => {
+          await act(
+            async () => {
+              await browser
+                .elementByCss(`input[data-link-accordion="${route}"]`)
+                .click()
+              await browser.elementByCss(`a[href="${route}"]`).click()
+            },
+            { includes: 'Dynamic content', block: true }
+          )
+
+          // Hydration retains the static content of its actual prerender. A
+          // cold dynamic RSC render retains the required shell's unresolved
+          // bottom param.
+          expect(await browser.elementByCss('main').text()).toContain(
+            `Top: ${top}`
+          )
+          expect(await browser.elementById('bottom-boundary').text()).toBe(
+            bottomIsStatic ? 'Bottom: b1' : 'Loading bottom...'
+          )
+          expect(await browser.elementById('connection-boundary').text()).toBe(
+            'Loading connection...'
+          )
+        })
+
+        expect(await browser.elementById('top').text()).toBe(`Top: ${top}`)
+        expect(await browser.elementById('bottom').text()).toBe('Bottom: b1')
+        expect(await browser.elementById('dynamic-content').text()).toBe(
+          'Dynamic content'
+        )
+      }
+    }
+  )
+
+  it('caches a fully static on-demand param for repeated navigations', async () => {
+    const route = '/fully-static-params/t4'
+    const startDate = Date.now()
+    let page: Playwright.Page
+    const browser = await next.browser('/fallback-params-hub/t4/start', {
+      async beforePageLoad(p: Playwright.Page) {
+        page = p
+        await page.clock.install()
+        await page.clock.setFixedTime(startDate)
+      },
+    })
+    const act = createRouterAct(page)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss(`input[data-link-accordion="${route}"]`)
+          .click()
+        await browser.elementByCss(`a[href="${route}"]`).click()
+      },
+      { includes: 'Top:' }
+    )
+    expect(await browser.elementById('top').text()).toBe('Top: t4')
+
+    for (const [index, step] of ['a', 'b'].entries()) {
+      const hub = `/fallback-params-hub/t4/${step}`
+      await act(
+        async () => {
+          await browser
+            .elementByCss(`input[data-link-accordion="${hub}"]`)
+            .click()
+          await browser.elementByCss(`a[href="${hub}"]`).click()
+        },
+        { includes: `Fallback params hub ${step}` }
+      )
+      expect(await browser.elementByCss('h1').text()).toBe(
+        `Fallback params hub ${step}`
+      )
+      await page.clock.setFixedTime(startDate + (index + 1) * 60_000)
+
+      const navigate = async () => {
+        await browser
+          .elementByCss(`input[data-link-accordion="${route}"]`)
+          .click()
+        await browser.elementByCss(`a[href="${route}"]`).click()
+      }
+      if (isNextDeploy) {
+        // The platform serves a completed static prerender, not an unmarked
+        // live-render prefix.
+        await act(navigate, 'no-requests')
+        expect(await browser.elementById('top').text()).toBe('Top: t4')
+        continue
+      }
+
+      await act(async () => {
+        await act(navigate, { includes: 'Top:', block: true })
+
+        // Live navigation prefixes remain marked partial even for a static
+        // page.
+        expect(await browser.elementByCss('main').text()).toContain('Top: t4')
+      })
+      expect(await browser.elementById('top').text()).toBe('Top: t4')
+    }
+  })
+
+  it('does not cache synchronous IO after a novel param resolves', async () => {
+    const route = '/fully-static-params/time'
+    if (isNextDeploy) {
+      // The platform must prerender this cold route before it can resume it.
+      // The prerender rejects the uncached timestamp instead of serving a
+      // cacheable result.
+      const response = await next.fetch(route)
+      expect(response.status).toBe(500)
+      expect(await response.text()).not.toContain('Top: time')
+      return
+    }
+    const hub = '/fallback-params-hub/time/a'
+    let page: Playwright.Page
+    const browser = await next.browser('/fallback-params-hub/time/start', {
+      async beforePageLoad(browserPage: Playwright.Page) {
+        page = browserPage
+        await page.clock.install()
+      },
+    })
+    const act = createRouterAct(page)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss(`input[data-link-accordion="${route}"]`)
+          .click()
+        await browser.elementByCss(`a[href="${route}"]`).click()
+      },
+      { includes: 'Top:' }
+    )
+    const timestamp = await browser.elementById('timestamp').text()
+    expect(timestamp).not.toBe('')
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss(`input[data-link-accordion="${hub}"]`)
+          .click()
+        await browser.elementByCss(`a[href="${hub}"]`).click()
+      },
+      { includes: 'Fallback params hub a' }
+    )
+    await page.clock.fastForward(60_000)
+
+    await act(async () => {
+      await act(
+        async () => {
+          await browser
+            .elementByCss(`input[data-link-accordion="${route}"]`)
+            .click()
+          await browser.elementByCss(`a[href="${route}"]`).click()
+        },
+        { includes: 'Top:', block: true }
+      )
+
+      expect(await browser.elementByCss('main').text()).not.toContain(
+        'Top: time'
+      )
+    })
+    expect(await browser.elementById('timestamp').text()).not.toBe(timestamp)
+  })
+
+  it('finishes a full prefetch after synchronous IO interrupts its shell', async () => {
+    const route = '/fully-static-params/time'
+    if (isNextDeploy) {
+      const response = await next.fetch(route)
+      expect(response.status).toBe(500)
+      return
+    }
+
+    let page: Playwright.Page
+    const browser = await next.browser('/fallback-params-hub/time/start', {
+      beforePageLoad(browserPage: Playwright.Page) {
+        page = browserPage
+      },
+    })
+    const act = createRouterAct(page)
+    await act(
+      async () => {
+        await browser
+          .elementByCss(`input[data-link-accordion="${route}"]`)
+          .click()
+        await browser.elementByCss(`a[href="${route}"]`).click()
+      },
+      { includes: 'Top:' }
+    )
+    const timestamp = await browser.elementById('timestamp').text()
+
+    const hub = '/fallback-params-hub/time/a'
+    await act(
+      async () => {
+        await browser
+          .elementByCss(`input[data-link-accordion="${hub}"]`)
+          .click()
+        await browser.elementByCss(`a[href="${hub}"]`).click()
+      },
+      { includes: 'Fallback params hub a' }
+    )
+    await act(
+      async () => {
+        await browser.eval('window.next.router.refresh()')
+      },
+      { includes: 'Fallback params hub a' }
+    )
+
+    // Refresh clears segment data and BFCache but retains the route tree. The
+    // full prefetch must fetch new data without a cold static tree prerender.
+    const fullPrefetchLink = `${route}#full-prefetch`
+    await act(
+      async () => {
+        await browser
+          .elementByCss(`input[data-link-accordion="${fullPrefetchLink}"]`)
+          .click()
+      },
+      { includes: 'Top:' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss(`a[href="${fullPrefetchLink}"]`).click()
+    }, 'no-requests')
+    expect(await browser.elementById('top').text()).toBe('Top: time')
+    expect(await browser.elementById('timestamp').text()).not.toBe(timestamp)
   })
 
   it('caches runtime-prefetchable content from a navigation for instant second visit', async () => {

--- a/test/e2e/app-dir/segment-cache/cached-navigations/default/app/fallback-params-hub/[top]/[step]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/default/app/fallback-params-hub/[top]/[step]/page.tsx
@@ -1,0 +1,53 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+import { LinkAccordion } from '../../../../components/link-accordion'
+
+export default function Page({
+  params,
+}: {
+  params: Promise<{ top: string; step: string }>
+}) {
+  return (
+    <main>
+      <Suspense fallback={<p>Loading hub...</p>}>
+        <Hub params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Hub({
+  params,
+}: {
+  params: Promise<{ top: string; step: string }>
+}) {
+  await connection()
+  const { top, step } = await params
+
+  return (
+    <>
+      <h1>{`Fallback params hub ${step}`}</h1>
+      <div>
+        <LinkAccordion
+          href={`/required-fallback-params/${top}/b1`}
+          prefetch={false}
+        >
+          Required fallback shell
+        </LinkAccordion>
+      </div>
+      <div>
+        <LinkAccordion href={`/fully-static-params/${top}`} prefetch={false}>
+          Fully static page
+        </LinkAccordion>
+      </div>
+      {top === 'time' ? (
+        <LinkAccordion
+          href="/fully-static-params/time#full-prefetch"
+          prefetch={true}
+        >
+          Full prefetch
+        </LinkAccordion>
+      ) : null}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/cached-navigations/default/app/fully-static-params/[top]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/default/app/fully-static-params/[top]/page.tsx
@@ -1,0 +1,31 @@
+import { LinkAccordion } from '../../../components/link-accordion'
+
+export function generateStaticParams() {
+  return [{ top: 't1' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ top: string }>
+}) {
+  const { top } = await params
+  const timestamp = top === 'time' ? Date.now() : null
+
+  return (
+    <main>
+      <p id="top">Top: {top}</p>
+      <p id="timestamp">{timestamp}</p>
+      {['a', 'b'].map((step) => (
+        <div key={step}>
+          <LinkAccordion
+            href={`/fallback-params-hub/${top}/${step}`}
+            prefetch={false}
+          >
+            Hub {step}
+          </LinkAccordion>
+        </div>
+      ))}
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/cached-navigations/default/app/required-fallback-params/[top]/[bottom]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/default/app/required-fallback-params/[top]/[bottom]/page.tsx
@@ -1,0 +1,37 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export default function Page({
+  params,
+}: {
+  params: Promise<{ top: string; bottom: string }>
+}) {
+  return (
+    <>
+      <div id="bottom-boundary">
+        <Suspense fallback={<p>Loading bottom...</p>}>
+          <Bottom params={params} />
+        </Suspense>
+      </div>
+      <div id="connection-boundary">
+        <Suspense fallback={<p>Loading connection...</p>}>
+          <DynamicContent />
+        </Suspense>
+      </div>
+    </>
+  )
+}
+
+async function Bottom({
+  params,
+}: {
+  params: Promise<{ top: string; bottom: string }>
+}) {
+  const { bottom } = await params
+  return <p id="bottom">Bottom: {bottom}</p>
+}
+
+async function DynamicContent() {
+  await connection()
+  return <p id="dynamic-content">Dynamic content</p>
+}

--- a/test/e2e/app-dir/segment-cache/cached-navigations/default/app/required-fallback-params/[top]/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/default/app/required-fallback-params/[top]/layout.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from 'react'
+import { LinkAccordion } from '../../../components/link-accordion'
+
+export function generateStaticParams() {
+  return [{ top: 't1' }]
+}
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: Promise<{ top: string }>
+}) {
+  const { top } = await params
+
+  return (
+    <main>
+      <p id="top">Top: {top}</p>
+      {children}
+      {['a', 'b'].map((step) => (
+        <div key={step}>
+          <LinkAccordion
+            href={`/fallback-params-hub/${top}/${step}`}
+            prefetch={false}
+          >
+            Hub {step}
+          </LinkAccordion>
+        </div>
+      ))}
+    </main>
+  )
+}

--- a/test/production/app-dir/action-only-fallback-resume-data-cache/action-only-fallback-resume-data-cache.test.ts
+++ b/test/production/app-dir/action-only-fallback-resume-data-cache/action-only-fallback-resume-data-cache.test.ts
@@ -37,13 +37,36 @@ describe('action-only fallback resume data cache', () => {
         'destination page rendered'
       )
     })
+
+    it('renders the concrete destination after an action revalidates it', async () => {
+      const browser = await next.browser('/concrete/foo')
+      const cachedValue = await browser
+        .elementByCss('#concrete-cached-value')
+        .text()
+
+      await browser.elementByCss('#revalidate-concrete').click()
+      await retry(async () => {
+        expect(
+          await browser.elementByCss('#concrete-action-result').text()
+        ).toBe('concrete action result')
+        expect(await browser.elementByCss('#concrete-destination').text()).toBe(
+          'concrete destination page rendered: foo'
+        )
+        expect(
+          await browser.elementByCss('#concrete-cached-value').text()
+        ).not.toBe(cachedValue)
+      })
+    })
   } else {
-    async function invokeAction(exportedName: string) {
-      const metadata = await next.readJSON(
-        '.next/server/app/events/[id]/group.meta'
-      )
+    async function invokeAction(
+      exportedName: string,
+      route = '/events/[id]/group',
+      pathname = route
+    ) {
+      const metadata = await next.readJSON(`.next/server/app${route}.meta`)
       const postponed = metadata.postponed as string
       expect(postponed).toEqual(expect.any(String))
+      expect(postponed).toMatch(/^\d+:\d+\[\["id",/)
 
       const manifest = await next.readJSON(
         '.next/server/server-reference-manifest.json'
@@ -51,19 +74,21 @@ describe('action-only fallback resume data cache', () => {
       const actionId = Object.keys(manifest.node).find(
         (id) => manifest.node[id].exportedName === exportedName
       )
-      expect(actionId).toEqual(expect.any(String))
+      if (!actionId) {
+        throw new Error(`Missing server action: ${exportedName}`)
+      }
 
       // Simulate the request received by the action worker after the platform
       // has selected the dynamic route's fallback and prepended its postponed
       // state to the action body.
       const actionBody = Buffer.from('[]')
       const postponedBody = Buffer.from(postponed)
-      return next.fetch('/events/[id]/group', {
+      return next.fetch(pathname, {
         method: 'POST',
         headers: {
           'content-type': 'text/plain;charset=UTF-8',
-          'next-action': actionId!,
-          'x-matched-path': '/events/[id]/group',
+          'next-action': actionId,
+          'x-matched-path': route,
           'x-next-resume-state-length': String(postponedBody.byteLength),
         },
         body: Buffer.concat([postponedBody, actionBody]),
@@ -78,6 +103,30 @@ describe('action-only fallback resume data cache', () => {
       const responseBody = await response.text()
       expect(responseBody).toContain('cached value')
       expect(responseBody).not.toContain('destination page rendered')
+    })
+
+    it('renders the concrete destination with postponed state and preserves the action result and revalidation', async () => {
+      const outputIndex = next.cliOutput.length
+
+      // The request has a concrete id, but the injected fallback artifact still
+      // records id in its staging mask.
+      const response = await invokeAction(
+        'revalidateConcretePage',
+        '/concrete/[id]',
+        '/concrete/foo'
+      )
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toContain('text/x-component')
+      expect(response.headers.get('x-action-revalidated')).toBe('1')
+      const responseBody = await response.text()
+      expect(responseBody).toContain('concrete action result')
+      expect(responseBody).toContain('concrete destination page rendered: foo')
+
+      const output = next.cliOutput.slice(outputIndex)
+      expect(output).toContain('ActionOnlyFallbackCacheHandler::updateTags')
+      expect(output).toContain('_N_T_/concrete/foo')
+      expect(output).not.toContain('Failed to parse postponed state')
     })
 
     it('applies pending revalidations without rendering the fallback route when the action calls notFound', async () => {

--- a/test/production/app-dir/action-only-fallback-resume-data-cache/app/concrete/[id]/actions.ts
+++ b/test/production/app-dir/action-only-fallback-resume-data-cache/app/concrete/[id]/actions.ts
@@ -1,0 +1,8 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+export async function revalidateConcretePage() {
+  revalidatePath('/concrete/foo')
+  return 'concrete action result'
+}

--- a/test/production/app-dir/action-only-fallback-resume-data-cache/app/concrete/[id]/button.tsx
+++ b/test/production/app-dir/action-only-fallback-resume-data-cache/app/concrete/[id]/button.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useState } from 'react'
+import { revalidateConcretePage } from './actions'
+
+export function Button() {
+  const [result, setResult] = useState('not called')
+
+  return (
+    <>
+      <button
+        id="revalidate-concrete"
+        onClick={async () => {
+          setResult(await revalidateConcretePage())
+        }}
+      >
+        revalidate concrete page
+      </button>
+      <p id="concrete-action-result">{result}</p>
+    </>
+  )
+}

--- a/test/production/app-dir/action-only-fallback-resume-data-cache/app/concrete/[id]/page.tsx
+++ b/test/production/app-dir/action-only-fallback-resume-data-cache/app/concrete/[id]/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react'
+import { Button } from './button'
+
+async function CachedValue() {
+  'use cache'
+
+  return <p id="concrete-cached-value">{Math.random()}</p>
+}
+
+async function Destination({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  return (
+    <p id="concrete-destination">
+      {`concrete destination page rendered: ${id}`}
+    </p>
+  )
+}
+
+export default function Page({ params }: { params: Promise<{ id: string }> }) {
+  return (
+    <>
+      <CachedValue />
+      <Suspense fallback={<p>loading concrete destination</p>}>
+        <Destination params={params} />
+      </Suspense>
+      <Button />
+    </>
+  )
+}


### PR DESCRIPTION
`next dev` reported missing Suspense boundaries in layouts that the build accepted. For `/[top]/items/[bottom]`, `generateStaticParams` returned `[{ top: 't1' }]`, and the page wrapped its `bottom` access in Suspense. A request for `/t2/items/b2` still reported the layout's access to `top` as an error. Development treated both parameters as unresolved because the requested `top` value was not generated, although the required static shell only needed to defer `bottom`.

Production Cached Navigations used the same overly broad parameter set and omitted eligible static content from repeat visits. Resumes also reconstructed that set from the original build manifest, even after an on-demand prerender had produced a more complete shell.

This replaces the alternative proposed in #98460. That proposal fixes the development error by selecting a separate fallback parameter set for validation while keeping response staging unchanged. The two sets are not intended to differ for the same shell target. Correcting only validation would preserve the incorrect staging decision and leave production Cached Navigations without the eligible static content.

Staging and static-shell validation now use one `stagedFallbackParams` set for each selected shell target. Required partial shells retain their unresolved parameters, even when a later request can complete them. Prerenders record their parameter set in postponed state, and resumes use that recorded set rather than reconstructing it from the generic source.

Dynamic RSC requests now read and revalidate the completed-shell cache key, so they find partial artifacts that the fully resolved pathname lookup missed. Request metadata and `RequestStore` both expose the set as `stagedFallbackParams`. Action-only fallback detection checks actual unresolved parameters instead of treating deferred values as missing.