### PR TITLE
fix(standalone): correct symlink type in node_modules on Windows

### DIFF
--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -1297,7 +1297,22 @@ export async function copyTracedFiles(
 
           if (symlink) {
             try {
-              await fs.symlink(symlink, fileOutputPath)
+              // On Windows, symlinks have two distinct types (file or dir), which must be
+              // determined at creation time. The symlink variable is a relative path, resolved
+              // relative to fileOutputPath. However, at the time of creation, this target path may
+              // not yet exist. When the target doesn't exist, Node.js defaults to creating a file
+              // type symlink. To avoid this, we first detect the type of the original target via
+              // tracedFilePath, then explicitly pass the correct type.
+              if (process.platform === 'win32') {
+                const tracedFileStat = await fs.stat(tracedFilePath)
+                await fs.symlink(
+                  symlink,
+                  fileOutputPath,
+                  tracedFileStat.isDirectory() ? 'dir' : 'file'
+                )
+              } else {
+                await fs.symlink(symlink, fileOutputPath)
+              }
             } catch (err: any) {
               // Windows doesn't support creating symlinks without elevated privileges, unless
               // "Developer Mode" is turned on. If we failed to create a symlink due to EPERM, try

--- a/test/production/standalone-mode/symlink-on-windows/symlink-on-windows.test.ts
+++ b/test/production/standalone-mode/symlink-on-windows/symlink-on-windows.test.ts
@@ -1,0 +1,139 @@
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { copyTracedFiles } from '../../../../packages/next/src/build/utils'
+
+/**
+ * Direct test for copyTracedFiles - verifies that symlinks are correctly
+ * recreated in the standalone output directory on Windows.
+ *
+ * On Windows, when creating a symlink where the target doesn't exist yet,
+ * Node.js defaults to creating a file-type symlink. The fix detects the
+ * original file type via tracedFilePath and passes the correct type to fs.symlink().
+ */
+describe('symlink-on-windows', () => {
+  let tmpDir: string
+  let srcDir: string
+  let distDir: string
+  let tracingRoot: string
+
+  beforeAll(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'copy-traced-test-'))
+    srcDir = path.join(tmpDir, 'src')
+    distDir = path.join(tmpDir, 'dist')
+    tracingRoot = srcDir
+
+    // Create source structure with symlinks:
+    // src/
+    //   real-dir/           (real directory)
+    //     inner.ts
+    //   real-file.ts        (real file)
+    //   symlink-dir   -> ./real-dir     (directory symlink)
+    //   symlink-file  -> ./real-file.ts (file symlink)
+    await fs.mkdir(path.join(srcDir, 'real-dir'), { recursive: true })
+    await fs.writeFile(
+      path.join(srcDir, 'real-dir', 'inner.ts'),
+      'export const value = 1'
+    )
+    await fs.writeFile(
+      path.join(srcDir, 'real-file.ts'),
+      'export const value = 2'
+    )
+    await fs.symlink('./real-dir', path.join(srcDir, 'symlink-dir'), 'dir')
+    await fs.symlink(
+      './real-file.ts',
+      path.join(srcDir, 'symlink-file'),
+      'file'
+    )
+
+    // Create dist directory
+    await fs.mkdir(distDir, { recursive: true })
+
+    // Create package.json in dist (required by copyTracedFiles)
+    await fs.writeFile(
+      path.join(distDir, 'package.json'),
+      JSON.stringify({ name: 'test' })
+    )
+
+    // Create NFT trace file that includes symlinks
+    // Paths in the trace are relative to the trace file location (distDir)
+    // So '../src/real-dir/inner.ts' means distDir/../src/real-dir/inner.ts = src/real-dir/inner.ts
+    const traceData = {
+      files: [
+        '../src/real-dir/inner.ts',
+        '../src/real-file.ts',
+        '../src/symlink-dir',
+        '../src/symlink-file',
+      ],
+    }
+    await fs.writeFile(
+      path.join(distDir, 'next-server.js.nft.json'),
+      JSON.stringify(traceData)
+    )
+  })
+
+  afterAll(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('should create correct symlink types in standalone output', async () => {
+    if (process.platform !== 'win32') {
+      return
+    }
+
+    await copyTracedFiles(
+      srcDir,
+      distDir,
+      [],
+      undefined,
+      tracingRoot,
+      { distDir: '.next' } as any,
+      { middleware: {}, functions: {} } as any,
+      false,
+      false,
+      new Set()
+    )
+
+    const standaloneDir = path.join(distDir, 'standalone')
+
+    // Verify real files/directories are copied correctly
+    const realDirStat = await fs.stat(path.join(standaloneDir, 'real-dir'))
+    expect(realDirStat.isDirectory()).toBe(true)
+
+    const realFileStat = await fs.stat(path.join(standaloneDir, 'real-file.ts'))
+    expect(realFileStat.isFile()).toBe(true)
+
+    // Verify symlink-dir is a directory symlink
+    const symlinkDirStat = await fs.lstat(
+      path.join(standaloneDir, 'symlink-dir')
+    )
+    expect(symlinkDirStat.isSymbolicLink()).toBe(true)
+    const symlinkDirTarget = await fs.stat(
+      path.join(standaloneDir, 'symlink-dir')
+    )
+    expect(symlinkDirTarget.isDirectory()).toBe(true)
+
+    // Verify symlink-file is a file symlink
+    const symlinkFileStat = await fs.lstat(
+      path.join(standaloneDir, 'symlink-file')
+    )
+    expect(symlinkFileStat.isSymbolicLink()).toBe(true)
+    const symlinkFileTarget = await fs.stat(
+      path.join(standaloneDir, 'symlink-file')
+    )
+    expect(symlinkFileTarget.isFile()).toBe(true)
+
+    // Verify content is accessible through symlinks
+    const dirContent = await fs.readFile(
+      path.join(standaloneDir, 'symlink-dir', 'inner.ts'),
+      'utf8'
+    )
+    expect(dirContent).toBe('export const value = 1')
+
+    const fileContent = await fs.readFile(
+      path.join(standaloneDir, 'symlink-file'),
+      'utf8'
+    )
+    expect(fileContent).toBe('export const value = 2')
+  })
+})


### PR DESCRIPTION
## What?

Fix incorrectly typed symlinks in `.next/standalone/node_modules` on Windows.

## Why?

On Windows, `fs.symlink()` requires the type (`file` or `dir`) at creation time and defaults to file type when the target doesn't exist yet. In `copyTracedFiles`, symlinks are recreated in NFT trace order (arbitrary), so directory symlink targets may not exist when the symlink is created. This causes directory symlinks to be incorrectly created as file symlinks in the standalone output.

While this doesn't break runtime behavior (Windows resolves the target correctly), it produces incorrect output that can confuse tools and users inspecting the standalone directory.

## How?

Detect the original file type via `tracedFilePath` (which points to the real file in the source tree) and pass the correct type explicitly to `fs.symlink()` on Windows.

### Testing

Added unit test in `test/production/standalone-mode/symlink-on-windows/` that directly exercises `copyTracedFiles` with both directory and file symlinks and verifies the output types are correct on Windows.