### PR TITLE
example: add X-Trust human presence attestation middleware

### DIFF
--- a/examples/x-trust/README.md
+++ b/examples/x-trust/README.md
@@ -1,0 +1,21 @@
+# X-Trust + Next.js
+
+Human presence attestation for Next.js API routes.
+Zero KYC, Zero PII. Annotate, never block.
+
+## How it works
+
+The middleware verifies the `X-Trust` header on every `/api/*` request.
+Each request is annotated with a human score (0..1) — never blocked.
+
+## Setup
+
+1. Install: `npm install @htl-syterme/htl-core`
+2. Set `HTL_SECRET` in `.env.local`
+3. The middleware annotates every request automatically
+
+## Links
+
+- OSS: https://github.com/htl-syterme/htl-core
+- JSR: https://jsr.io/@htl-syterme/htl-core
+- Live demo: https://htl-syterme.github.io/htl-core

--- a/examples/x-trust/middleware.ts
+++ b/examples/x-trust/middleware.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const SECRET = process.env.HTL_SECRET ?? "";
+
+function b64urlToBytes(s: string): Uint8Array {
+  const bin = atob(s.replace(/-/g, "+").replace(/_/g, "/"));
+  return Uint8Array.from(bin, (c) => c.charCodeAt(0));
+}
+
+async function verifyXTrust(token: string): Promise<number | null> {
+  const parts = token.split(".");
+  if (parts.length !== 3 || parts[0] !== "v1") return null;
+  const [, payloadB64, sigB64] = parts;
+  try {
+    const key = await crypto.subtle.importKey("raw", new TextEncoder().encode(SECRET), { name: "HMAC", hash: "SHA-256" }, false, ["verify"]);
+    const ok = await crypto.subtle.verify("HMAC", key, b64urlToBytes(sigB64), new TextEncoder().encode(payloadB64));
+    if (!ok) return null;
+    const payload = JSON.parse(new TextDecoder().decode(b64urlToBytes(payloadB64)));
+    const now = Math.floor(Date.now() / 1000);
+    if (payload.score < 0 || payload.score > 1) return null;
+    if (now > payload.exp || now - payload.iat > 120) return null;
+    return payload.score;
+  } catch { return null; }
+}
+
+export async function middleware(req: NextRequest) {
+  const token = req.headers.get("x-trust") ?? "";
+  const score = token ? await verifyXTrust(token) : null;
+  const res = NextResponse.next();
+  res.headers.set("x-trust-score", score?.toString() ?? "0");
+  res.headers.set("x-trust-annotated", "true");
+  return res;
+}
+
+export const config = { matcher: "/api/:path*" };


### PR DESCRIPTION
Adds an example showing X-Trust middleware integration for Next.js API routes.

X-Trust proves human presence via a signed HTTP header (HMAC-SHA256).
Complements Web Bot Auth — the IETF charter explicitly scopes human 
verification as out-of-scope. X-Trust fills that gap.

- Zero KYC, Zero PII
- Annotate, never block (Doctrine AIR)
- 120s TTL, score 0..1
- Works alongside Cloudflare Turnstile (different layer)

OSS: https://github.com/htl-syterme/htl-core
JSR: https://jsr.io/@htl-syterme/htl-core