### PR TITLE
Disable prefetching in draft mode

### DIFF
--- a/docs/01-app/02-guides/draft-mode.mdx
+++ b/docs/01-app/02-guides/draft-mode.mdx
@@ -21,8 +21,11 @@ When Draft Mode is enabled for a request:
 - Components and functions inside [`'use cache'`](/docs/app/api-reference/directives/use-cache) re-execute on every request, and their results are not saved to the cache.
 - [`unstable_cache`](/docs/app/api-reference/functions/unstable_cache) reads and writes are bypassed in the same way.
 - The page is excluded from the ISR response cache and is served with `Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate`.
+- The App Router disables prefetching through [`<Link>`](/docs/app/api-reference/components/link) and [`router.prefetch()`](/docs/app/api-reference/functions/use-router). Client-side navigation still works and fetches missing data when needed.
 
 The effect applies whether the page is statically generated, served from cache, or revalidated through ISR.
+
+> **Good to know:** The router learns the Draft Mode state from the initial page load and from Server Actions that call `enable()` or `disable()`. A Route Handler that toggles Draft Mode should redirect, as in the examples below, so that the browser loads a new document. Toggling the cookie with a client-side `fetch()` and calling `router.refresh()` does not update the router's prefetching behavior until the next page load.
 
 ## What this guide covers
 

