### PR TITLE
feat(next/image): Add experimental imgOptMozjpeg config

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -273,6 +273,7 @@ export const experimentalSchema = {
   imgOptTimeoutInSeconds: z.number().int().optional(),
   imgOptMaxInputPixels: z.number().int().optional(),
   imgOptSequentialRead: z.boolean().optional().nullable(),
+  imgOptMozjpeg: z.boolean().optional(),
   isrFlushToDisk: z.boolean().optional(),
   largePageDataBytes: z.number().optional(),
   linkNoTouchStart: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -606,6 +606,7 @@ export interface ExperimentalConfig {
   imgOptTimeoutInSeconds?: number
   imgOptMaxInputPixels?: number
   imgOptSequentialRead?: boolean | null
+  imgOptMozjpeg?: boolean
   optimisticClientCache?: boolean
   /**
    * @deprecated use config.expireTime instead
@@ -2326,6 +2327,7 @@ export const defaultConfig = Object.freeze({
     imgOptTimeoutInSeconds: 7,
     imgOptMaxInputPixels: 268_402_689, // https://sharp.pixelplumbing.com/api-constructor#:~:text=%5Boptions.limitInputPixels%5D
     imgOptSequentialRead: null,
+    imgOptMozjpeg: true,
     isrFlushToDisk: true,
     workerThreads: false,
     proxyTimeout: undefined,
@@ -2495,6 +2497,7 @@ export interface NextConfigRuntime {
     | 'imgOptMaxInputPixels'
     | 'imgOptSequentialRead'
     | 'imgOptTimeoutInSeconds'
+    | 'imgOptMozjpeg'
     | 'proxyClientMaxBodySize'
     | 'proxyTimeout'
     | 'testProxy'
@@ -2566,6 +2569,7 @@ export function getNextConfigRuntime(
     imgOptMaxInputPixels: ex.imgOptMaxInputPixels,
     imgOptSequentialRead: ex.imgOptSequentialRead,
     imgOptTimeoutInSeconds: ex.imgOptTimeoutInSeconds,
+    imgOptMozjpeg: ex.imgOptMozjpeg,
     proxyClientMaxBodySize: ex.proxyClientMaxBodySize,
     proxyTimeout: ex.proxyTimeout,
     testProxy: ex.testProxy,

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -752,6 +752,7 @@ export async function imageOptimizer(
       | 'imgOptMaxInputPixels'
       | 'imgOptSequentialRead'
       | 'imgOptTimeoutInSeconds'
+      | 'imgOptMozjpeg'
     >
     images: Pick<
       NextConfigComplete['images'],

--- a/packages/next/src/server/image-optimizer/transform.ts
+++ b/packages/next/src/server/image-optimizer/transform.ts
@@ -49,6 +49,7 @@ export type ImageOptimizerTransformConfig = {
     | 'imgOptMaxInputPixels'
     | 'imgOptSequentialRead'
     | 'imgOptTimeoutInSeconds'
+    | 'imgOptMozjpeg'
   >
   images: Pick<
     NextConfigComplete['images'],
@@ -139,6 +140,7 @@ export async function optimizeImage({
   limitInputPixels,
   sequentialRead,
   timeoutInSeconds,
+  mozjpeg = true,
 }: {
   buffer: Buffer
   contentType: string
@@ -150,6 +152,7 @@ export async function optimizeImage({
   limitInputPixels?: number
   sequentialRead?: boolean | null
   timeoutInSeconds?: number
+  mozjpeg?: boolean
 }): Promise<Buffer> {
   const sharp = getSharp(concurrency, operationCache)
   const transformer = sharp(buffer, {
@@ -182,7 +185,7 @@ export async function optimizeImage({
   } else if (contentType === PNG) {
     transformer.png({ quality })
   } else if (contentType === JPEG) {
-    transformer.jpeg({ quality, mozjpeg: true })
+    transformer.jpeg({ quality, mozjpeg })
   }
 
   const optimizedBuffer = await transformer.toBuffer()
@@ -283,6 +286,7 @@ export async function imageOptimizerTransform(
       limitInputPixels: nextConfig.experimental.imgOptMaxInputPixels,
       sequentialRead: nextConfig.experimental.imgOptSequentialRead,
       timeoutInSeconds: nextConfig.experimental.imgOptTimeoutInSeconds,
+      mozjpeg: nextConfig.experimental.imgOptMozjpeg,
     })
     if (opts.handleDevOutput) {
       const output = await opts.handleDevOutput(optimizedBuffer, contentType)

--- a/test/unit/image-optimizer/transform.test.ts
+++ b/test/unit/image-optimizer/transform.test.ts
@@ -1,7 +1,11 @@
 /* eslint-env jest */
 import { readFile } from 'fs-extra'
 import { join } from 'path'
-import { imageOptimizerTransform } from 'next/dist/server/image-optimizer/transform'
+import {
+  getSharp,
+  imageOptimizerTransform,
+  type ImageOptimizerTransformConfig,
+} from 'next/dist/server/image-optimizer/transform'
 import type {
   CachedRouteKind,
   IncrementalResponseCacheEntry,
@@ -24,7 +28,11 @@ const config = {
   },
 }
 
-async function transform(filename: string, mimeType = 'image/webp') {
+async function transform(
+  filename: string,
+  mimeType = 'image/webp',
+  nextConfig: ImageOptimizerTransformConfig = config
+) {
   const buffer = await getImage(filename)
   return imageOptimizerTransform(
     {
@@ -34,7 +42,7 @@ async function transform(filename: string, mimeType = 'image/webp') {
       etag: 'source-etag',
     },
     { href: `/${filename}`, width: 64, quality: 75, mimeType },
-    config
+    nextConfig
   )
 }
 
@@ -87,6 +95,24 @@ describe('imageOptimizerTransform', () => {
     expect(result.buffer.byteLength).toBeGreaterThan(0)
     expect(result.maxAge).toBe(120)
   })
+
+  it.each([undefined, true, false])(
+    'encodes JPEGs with imgOptMozjpeg=%s',
+    async (imgOptMozjpeg) => {
+      const result = await transform('test.jpg', 'image/jpeg', {
+        ...config,
+        experimental: { ...config.experimental, imgOptMozjpeg },
+      })
+      expect(result.error).toBeUndefined()
+      expect(result.contentType).toBe('image/jpeg')
+      const sharp = getSharp(1, false)
+      expect(await sharp(result.buffer).metadata()).toMatchObject({
+        format: 'jpeg',
+        width: 64,
+        isProgressive: imgOptMozjpeg ?? true,
+      })
+    }
+  )
 
   it('preserves the source format when no output format is requested', async () => {
     const result = await transform('test.png', '')

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -108,6 +108,27 @@ describe('config', () => {
     expect(disabledConfig.experimental.devMemoryThresholdRestart).toBe(false)
   })
 
+  it.each([undefined, true, false])(
+    'Should preserve imgOptMozjpeg=%s in the runtime config',
+    async (imgOptMozjpeg) => {
+      const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
+        customConfig: {
+          experimental: {
+            imgOptMozjpeg,
+            runtimeServerDeploymentId: true,
+          },
+        },
+      })
+      const { getNextConfigRuntime } = await import(
+        'next/dist/server/config-shared'
+      )
+      expect(config.experimental.imgOptMozjpeg).toBe(imgOptMozjpeg ?? true)
+      expect(getNextConfigRuntime(config).experimental.imgOptMozjpeg).toBe(
+        imgOptMozjpeg ?? true
+      )
+    }
+  )
+
   it('Should allow bundler-specific options during the test phase', async () => {
     const config = await loadConfig(PHASE_TEST, '<rootDir>-test-phase', {
       customConfig: {


### PR DESCRIPTION
In a previous PR, `mozjpeg` was set to true which might be the reason output jpeg spikes cpu.

- https://github.com/vercel/next.js/pull/65846

I made a benchmark and found that disabling MozJPEG saved 72% CPU, with average outputs 31% larger.

- https://github.com/lovell/sharp/issues/4603

So this PR adds a new experimental flag to enable (or rather disable) mozjpeg and try with real workloads. This is useful becaues in many cases, cpu is more costly than bandwidth since most CDNs provide [near unlimited bandwidth](https://vercel.com/blog/introducing-flat-rate-cdn).