### PR TITLE
docs(open-telemetry): explain why core module instrumentations do not attach

### DIFF
--- a/docs/01-app/02-guides/open-telemetry.mdx
+++ b/docs/01-app/02-guides/open-telemetry.mdx
@@ -173,6 +173,28 @@ sdk.start()
 
 Doing this is equivalent to using `@vercel/otel`, but it's possible to modify and extend some features that are not exposed by the `@vercel/otel`. If edge runtime support is necessary, you will have to use `@vercel/otel`.
 
+#### Instrumenting Node.js core modules
+
+Instrumentations that patch Node.js core modules, such as [`@opentelemetry/instrumentation-http`](https://www.npmjs.com/package/@opentelemetry/instrumentation-http), apply their patch the next time the module is loaded. Next.js loads `http` and `https` while it starts the server, before `register` is called, so those modules are already in the module cache when the instrumentation registers its hook and nothing triggers the patch. Incoming requests are then left uninstrumented, without an error being reported.
+
+Load the core modules you rely on again after starting the SDK so the pending patches are applied:
+
+```ts filename="instrumentation.node.ts" switcher
+sdk.start()
+
+process.getBuiltinModule('http')
+process.getBuiltinModule('https')
+```
+
+```js filename="instrumentation.node.js" switcher
+sdk.start()
+
+process.getBuiltinModule('http')
+process.getBuiltinModule('https')
+```
+
+> **Good to know**: [`process.getBuiltinModule`](https://nodejs.org/api/process.html#processgetbuiltinmoduleid) is available in Node.js 20.16 and later. It is used here instead of `require('http')` because a bundled `require` call is compiled into the bundler's own module runtime and never reaches the instrumentation hook.
+
 ## Testing your instrumentation
 
 You need an OpenTelemetry collector with a compatible backend to test OpenTelemetry traces locally.


### PR DESCRIPTION
### What?

The OpenTelemetry guide shows how to start a `NodeSDK` from `register()` in `instrumentation.ts`, but it never mentions that an instrumentation which patches a Node.js core module will not attach when you do that. `@opentelemetry/instrumentation-http` is the one people keep hitting: the SDK starts, Next.js keeps emitting its own spans, and incoming requests produce no HTTP server span at all. Nothing throws, so there is nothing to grep for.

This adds a short subsection under "Manual OpenTelemetry configuration" explaining the ordering, plus the two lines that fix it.

### Why?

`@opentelemetry/instrumentation` patches core modules through `require-in-the-middle`, which applies a patch on the next load of the module. `packages/next/src/server/lib/start-server.ts` imports `http` and `https` at the top of the file (lines 15 and 16), and `register()` runs much later. `server.listen()` goes first, and the `listening` handler is what eventually reaches `NextServer.prepare()` and `ensureInstrumentationRegistered()`. By then both modules sit in the require cache, so the hook that was just installed never sees them.

#64879 and #80262 were both closed as duplicates of #95894, and #51233 sits on the same mechanism. Today the only way to work this out is to go read `require-in-the-middle` and guess, which seems like a good reason to put it in the guide.

### How?

A new `#### Instrumenting Node.js core modules` subsection with a `ts`/`js` switcher pair showing `process.getBuiltinModule('http')` after `sdk.start()`. `require-in-the-middle` hooks `process.getBuiltinModule` as well as `require`, and it hands back the same module object the server is already holding, so the patch lands on the live `http` module instead of a copy.

The note also calls out that a plain `require('http')` does not work from `instrumentation.node.ts`, because the bundler compiles that call into its own module runtime and Node never sees a second require.

Only `docs/01-app/02-guides/open-telemetry.mdx` is edited. `docs/02-pages/02-guides/open-telemetry.mdx` carries `source: app/guides/open-telemetry` and a DO NOT EDIT banner, so the Pages Router copy is generated from the App Router page.

### Verification

Minimal app on `next@16.4.0-canary.25`, Node 20.18.1, `@opentelemetry/instrumentation-http@0.219.0` (which resolves `require-in-the-middle@8.0.1`), a `ConsoleSpanExporter`, and three requests against `next start`. Counting spans whose instrumentation scope is `@opentelemetry/instrumentation-http`:

- nothing after `sdk.start()`: 0 spans
- `require('http')` after `sdk.start()`: 0 spans
- `process.getBuiltinModule('http')` after `sdk.start()`: 3 spans

Same numbers for a Turbopack build and for a webpack build. The Next.js `GET /` spans showed up in every run, which is a big part of why the missing HTTP spans are easy to miss.

Prettier reports the page as already formatted, and `alex` finds nothing new on it (the one warning there is on a pre-existing line).

Fixes #95894

<!-- NEXT_JS_LLM -->
