### PR TITLE
Fix addMissingDependency

### DIFF
--- a/test/development/app-dir/turbopack-loader-file-dependencies/loader.js
+++ b/test/development/app-dir/turbopack-loader-file-dependencies/loader.js
@@ -1,4 +1,5 @@
 const path = require('node:path')
+const fs = require('node:fs')
 
 const loader = async function (content) {
   this.async()
@@ -12,10 +13,12 @@ const loader = async function (content) {
   const resolve = this.getResolve({})
   const result = await resolve(context, dependencyFile)
   this.addDependency(result)
+  const missingDependency = path.join(context, 'missing-dependency.ts')
+  this.addMissingDependency(missingDependency)
 
   this.callback(
     null,
-    `export const utilFn = () => 'Generated at ${new Date().toISOString()}';`
+    `export const utilFn = () => 'Generated at ${new Date().toISOString()}, missing dependency: ${fs.existsSync(missingDependency)}';`
   )
 }
 

--- a/test/development/app-dir/turbopack-loader-file-dependencies/turbopack-loader-file-dependencies.test.ts
+++ b/test/development/app-dir/turbopack-loader-file-dependencies/turbopack-loader-file-dependencies.test.ts
@@ -22,4 +22,20 @@ describe('turbopack-loader-file-dependencies', () => {
     const newText = await $2('p').text()
     expect(newText).not.toBe(initialText)
   })
+
+  it('should update when a missing dependency is created', async () => {
+    const $ = await next.render$('/')
+    const initialText = $('p').text()
+    expect(initialText).toContain('missing dependency: false')
+
+    await next.patchFile(
+      'utils/missing-dependency.ts',
+      'export const value = "created"'
+    )
+
+    await waitFor(1000)
+
+    const $2 = await next.render$('/')
+    expect($2('p').text()).toContain('missing dependency: true')
+  })
 })

--- a/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
+++ b/turbopack/crates/turbopack-node/js/src/transforms/webpack-loaders.ts
@@ -551,10 +551,15 @@ const transform = (
           ipc.sendInfo({ type: 'log', logs: logs })
           logs.length = 0
         }
+        const { missingDependencies } = result as typeof result & {
+          missingDependencies: string[]
+        }
         ipc.sendInfo({
           type: 'dependencies',
           envVariables: getReadEnvVariables(),
-          filePaths: result.fileDependencies.map(toPath),
+          filePaths: [...result.fileDependencies, ...missingDependencies].map(
+            toPath
+          ),
           directories: result.contextDependencies.map((dep) => [
             toPath(dep),
             '**',


### PR DESCRIPTION
While before this change we had addMissingDependency, we didn't properly respond when the file for that missing dep was added.

The way webpack does this internally is not the exact same shape as the IPC here, it has them as a separate field. I could not find any reason not to just add them to the filePaths here. So that's what I did to keep things simple.