--- a/docs/01-app/03-api-reference/04-functions/draft-mode.mdx
+++ b/docs/01-app/03-api-reference/04-functions/draft-mode.mdx
@@ -45,6 +45,7 @@ The following methods and properties are available:
 - [`isEnabled`](#checking-if-draft-mode-is-enabled) is readable inside a [caching directive](/docs/app/api-reference/directives/use-cache) scope. Other runtime APIs like `cookies()` and `headers()` are not allowed inside caching directive scopes, even when Draft Mode is active.
 - Calling `enable()` or `disable()` inside a caching directive scope will throw an error.
 - When Draft Mode is enabled, all functions and components under a caching directive scope re-execute on every request and results are not saved to the cache. This ensures draft content is always fresh.
+- In the App Router, [`<Link>`](/docs/app/api-reference/components/link) and [`router.prefetch()`](/docs/app/api-reference/functions/use-router) do not prefetch routes while Draft Mode is enabled. Client-side navigation still works and fetches missing data when needed. The router learns the state from the initial page load and from Server Actions that call `enable()` or `disable()`; a Route Handler that toggles Draft Mode should redirect so the browser loads a new document.
 
 ## Examples
 

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -27,6 +27,7 @@ import type { StaticIndicatorState } from './dev/hot-reloader/app/hot-reloader-a
 import { createInitialRSCPayloadFromFallbackPrerender } from './flight-data-helpers'
 import { getDeploymentId } from '../shared/lib/deployment-id'
 import { setNavigationBuildId } from './navigation-build-id'
+import { setIsDraftMode } from './components/segment-cache/scheduler'
 import type { ClientInstrumentationModules } from './router-transition-types'
 import { initializeRouterTransitionModules } from './components/router-transition'
 
@@ -374,6 +375,10 @@ export async function hydrate(
   }
 
   initializeRouterTransitionModules(instrumentationModules)
+
+  // The prefetch scheduler needs the draft-mode state before the first Link
+  // mounts/hydrates.
+  setIsDraftMode(initialRSCPayload.D)
 
   const initialTimestamp = Date.now()
   const actionQueue: AppRouterActionQueue = createMutableActionQueue(

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -42,3 +42,4 @@ export const NEXT_HTML_REQUEST_ID_HEADER = 'x-nextjs-html-request-id' as const
 
 // TODO: Should this include nextjs in the name, like the others?
 export const NEXT_ACTION_REVALIDATED_HEADER = 'x-action-revalidated' as const
+export const NEXT_ACTION_DRAFT_MODE_HEADER = 'x-action-draft-mode' as const

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -7,6 +7,7 @@ import { findSourceMapURL } from '../../../app-find-source-map-url'
 import {
   ACTION_HEADER,
   NEXT_ACTION_NOT_FOUND_HEADER,
+  NEXT_ACTION_DRAFT_MODE_HEADER,
   NEXT_IS_PRERENDER_HEADER,
   NEXT_HTML_REQUEST_ID_HEADER,
   NEXT_ROUTER_STATE_TREE_HEADER,
@@ -48,7 +49,10 @@ import {
   invalidateEntirePrefetchCache,
   segmentCacheMap,
 } from '../../segment-cache/cache'
-import { startRevalidationCooldown } from '../../segment-cache/scheduler'
+import {
+  setIsDraftMode,
+  startRevalidationCooldown,
+} from '../../segment-cache/scheduler'
 import { getDeploymentId } from '../../../../shared/lib/deployment-id'
 import { getNavigationBuildId } from '../../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../../lib/constants'
@@ -172,6 +176,18 @@ async function fetchServerAction(
       }
     }
     throw err
+  }
+
+  // The action wrote the draft cookie. Update the scheduler from the headers,
+  // before the cache invalidation below reschedules visible links and before
+  // the body can fail to decode.
+  const draftMode = res.headers.get(NEXT_ACTION_DRAFT_MODE_HEADER)
+  if (draftMode !== null) {
+    if (draftMode !== '0' && draftMode !== '1') {
+      throw new Error('Invalid draft mode header in Server Action response.')
+    }
+    setIsDraftMode(draftMode === '1')
+    action.didRevalidate = true
   }
 
   // Handle server actions that the server didn't recognize.
@@ -560,6 +576,14 @@ export function serverActionReducer(
       )
     },
     (e: any) => {
+      if (action.didRevalidate) {
+        // The draft cookie can change even if decoding the action response
+        // fails. Invalidate its old cache entries and let the normal cooldown
+        // restart queued prefetches.
+        invalidateBfCache()
+        invalidateEntirePrefetchCache(nextUrl, state.tree)
+        startRevalidationCooldown()
+      }
       // When the server action is rejected we don't update the state and instead call the reject handler of the promise.
       reject(e)
 

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -25,6 +25,7 @@ import { fetch } from './fetch'
 import {
   pingPrefetchTask,
   isPrefetchTaskDirty,
+  isPrefetchingAllowed,
   type PrefetchTask,
   type PrefetchSubtaskResult,
 } from './scheduler'
@@ -2446,13 +2447,14 @@ function readFulfilledStaleAt(
  * task's *other* fallback segments get re-attempted. If every attempt is
  * still a fallback (or fails), it gives up.
  *
- * A loop runs at most once per task, ever (fetchAndWritePerSegmentPrefetchResponse
- * gates on `fallbackRetryStatus === Empty`, set to `Pending` before this runs
- * and never reset to `Empty`). The sleep timer is never `clearTimeout`-ed, so
- * the awaited sleep always settles; the loop simply checks `isCanceled` after
- * waking and bails if the task was canceled in the meantime. On success the
- * status becomes `Fulfilled`; on any non-success exit (exhausted retries,
- * fetch error, or cancel) it becomes `Rejected`.
+ * A loop runs at most once per task, ever
+ * (fetchAndWritePerSegmentPrefetchResponse gates on `fallbackRetryStatus ===
+ * Empty`, set to `Pending` before this runs and never reset to `Empty`). The
+ * sleep timer is never `clearTimeout`-ed, so the awaited sleep always settles;
+ * the loop simply checks `isCanceled` and `isPrefetchingAllowed` after waking
+ * and bails if the task was canceled or prefetching was paused in the meantime.
+ * On success the status becomes `Fulfilled`; on any non-success exit (exhausted
+ * retries, fetch error, cancel, or pause) it becomes `Rejected`.
  */
 async function retryUpgradeableFallbackPrefetch(
   task: PrefetchTask,
@@ -2467,7 +2469,7 @@ async function retryUpgradeableFallbackPrefetch(
     await new Promise<void>((resolve) =>
       setTimeout(resolve, FALLBACK_RETRY_DELAY_MS)
     )
-    if (task.isCanceled) {
+    if (task.isCanceled || !isPrefetchingAllowed(task)) {
       break
     }
 
@@ -2512,7 +2514,8 @@ async function retryUpgradeableFallbackPrefetch(
   }
 
   // The loop finished without success (exhausted its retries, broke out on a
-  // fetch error, or the task was canceled). It won't run again for this task.
+  // fetch error, the task was canceled, or prefetching was paused). It won't
+  // run again for this task.
   task.fallbackRetryStatus = EntryStatus.Rejected
 }
 

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -298,6 +298,18 @@ export function startRevalidationCooldown(): void {
   }, REVALIDATION_COOLDOWN_MS)
 }
 
+// Whether the browser session is in draft mode. Prefetching pauses while it is,
+// because a draft response must not be stored as speculative data. Null until
+// hydration reports the initial state; a Server Action that writes the draft
+// cookie updates it from its response headers. The state lives here, not in the
+// router state, because the cookie still changes when a navigation discards the
+// action's render result.
+let isDraftMode: boolean | null = null
+
+export function setIsDraftMode(value: boolean): void {
+  isDraftMode = value
+}
+
 export type IncludeDynamicData = null | 'full' | 'dynamic'
 
 /**
@@ -478,6 +490,24 @@ export function pingPrefetchScheduler() {
   scheduleMicrotask(processQueueInMicrotask)
 }
 
+export function isPrefetchingAllowed(task: PrefetchTask): boolean {
+  if (
+    process.env.__NEXT_EXPOSE_TESTING_API &&
+    task._navigationLockPrefetch != null
+  ) {
+    // The testing API uses this task to fulfill a navigation, not to fetch
+    // speculative data. Blocking it would leave that navigation waiting
+    // forever.
+    return true
+  }
+  if (isDraftMode === null) {
+    throw new Error(
+      'Internal Next.js error: Prefetch scheduled before hydration.'
+    )
+  }
+  return !isDraftMode
+}
+
 /**
  * Checks if we've exceeded the maximum number of concurrent prefetch requests,
  * to avoid saturating the browser's internal network queue. This is a
@@ -591,8 +621,27 @@ function processQueueInMicrotask() {
   const now = Date.now()
 
   // Process the task queue until we run out of network bandwidth.
+  let pausedTasks: PrefetchTask[] | null = null
   let task = heapPeek(taskHeap)
-  while (task !== null && hasNetworkBandwidth(task)) {
+  processTasks: while (task !== null) {
+    if (!isPrefetchingAllowed(task)) {
+      if (process.env.__NEXT_EXPOSE_TESTING_API) {
+        // A navigation-testing task may be behind a paused Link prefetch. Keep
+        // the paused tasks out of this pass so they cannot block the
+        // navigation.
+        heapPop(taskHeap)
+        if (pausedTasks === null) {
+          pausedTasks = []
+        }
+        pausedTasks.push(task)
+        task = heapPeek(taskHeap)
+        continue
+      }
+      break
+    }
+    if (!hasNetworkBandwidth(task)) {
+      break
+    }
     task.routeCacheVersion = getCurrentRouteCacheVersion()
     task.segmentCacheVersion = getCurrentSegmentCacheVersion()
 
@@ -611,7 +660,7 @@ function processQueueInMicrotask() {
       case PrefetchTaskExitStatus.InProgress:
         // The task yielded because there are too many requests in progress.
         // Stop processing tasks until we have more bandwidth.
-        return
+        break processTasks
       case PrefetchTaskExitStatus.Blocked:
         // The task is blocked. It needs more data before it can proceed.
         // Keep the task out of the queue until the server responds.
@@ -694,11 +743,21 @@ function processQueueInMicrotask() {
     }
   }
 
-  // Run LRU cleanup only when the scheduler is fully idle: no queued tasks and
-  // no in-progress requests. At that point, all active prefetch tasks have
+  if (pausedTasks !== null) {
+    for (const pausedTask of pausedTasks) {
+      heapPush(taskHeap, pausedTask)
+    }
+    task = heapPeek(taskHeap)
+  }
+
+  // Run LRU cleanup only when the scheduler is fully idle: no runnable tasks
+  // and no in-progress requests. At that point, all active prefetch tasks have
   // finished reading from the cache (moving recently used entries to the front
   // of the list), so only genuinely stale data gets evicted.
-  if (task === null && inProgressRequests === 0) {
+  if (
+    inProgressRequests === 0 &&
+    (task === null || !isPrefetchingAllowed(task))
+  ) {
     cleanup()
   }
 }

--- a/packages/next/src/client/flight-data-helpers.ts
+++ b/packages/next/src/client/flight-data-helpers.ts
@@ -50,6 +50,7 @@ export function createInitialRSCPayloadFromFallbackPrerender(
   const canonicalUrl = createHrefFromUrl(new URL(location.href))
   const fallbackTransportData = fallbackInitialRSCPayload.t
   const payload: InitialRSCPayload = {
+    D: fallbackInitialRSCPayload.D,
     c: canonicalUrl.split('/'),
     q: renderedSearch,
     i: fallbackInitialRSCPayload.i,

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -15,6 +15,7 @@ import {
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_URL,
   NEXT_ACTION_REVALIDATED_HEADER,
+  NEXT_ACTION_DRAFT_MODE_HEADER,
 } from '../../client/components/app-router-headers'
 import {
   getAccessFallbackHTTPStatus,
@@ -79,6 +80,7 @@ import {
   ActionDidRevalidateStaticAndDynamic,
 } from '../../shared/lib/action-revalidation-kind'
 import { computeCacheBustingSearchParam } from '../../shared/lib/router/utils/cache-busting-search-param'
+import { COOKIE_NAME_PRERENDER_BYPASS } from '../api-utils'
 
 const INLINE_ACTION_PREFIX = '$$RSC_SERVER_ACTION_'
 
@@ -158,7 +160,7 @@ function getForwardedHeaders(
   return new Headers(mergedHeaders)
 }
 
-function addRevalidationHeader(
+function addActionResponseHeaders(
   res: BaseNextResponse,
   {
     workStore,
@@ -190,11 +192,22 @@ function addRevalidationHeader(
   )
     ? 1
     : 0
-  const isCookieRevalidated = getModifiedCookieValues(
-    requestStore.mutableCookies
-  ).length
-    ? 1
-    : 0
+  const modifiedCookies = getModifiedCookieValues(requestStore.mutableCookies)
+  const isCookieRevalidated = modifiedCookies.length ? 1 : 0
+
+  // Report draft mode only when this action writes its cookie. An unrelated
+  // action can finish after a mode change and still have the old request's
+  // draft state.
+  if (
+    modifiedCookies.some(
+      (cookie) => cookie.name === COOKIE_NAME_PRERENDER_BYPASS
+    )
+  ) {
+    res.setHeader(
+      NEXT_ACTION_DRAFT_MODE_HEADER,
+      requestStore.draftMode.isEnabled ? '1' : '0'
+    )
+  }
 
   // First check if a tag, cookie, or path was revalidated.
   if (isTagRevalidated || isCookieRevalidated) {
@@ -299,6 +312,11 @@ async function createForwardedActionResponse(
     if (
       response.headers.get('content-type')?.startsWith(RSC_CONTENT_TYPE_HEADER)
     ) {
+      // Forward cookie changes together with the action's revalidation and
+      // draft-mode headers.
+      for (const cookie of response.headers.getSetCookie()) {
+        res.appendHeader('set-cookie', cookie)
+      }
       // copy the headers from the redirect response to the response we're sending
       for (const [key, value] of response.headers) {
         if (!actionsForbiddenHeaders.includes(key)) {
@@ -1284,7 +1302,7 @@ export async function handleAction({
             requestStore,
             shouldSkipPageRendering
           ).finally(() => {
-            addRevalidationHeader(res, { workStore, requestStore })
+            addActionResponseHeaders(res, { workStore, requestStore })
             if (logInfo) {
               // Store server action log info to be logged after the request log
               const duration = Math.round(performance.now() - startTime)

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -246,6 +246,7 @@ import { runInSequentialTasks } from './app-render-render-utils'
 import { waitAtLeastOneReactRenderTask } from '../../lib/scheduler'
 import {
   getHmrRefreshHash,
+  throwInvariantForMissingStore,
   workUnitAsyncStorage,
   type PrerenderStore,
 } from './work-unit-async-storage.external'
@@ -2139,6 +2140,34 @@ function getRenderedSearch(query: NextParsedUrlQuery): string {
   return '?' + pairs.join('&')
 }
 
+function getInitialDraftMode(workStore: WorkStore): boolean {
+  const workUnitStore = workUnitAsyncStorage.getStore()
+  if (!workUnitStore) {
+    throwInvariantForMissingStore()
+  }
+
+  switch (workUnitStore.type) {
+    case 'request':
+    case 'prerender-runtime':
+      // These stores carry the request's validated draft-cookie state. The Edge
+      // SSR entrypoint sets renderOpts.isDraftMode to false, so
+      // workStore.isDraftMode can be false even when the request is in draft
+      // mode.
+      return workUnitStore.draftMode.isEnabled
+    case 'prerender':
+    case 'prerender-client':
+    case 'prerender-legacy':
+    case 'validation-client':
+    case 'cache':
+    case 'private-cache':
+    case 'unstable-cache':
+    case 'generate-static-params':
+      return workStore.isDraftMode === true
+    default:
+      return workUnitStore satisfies never
+  }
+}
+
 // This is the data necessary to render <AppRouter /> when no SSR errors are encountered
 async function getRSCPayload(
   tree: LoaderTree,
@@ -2266,6 +2295,7 @@ async function getRSCPayload(
     P: createElement(Preloads, {
       preloadCallbacks: preloadCallbacks,
     }),
+    D: getInitialDraftMode(ctx.workStore),
     c: prepareInitialCanonicalUrl(url),
     q: getRenderedSearch(query),
     i: !!couldBeIntercepted,
@@ -2415,6 +2445,7 @@ async function getErrorRSCPayload(
   const isPossiblyPartialHead = ctx.renderCapabilities.isPossiblyPartialResponse
 
   return maybeAppendBuildIdToRSCPayload(ctx, {
+    D: getInitialDraftMode(ctx.workStore),
     c: prepareInitialCanonicalUrl(url),
     q: getRenderedSearch(query),
     m: undefined,

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -385,6 +385,10 @@ export type PrefetchHints = {
 export type ActionResult = Promise<any>
 
 export type InitialRSCPayload = {
+  /**
+   * isDraftMode
+   */
+  D: boolean
   /** buildId, can be empty if the x-nextjs-build-id header is set */
   b?: string
   /** initialCanonicalUrlParts */

--- a/test/e2e/app-dir/draft-mode-prefetch-edge/app/article/[slug]/page.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch-edge/app/article/[slug]/page.tsx
@@ -1,0 +1,16 @@
+import { draftMode } from 'next/headers'
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const { isEnabled } = await draftMode()
+
+  return (
+    <p id="target-content">
+      {`${isEnabled ? 'Draft' : 'Published'} content: ${slug}`}
+    </p>
+  )
+}

--- a/test/e2e/app-dir/draft-mode-prefetch-edge/app/article/loading.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch-edge/app/article/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>Loading article...</p>
+}

