### PR TITLE
fix(after): don't retain the caller's async context for tasks that never settle

### DIFF
--- a/packages/next/src/server/after/awaiter.test.ts
+++ b/packages/next/src/server/after/awaiter.test.ts
@@ -1,5 +1,15 @@
+/**
+ * @jest-environment node
+ */
+
+import { AsyncLocalStorage } from 'async_hooks'
+import { runInNewContext } from 'node:vm'
+import { setFlagsFromString } from 'node:v8'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { AwaiterMulti, AwaiterOnce } from './awaiter'
+
+setFlagsFromString('--expose-gc')
+const forceGarbageCollection = runInNewContext('gc') as () => void
 
 describe('AwaiterOnce/AwaiterMulti', () => {
   describe.each([
@@ -59,6 +69,74 @@ describe('AwaiterOnce', () => {
     expect(() => awaiter.waitUntil(Promise.resolve(2))).toThrow(InvariantError)
   })
 })
+
+describe('AwaiterMulti/AwaiterOnce retention', () => {
+  // Install AsyncLocalStorage before importing the module that captures the snapshot.
+  type AwaiterMod = typeof import('./awaiter')
+  let Awaiters: AwaiterMod
+
+  beforeAll(async () => {
+    // @ts-expect-error
+    globalThis.AsyncLocalStorage = AsyncLocalStorage
+    jest.resetModules()
+    Awaiters = await import('./awaiter')
+  })
+
+  describe.each(['AwaiterMulti', 'AwaiterOnce'] as const)('%s', (implName) => {
+    it('does not retain the async context of a task that never settles', async () => {
+      const awaiter = new Awaiters[implName]({ onError: () => {} })
+
+      const requestStoreRef = await runInRequestContext(() => {
+        awaiter.waitUntil(new Promise<void>(() => {}))
+      })
+
+      await expectCollected(requestStoreRef)
+    })
+
+    it('does not retain the async context of a task that settles', async () => {
+      const awaiter = new Awaiters[implName]({ onError: () => {} })
+
+      const requestStoreRef = await runInRequestContext(() => {
+        awaiter.waitUntil(Promise.resolve())
+      })
+
+      await expectCollected(requestStoreRef)
+    })
+  })
+})
+
+async function runInRequestContext(
+  callback: () => void
+): Promise<WeakRef<object>> {
+  const requestStorage = new AsyncLocalStorage<object>()
+  let requestStoreRef: WeakRef<object> | undefined
+
+  await requestStorage.run({ requestId: 'request' }, async () => {
+    const requestStore = requestStorage.getStore()
+
+    if (!requestStore) {
+      throw new Error('Expected a request store')
+    }
+
+    requestStoreRef = new WeakRef(requestStore)
+    callback()
+  })
+
+  if (!requestStoreRef) {
+    throw new Error('Expected a request store reference')
+  }
+
+  return requestStoreRef
+}
+
+async function expectCollected(ref: WeakRef<object>): Promise<void> {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    forceGarbageCollection()
+    await new Promise<void>((resolve) => setImmediate(resolve))
+  }
+
+  expect(ref.deref()).toBeUndefined()
+}
 
 type TrackedPromise<T> = Promise<T> & { isSettled: boolean }
 

--- a/packages/next/src/server/after/awaiter.ts
+++ b/packages/next/src/server/after/awaiter.ts
@@ -1,4 +1,8 @@
 import { InvariantError } from '../../shared/lib/invariant-error'
+import { createSnapshot } from '../app-render/async-local-storage'
+
+// Capture an empty context so pending tasks do not retain request data.
+const registerOutsideCallerContext = createSnapshot()
 
 /**
  * Provides a `waitUntil` implementation which gathers promises to be awaited later (via {@link AwaiterMulti.awaiting}).
@@ -21,9 +25,11 @@ export class AwaiterMulti {
       this.promises.delete(promise)
     }
 
-    promise.then(cleanup, (err) => {
-      cleanup()
-      this.onError(err)
+    registerOutsideCallerContext(() => {
+      promise.then(cleanup, (err) => {
+        cleanup()
+        this.onError(err)
+      })
     })
 
     this.promises.add(promise)


### PR DESCRIPTION
fixes #98561

`AwaiterMulti.waitUntil` registers a bookkeeping `.then()` in the caller’s async context. If the promise never settles, that context stays in memory. On self-hosted servers, the shared awaiter only drains when the server closes, so retained request data keeps growing.

The fix uses `createSnapshot()` to register the bookkeeping callback in an empty context. Tasks are still tracked and awaited.

All nine unit tests pass with the fix. Reverting the fix causes the two never-settling tests to fail.