### PR TITLE
fix(next/form): normalize newlines in GET submissions

### DIFF
--- a/packages/next/src/client/form-shared.tsx
+++ b/packages/next/src/client/form-shared.tsx
@@ -80,6 +80,8 @@ export function createFormSubmitDestinationUrl(
   const formData = new FormData(formElement)
 
   for (let [name, value] of formData) {
+    name = normalizeFormEntryNewlines(name)
+
     if (typeof value !== 'string') {
       // For file inputs, the native browser behavior is to use the filename as the value instead:
       //
@@ -93,11 +95,17 @@ export function createFormSubmitDestinationUrl(
         )
       }
       value = value.name
+    } else {
+      value = normalizeFormEntryNewlines(value)
     }
 
     targetUrl.searchParams.append(name, value)
   }
   return targetUrl
+}
+
+function normalizeFormEntryNewlines(value: string): string {
+  return value.replace(/\r\n|\r|\n/g, '\r\n')
 }
 
 export function checkFormActionUrl(

--- a/test/e2e/next-form/default/app/forms/textarea/hydration-marker.tsx
+++ b/test/e2e/next-form/default/app/forms/textarea/hydration-marker.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import * as React from 'react'
+
+export default function HydrationMarker() {
+  const [hydrated, setHydrated] = React.useState(false)
+
+  React.useEffect(() => setHydrated(true), [])
+
+  return hydrated ? <span id="hydrated">true</span> : null
+}

--- a/test/e2e/next-form/default/app/forms/textarea/page.tsx
+++ b/test/e2e/next-form/default/app/forms/textarea/page.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import Form from 'next/form'
+import HydrationMarker from './hydration-marker'
+
+export default function Page() {
+  return (
+    <>
+      <HydrationMarker />
+      <Form action="/search" id="next-form">
+        <textarea name="query" defaultValue={'line1\nline2'} />
+        <button type="submit">Submit</button>
+      </Form>
+      <form action="/search" id="native-form">
+        <textarea name="query" defaultValue={'line1\nline2'} />
+        <button type="submit">Submit</button>
+      </form>
+    </>
+  )
+}

--- a/test/e2e/next-form/default/pages/pages-dir/forms/textarea/index.tsx
+++ b/test/e2e/next-form/default/pages/pages-dir/forms/textarea/index.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+import Form from 'next/form'
+
+function HydrationMarker() {
+  const [hydrated, setHydrated] = React.useState(false)
+
+  React.useEffect(() => setHydrated(true), [])
+
+  return hydrated ? <span id="hydrated">true</span> : null
+}
+
+export default function Page() {
+  return (
+    <>
+      <HydrationMarker />
+      <Form action="/pages-dir/search" id="next-form">
+        <textarea name="query" defaultValue={'line1\nline2'} />
+        <button type="submit">Submit</button>
+      </Form>
+      <form action="/pages-dir/search" id="native-form">
+        <textarea name="query" defaultValue={'line1\nline2'} />
+        <button type="submit">Submit</button>
+      </form>
+    </>
+  )
+}

--- a/test/e2e/next-form/default/shared-tests.util.ts
+++ b/test/e2e/next-form/default/shared-tests.util.ts
@@ -285,6 +285,32 @@ export function runSharedTests(type: 'app' | 'pages') {
         ['file', 'hello.txt'],
       ])
     })
+
+    it('normalizes line endings in textarea values to CRLF', async () => {
+      let session = await next.browser(pathPrefix + '/forms/textarea')
+
+      await session.elementByCss('#native-form [type="submit"]').click()
+
+      const nativeResult = await session
+        .waitForElementByCss('#search-results')
+        .text()
+      expect(nativeResult).toBe('query: "line1\\r\\nline2"')
+
+      session = await next.browser(pathPrefix + '/forms/textarea')
+      const navigationTracker = await trackMpaNavs(session)
+
+      await session.waitForElementByCss('#hydrated')
+      await session.elementByCss('#next-form [type="submit"]').click()
+
+      const nextFormResult = await session
+        .waitForElementByCss('#search-results')
+        .text()
+      expect(nextFormResult).toBe(nativeResult)
+      expect(await navigationTracker.didMpaNavigate()).toBe(false)
+
+      const url = new URL(await session.url())
+      expect(url.searchParams.get('query')).toBe('line1\r\nline2')
+    })
   })
 
   async function trackMpaNavs(session: Playwright) {


### PR DESCRIPTION
## What?

Fix `next/form` GET submissions so newline characters are normalized consistently with native HTML form submissions after hydration.

## Why?

When a textarea was submitted through a hydrated `next/form` with a string action, newline characters were sent as LF (`\n`).

Native `application/x-www-form-urlencoded` GET forms normalize standalone CR and LF characters to CRLF (`\r\n`) before URL encoding. This caused native forms and hydrated `next/form` components to submit different values for identical textarea content.

## How?

Normalize form entry names and string values to CRLF before appending them to the target URL's search parameters.

Existing file-input handling remains unchanged because native form submission uses the file name directly.

Added end-to-end coverage for:

- App Router forms
- Pages Router forms
- Hydrated `next/form` submissions
- Comparison with native form submissions
- CRLF values in the resulting server search parameters and URL

## Testing

- Editor diagnostics: passed
- Prettier check: passed
- `git diff --check`: passed
- Focused E2E tests could not be completed locally because the checkout was missing generated Next.js build artifacts required by the test runner.

## Related Issue

Fixes #98405