--- a/test/e2e/app-dir/draft-mode-prefetch-edge/app/draft/route.ts
+++ b/test/e2e/app-dir/draft-mode-prefetch-edge/app/draft/route.ts
@@ -1,0 +1,10 @@
+import { draftMode } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+export const runtime = 'edge'
+
+export async function GET(request: Request) {
+  const draft = await draftMode()
+  draft.enable()
+  redirect(new URL(request.url).searchParams.has('error') ? '/error' : '/')
+}

--- a/test/e2e/app-dir/draft-mode-prefetch-edge/app/error/page.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch-edge/app/error/page.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function Page(): never {
+  throw new Error('Edge page render error')
+}

--- a/test/e2e/app-dir/draft-mode-prefetch-edge/app/global-error.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch-edge/app/global-error.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { Links } from './links'
+
+export default function GlobalError() {
+  return (
+    <html>
+      <body>
+        <h1>Edge global error</h1>
+        <Links />
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/draft-mode-prefetch-edge/app/layout.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch-edge/app/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react'
+
+export const runtime = 'edge'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/draft-mode-prefetch-edge/app/links.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch-edge/app/links.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState, type ReactNode } from 'react'
+
+function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        aria-label={`Show ${href}`}
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <span>{children} (link is hidden)</span>
+      )}
+    </>
+  )
+}
+
+export function Links() {
+  return (
+    <nav>
+      <LinkAccordion href="/article/auto">Automatic prefetch</LinkAccordion>
+      <LinkAccordion href="/article/full" prefetch={true}>
+        Full prefetch
+      </LinkAccordion>
+    </nav>
+  )
+}

