### PR TITLE
fix(next-codemod): only bump eslint when it does not satisfy the eslint-config-next peer range

### DIFF
--- a/packages/next-codemod/bin/__tests__/eslint-upgrade-target.test.ts
+++ b/packages/next-codemod/bin/__tests__/eslint-upgrade-target.test.ts
@@ -1,0 +1,48 @@
+import { resolveEslintUpgradeTarget } from '../shared'
+
+describe('resolveEslintUpgradeTarget', () => {
+  const resolveHighestVersion = async (query: string) =>
+    `highest-for:${query}`
+
+  it('keeps the installed specifier when it satisfies the peer range', async () => {
+    await expect(
+      resolveEslintUpgradeTarget('^9.4.0', '>=9', resolveHighestVersion)
+    ).resolves.toBe(null)
+  })
+
+  it('keeps an exact installed version that satisfies the peer range', async () => {
+    await expect(
+      resolveEslintUpgradeTarget('10.10.0', '>=9', resolveHighestVersion)
+    ).resolves.toBe(null)
+  })
+
+  it('keeps a specifier entirely above the peer minimum instead of downgrading', async () => {
+    await expect(
+      resolveEslintUpgradeTarget('^11', '>=9', resolveHighestVersion)
+    ).resolves.toBe(null)
+  })
+
+  it('bumps a below-range specifier to the highest release of the lowest satisfying major', async () => {
+    await expect(
+      resolveEslintUpgradeTarget('^8.7.0', '>=9', resolveHighestVersion)
+    ).resolves.toBe('highest-for:eslint@^9.0.0')
+  })
+
+  it('bumps a caret-pinned old major to the lowest satisfying major, not the newest eslint', async () => {
+    await expect(
+      resolveEslintUpgradeTarget('^7', '>=8.0.0 <9 || >=9', resolveHighestVersion)
+    ).resolves.toBe('highest-for:eslint@^8.0.0')
+  })
+
+  it('leaves specifiers it cannot interpret untouched', async () => {
+    await expect(
+      resolveEslintUpgradeTarget('latest', '>=9', resolveHighestVersion)
+    ).resolves.toBe(null)
+  })
+
+  it('leaves the project alone when the peer range is not a valid semver range', async () => {
+    await expect(
+      resolveEslintUpgradeTarget('^8.7.0', 'not-a-range', resolveHighestVersion)
+    ).resolves.toBe(null)
+  })
+})

--- a/packages/next-codemod/bin/shared.ts
+++ b/packages/next-codemod/bin/shared.ts
@@ -1,1 +1,57 @@
+import { minVersion, satisfies, major } from 'semver'
+
 export class BadInput extends Error {}
+
+/**
+ * Decide what `upgrade` should do with the project's `eslint` specifier given
+ * the `eslint` peer range of the target `eslint-config-next` version.
+ *
+ * Returns null when the existing specifier should be left untouched:
+ * - it already satisfies the peer range. The project may deliberately track an
+ *   older major (e.g. eslint plugins that do not support the newest eslint
+ *   release yet), so we must not pin them onto a newer major unprompted.
+ * - it is not something we can interpret as a semver range (e.g. `latest`, a
+ *   workspace or npm alias).
+ *
+ * Otherwise resolves the highest release of the lowest major satisfying the
+ * peer range (e.g. `eslint@^9.0.0` for a `>=9` peer), so a project below the
+ * range lands on the closest satisfying major instead of the newest eslint
+ * release. Returns the resolved version, or null if resolution fails.
+ */
+export async function resolveEslintUpgradeTarget(
+  installedEslintSpecifier: string,
+  eslintPeerRange: string,
+  resolveHighestVersion: (query: string) => Promise<string>
+): Promise<string | null> {
+  let peerMinimum
+  try {
+    peerMinimum = minVersion(eslintPeerRange)
+  } catch {
+    return null
+  }
+  if (!peerMinimum) {
+    return null
+  }
+
+  let installedSatisfiesPeer: boolean
+  try {
+    const installedMinimum = minVersion(installedEslintSpecifier)
+    if (!installedMinimum) {
+      return null
+    }
+    installedSatisfiesPeer = satisfies(
+      installedMinimum.version,
+      eslintPeerRange
+    )
+  } catch {
+    return null
+  }
+
+  if (installedSatisfiesPeer) {
+    return null
+  }
+
+  return resolveHighestVersion(
+    `eslint@^${major(peerMinimum.version)}.0.0`
+  )
+}

