### PR TITLE
Durable use cache: fix runtime env var mutation

### DIFF
--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -2122,20 +2122,19 @@ export async function cache(
 
   const temporaryReferences = createClientTemporaryReferenceSet()
 
-  // The base serialized cache key doesn't include the cookies or headers that
-  // private caches are allowed to read. In production this is because private
-  // cache entries aren't stored in a cache handler, only in the Resume Data
-  // Cache (RDC): private caches are only used during dynamic requests and
-  // runtime prefetches; for dynamic requests the RDC is immutable and excludes
-  // private caches, and for runtime prefetches it's mutable but lives only as
-  // long as the request. In development private caches are persisted across
-  // requests, so `cacheHandlerKeyBase` (below) additionally scopes the handler
-  // key by the request's cookies and headers.
-  const cacheKeyParts: CacheKeyParts = [
-    id,
-    args,
-    await computeCacheKeyImplementationPart(workStore, workUnitStore, id),
-  ]
+  // The base serialized cache key doesn't include runtime env var state or the
+  // cookies and headers that private caches are allowed to read. Env var state
+  // only scopes the cache handler because the RDC must reuse entries across
+  // rendering phases. In production private cache entries aren't stored in a
+  // cache handler, only in the Resume Data Cache (RDC): private caches are only
+  // used during dynamic requests and runtime prefetches; for dynamic requests
+  // the RDC is immutable and excludes private caches, and for runtime prefetches
+  // it's mutable but lives only as long as the request. In development private
+  // caches are persisted across requests, so `cacheHandlerKeyBase` (below)
+  // additionally scopes the handler key by the request's cookies and headers.
+  const { implementationPart, runtimeEnvVarStateHash } =
+    await computeCacheKeyImplementationPart(workStore, workUnitStore, id)
+  const cacheKeyParts: CacheKeyParts = [id, args, implementationPart]
 
   const encodeCacheKeyParts = () =>
     encodeReply(cacheKeyParts, {
@@ -2270,19 +2269,19 @@ export async function cache(
 
   // The coarse cache-handler key. With no root params read, it locates the
   // entry directly; otherwise it locates a redirect entry from which the
-  // specific key (this key + root params, computed below) is derived. For
-  // private caches in development (persisted in the built-in in-memory handler)
-  // it's additionally scoped by the request's cookies and headers, so entries
-  // for requests with different request data don't collide; keys derived from
-  // it inherit that scoping.
+  // specific key (this key + root params, computed below) is derived. It's
+  // scoped by runtime env var state and, for private caches in development
+  // (persisted in the built-in in-memory handler), the request's cookies and
+  // headers. Keys derived from it inherit that scoping.
   const cacheHandlerKeyBase =
-    process.env.__NEXT_DEV_SERVER && cacheContext.kind === 'private'
-      ? serializedCacheKey +
-        computePrivateCacheKeyRequestSuffix(
+    serializedCacheKey +
+    (runtimeEnvVarStateHash ?? '') +
+    (process.env.__NEXT_DEV_SERVER && cacheContext.kind === 'private'
+      ? computePrivateCacheKeyRequestSuffix(
           cacheContext.outerWorkUnitStore.cookies,
           cacheContext.outerWorkUnitStore.headers
         )
-      : serializedCacheKey
+      : '')
   // If we already know which root params this function reads, include them in
   // the cache handler key for a direct hit (skipping the redirect entry).
   // rootParams is undefined when nested inside unstable_cache.
@@ -3672,8 +3671,12 @@ export async function cache(
 }
 
 /**
- * This returns a cache key that has to cover everything that can affect the result of the cached
- * function (apart from the arguments). So
+ * This returns cache key parts that cover everything that can affect the result of the cached
+ * function (apart from the arguments). The implementation part is used by both the RDC and cache
+ * handler, while the runtime env var state hash is only used by the cache handler. The RDC is
+ * per-page and must reuse entries across rendering phases even if an env var changes between them.
+ *
+ * The parts cover:
  * - codeHash: the code itself that generates the return value
  *    - Notably, this excludes the following modules.  Those are included via the Next.js version anyway:
  *    - react, react-dom, private-next-rsc-server-reference, private-next-rsc-cache-wrapper
@@ -3688,7 +3691,10 @@ async function computeCacheKeyImplementationPart(
   workStore: WorkStore,
   workUnitStore: WorkUnitStore,
   id: string
-): Promise<unknown> {
+): Promise<{
+  implementationPart: unknown
+  runtimeEnvVarStateHash: string | undefined
+}> {
   let durability = workStore.durableUseCacheEntries
     ? getServerActionsManifest().node[id].workers?.[
         normalizeWorkerPageName(workStore.page)
@@ -3715,8 +3721,12 @@ async function computeCacheKeyImplementationPart(
       )
       .digest('hex')
 
-    // When more accurate analysis information is available, use codeHash + runtime env vars
-    return [durability.codeHash, nextVersion, runtimeEnvVarStateHash]
+    // The env var state is added to the cache handler key separately so it
+    // doesn't affect RDC lookups between rendering phases.
+    return {
+      implementationPart: [durability.codeHash, nextVersion],
+      runtimeEnvVarStateHash,
+    }
   } else {
     // Because the Action ID is not yet unique per implementation of that Action we can't
     // safely reuse the results across builds yet. In the meantime we add the buildId to the
@@ -3732,7 +3742,12 @@ async function computeCacheKeyImplementationPart(
     const hmrRefreshHash = getHmrRefreshHash(workUnitStore)
 
     // otherwise fall back to buildId and/or the HMR hash.
-    return hmrRefreshHash ? [buildId, hmrRefreshHash] : [buildId]
+    return {
+      implementationPart: hmrRefreshHash
+        ? [buildId, hmrRefreshHash]
+        : [buildId],
+      runtimeEnvVarStateHash: undefined,
+    }
   }
 }
 

--- a/test/production/app-dir/use-cache-cross-deployment/app/env-mutation/[slug]/mutate-env.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/env-mutation/[slug]/mutate-env.tsx
@@ -1,0 +1,4 @@
+export function MutateEnv() {
+  process.env.MUTATED_DURING_CACHE_GENERATION = '1'
+  return null
+}

--- a/test/production/app-dir/use-cache-cross-deployment/app/env-mutation/[slug]/page.tsx
+++ b/test/production/app-dir/use-cache-cross-deployment/app/env-mutation/[slug]/page.tsx
@@ -1,0 +1,45 @@
+import { cacheLife } from 'next/cache'
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+import { MutateEnv } from './mutate-env'
+
+export const prefetch = 'partial'
+
+async function CachedValue({ slug }: { slug: string }) {
+  'use cache'
+  cacheLife('days')
+
+  const value = process.env.MUTATED_DURING_CACHE_GENERATION ?? 'unset'
+
+  return (
+    <>
+      <p id="data">{`${slug}:${value}`}</p>
+      <MutateEnv />
+    </>
+  )
+}
+
+async function Content({ slug }: { slug: string }) {
+  if (slug === 'known') {
+    await cookies()
+  }
+
+  return <CachedValue slug={slug} />
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return (
+    <Suspense>
+      <Content slug={slug} />
+    </Suspense>
+  )
+}
+
+export function generateStaticParams() {
+  return [{ slug: 'known' }]
+}

--- a/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
+++ b/test/production/app-dir/use-cache-cross-deployment/use-cache-cross-deployment.test.ts
@@ -220,6 +220,38 @@ describe.each(['NEXT_DEPLOYMENT_ID', 'BUILD_ID', 'default'])(
       await next.deleteFile('handler-remote-data.json')
     })
 
+    it('should not miss when an env var changes during cache generation', async () => {
+      // Regression test for mutating env vars which changes the cache key mid-rendering and breaks
+      // the multi-phase rendering process (be it within the next build prerendering, or in the
+      // resume case at runtime).
+      // RDC stores cache entries, and we should use those entries regardless of whether env vars
+      // changed in the meantime (among other things, to prevent tearing).
+      //
+      // Error: Route "foo": Unexpected cache miss after cache warming phase during prerendering.
+      // This is likely caused by non-deterministic arguments that differ between the cache warming
+      // phase and the final prerender phase (e.g. unstable array order). Ensure that arguments
+      // passed to cached functions are deterministic.
+      //
+      // Error: Route "foo": Next.js encountered uncached or runtime data during prerendering.
+      await next.stop()
+      delete next.env.MUTATED_DURING_CACHE_GENERATION
+
+      try {
+        await next.start()
+        const output = next.getCliOutputFromHere()
+        const browser = await next.browser('/env-mutation/test')
+
+        expect(output()).not.toContain('Error')
+        expect(output()).not.toContain(
+          'Unexpected cache miss after cache warming phase during prerendering'
+        )
+        expect(await browser.elementById('data').text()).toBe('test:unset')
+      } finally {
+        await next.stop()
+        delete next.env.MUTATED_DURING_CACHE_GENERATION
+      }
+    })
+
     it('should not recompute when nothing changes', async () => {
       const key1 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-1')
       const key2 = await execute(next, 'NEXT_DEPLOYMENT_ID', 'dpl-id-2')


### PR DESCRIPTION
### Problem
1. Next computes the warmup cache key while `SOME_ENV_VAR` is unset.
2. Rendering ends up setting `SOME_ENV_VAR`.
3. Final prerender expects the cache entry to exist, but the env var changed, so the key changed and it's a miss.
4. Unexpected miss and bailout.

This lead to
```
Error: Route "foo": Unexpected cache miss after cache warming phase during prerendering. This is
likely caused by non-deterministic arguments that differ between the cache warming phase and the
final prerender phase (e.g. unstable array order). Ensure that arguments passed to cached functions
are deterministic.

Error: Route "foo": Next.js encountered uncached or runtime data during
prerendering.
```

### Solution

~~Instead, snapshot the env vars once at module evaluation time of the `use cache` function. This ensures that the cache key doesn't change over time. This is also how it worked thus far (with deployment id as the cache key): changing the env var over the lifetime of the process didn't lead to a reexecution of the `use cache` function~~

RDC already stores cache entries generated in the previous phase (be it during `next build` multi-phase rendering, or from prerender->resuming at runtime). Root params are already excluded from the cache keys when storing in RDC. Also exclude the env var hash bit, to conform to this system of preventing tearing (at the cost of potential staleness).