### PR TITLE
[test] Fix `proxy-request-with-middleware` deploy test

### DIFF
--- a/test/e2e/proxy-request-with-middleware/app/pages/api/index.js
+++ b/test/e2e/proxy-request-with-middleware/app/pages/api/index.js
@@ -10,7 +10,9 @@ export default function handler(req, res) {
   return req
     .pipe(
       request(
-        `http://${
+        // Plain HTTP to a Vercel deployment is 308-upgraded to HTTPS, which
+        // would pipe a redirect back to the client instead of the echo.
+        `${process.env.VERCEL_URL ? 'https' : 'http'}://${
           // node v18 resolves to IPv6 by default so force IPv4
           process.version.startsWith('v18.') && !process.env.VERCEL_URL
             ? `127.0.0.1:${req.headers.host.split(':').pop() || ''}`

--- a/test/e2e/proxy-request-with-middleware/test/index.test.ts
+++ b/test/e2e/proxy-request-with-middleware/test/index.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { fetchViaHTTP } from 'next-test-utils'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 
+// forceful deploy test v1
 describe('Requests not effected when middleware used', () => {
   const { next } = nextTestSetup({
     files: {


### PR DESCRIPTION

The fixture's API route proxies the incoming request to `http://<host>/api/post`. On Vercel, that plain-HTTP hop hits the edge's http→https upgrade and the handler pipes the resulting 308 back to the test client, which then has to replay the POST body across the redirect. Node.js'  fetch implementation cannot replay bodies across 307/308 redirects and fails the request with `UND_ERR_REQ_CONTENT_LENGTH_MISMATCH`, which broke this test in deploy mode after the test harness switched from `node-fetch` to global `fetch` in #98195. 

This change proxies over `https` when `VERCEL_URL` is set so no client-visible redirect occurs, while local dev and start modes are unaffected since they keep using plain HTTP.

Fixes

```
TypeError: fetch failed

      29 |         'x-custom-header': 'some value',
      30 |       }
    > 31 |       const res = await fetchViaHTTP(next.url, `api`, '', {
         |                   ^
      32 |         method: method.toUpperCase(),
      33 |         headers,
      34 |         body: method.toLowerCase() !== 'get' ? body : undefined,

      at Object.<anonymous> (e2e/proxy-request-with-middleware/test/index.test.ts:31:19)

    Cause:
    RequestContentLengthMismatchError: Request body length does not match content-length header
```
-- https://github.com/vercel/next.js/actions/runs/34543344283/job/103105861941#step:35:555