--- a/packages/next-codemod/bin/upgrade.ts
+++ b/packages/next-codemod/bin/upgrade.ts
@@ -19,7 +19,7 @@ import {
 import { runTransform } from './transform'
 import { onCancel, TRANSFORMER_INQUIRER_CHOICES } from '../lib/utils'
 import { refreshAgentRulesBlock } from '../lib/agents-md'
-import { BadInput } from './shared'
+import { BadInput, resolveEslintUpgradeTarget } from './shared'
 
 type PackageManager = 'pnpm' | 'npm' | 'yarn' | 'bun'
 
@@ -363,16 +363,22 @@ export async function runUpgrade(
     }
   }
 
-  // Bump `eslint` alongside `eslint-config-next` so the install doesn't fail
+  // Align `eslint` with `eslint-config-next` so the install doesn't fail
   // on a peer-dep mismatch. e.g. `eslint-config-next@16.x` requires
   // `eslint@>=9`, but a project upgrading from Next 15 will still have
-  // `eslint@^8` from create-next-app. Skip silently if anything goes wrong;
-  // the worst case is the user hits the same peer-dep error they would have
-  // without this bump.
+  // `eslint@^8` from create-next-app.
+  //
+  // A specifier that already satisfies the peer range is left untouched: the
+  // project may deliberately track an older major, e.g. when eslint plugins
+  // it uses do not support the newest eslint release yet. When a bump is
+  // required, pin the highest release of the lowest major satisfying the peer
+  // range instead of the newest eslint release.
   //
   // Only act when the project is actually using `eslint-config-next` — we
   // don't want to silently upgrade eslint majors for projects that use
-  // eslint for unrelated reasons.
+  // eslint for unrelated reasons. Skip silently if anything goes wrong;
+  // the worst case is the user hits the same peer-dep error they would have
+  // without this alignment.
   if (allDependencies['eslint'] && allDependencies['eslint-config-next']) {
     try {
       const eslintConfigNextPeerDepsJSON = execSync(
@@ -385,12 +391,16 @@ export async function runUpgrade(
           : JSON.parse(eslintConfigNextPeerDepsJSON)
       const eslintRange = eslintConfigNextPeerDeps?.eslint
       if (eslintRange) {
-        const targetEslintVersion = await loadHighestNPMVersionMatching(
-          `eslint@${eslintRange}`
+        const targetEslintVersion = await resolveEslintUpgradeTarget(
+          allDependencies['eslint'],
+          eslintRange,
+          loadHighestNPMVersionMatching
         )
-        versionMapping['eslint'] = {
-          version: targetEslintVersion,
-          required: false,
+        if (targetEslintVersion) {
+          versionMapping['eslint'] = {
+            version: targetEslintVersion,
+            required: false,
+          }
         }
       }
     } catch (e) {


### PR DESCRIPTION
### What?

`@next/codemod upgrade` no longer rewrites the project's `eslint` specifier
when it already satisfies the `eslint-config-next` peer range. A project on
`eslint@^9` stays on `^9` instead of being pinned to the newest ESLint 10
release.

When a bump is still required (for example `eslint@^8` against a `>=9` peer),
the tool pins the highest release of the lowest major satisfying the peer
range, so projects land on the closest satisfying major instead of the newest
eslint release.

Fixes #98417

### Why?

`eslint-config-next@16` declares `eslint: ">=9.0.0"`. The upgrade tool called
`loadHighestNPMVersionMatching("eslint@>=9")` and wrote the result as an exact
pin, so a project on `^9` got forced onto the newest ESLint 10 release. With
plugins that do not support ESLint 10 yet (e.g. `eslint-plugin-import`), the
post-upgrade `npm install` failed before any transformation ran, per the
linked issue's repro.

### How did you fix it?

- New pure helper `resolveEslintUpgradeTarget` in `bin/shared.ts`. It returns
  null (leave the specifier untouched) when the installed specifier satisfies
  the peer range - including specifiers entirely above the peer minimum, so
  nothing gets downgraded - or when it cannot be interpreted as a semver range
  (`latest`, workspace/npm aliases). Otherwise it resolves the highest release
  of the lowest major satisfying the peer range through the injected resolver.
- `bin/upgrade.ts` uses the helper for the eslint alignment step. Behavior for
  projects below the peer range is unchanged except that the target is the
  lowest satisfying major rather than the newest release.
- Unit tests for the decision table in
  `bin/__tests__/eslint-upgrade-target.test.ts`.

### How to test?

- `pnpm test packages/next-codemod/bin/__tests__/eslint-upgrade-target.test.ts`
- Or against the repro in #98417: `npx @next/codemod@canary upgrade latest`
  on a `create-next-app@15.5.0` project with `eslint@^9` +
  `eslint-plugin-import`. The manifest keeps `"eslint": "^9"` and the install
  succeeds.