--- a/test/e2e/app-dir/draft-mode-prefetch-edge/app/page.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch-edge/app/page.tsx
@@ -1,0 +1,16 @@
+import { draftMode } from 'next/headers'
+import { Links } from './links'
+
+export default async function Page() {
+  const { isEnabled } = await draftMode()
+
+  return (
+    <>
+      <h1>Edge page</h1>
+      <p id="draft-mode">
+        {`Draft mode: ${isEnabled ? 'enabled' : 'disabled'}`}
+      </p>
+      <Links />
+    </>
+  )
+}

--- a/test/e2e/app-dir/draft-mode-prefetch-edge/draft-mode-prefetch-edge.test.ts
+++ b/test/e2e/app-dir/draft-mode-prefetch-edge/draft-mode-prefetch-edge.test.ts
@@ -1,0 +1,104 @@
+import { nextTestSetup } from 'e2e-utils'
+import { createRouterAct } from 'router-act'
+
+// @force-gate prefetching
+describe('draft-mode-prefetch-edge', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  let browserForCleanup: Awaited<ReturnType<typeof next.browser>> | undefined
+  afterEach(async () => {
+    if (browserForCleanup !== undefined) {
+      await browserForCleanup.deleteCookies()
+      browserForCleanup = undefined
+    }
+  })
+
+  async function startBrowser(url: string) {
+    let act: ReturnType<typeof createRouterAct> | undefined
+    const browser = await next.browser(url, {
+      beforePageLoad(page) {
+        act = createRouterAct(page, { includeAppShellRequests: true })
+      },
+    })
+    browserForCleanup = browser
+    if (act === undefined) {
+      throw new Error('Router act was not initialized')
+    }
+    await browser.eval('window.__testDocument = "retained"')
+    return { browser, act }
+  }
+
+  describe.each([
+    {
+      name: 'initial document',
+      pathname: '/',
+      enablePathname: '/draft',
+      heading: 'Edge page',
+    },
+    {
+      name: 'initial error document',
+      pathname: '/error',
+      enablePathname: '/draft?error',
+      heading: 'Edge global error',
+    },
+  ])('$name', ({ pathname, enablePathname, heading }) => {
+    it('prefetches automatic and full Links when draft mode is disabled', async () => {
+      const { browser, act } = await startBrowser(pathname)
+      expect(await browser.elementByCss('h1').text()).toBe(heading)
+      if (pathname === '/') {
+        expect(await browser.elementById('draft-mode').text()).toBe(
+          'Draft mode: disabled'
+        )
+      }
+
+      await act(async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/article/auto"]')
+          .click()
+      })
+      await act(
+        async () => {
+          await browser
+            .elementByCss('input[data-link-accordion="/article/full"]')
+            .click()
+        },
+        { includes: 'Published content: full' }
+      )
+    })
+
+    it('suppresses draft-mode prefetches and hover without preventing SPA navigation', async () => {
+      const { browser, act } = await startBrowser(enablePathname)
+      expect(new URL(await browser.url()).pathname).toBe(pathname)
+      expect(await browser.elementByCss('h1').text()).toBe(heading)
+      if (pathname === '/') {
+        expect(await browser.elementById('draft-mode').text()).toBe(
+          'Draft mode: enabled'
+        )
+      }
+
+      for (const target of ['auto', 'full']) {
+        await act(async () => {
+          await browser
+            .elementByCss(`input[data-link-accordion="/article/${target}"]`)
+            .click()
+        }, 'no-requests')
+        await act(async () => {
+          await browser.locator(`a[href="/article/${target}"]`).hover()
+        }, 'no-requests')
+      }
+
+      await act(
+        async () => {
+          await browser.elementByCss('a[href="/article/full"]').click()
+        },
+        { includes: 'Draft content: full' }
+      )
+      expect(await browser.elementById('target-content').text()).toBe(
+        'Draft content: full'
+      )
+      expect(await browser.eval('window.__testDocument')).toBe('retained')
+    })
+  })
+})

--- a/test/e2e/app-dir/draft-mode-prefetch-edge/next.config.ts
+++ b/test/e2e/app-dir/draft-mode-prefetch-edge/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: false,
+  partialPrefetching: false,
+  experimental: { cachedNavigations: false },
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/draft-mode-prefetch/app/actions.ts
+++ b/test/e2e/app-dir/draft-mode-prefetch/app/actions.ts
@@ -1,0 +1,24 @@
+'use server'
+
+import { draftMode } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+export async function enableDraftMode() {
+  const draft = await draftMode()
+  draft.enable()
+}
+
+export async function disableDraftMode() {
+  const draft = await draftMode()
+  draft.disable()
+}
+
+export async function enableDraftModeAndRedirect() {
+  const draft = await draftMode()
+  draft.enable()
+  redirect('/article/redirect')
+}
+
+export async function unrelatedAction() {
+  return 'Unrelated action done'
+}

--- a/test/e2e/app-dir/draft-mode-prefetch/app/article/[slug]/page.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch/app/article/[slug]/page.tsx
@@ -1,0 +1,36 @@
+import { draftMode } from 'next/headers'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+async function Content({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const { isEnabled } = await draftMode()
+
+  return (
+    <>
+      <p id="target-content">
+        {`${isEnabled ? 'Draft' : 'Published'} content: ${slug}`}
+      </p>
+      <Suspense fallback={<p>Loading dynamic content...</p>}>
+        <DynamicContent />
+      </Suspense>
+    </>
+  )
+}
+
+async function DynamicContent() {
+  await connection()
+  return <p id="dynamic-content">Dynamic content</p>
+}
+
+export default function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  return (
+    <Suspense fallback={<p>Loading target content...</p>}>
+      <Content params={params} />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/draft-mode-prefetch/app/article/loading.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch/app/article/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>Loading target...</p>
+}

--- a/test/e2e/app-dir/draft-mode-prefetch/app/controls.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch/app/controls.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import {
+  disableDraftMode,
+  enableDraftMode,
+  enableDraftModeAndRedirect,
+  unrelatedAction,
+} from './actions'
+import { LinkAccordion } from './link-accordion'
+
+export function Controls() {
+  const router = useRouter()
+  const [actionResult, setActionResult] = useState<string | null>(null)
+
+  return (
+    <>
+      <form action={enableDraftMode}>
+        <button id="enable-draft-mode">Enable draft mode</button>
+      </form>
+      <form action={disableDraftMode}>
+        <button id="disable-draft-mode">Disable draft mode</button>
+      </form>
+      <button
+        id="disable-with-catch"
+        onClick={async () => {
+          try {
+            await disableDraftMode()
+          } catch {
+            setActionResult('Action response failed')
+          }
+        }}
+      >
+        Disable draft mode and catch errors
+      </button>
+      <form action={enableDraftModeAndRedirect}>
+        <button id="enable-and-redirect">Enable draft mode and redirect</button>
+      </form>
+      <button
+        id="unrelated-action"
+        onClick={async () => setActionResult(await unrelatedAction())}
+      >
+        Run unrelated action
+      </button>
+      <p id="action-result">{actionResult}</p>
+      <div>
+        <LinkAccordion href="/article/foreground" prefetch={false}>
+          Navigate without prefetching
+        </LinkAccordion>
+      </div>
+      <div>
+        <LinkAccordion href="/article/auto">Auto target</LinkAccordion>
+      </div>
+      <div>
+        <LinkAccordion href="/article/full" prefetch={true}>
+          Full target
+        </LinkAccordion>
+      </div>
+      <div>
+        <LinkAccordion href="/article/retained" prefetch={true}>
+          Retained target
+        </LinkAccordion>
+      </div>
+      <button
+        id="router-prefetch"
+        onClick={() => router.prefetch('/article/imperative')}
+      >
+        Prefetch imperative target
+      </button>
+      <fieldset>
+        <legend>Queued prefetches</legend>
+        {Array.from({ length: 9 }, (_, index) => (
+          <div key={index}>
+            <LinkAccordion href={`/article/queued-${index}`} prefetch={true}>
+              Queued target {index}
+            </LinkAccordion>
+          </div>
+        ))}
+      </fieldset>
+    </>
+  )
+}

--- a/test/e2e/app-dir/draft-mode-prefetch/app/draft/route.ts
+++ b/test/e2e/app-dir/draft-mode-prefetch/app/draft/route.ts
@@ -1,0 +1,8 @@
+import { draftMode } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+export async function GET() {
+  const draft = await draftMode()
+  draft.enable()
+  redirect('/')
+}

--- a/test/e2e/app-dir/draft-mode-prefetch/app/forwarded/action-target/page.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch/app/forwarded/action-target/page.tsx
@@ -1,0 +1,28 @@
+import { draftMode } from 'next/headers'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+import { RetainedActionControls } from '../retained-actions'
+
+async function Mode() {
+  await connection()
+  const { isEnabled } = await draftMode()
+  return (
+    <p id="forwarded-target-mode">
+      {isEnabled
+        ? 'Forwarded target draft mode: enabled'
+        : 'Forwarded target draft mode: disabled'}
+    </p>
+  )
+}
+
+export default function Page() {
+  return (
+    <>
+      <h1>Forwarded target</h1>
+      <Suspense fallback={<p>Loading forwarded draft mode...</p>}>
+        <Mode />
+      </Suspense>
+      <RetainedActionControls />
+    </>
+  )
+}

--- a/test/e2e/app-dir/draft-mode-prefetch/app/forwarded/layout.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch/app/forwarded/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react'
+import { RetainedActionsProvider } from './retained-actions'
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <RetainedActionsProvider>{children}</RetainedActionsProvider>
+}

