### PR TITLE
docs: scope React cache() guidance to Server Components in the auth guide and after() reference

### DIFF
--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -1139,7 +1139,9 @@ For example, create a separate file for your DAL that includes a `verifySession(
 ```tsx filename="app/lib/dal.ts" switcher
 import 'server-only'
 
+import { cache } from 'react'
 import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
 import { decrypt } from '@/app/lib/session'
 
 export const verifySession = cache(async () => {
@@ -1157,7 +1159,9 @@ export const verifySession = cache(async () => {
 ```js filename="app/lib/dal.js" switcher
 import 'server-only'
 
+import { cache } from 'react'
 import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
 import { decrypt } from '@/app/lib/session'
 
 export const verifySession = cache(async () => {
@@ -1172,7 +1176,9 @@ export const verifySession = cache(async () => {
 })
 ```
 
-You can then invoke the `verifySession()` function in your data requests, Server Actions, Route Handlers:
+You can then invoke the `verifySession()` function in your data requests, Server Actions, and Route Handlers:
+
+> **Good to know:** React's [`cache`](https://react.dev/reference/react/cache) only memoizes during a React render pass. Server Actions and Route Handlers do not render, so a `cache`-wrapped function runs again on every call there — it is not an error, and there is no warning. Call it once and pass the result down if you need the value more than once.
 
 ```tsx filename="app/lib/dal.ts" switcher
 export const getUser = cache(async () => {
@@ -1487,7 +1493,7 @@ import { verifySession } from '@/app/lib/dal'
 
 export async function serverAction() {
   const session = await verifySession()
-  const userRole = session.user.role
+  const userRole = session?.user?.role // Assuming 'role' is part of the session object
 
   // Return early if user is not authorized to perform the action
   if (userRole !== 'admin') {
@@ -1518,7 +1524,7 @@ export async function GET() {
   }
 
   // Check if the user has the 'admin' role
-  if (session.user.role !== 'admin') {
+  if (session?.user?.role !== 'admin') {
     // User is authenticated but does not have the right permissions
     return new Response(null, { status: 403 })
   }
@@ -1541,7 +1547,7 @@ export async function GET() {
   }
 
   // Check if the user has the 'admin' role
-  if (session.user.role !== 'admin') {
+  if (session?.user?.role !== 'admin') {
     // User is authenticated but does not have the right permissions
     return new Response(null, { status: 403 })
   }

--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -1152,7 +1152,7 @@ export const verifySession = cache(async () => {
     redirect('/login')
   }
 
-  return { isAuth: true, userId: session.userId }
+  return { isAuth: true, userId: session.userId, role: session.role }
 })
 ```
 
@@ -1172,7 +1172,7 @@ export const verifySession = cache(async () => {
     redirect('/login')
   }
 
-  return { isAuth: true, userId: session.userId }
+  return { isAuth: true, userId: session.userId, role: session.role }
 })
 ```
 
@@ -1243,7 +1243,7 @@ export async function getSession() {
     return null
   }
 
-  return { isAuth: true, userId: session.userId }
+  return { isAuth: true, userId: session.userId, role: session.role }
 }
 ```
 
@@ -1256,7 +1256,7 @@ export async function getSession() {
     return null
   }
 
-  return { isAuth: true, userId: session.userId }
+  return { isAuth: true, userId: session.userId, role: session.role }
 }
 ```
 
@@ -1350,7 +1350,7 @@ import { verifySession } from '@/app/lib/dal'
 
 export default async function Dashboard() {
   const session = await verifySession()
-  const userRole = session?.user?.role // Assuming 'role' is part of the session object
+  const userRole = session?.role // Assuming you included 'role' in the session payload
 
   if (userRole === 'admin') {
     return <AdminDashboard />
@@ -1367,7 +1367,7 @@ import { verifySession } from '@/app/lib/dal'
 
 export default async function Dashboard() {
   const session = await verifySession()
-  const userRole = session?.user?.role // Assuming 'role' is part of the session object
+  const userRole = session?.role // Assuming you included 'role' in the session payload
 
   if (userRole === 'admin') {
     return <AdminDashboard />
@@ -1450,7 +1450,7 @@ import { verifySession } from '@/app/lib/dal'
 
 export default async function AdminActions() {
   const session = await verifySession()
-  const userRole = session?.user?.role
+  const userRole = session?.role
 
   if (userRole !== 'admin') {
     return null
@@ -1470,7 +1470,7 @@ import { verifySession } from '@/app/lib/dal'
 
 export default async function AdminActions() {
   const session = await verifySession()
-  const userRole = session?.user?.role
+  const userRole = session?.role
 
   if (userRole !== 'admin') {
     return null
@@ -1504,7 +1504,7 @@ import { verifySession } from '@/app/lib/dal'
 
 export async function serverAction(formData: FormData) {
   const session = await verifySession()
-  const userRole = session?.user?.role
+  const userRole = session?.role
 
   // Return early if user is not authorized to perform the action
   if (userRole !== 'admin') {
@@ -1521,7 +1521,7 @@ import { verifySession } from '@/app/lib/dal'
 
 export async function serverAction() {
   const session = await verifySession()
-  const userRole = session?.user?.role // Assuming 'role' is part of the session object
+  const userRole = session?.role // Assuming you included 'role' in the session payload
 
   // Return early if user is not authorized to perform the action
   if (userRole !== 'admin') {
@@ -1554,7 +1554,7 @@ export async function GET() {
   }
 
   // Check if the user has the 'admin' role
-  if (session?.user?.role !== 'admin') {
+  if (session?.role !== 'admin') {
     // User is authenticated but does not have the right permissions
     return new Response(null, { status: 403 })
   }
@@ -1577,7 +1577,7 @@ export async function GET() {
   }
 
   // Check if the user has the 'admin' role
-  if (session?.user?.role !== 'admin') {
+  if (session?.role !== 'admin') {
     // User is authenticated but does not have the right permissions
     return new Response(null, { status: 403 })
   }

--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -1232,6 +1232,34 @@ export const getUser = cache(async () => {
 })
 ```
 
+`verifySession()` redirects, which suits pages. Callers that need to _respond_ rather than navigate — Route Handlers, for example — want a variant that reports failure instead of redirecting:
+
+```tsx filename="app/lib/dal.ts" switcher
+export async function getSession() {
+  const cookie = (await cookies()).get('session')?.value
+  const session = await decrypt(cookie)
+
+  if (!session?.userId) {
+    return null
+  }
+
+  return { isAuth: true, userId: session.userId }
+}
+```
+
+```js filename="app/lib/dal.js" switcher
+export async function getSession() {
+  const cookie = (await cookies()).get('session')?.value
+  const session = await decrypt(cookie)
+
+  if (!session?.userId) {
+    return null
+  }
+
+  return { isAuth: true, userId: session.userId }
+}
+```
+
 > **Tip**:
 >
 > - A DAL can be used to protect data fetched at request time. However, for static routes that share data between users, data will be fetched at build time and not at request time. Use [Proxy](#optimistic-checks-with-proxy-optional) to protect static routes.
@@ -1508,14 +1536,16 @@ export async function serverAction() {
 
 Treat [Route Handlers](/docs/app/api-reference/file-conventions/route) with the same security considerations as public-facing API endpoints, and verify if the user is allowed to access the Route Handler.
 
+Use `getSession()` rather than `verifySession()` here. A Route Handler should answer with a status code a programmatic caller can act on, not redirect it to a login page.
+
 For example:
 
 ```ts filename="app/api/route.ts" switcher
-import { verifySession } from '@/app/lib/dal'
+import { getSession } from '@/app/lib/dal'
 
 export async function GET() {
   // User authentication and role verification
-  const session = await verifySession()
+  const session = await getSession()
 
   // Check if the user is authenticated
   if (!session) {
@@ -1534,11 +1564,11 @@ export async function GET() {
 ```
 
 ```js filename="app/api/route.js" switcher
-import { verifySession } from '@/app/lib/dal'
+import { getSession } from '@/app/lib/dal'
 
 export async function GET() {
   // User authentication and role verification
-  const session = await verifySession()
+  const session = await getSession()
 
   // Check if the user is authenticated
   if (!session) {

--- a/docs/01-app/03-api-reference/04-functions/after.mdx
+++ b/docs/01-app/03-api-reference/04-functions/after.mdx
@@ -52,7 +52,7 @@ export default function Layout({ children }) {
 ## Good to know
 
 - `after` will be executed even if the response didn't complete successfully. Including when an error is thrown or when `notFound` or `redirect` is called.
-- You can use React `cache` to deduplicate functions called inside `after`.
+- In Server Components, you can use React [`cache`](https://react.dev/reference/react/cache) to deduplicate functions called inside `after`. The callback shares the render pass's cache, so a value already computed during the render is not computed again. `cache` does not deduplicate in Route Handlers or Server Functions, which do not render — a `cache`-wrapped function runs again on every call there.
 - `after` can be nested inside other `after` calls, for example, you can create utility functions that wrap `after` calls to add additional functionality.
 
 ## Examples


### PR DESCRIPTION
## What

Two docs pages recommend React `cache()` in contexts where it does not memoize. This qualifies both, and fixes three smaller defects in the examples I had to touch anyway.

Previously filed as #98577 / #98578, both auto-closed by the triage bot for a missing reproduction link — they were created through the API, which bypasses the issue template and so never set the `Documentation` type the bot checks for. Opening a PR instead, as the docs report template suggests.

## Why

React's reference says `cache` "is for use in Server Components only," and that calling a memoized function outside a component "will still evaluate the function but not read or update the cache." There is no error and no warning — the wrapper simply does nothing.

Measured on **Next.js 16.3.4 / React 19.2.4**, counting executions of the underlying function and comparing returned object identity:

| context | deduped in body | deduped inside `after` | `after` shares the body's cache |
| --- | --- | --- | --- |
| Server Component | **yes** | **yes** | **yes** |
| Route Handler | no | no | no |
| Server Function | no | no | no |

Consistent with `packages/next/src/server/route-modules/app-route/module.ts` containing no reference to React at all — no `ReactSharedInternals`, no `getCacheForType` — so `cache()` falls through to the pass-through in React's `ReactCacheImpl.js`.

This is not hypothetical. Following the Authentication guide's pattern in a production app, an auth wrapper resolved the caller once and then every service-layer call inside the handler re-resolved it, because the `cache()` wrapper did nothing: one `GET` performed **three session decrypts and three identical permission-user database queries** where one of each was needed. Diagnosing it required reading the compiled runtime, precisely because the documented pattern looks correct.

## Changes

**`guides/authentication.mdx`**

- Adds a "Good to know" after "You can then invoke the `verifySession()` function in your data requests, Server Actions, and Route Handlers" — `cache` only memoizes during a render pass, so it gives Server Actions and Route Handlers nothing. The page already uses the right phrase elsewhere ("during a React render pass"); it just was not carried into the sentence naming the call sites.
- Adds the missing `cache` and `redirect` imports to both DAL snippets.
- Guards `session.user.role` in the three `verifySession`-based examples. `verifySession()` returns `{ isAuth, userId }` — there is no `user` property, so the unguarded access throws a TypeError. The Server Component examples already guard it with `session?.user?.role`, so this just makes the Server Action and Route Handler examples consistent. The Pages Router examples use a different `getSession(req)` and are untouched.

**`api-reference/functions/after.mdx`**

- Scopes the `cache` bullet to Server Components. The page lists Server Components, Server Functions, Route Handlers and Proxy as supported contexts, and the bullet sat a few lines below that list, unqualified. Also records what does happen in a Server Component, which is better than the original promised: the callback shares the render pass's cache, so a value already computed during the render is not recomputed.

Prettier clean under the repo's `.prettierrc.json`.

## The Route Handler example's unreachable 401

The example previously read:

```ts
const session = await verifySession()

if (!session) {
  return new Response(null, { status: 401 })
}
```

`verifySession()` either calls `redirect()`, which throws, or returns a truthy object — it never returns a falsy value, so the 401 was dead code. The only failure a Route Handler could actually produce was a redirect to `/login`, from an endpoint the same section says to "treat with the same security considerations as public-facing API endpoints."

Fixed by adding a non-redirecting `getSession()` to the DAL and using it in the Route Handler example, so the documented 401 is reachable and a programmatic caller gets a status code rather than a navigation. `verifySession()` is unchanged and remains the right choice for pages, which is where a redirect belongs.

`getSession()` is deliberately **not** `cache()`-wrapped — its callers do not render, so the wrapper would do nothing, which is the point of the rest of this PR.

I took this direction rather than the alternative (leave the redirect and delete the 401) because the guide's own framing of Route Handlers as public-facing API endpoints argues for it. Happy to flip it if you disagree — it is a small commit either way.

## The role shape

Every App Router example read `session.user.role`, but nothing in the guide ever produces a nested `user` object — `verifySession()` returns `{ isAuth, userId }`. So the access was `undefined`, the role checks could never pass, and before this PR it threw a TypeError outright.

Checked against the sibling [Authentication with Cache Components](https://nextjs.org/docs/app/guides/authentication-with-cache-components) guide, which models the session flat too:

```ts
export type SessionData = {
  userId?: string
}
```

So the fix is to read `session.role`, and to have `verifySession()` / `getSession()` forward the role from the decrypted payload. `decrypt()` returns the raw JWT payload, so the value was already reachable — the DAL was simply dropping it. That matches what the guide's own Tips section asks for:

> The payload should contain the **minimum**, unique user data that'll be used in subsequent requests, such as the user's ID, role, etc.

`createSession()` is deliberately left alone. Whether a role belongs in the payload is the reader's decision, and threading one through would mean presuming a `role` column in the signup example's insert. The examples keep an explicit `// Assuming you included 'role' in the session payload` comment instead — the same caveat the guide already had, now attached to a path that works.

The two Pages Router examples use a different `getSession(req)` from an auth library and are untouched.
