### PR TITLE
Fix devtools panel close button spacing

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-header.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/dev-tools-indicator/dev-tools-info/dev-tools-header.tsx
@@ -21,7 +21,7 @@ export function DevToolsHeader({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        padding: '8px 20px',
+        padding: '8px 8px 8px 20px',
         userSelect: 'none',
         WebkitUserSelect: 'none',
         borderBottom: '1px solid var(--color-gray-alpha-400)',


### PR DESCRIPTION
## Summary

Give the shared devtools panel close button equal top and right spacing, fixing its uneven inset in the Navigation Inspector.

## Verification

- Rendered the actual header in an isolated browser preview: the close button has 8px top/right spacing, the title retains its 20px left inset, and the button remains 30×30px.
- The devtools bundle compiles successfully.
- Full bootstrap and Storybook validation were blocked by local setup errors: Turbopack rejected the worktree's external dependency symlink, and Storybook failed to transpile existing TypeScript stories.

<!-- NEXT_JS_LLM -->