--- a/test/e2e/app-dir/draft-mode-prefetch/app/forwarded/retained-actions.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch/app/forwarded/retained-actions.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react'
+import { LinkAccordion } from '../link-accordion'
+
+type RetainedActions = {
+  enable: () => Promise<void>
+  disable: () => Promise<void>
+  enableAndRedirect: () => Promise<void>
+}
+
+const RetainedActionsContext = createContext<{
+  actions: RetainedActions | null
+  setActions: (actions: RetainedActions) => void
+} | null>(null)
+
+export function RetainedActionsProvider({ children }: { children: ReactNode }) {
+  const [actions, setActions] = useState<RetainedActions | null>(null)
+
+  return (
+    <RetainedActionsContext.Provider value={{ actions, setActions }}>
+      {children}
+    </RetainedActionsContext.Provider>
+  )
+}
+
+export function RegisterActions({ actions }: { actions: RetainedActions }) {
+  const context = useContext(RetainedActionsContext)
+  if (context === null) {
+    throw new Error('RegisterActions requires RetainedActionsProvider')
+  }
+  const { setActions } = context
+
+  useEffect(() => {
+    // Keep the action references after the source page unmounts.
+    setActions(actions)
+  }, [actions, setActions])
+
+  return context.actions === null ? null : (
+    <p id="forwarded-actions-ready">Forwarded actions registered</p>
+  )
+}
+
+export function RetainedActionControls() {
+  const context = useContext(RetainedActionsContext)
+  if (context === null) {
+    throw new Error('RetainedActionControls requires RetainedActionsProvider')
+  }
+  const { actions } = context
+  if (actions === null) {
+    return <p>Visit the source page to register its actions.</p>
+  }
+
+  return (
+    <>
+      <div>
+        <LinkAccordion href="/article/forwarded-retained" prefetch={true}>
+          Forwarded retained target
+        </LinkAccordion>
+      </div>
+      <form action={actions.enable}>
+        <button id="forwarded-enable-draft-mode">Enable draft mode</button>
+      </form>
+      <form action={actions.disable}>
+        <button id="forwarded-disable-draft-mode">Disable draft mode</button>
+      </form>
+      <form action={actions.enableAndRedirect}>
+        <button id="forwarded-enable-and-redirect">
+          Enable draft mode and redirect
+        </button>
+      </form>
+    </>
+  )
+}

--- a/test/e2e/app-dir/draft-mode-prefetch/app/forwarded/source/actions.ts
+++ b/test/e2e/app-dir/draft-mode-prefetch/app/forwarded/source/actions.ts
@@ -1,0 +1,29 @@
+'use server'
+
+import { draftMode, headers } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+export async function enableDraftMode() {
+  await assertForwarded()
+  const draft = await draftMode()
+  draft.enable()
+}
+
+export async function disableDraftMode() {
+  await assertForwarded()
+  const draft = await draftMode()
+  draft.disable()
+}
+
+export async function enableDraftModeAndRedirect() {
+  await assertForwarded()
+  const draft = await draftMode()
+  draft.enable()
+  redirect('/article/forwarded-redirect')
+}
+
+async function assertForwarded() {
+  if ((await headers()).get('x-action-forwarded') !== '1') {
+    throw new Error('Expected this action to run on the forwarded worker')
+  }
+}

--- a/test/e2e/app-dir/draft-mode-prefetch/app/forwarded/source/page.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch/app/forwarded/source/page.tsx
@@ -1,0 +1,25 @@
+import { LinkAccordion } from '../../link-accordion'
+import { RegisterActions } from '../retained-actions'
+import {
+  disableDraftMode,
+  enableDraftMode,
+  enableDraftModeAndRedirect,
+} from './actions'
+
+export default function Page() {
+  return (
+    <>
+      <h1>Forwarded source</h1>
+      <RegisterActions
+        actions={{
+          enable: enableDraftMode,
+          disable: disableDraftMode,
+          enableAndRedirect: enableDraftModeAndRedirect,
+        }}
+      />
+      <LinkAccordion href="/forwarded/action-target" prefetch={false}>
+        Forwarded target
+      </LinkAccordion>
+    </>
+  )
+}

