### PR TITLE
fix(next-codemod): keep a satisfying eslint specifier during upgrade

### DIFF
--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -16,6 +16,10 @@ import {
   addPackageDependency,
   runInstallation,
 } from '../lib/handle-package'
+import {
+  eslintSpecifierSatisfiesPeer,
+  resolveEslintUpgradeVersion,
+} from '../lib/resolve-eslint-upgrade'
 import { runTransform } from './transform'
 import { onCancel, TRANSFORMER_INQUIRER_CHOICES } from '../lib/utils'
 import { refreshAgentRulesBlock } from '../lib/agents-md'
@@ -385,12 +389,27 @@ export async function runUpgrade(
           : JSON.parse(eslintConfigNextPeerDepsJSON)
       const eslintRange = eslintConfigNextPeerDeps?.eslint
       if (eslintRange) {
-        const targetEslintVersion = await loadHighestNPMVersionMatching(
-          `eslint@${eslintRange}`
-        )
-        versionMapping['eslint'] = {
-          version: targetEslintVersion,
-          required: false,
+        const currentEslint = allDependencies['eslint']
+        if (!eslintSpecifierSatisfiesPeer(currentEslint, eslintRange)) {
+          const versionsJSON = execSync(
+            `npm --silent view "eslint@${eslintRange}" --json --field version`,
+            { encoding: 'utf-8' }
+          )
+          const versionOrVersions = JSON.parse(versionsJSON)
+          const versionsMatchingPeer = Array.isArray(versionOrVersions)
+            ? versionOrVersions
+            : [versionOrVersions]
+          const targetEslintVersion = resolveEslintUpgradeVersion(
+            currentEslint,
+            eslintRange,
+            versionsMatchingPeer
+          )
+          if (targetEslintVersion) {
+            versionMapping['eslint'] = {
+              version: targetEslintVersion,
+              required: false,
+            }
+          }
         }
       }
     } catch (e) {

--- a/packages/next-codemod/lib/__tests__/resolve-eslint-upgrade.test.ts
+++ b/packages/next-codemod/lib/__tests__/resolve-eslint-upgrade.test.ts
@@ -1,0 +1,52 @@
+import { resolveEslintUpgradeVersion } from '../resolve-eslint-upgrade'
+
+const peerRange = '>=9.0.0'
+const versionsMatchingPeer = ['9.0.0', '9.39.1', '10.0.0', '10.10.0']
+
+describe('resolveEslintUpgradeVersion', () => {
+  it('leaves a ^9 specifier alone when eslint-config-next only needs >=9', () => {
+    expect(
+      resolveEslintUpgradeVersion('^9', peerRange, versionsMatchingPeer)
+    ).toBeNull()
+  })
+
+  it('leaves a caret-minor 9 specifier alone', () => {
+    expect(
+      resolveEslintUpgradeVersion('^9.0.0', peerRange, versionsMatchingPeer)
+    ).toBeNull()
+  })
+
+  it('leaves an exact 9.x pin alone when it already satisfies the peer', () => {
+    expect(
+      resolveEslintUpgradeVersion('9.39.1', peerRange, versionsMatchingPeer)
+    ).toBeNull()
+  })
+
+  it('leaves an already-installed ESLint 10 pin alone', () => {
+    expect(
+      resolveEslintUpgradeVersion('10.10.0', peerRange, versionsMatchingPeer)
+    ).toBeNull()
+  })
+
+  it('bumps ^8 to the highest release of the lowest satisfying major, not ESLint 10', () => {
+    expect(
+      resolveEslintUpgradeVersion('^8', peerRange, versionsMatchingPeer)
+    ).toBe('9.39.1')
+  })
+
+  it('bumps an exact 8.x pin to the highest 9.x', () => {
+    expect(
+      resolveEslintUpgradeVersion('8.57.1', peerRange, versionsMatchingPeer)
+    ).toBe('9.39.1')
+  })
+
+  it('leaves an unparseable specifier alone rather than rewriting it', () => {
+    expect(
+      resolveEslintUpgradeVersion('latest', peerRange, versionsMatchingPeer)
+    ).toBeNull()
+  })
+
+  it('returns null when npm reported no versions in the peer range', () => {
+    expect(resolveEslintUpgradeVersion('^8', peerRange, [])).toBeNull()
+  })
+})

--- a/packages/next-codemod/lib/resolve-eslint-upgrade.ts
+++ b/packages/next-codemod/lib/resolve-eslint-upgrade.ts
@@ -1,0 +1,13 @@
+import { compare as compareVersions } from 'semver'
+
+export function resolveEslintUpgradeVersion(
+  _currentSpecifier: string,
+  _peerRange: string,
+  versionsMatchingPeer: string[]
+): string | null {
+  if (versionsMatchingPeer.length === 0) {
+    return null
+  }
+  const sorted = [...versionsMatchingPeer].sort(compareVersions)
+  return sorted[sorted.length - 1]
+}

--- a/packages/next-codemod/lib/resolve-eslint-upgrade.ts
+++ b/packages/next-codemod/lib/resolve-eslint-upgrade.ts
@@ -1,13 +1,39 @@
-import { compare as compareVersions } from 'semver'
+import {
+  compare as compareVersions,
+  intersects as rangesIntersect,
+  major,
+} from 'semver'
+
+export function eslintSpecifierSatisfiesPeer(
+  currentSpecifier: string,
+  peerRange: string
+): boolean {
+  try {
+    return rangesIntersect(currentSpecifier, peerRange, {
+      includePrerelease: true,
+    })
+  } catch {
+    return true
+  }
+}
 
 export function resolveEslintUpgradeVersion(
-  _currentSpecifier: string,
-  _peerRange: string,
+  currentSpecifier: string,
+  peerRange: string,
   versionsMatchingPeer: string[]
 ): string | null {
+  if (eslintSpecifierSatisfiesPeer(currentSpecifier, peerRange)) {
+    return null
+  }
+
   if (versionsMatchingPeer.length === 0) {
     return null
   }
+
   const sorted = [...versionsMatchingPeer].sort(compareVersions)
-  return sorted[sorted.length - 1]
+  const lowestMajor = major(sorted[0])
+  const inLowestMajor = sorted.filter(
+    (version) => major(version) === lowestMajor
+  )
+  return inLowestMajor[inLowestMajor.length - 1]
 }


### PR DESCRIPTION
### What?

`@next/codemod upgrade` no longer rewrites an `eslint` specifier that already satisfies `eslint-config-next`'s peer range. A project on `eslint@^9` stays on `^9` instead of being pinned to the newest ESLint 10 release.

When a bump is still required (for example `eslint@^8` against a `>=9` peer), the upgrade pins the highest release of the lowest satisfying major.

Fixes #98417

### Why?

`eslint-config-next@16` declares `eslint: '>=9.0.0'`. The upgrade tool treated that range as "install the newest ESLint that matches", so `loadHighestNPMVersionMatching` wrote `eslint: "10.10.0"` into `package.json`.

That pin is not required by Next.js. `eslint-plugin-import@2.32.0` and other common plugins still declare peers that stop at ESLint 9, so `npm install` fails and the Next.js upgrade never runs.

The bump exists so `eslint@^8` still installs against a `>=9` peer. Leaving a specifier that already intersects that peer matches that intent.

### How?

`semver.intersects` decides whether the current specifier already satisfies the target peer range. Unparseable specifiers are left alone.

If a bump is required, matching versions from `npm view` are grouped by major and the highest version of the lowest major is pinned.

Unit tests in `packages/next-codemod/lib/__tests__/resolve-eslint-upgrade.test.ts` lock both paths.

<!-- NEXT_JS_LLM -->
