### PR TITLE
Server render the nearest not-found boundary

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1,5 +1,8 @@
 import type { ComponentType, ErrorInfo, JSX, ReactNode } from 'react'
-import type { PartialTransportData } from '../../shared/lib/rsc-transport'
+import type {
+  FullTransportNode,
+  PartialTransportData,
+} from '../../shared/lib/rsc-transport'
 import type { RenderOpts, PreloadCallbacks } from './types'
 import type {
   ActionResult,
@@ -2308,6 +2311,66 @@ function Preloads({ preloadCallbacks }: { preloadCallbacks: Function[] }) {
   return null
 }
 
+function nearestNotFoundLoaderTree(tree: LoaderTree): LoaderTree | null {
+  const [segment, parallelRoutes, components, staticSiblings] = tree
+  const children = parallelRoutes.children
+  if (children) {
+    const nested = nearestNotFoundLoaderTree(children)
+    if (nested !== null) {
+      return [
+        segment,
+        { ...parallelRoutes, children: nested },
+        components,
+        staticSiblings,
+      ]
+    }
+  }
+  const notFound = components['not-found']
+  if (!notFound) {
+    return null
+  }
+  return [
+    segment,
+    { children: [PAGE_SEGMENT_KEY, {}, { page: notFound }, null] },
+    components,
+    staticSiblings,
+  ]
+}
+
+async function notFoundTransportTree(
+  tree: LoaderTree,
+  ctx: AppRenderContext,
+  hintTree: PrefetchHints | null,
+  MetadataOutlet: ComponentType<{ tree: LoaderTree }>
+): Promise<FullTransportNode | null> {
+  const loaderTree = tree[2]['global-not-found']
+    ? createNotFoundLoaderTree(tree)
+    : nearestNotFoundLoaderTree(tree)
+  if (loaderTree === null) {
+    return null
+  }
+  try {
+    return await createFullComponentTree({
+      ctx,
+      loaderTree,
+      parentParams: {},
+      parentOptionalCatchAllParamName: null,
+      parentRuntimePrefetchable: false,
+      rootLayoutIncluded: false,
+      injectedCSS: new Set(),
+      injectedJS: new Set(),
+      injectedFontPreloadTags: new Set(),
+      preloadCallbacks: [],
+      authInterrupts: ctx.renderOpts.experimental.authInterrupts,
+      MetadataOutlet,
+      isPrerendering: false,
+      hintTree,
+    })
+  } catch {
+    return null
+  }
+}
+
 // This is the data necessary to render <AppRouter /> when an error state is triggered
 async function getErrorRSCPayload(
   tree: LoaderTree,
@@ -2325,6 +2388,7 @@ async function getErrorRSCPayload(
 
   let Viewport: ComponentType | null = null
   let Metadata: ComponentType | null = null
+  let MetadataOutlet: ComponentType<{ tree: LoaderTree }> = () => null
   if (shouldRenderMetadataAndViewport) {
     const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
     const metadataComponents = createMetadataComponents({
@@ -2338,6 +2402,7 @@ async function getErrorRSCPayload(
     })
     Viewport = metadataComponents.Viewport
     Metadata = metadataComponents.Metadata
+    MetadataOutlet = metadataComponents.MetadataOutlet
   }
 
   const initialHead = createElement(
@@ -2391,18 +2456,29 @@ async function getErrorRSCPayload(
     )
   )
 
-  const initialTree = await createFullTransportTreeFromLoaderTree(
-    tree,
-    errorHints,
-    errorPrefetchInliningEnabled,
-    ctx.missingPrefetchHintPolicy,
-    Boolean(ctx.renderOpts.partialPrefetching),
-    getDynamicParamFromSegment,
-    query
-  )
-  // Attach the error shell as the root's render output. Vary params are not
-  // tracked for error pages.
-  initialTree.d = { r: errorShell, p: false, v: null }
+  let initialTree: FullTransportNode | null = null
+  if (errorType === 'not-found') {
+    initialTree = await notFoundTransportTree(
+      tree,
+      ctx,
+      errorHints,
+      MetadataOutlet
+    )
+  }
+  if (initialTree === null) {
+    initialTree = await createFullTransportTreeFromLoaderTree(
+      tree,
+      errorHints,
+      errorPrefetchInliningEnabled,
+      ctx.missingPrefetchHintPolicy,
+      Boolean(ctx.renderOpts.partialPrefetching),
+      getDynamicParamFromSegment,
+      query
+    )
+    // Attach the error shell as the root's render output. Vary params are not
+    // tracked for error pages.
+    initialTree.d = { r: errorShell, p: false, v: null }
+  }
 
   const { GlobalError, styles: globalErrorStyles } = await getGlobalErrorStyles(
     tree,

--- a/test/e2e/app-dir/not-found/basic/index.test.ts
+++ b/test/e2e/app-dir/not-found/basic/index.test.ts
@@ -33,6 +33,21 @@ describe('app dir - not-found - basic', () => {
     expect(res.status).toBe(404)
   })
 
+  it('should server render the nearest not-found boundary inside its layout', async () => {
+    const markup = (html: string) =>
+      html.replace(/<script\b[\s\S]*?<\/script>/g, '')
+
+    const root = await next.fetch('/shell-not-found')
+    expect(root.status).toBe(404)
+    expect(markup(await root.text())).toContain('Root Not Found')
+
+    const nested = await next.fetch('/error-boundary/nested/trigger-not-found')
+    expect(nested.status).toBe(404)
+    const nestedMarkup = markup(await nested.text())
+    expect(nestedMarkup).toContain('Not Found (error-boundary/nested)')
+    expect(nestedMarkup).toContain('Navbar')
+  })
+
   if (isNextStart) {
     it('should include not found client reference manifest in the file trace', async () => {
       const fileTrace = JSON.parse(


### PR DESCRIPTION
Fixes #62228.

`notFound()` answers with the empty error shell. React's streaming SSR does not run client error boundaries, so `HTTPAccessFallbackBoundary` never produces markup on the server: the not-found page and the layouts around it are drawn by the client only. Crawlers and the first frame get an empty body, and a blocking script in the root layout never runs.

The error payload now builds the nearest not-found boundary inside its layouts with `createFullComponentTree` — the subtree builder of a matched path — and keeps the shell when the route declares no boundary or the build fails. `global-not-found` keeps its own tree.

Server HTML now matches what the client renders: the root boundary for a root-level `notFound()`, the nested one for a nested route. Covered by a new assertion in `not-found/basic` on the fetched markup; the 16 not-found and global-not-found e2e suites pass.