--- a/test/e2e/app-dir/draft-mode-prefetch/app/layout.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch/app/layout.tsx
@@ -1,0 +1,28 @@
+import { draftMode } from 'next/headers'
+import { connection } from 'next/server'
+import { Suspense, type ReactNode } from 'react'
+import { Controls } from './controls'
+
+async function Mode() {
+  await connection()
+  const { isEnabled } = await draftMode()
+  return (
+    <p id="draft-mode">
+      {isEnabled ? 'Draft mode: enabled' : 'Draft mode: disabled'}
+    </p>
+  )
+}
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <Suspense fallback={<p>Loading draft mode...</p>}>
+          <Mode />
+        </Suspense>
+        <Controls />
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/draft-mode-prefetch/app/link-accordion.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch/app/link-accordion.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState, type ReactNode } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+
+  return (
+    <>
+      <input
+        type="checkbox"
+        aria-label={`Show ${href}`}
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <span>{children} (link is hidden)</span>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/draft-mode-prefetch/app/page.tsx
+++ b/test/e2e/app-dir/draft-mode-prefetch/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Draft mode prefetching</h1>
+}

--- a/test/e2e/app-dir/draft-mode-prefetch/draft-mode-prefetch.test.ts
+++ b/test/e2e/app-dir/draft-mode-prefetch/draft-mode-prefetch.test.ts
@@ -1,0 +1,585 @@
+import { nextTestSetup } from 'e2e-utils'
+import { createRouterAct } from 'router-act'
+import type * as Playwright from 'playwright'
+import { instant } from '@next/playwright'
+
+// @force-gate prefetching
+describe.each([
+  { cacheComponents: false, partialPrefetching: false },
+  { cacheComponents: true, partialPrefetching: false },
+  { cacheComponents: true, partialPrefetching: true },
+])(
+  'draft-mode-prefetch - Cache Components: $cacheComponents, Partial Prefetching: $partialPrefetching',
+  ({ cacheComponents, partialPrefetching }) => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      nextConfig: {
+        cacheComponents,
+        partialPrefetching,
+        experimental: {
+          cachedNavigations: cacheComponents,
+          exposeTestingApiInProductionBuild: true,
+        },
+      },
+    })
+
+    async function startBrowser(url: string) {
+      let act: ReturnType<typeof createRouterAct> | undefined
+      let page: Playwright.Page | undefined
+      const browser = await next.browser(url, {
+        // A new permissions array makes the harness create a fresh context, so
+        // neither a paused clock nor the draft cookie can carry over from the
+        // previous test.
+        permissions: [],
+        beforePageLoad(browserPage) {
+          page = browserPage
+          // Suppression must also cover App Shell requests (prefetch header 3).
+          act = createRouterAct(page, { includeAppShellRequests: true })
+        },
+      })
+      if (act === undefined || page === undefined) {
+        throw new Error('Router act was not initialized')
+      }
+      await browser.eval('window.__testDocument = "retained"')
+      return { browser, act, page }
+    }
+
+    async function queuePrefetches({
+      browser,
+      act,
+    }: Awaited<ReturnType<typeof startBrowser>>) {
+      // Hold enough responses to fill the scheduler's viewport request limit.
+      await act(async () => {
+        for (let index = 0; index < 8; index++) {
+          await browser
+            .elementByCss(
+              `input[data-link-accordion="/article/queued-${index}"]`
+            )
+            .click()
+        }
+      }, 'block')
+
+      // This link must wait for the responses held by the outer act scope.
+      await act(async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/article/queued-8"]')
+          .click()
+      }, 'no-requests')
+    }
+
+    describe.each([
+      {
+        name: 'auto Link',
+        selector: 'input[data-link-accordion="/article/auto"]',
+      },
+      {
+        name: 'prefetch=true Link',
+        selector: 'input[data-link-accordion="/article/full"]',
+      },
+      { name: 'router.prefetch', selector: '#router-prefetch' },
+    ])('$name', ({ selector }) => {
+      it('issues prefetch requests when draft mode is disabled', async () => {
+        const { browser, act } = await startBrowser('/')
+        expect(await browser.elementById('draft-mode').text()).toBe(
+          'Draft mode: disabled'
+        )
+
+        // No navigation occurs, so these requests must come from prefetching.
+        await act(async () => {
+          await browser.elementByCss(selector).click()
+        })
+      })
+    })
+
+    it('suppresses initial draft-mode prefetches and hover without preventing SPA navigation', async () => {
+      const { browser, act } = await startBrowser('/draft')
+      expect(new URL(await browser.url()).pathname).toBe('/')
+      expect(await browser.elementById('draft-mode').text()).toBe(
+        'Draft mode: enabled'
+      )
+
+      for (const target of ['auto', 'full']) {
+        await act(async () => {
+          await browser
+            .elementByCss(`input[data-link-accordion="/article/${target}"]`)
+            .click()
+        }, 'no-requests')
+        await act(async () => {
+          await browser.locator(`a[href="/article/${target}"]`).hover()
+        }, 'no-requests')
+      }
+      await act(async () => {
+        await browser.elementById('router-prefetch').click()
+      }, 'no-requests')
+
+      await act(
+        async () => {
+          await browser.elementByCss('a[href="/article/full"]').click()
+        },
+        { includes: 'Draft content: full' }
+      )
+      expect(await browser.elementById('target-content').text()).toBe(
+        'Draft content: full'
+      )
+      expect(await browser.eval('window.__testDocument')).toBe('retained')
+      await act(async () => {
+        await browser.locator('a[href="/article/auto"]').hover()
+        await browser.elementById('router-prefetch').click()
+      }, 'no-requests')
+    })
+
+    it('updates prefetch suppression before Server Action invalidation and resumes an open Link after disabling', async () => {
+      const { browser, act, page } = await startBrowser('/')
+      expect(await browser.elementById('draft-mode').text()).toBe(
+        'Draft mode: disabled'
+      )
+
+      await act(
+        async () => {
+          await browser
+            .elementByCss('input[data-link-accordion="/article/retained"]')
+            .click()
+        },
+        { includes: 'Published content: retained' }
+      )
+      await pauseClock(page)
+
+      // Only the action request is allowed. Its response must disable
+      // prefetching before cache invalidation reschedules visible links.
+      await act(async () => {
+        await act(
+          async () => {
+            await browser.elementById('enable-draft-mode').click()
+          },
+          { includes: 'Draft mode: enabled', block: true }
+        )
+      }, 'no-requests')
+      // Expiring the action's cooldown must not resume prefetches in draft
+      // mode.
+      await act(async () => {
+        await page.clock.fastForward(300)
+      }, 'no-requests')
+      expect(await browser.elementById('draft-mode').text()).toBe(
+        'Draft mode: enabled'
+      )
+      expect(
+        await browser.hasElementByCssSelector(
+          'input[data-link-accordion="/article/retained"]:checked'
+        )
+      ).toBe(true)
+      expect(await browser.eval('window.__testDocument')).toBe('retained')
+
+      await act(async () => {
+        await browser.locator('a[href="/article/retained"]').hover()
+        await browser.elementById('router-prefetch').click()
+      }, 'no-requests')
+
+      // The retained Link must resume without a remount, another hover, or a
+      // document reload.
+      await act(
+        async () => {
+          await browser.elementById('disable-draft-mode').click()
+        },
+        { includes: 'Draft mode: disabled' }
+      )
+      // Re-prefetching resumes through the existing revalidation cooldown.
+      await act(
+        async () => {
+          await page.clock.fastForward(300)
+        },
+        { includes: 'Published content: retained' }
+      )
+      expect(await browser.elementById('draft-mode').text()).toBe(
+        'Draft mode: disabled'
+      )
+      expect(
+        await browser.hasElementByCssSelector(
+          'input[data-link-accordion="/article/retained"]:checked'
+        )
+      ).toBe(true)
+      expect(await browser.eval('window.__testDocument')).toBe('retained')
+    })
+
+    it('suppresses prefetches after a redirecting Server Action enables draft mode', async () => {
+      const { browser, act, page } = await startBrowser('/')
+      expect(await browser.elementById('draft-mode').text()).toBe(
+        'Draft mode: disabled'
+      )
+      await pauseClock(page)
+
+      await act(
+        async () => {
+          await browser.elementById('enable-and-redirect').click()
+        },
+        { includes: 'Draft content: redirect' }
+      )
+      expect(new URL(await browser.url()).pathname).toBe('/article/redirect')
+      expect(await browser.elementById('draft-mode').text()).toBe(
+        'Draft mode: enabled'
+      )
+      expect(await browser.elementById('target-content').text()).toBe(
+        'Draft content: redirect'
+      )
+      expect(await browser.eval('window.__testDocument')).toBe('retained')
+
+      await act(async () => {
+        await page.clock.fastForward(300)
+        await browser
+          .elementByCss('input[data-link-accordion="/article/full"]')
+          .click()
+        await browser.locator('a[href="/article/full"]').hover()
+        await browser.elementById('router-prefetch').click()
+      }, 'no-requests')
+    })
+
+    it('finishes queued prefetches when draft mode remains disabled', async () => {
+      const session = await startBrowser('/')
+      expect(await session.browser.elementById('draft-mode').text()).toBe(
+        'Draft mode: disabled'
+      )
+
+      await session.act(
+        async () => {
+          await queuePrefetches(session)
+        },
+        { includes: 'Published content: queued-8' }
+      )
+    })
+
+    it('does not reset draft mode when an earlier unrelated action finishes', async () => {
+      const { browser, act, page } = await startBrowser('/')
+      await pauseClock(page)
+
+      await act(async () => {
+        await act(
+          async () => {
+            await browser.elementById('unrelated-action').click()
+          },
+          { includes: 'Unrelated action done', block: true }
+        )
+
+        await act(
+          async () => {
+            await browser
+              .elementByCss('input[data-link-accordion="/article/foreground"]')
+              .click()
+            await browser.elementByCss('a[href="/article/foreground"]').click()
+          },
+          { includes: 'Published content: foreground' }
+        )
+
+        await act(
+          async () => {
+            await browser.elementById('enable-draft-mode').click()
+          },
+          { includes: 'Draft mode: enabled' }
+        )
+      }, 'no-requests')
+
+      expect(await browser.elementById('action-result').text()).toBe(
+        'Unrelated action done'
+      )
+      expect(await browser.elementById('draft-mode').text()).toBe(
+        'Draft mode: enabled'
+      )
+      await act(async () => {
+        await page.clock.fastForward(300)
+        await browser
+          .elementByCss('input[data-link-accordion="/article/full"]')
+          .click()
+        await browser.elementById('router-prefetch').click()
+      }, 'no-requests')
+    })
+
+    it('suppresses and resumes prefetches after forwarded draft-mode actions', async () => {
+      const { browser, act, page } = await startBrowser('/forwarded/source')
+      expect(await browser.elementById('forwarded-actions-ready').text()).toBe(
+        'Forwarded actions registered'
+      )
+
+      // Only the source worker has these action IDs. The shared layout retains
+      // their references after navigation.
+      await act(
+        async () => {
+          await browser
+            .elementByCss(
+              'input[data-link-accordion="/forwarded/action-target"]'
+            )
+            .click()
+          await browser
+            .elementByCss('a[href="/forwarded/action-target"]')
+            .click()
+        },
+        { includes: 'Forwarded target draft mode: disabled' }
+      )
+      expect(new URL(await browser.url()).pathname).toBe(
+        '/forwarded/action-target'
+      )
+
+      const actionPaths: string[] = []
+      page.on('request', (request) => {
+        if (request.method() === 'POST' && request.headers()['next-action']) {
+          actionPaths.push(new URL(request.url()).pathname)
+        }
+      })
+
+      await act(
+        async () => {
+          await browser
+            .elementByCss(
+              'input[data-link-accordion="/article/forwarded-retained"]'
+            )
+            .click()
+        },
+        { includes: 'Published content: forwarded-retained' }
+      )
+      await pauseClock(page)
+
+      // The forwarded worker skips the page render. The target must read the
+      // updated cookie in a new request.
+      await act(
+        async () => {
+          await browser.elementById('forwarded-enable-draft-mode').click()
+        },
+        { includes: 'Forwarded target draft mode: enabled' }
+      )
+      expect(await browser.elementById('forwarded-target-mode').text()).toBe(
+        'Forwarded target draft mode: enabled'
+      )
+      expect(new URL(await browser.url()).pathname).toBe(
+        '/forwarded/action-target'
+      )
+
+      await act(async () => {
+        await page.clock.fastForward(300)
+        await browser.locator('a[href="/article/forwarded-retained"]').hover()
+      }, 'no-requests')
+
+      await act(
+        async () => {
+          await browser.elementById('forwarded-disable-draft-mode').click()
+        },
+        { includes: 'Forwarded target draft mode: disabled' }
+      )
+      expect(await browser.elementById('forwarded-target-mode').text()).toBe(
+        'Forwarded target draft mode: disabled'
+      )
+
+      // The retained Link resumes through the native revalidation cooldown
+      // without another hover or remount.
+      await act(
+        async () => {
+          await page.clock.fastForward(300)
+        },
+        { includes: 'Published content: forwarded-retained' }
+      )
+      expect(
+        await browser.hasElementByCssSelector(
+          'input[data-link-accordion="/article/forwarded-retained"]:checked'
+        )
+      ).toBe(true)
+      expect(actionPaths).toEqual([
+        '/forwarded/action-target',
+        '/forwarded/action-target',
+      ])
+      expect(await browser.eval('window.__testDocument')).toBe('retained')
+    })
+
+    it('preserves draft mode after a forwarded action redirects', async () => {
+      const { browser, act, page } = await startBrowser('/forwarded/source')
+      expect(await browser.elementById('forwarded-actions-ready').text()).toBe(
+        'Forwarded actions registered'
+      )
+
+      await act(
+        async () => {
+          await browser
+            .elementByCss(
+              'input[data-link-accordion="/forwarded/action-target"]'
+            )
+            .click()
+          await browser
+            .elementByCss('a[href="/forwarded/action-target"]')
+            .click()
+        },
+        { includes: 'Forwarded target draft mode: disabled' }
+      )
+      expect(new URL(await browser.url()).pathname).toBe(
+        '/forwarded/action-target'
+      )
+      await pauseClock(page)
+
+      const actionRequest = page.waitForRequest(
+        (request) =>
+          request.method() === 'POST' &&
+          Boolean(request.headers()['next-action'])
+      )
+      await act(
+        async () => {
+          await browser.elementById('forwarded-enable-and-redirect').click()
+        },
+        { includes: 'Draft content: forwarded-redirect' }
+      )
+      expect(new URL((await actionRequest).url()).pathname).toBe(
+        '/forwarded/action-target'
+      )
+      expect(new URL(await browser.url()).pathname).toBe(
+        '/article/forwarded-redirect'
+      )
+      expect(await browser.elementById('target-content').text()).toBe(
+        'Draft content: forwarded-redirect'
+      )
+
+      await act(async () => {
+        await page.clock.fastForward(300)
+        await browser
+          .elementByCss('input[data-link-accordion="/article/full"]')
+          .click()
+        await browser.locator('a[href="/article/full"]').hover()
+        await browser.elementById('router-prefetch').click()
+      }, 'no-requests')
+
+      // A fresh navigation verifies the browser received the cookie, not just
+      // the redirected Flight data.
+      //
+      // TODO: Fix the adapter's rscSuffix query leak and restore the includes
+      // assertion. The first request asks for the article, since the client
+      // already has its shared layouts. The extra search parameter makes the
+      // returned page differ from the router's prediction. The retry renders
+      // the destination from the root layout, so both responses include the
+      // article.
+      await act(
+        async () => {
+          await browser.elementByCss('a[href="/article/full"]').click()
+        }
+        // , { includes: 'Draft content: full' }
+      )
+      expect(await browser.elementById('target-content').text()).toBe(
+        'Draft content: full'
+      )
+      expect(await browser.eval('window.__testDocument')).toBe('retained')
+    })
+
+    it('stops queued prefetches after a Server Action enables draft mode', async () => {
+      const session = await startBrowser('/')
+      const { browser, act, page } = session
+      expect(await browser.elementById('draft-mode').text()).toBe(
+        'Draft mode: disabled'
+      )
+
+      await act(async () => {
+        await queuePrefetches(session)
+        await pauseClock(page)
+
+        // Apply the action before the pending prefetch responses reach the
+        // client.
+        await act(async () => {
+          await act(
+            async () => {
+              await browser.elementById('enable-draft-mode').click()
+            },
+            { includes: 'Draft mode: enabled', block: true }
+          )
+        }, 'no-requests')
+        await act(async () => {
+          await page.clock.fastForward(300)
+        }, 'no-requests')
+        expect(await browser.elementById('draft-mode').text()).toBe(
+          'Draft mode: enabled'
+        )
+      }, 'no-requests')
+
+      expect(
+        await browser.hasElementByCssSelector(
+          'input[data-link-accordion="/article/queued-8"]:checked'
+        )
+      ).toBe(true)
+      expect(await browser.eval('window.__testDocument')).toBe('retained')
+    })
+
+    it('resumes prefetches if the disable action response body fails', async () => {
+      const { browser, act, page } = await startBrowser('/draft')
+      await pauseClock(page)
+      await act(async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/article/retained"]')
+          .click()
+      }, 'no-requests')
+
+      const failActionBody = async (route: Playwright.Route) => {
+        if (route.request().method() === 'POST') {
+          const response = await route.fetch()
+          await route.fulfill({ response, body: '' })
+        } else {
+          await route.fallback()
+        }
+      }
+      try {
+        await act(
+          async () => {
+            // Keep the actual action's headers, including its cookie mutation,
+            // but close the response before its Flight body arrives.
+            await page.route('**/*', failActionBody)
+            await browser.elementById('disable-with-catch').click()
+            expect(await browser.elementById('action-result').text()).toBe(
+              'Action response failed'
+            )
+            await page.clock.fastForward(300)
+          },
+          { includes: 'Published content: retained' }
+        )
+      } finally {
+        await page.unroute('**/*', failActionBody)
+      }
+
+      expect(
+        (await page.context().cookies()).some(
+          (cookie) => cookie.name === '__prerender_bypass'
+        )
+      ).toBe(false)
+    })
+
+    if (cacheComponents) {
+      it('does not let paused Link prefetches block an instant test navigation', async () => {
+        const { browser, act, page } = await startBrowser('/draft')
+        await act(async () => {
+          for (const target of ['auto', 'full']) {
+            await browser
+              .elementByCss(`input[data-link-accordion="/article/${target}"]`)
+              .click()
+          }
+          await browser.locator('a[href="/article/auto"]').hover()
+        }, 'no-requests')
+
+        await act(async () => {
+          await instant(page, async () => {
+            await act(async () => {
+              await browser.elementByCss('a[href="/article/full"]').click()
+            })
+            expect(await browser.elementById('target-content').text()).toBe(
+              'Draft content: full'
+            )
+            expect(await browser.eval('window.__testDocument')).toBe('retained')
+          })
+        })
+        expect(await browser.elementById('draft-mode').text()).toBe(
+          'Draft mode: enabled'
+        )
+      })
+    }
+  }
+)
+
+async function pauseClock(page: Playwright.Page) {
+  // Keep router-act's idle barrier running while revalidation timers are
+  // paused.
+  const requestIdleCallback = await page.evaluateHandle(() =>
+    window.requestIdleCallback.bind(window)
+  )
+  await page.clock.install({ time: new Date('2026-01-01T00:00:00Z') })
+  await page.clock.pauseAt(new Date('2026-01-02T00:00:00Z'))
+  await page.evaluate((callback) => {
+    window.requestIdleCallback = callback
+  }, requestIdleCallback)
+  await requestIdleCallback.dispose()
+}


### PR DESCRIPTION
With Cache Components enabled, draft-mode prefetches bypass prerendered output and can receive full dynamic RSC responses. The loading-boundary fallback can cache completed content using static-stage param dependencies, allowing sibling URLs to reuse the wrong content.

We considered preserving prefetching by fixing request scoping and skipping staged rendering for draft responses. That still performs speculative server work and can retain preview content after a CMS edit. Disabling draft prefetches avoids creating those speculative snapshots, without on-demand segment prerenders or a blanket restriction on valid vary-param reuse.

The segment cache scheduler now rejects new and requeued prefetch tasks while draft mode is enabled, and cancels queued prefetches when entering that mode. The initial RSC payload reports the draft state, and Server Actions that write the draft cookie report updates in a response header. The router applies those updates before Flight decoding and cache invalidation. Disabling draft mode lets normal invalidation and the revalidation cooldown schedule fresh work for visible links, including when the action body fails to decode. Ignored or canceled imperative prefetches are not replayed. The ordinary processing loop, navigation, and cache-consumption policies remain unchanged, and foreground tasks used by the Instant Navigation Testing API remain supported.

The router learns the state only from the initial document and from Server Actions. A Route Handler that toggles the cookie and is called with a client-side `fetch()` followed by `router.refresh()` leaves the prefetching state unchanged until the next page load; the docs now say to redirect from such a handler.

Forwarded Server Actions now also pass the worker's `Set-Cookie` headers through to the browser. They were previously dropped together with the other `actionsForbiddenHeaders`, so a `cookies().set()` inside a forwarded action never reached the client. Draft mode depends on this, but it applies to every cookie a forwarded action writes.